### PR TITLE
Use valid template for mktemp.

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -85,7 +85,7 @@ done
 NPMPKG="$(dirname -- "$(dirname -- "$SELF_PATH")")"
 NPMCLI="$NPMPKG/cli.js"
 TESTDIR="$NPMPKG/test/"
-TMP=$(mktemp -dt npm)
+TMP=$(mktemp -dt npm.XXXXXX)
 ROOTDIR="$TMP/root"
 BINDIR="$TMP/bin"
 MANDIR="$TMP/man"


### PR DESCRIPTION
I just cloned npm and did a `make test` and this happened:

```
$ make test
./test/run.sh
mktemp: too few X's in template `npm'
rm: cannot remove # ... lost of files from /bin and  but permission denied.
# Thank god I'm not root.
```

So I commited this :)
