### PR TITLE
Bundle adds cache to cache

### DIFF
--- a/doc/bundle.md
+++ b/doc/bundle.md
@@ -17,10 +17,6 @@ http://github.com/isaacs/npm/issues/issue/74
   The package whose dependencies are to be bundled. Defaults to $PWD.
   See `npm help install` for more on the ways to identify a package.
 
-Bundle does *not* support version ranges like
-
-    npm bundle deps sax@">=0.1.0 <0.2.0"
-
 ## DESCRIPTION
 
 Bundles all the dependencies of a package into a specific folder.
@@ -72,4 +68,8 @@ or run `npm bundle deps` on the target machine.
 The `npm update` command will do *horrible* things to a bundle folder.
 Don't ever point update at that root, or your bundles may no longer
 satisfy your dependencies.
+
+Bundle does *not* support version ranges like
+
+    npm bundle deps sax@">=0.1.0 <0.2.0"
 

--- a/doc/bundle.md
+++ b/doc/bundle.md
@@ -17,6 +17,10 @@ http://github.com/isaacs/npm/issues/issue/74
   The package whose dependencies are to be bundled. Defaults to $PWD.
   See `npm help install` for more on the ways to identify a package.
 
+Bundle does *not* support version ranges like
+
+    npm bundle deps sax@">=0.1.0 <0.2.0"
+
 ## DESCRIPTION
 
 Bundles all the dependencies of a package into a specific folder.
@@ -68,3 +72,4 @@ or run `npm bundle deps` on the target machine.
 The `npm update` command will do *horrible* things to a bundle folder.
 Don't ever point update at that root, or your bundles may no longer
 satisfy your dependencies.
+

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -2,9 +2,9 @@
 module.exports = bundle
 
 var npm = require("../npm")
-  , fs = require("fs")
   , path = require("path")
   , log = require("./utils/log")
+  , cache = require("./cache")
   , readJson = require("./utils/read-json")
   , mkdir = require("./utils/mkdir-p")
   , fs = require("./utils/graceful-fs")
