### PR TITLE
Readme error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ and package installations can run arbitrary scripts.
 
 Don't do this if you don't know what it does!  If you have software in
 /usr/local that depends on a specific ownership (such as MySQL), then it
-might break if you change its ownership.  Be careful.  Unix does not
-assume you don't know what you're doing!
+might break if you change its ownership.  Be careful.  Unix assumes
+you know what you're doing!
 
 This is convenient if you have a single-user machine.  Run this command
 once, and never use sudo again to install stuff in /usr/local:


### PR DESCRIPTION
I noticed a slight bug in the wording of the readme. You state that you should be careful because "Unix does not assume you don't know what you're doing!". In fact, Unix DOES assume you know what you are doing, and of course typically does exactly what you tell it to do, regardless of whether or not it's a good idea. The associated commit inverts the statement. (I figured it would be easier and more convenient to correct in diff form :)
