### PR TITLE
Added --force option to npm install

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -78,6 +78,10 @@ You may combine multiple arguments, and even multiple types of arguments.  For e
 
 The `--tag` argument will apply to all of the specified install targets.
 
+The `--force` argument will force npm to fetch remote resources even if a local copy exists on disk.
+
+    npm install sax --force
+
 ## CONFIGURATION
 
 ### root

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -221,7 +221,7 @@ function addNameVersion (name, ver, cb) {
     if (!data.dist || !data.dist.tarball) return cb(new Error(
       "No dist.tarball in package data"))
     //TODO: put the shasum in the data, and pass to addRemoteTarball
-    if (response.statusCode !== 304) return fetchit()
+    if (response.statusCode !== 304 || npm.config.get("force")) return fetchit()
     // we got cached data, so let's see if we have a tarball.
     fs.stat(path.join(npm.cache, name, ver, "package.tgz"), function (er, s) {
       if (!er) return cb(null, data)

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -109,6 +109,11 @@ function read (name, ver, cb) {
     if (data) deprCheck(data)
     return cb(er, data)
   }
+  if (npm.config.get("force")) {
+    log.verbose(true, "force found, skipping cache")
+    return addNameVersion(name, ver, c)
+  }
+
   if (name+"@"+ver in cacheSeen) {
     return cb(null, cacheSeen[name+"@"+ver])
   }

--- a/lib/utils/registry/get.js
+++ b/lib/utils/registry/get.js
@@ -31,7 +31,7 @@ function get (project, version, timeout, nofollow, cb) {
 }
 function get_ (uri, timeout, cache, stat, data, nofollow, cb) {
   var etag
-  if (data && data._etag && !npm.config.get("force")) etag = data._etag
+  if (data && data._etag) etag = data._etag
   if (timeout && timeout > 0 && stat && data) {
     if ((Date.now() - stat.mtime.getTime())/1000 < timeout) {
       log.verbose("not expired, no request", "registry.get " +uri)

--- a/lib/utils/registry/get.js
+++ b/lib/utils/registry/get.js
@@ -31,7 +31,7 @@ function get (project, version, timeout, nofollow, cb) {
 }
 function get_ (uri, timeout, cache, stat, data, nofollow, cb) {
   var etag
-  if (data && data._etag) etag = data._etag
+  if (data && data._etag && !npm.config.get("force")) etag = data._etag
   if (timeout && timeout > 0 && stat && data) {
     if ((Date.now() - stat.mtime.getTime())/1000 < timeout) {
       log.verbose("not expired, no request", "registry.get " +uri)


### PR DESCRIPTION
I have noticed that it's kind of difficult to "reinstall" a package that already exists in the local cache. For example:

If an author "republishes" a package you already have installed.

If you are working on a package and `npm install .` but the package.json file had the last published version in it. So you can't easily roll back to that remote version for testing without deleting all the cache files.

Adding this small patch just short circuits some of the fetch checks in npm to force it to always fetch the remote resource.

Note that it's only for the package specified, it won't pull fresh copies of all the dependencies. I didn't think that was needed in this case, but you might think otherwise.
