### PR TITLE
make the makefile more enviroment agnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = bash
+
 
 docs = $(shell find doc -name '*.md' \
 				|sed 's|.md|.1|g' \


### PR DESCRIPTION
Hi,

If you set the SHELL variable at the top of the makefile to use bash explicitly the make file now works on systems where the default shell is different. I noticed this as we're developing on solaris-x86 where /bin/sh is the default shell. 
