### PR TITLE
Get active module version from NPM

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -13,6 +13,25 @@ npm.commands = {}
 npm.ELIFECYCLE = {}
 npm.E404 = {}
 
+npm.getActiveVersion = function(module, cb) {
+    if (!cb) throw new Error('Requires a callback')
+    require("./lib/utils/read-installed")(module, function(err, data) {
+					      data = data[module]
+					      if (data) {
+						  for (var p in data) {
+						      var o = data[p]
+						      if ('active' in o && o.active) {
+							  cb(null, p)
+							  return;
+						      }
+						  }
+						  cb('No version found')
+					      } else {
+						  cb('Module is not installed')
+					      }
+					  })
+}
+
 if (process.getuid() === 0) {
   log.error( "\nRunning npm as root is not recommended!\n"
            + "Seriously, don't do this!\n", "sudon't!")


### PR DESCRIPTION
There are two ways to get a module version, from the module itself, although this is unreliable, and through the packaging system.

Requiring npm into a project and then asking for the version number is the least invasive approach and guarantees that if the module is in npm, it will have a version.

Usage: require('npm').getActiveVersion('module', function(err, version) { require('sys').debug(err + ' - ' + version)})

I am not really content on the function name, but it was the best that I came up with- feel free to change it.
