### PR TITLE
`npm list` attribute positions

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -30,7 +30,7 @@ function prettify (data, args) {
     , attrs = []
     , names = []
     , pretty = []
-    , maxNameLen = 0
+    , beginAttrList = 28
   pkgs.forEach(function (name) {
     var pkg = data[name]
     Object.keys(pkg.versions).sort(semver.compare).forEach(function (v) {
@@ -46,13 +46,12 @@ function prettify (data, args) {
         p.push('='+m.name)
       })
       names.push(name + "@" + v)
-      maxNameLen = Math.max(maxNameLen, (name + "@" + v).length)
       attrs.push(p.sort(strcmp).join(" "))
     })
   })
   var space = "                                   "
   for (var n = 0, l = names.length; n < l; n ++) {
-    names[n] += space.substr(0, maxNameLen - names[n].length)
+    names[n] += space.substr(0, beginAttrList - names[n].length)
     pretty.push(names[n] + " " + attrs[n])
   }
   var doColor


### PR DESCRIPTION
Gave the attributes list in `npm list` a default starting position at position 28 (what looked nicest). 

It clears nearly all packages (i would estimate more than 99%), but more importantly, prevents too frequent line wraps in `npm list installed` and similar. The longer names are few and far between, and will just push the attributes list to start from the end of the package name.
