### PR TITLE
Install permission error

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -45,7 +45,9 @@ function read (name, ver, cb) {
   var jsonFile = path.join(npm.cache, name, ver, "package.json")
   function c (er, data) {
     if (!er) cacheSeen[data._id] = data
-    deprCheck(data)
+
+    if (data) deprCheck(data)
+
     return cb(er, data)
   }
   if (name+"@"+ver in cacheSeen) {

--- a/lib/utils/mkdir-p.js
+++ b/lib/utils/mkdir-p.js
@@ -28,8 +28,7 @@ function mkdir (ensure, chmod, cb) {
             // the stat to make sure it's a dir and not a file.
             return fs.stat(dir, STATCB)
           }
-          if (er) return cb(new Error(
-            "Failed to make "+dir+" while ensuring "+ensure+"\n"+er.message))
+          if (er) return cb(er)
           S(dirs.shift())
         })
       } else {


### PR DESCRIPTION
Currently if you don't have write permission on the npm cache folder and you try to install a package, the following error is thrown:

```
npm info it worked if it ends with ok
npm info using npm@0.2.6alpha-1
npm info using node@v0.2.4
npm ERR! TypeError: Cannot read property '_id' of undefined
npm ERR!     at deprCheck (/home/dev/npm/lib/cache.js:300:22)
npm ERR!     at c (/home/dev/npm/lib/cache.js:51:5)
npm ERR!     at /home/dev/npm/lib/cache.js:150:22
npm ERR!     at MKDIRCB (/home/dev/npm/lib/utils/mkdir-p.js:31:26)
npm ERR!     at cb (/home/dev/npm/lib/utils/graceful-fs.js:32:9)
npm ERR!     at node.js:772:9
npm ERR! Report this *entire* log at <http://github.com/isaacs/npm/issues>
npm ERR! or email it to <npm-@googlegroups.com>
npm ERR! Just tweeting a tiny part of the error will not be helpful.
npm not ok
```

I have changed it so that the deprCheck function is not called if data is undefined / null and that the mkdir function doesn't throw a custom error so that the errorHandler can catch the original error and display a more meaningful error message:

```
npm info it worked if it ends with ok
npm info using npm@0.2.6
npm info using node@v0.2.4
npm ERR! Error installing amqp@0.0.2-squaremo01.184010
npm ERR! Error: EACCES, Permission denied '/home/dev/node/.npm/.cache/amqp'
npm ERR!     at node.js:772:9
npm ERR! There appear to be some permission problems
npm ERR! See the section on 'Permission Errors' at
npm ERR!   http://github.com/isaacs/npm#readme
npm ERR! This will get better in the future, I promise.
npm not ok
```
