### PR TITLE
Missing word in help text

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -66,7 +66,7 @@ function help (args, cb) {
       , ""
       , "Specify configs in the ini-formatted file at "+npm.config.get("userconfig")
       , "or on the command line via: npm <command> --key value"
-      , "Config info can be by running: npm help config"
+      , "Config info can be get by running: npm help config"
       , ""
       , "Help usage: npm help <section>"
       , ""


### PR DESCRIPTION
Adds a missing word to the help text.