@@ -24,22 +24,81 @@ function bundle (args, cb) {
     npm.config.set("root", location)
     npm.config.set("binroot", null)
     npm.config.set("manroot", null)
-    readJson(path.join(pkg, "package.json"), function (er, data) {
-      if (er) return log.er(cb, "Error adding "+pkg+" to bundle cache")(er)
-      var depNames = Object.keys(data.dependencies)
-        , deps = depNames.map(function (d) {
-            var v = data.dependencies[d]
-            if (v === "*") v = ""
-            return d+"@"+v
-          })
-      log.verbose(deps, "bundle deps")
-      npm.commands.install(deps, function (er) {
+    mkdir(npm.dir, function(er) {
+      if (er) return log.er(cb, "Error creating "+npm.dir+" for bundling")(er)
+
+      isDirectory(pkg, function(er, dir) {
         if (er) return cb(er)
-        writeBundleShim(location, depNames, function (er) {
-          return cb(er)
-        })
+        if (dir) {
+          // just read the package.json from the directory to
+          // avoid adding the whole package to the cache
+          readJson(path.join(pkg, "package.json"), function (er, data) {
+            if (er) {
+              return log.er(cb, "Error reading "+pkg+"/package.json")(er)
+            }
+            install(data, location, cb)
+          })
+        } else {
+          // AND for my NEXT trick...
+          // add the pkg to the cache, so that we get its data whether it's
+          // a file, name or whatever, and then delete the cache after.
+          var ver
+          if (pkg.indexOf("@") !== -1) {
+            pkg = pkg.split("@")
+            ver = pkg[1]
+            pkg = pkg[0]
+          }
+          cache.add(pkg, ver, function (er, data) {
+            if (er) {
+              return log.er(cb, "Error adding "+pkg+" to bundle cache")(er)
+            }
+            install(data, location, function(er) {
+              cleanup (er, cb)
+            })
+          })
+        }
       })
     })
+  })
+}
+
+function isDirectory(pkg, cb) {
+  if (pkg.match(/^https?:\/\//)) cb()
+  else {
+    path.exists(pkg, function(exists) {
+      if (exists) {
+        fs.stat(pkg, function (er, s) {
+          if (er) return cb(er)
+          cb(er, s.isDirectory())
+        })
+      } else cb()
+    })
+  }
+}
+
+function install (data, location, cb) {
+  if (typeof data.dependencies === 'undefined') {
+    return cb(new Error("Package has no dependencies"))
+  }
+  var depNames = Object.keys(data.dependencies)
+    , deps = depNames.map(function (d) {
+        var v = data.dependencies[d]
+        if (v === "*") v = ""
+        return d+"@"+v
+      })
+  log.verbose(deps, "bundle deps")
+  npm.commands.install(deps, function (er) {
+    if (er) return cb(er)
+    writeBundleShim(location, depNames, function (er) {
+      return cb(er)
+    })
+  })
+}
+
+function cleanup (er_, cb) {
+  cache.clean(function (er) {
+    if (er) log.error(er, "Error cleaning bundle cache")
+    return cb(er_)
   })
 }
 

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -34,7 +34,7 @@ function bundle (args, cb) {
           })
       log.verbose(deps, "bundle deps")
       npm.commands.install(deps, function (er) {
-        if (er) return cleanup(er, cb)
+        if (er) return cb(er)
         writeBundleShim(location, depNames, function (er) {
           return cb(er)
         })

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -5,7 +5,7 @@ var npm = require("../npm")
   , fs = require("fs")
   , path = require("path")
   , log = require("./utils/log")
-  , cache = require("./cache")
+  , readJson = require("./utils/read-json")
   , mkdir = require("./utils/mkdir-p")
   , fs = require("./utils/graceful-fs")
 
@@ -24,10 +24,7 @@ function bundle (args, cb) {
     npm.config.set("root", location)
     npm.config.set("binroot", null)
     npm.config.set("manroot", null)
-    // AND for my NEXT trick...
-    // add the pkg to the cache, so that we get its data whether it's
-    // a folder or name or whatever, and then delete the cache after.
-    cache.add(pkg, function (er, data) {
+    readJson(path.join(pkg, "package.json"), function (er, data) {
       if (er) return log.er(cb, "Error adding "+pkg+" to bundle cache")(er)
       var depNames = Object.keys(data.dependencies)
         , deps = depNames.map(function (d) {
@@ -39,17 +36,10 @@ function bundle (args, cb) {
       npm.commands.install(deps, function (er) {
         if (er) return cleanup(er, cb)
         writeBundleShim(location, depNames, function (er) {
-          cleanup(er, cb)
+          return cb(er)
         })
       })
     })
-  })
-}
-
-function cleanup (er_, cb) {
-  cache.clean(function (er) {
-    if (er) log.error(er, "Error cleaning bundle cache")
-    return cb(er_)
   })
 }
 
@@ -63,3 +53,4 @@ function writeBundleShim (location, depNames, cb) {
              }).join("\n")
   fs.writeFile(path.join(location, "index.js"), data, cb)
 }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name" : "npm"
 , "description" : "A package manager for node"
-, "version" : "0.2.3-3"
+, "version" : "0.2.3-4"
 , "homepage" : "http://npmjs.org/"
 , "author" : "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)"
 , "contributors" :


### PR DESCRIPTION
Hey Isaac,

yesterday I wrote a message on the mailing list. I tracked it down to cache.add that tries to add the bundle cache to the cache. Tar fails with a "File changed while reading" or something similar (my error is in german). This certainly has to do with our large repository, cause it doesn't happen on a smaller one. The pipe/syspump creates the targetTarball, which is later on read by the input tar process.

Tests are passing with this patch and bundle is a lot faster.

Cheers,
Timo
