### PR TITLE
An "npm complete -- $@" completion wrapper for zsh users

### DIFF
--- a/lib/utils/registry/get.js
+++ b/lib/utils/registry/get.js
@@ -51,12 +51,14 @@ function get_ (uri, timeout, cache, stat, data, nofollow, cb) {
     data = remoteData
     if (er) return cb(er, data, raw, response)
     // just give the write the old college try.  if it fails, whatever.
-    function saved () {
+    function saved (saveError) {
       delete data._etag
+      if (saveError)
+        log.error('Failed to save registry cache: '+ saveError.message);
       cb(er, data, raw, response)
     }
     mkdir(path.dirname(cache), 0777, function (er) {
-      if (er) return saved()
+      if (er) return saved(er)
       fs.writeFile(cache, JSON.stringify(data), saved)
     })
   })

--- a/npm-completion.zsh
+++ b/npm-completion.zsh
@@ -1,0 +1,24 @@
+#compdef npm
+
+# Zsh completion script for npm, delegating the whole affair to "npm complete"
+# The only trouble with this approach is that not all npm comands do completion
+# (so if you try one of those, some happy "npm ERR!" spew fills your terminal).
+#
+# To install, rename this file to "_npm" and drop it somewhere in your $fpath;
+# /usr/share/zsh/site-functions for instance
+
+_npm() {
+  compadd -- $(_npm_complete $words)
+}
+
+# We want to show all errors of any substance, but never the "npm (not )ok" one.
+# (Also doesn't consider "ERR! no match found" worth breaking the terminal for.)
+_npm_complete() {
+  local ask_npm
+  ask_npm=(npm completion --color false --loglevel error -- $@)
+  { _call_program npm $ask_npm 2>&1 >&3 \
+  | egrep -v '^(npm (not |)ok|ERR! no match found)$' >&2; \
+  } 3>&1
+}
+
+_npm "$@"


### PR DESCRIPTION
The .zsh script is pretty self-explanatory (in zsh, completions are never dumped in .zshrc these days; it's just a file named _npm put anywhere in the user's fpath together with all the other files by its side).

The change to make failed-to-write-cache an error might be worth a note, though. When I first installed the script, it surprised me that completion of anything except the commands ALWAYS took a really slow network request (bad net weather here made it especially painful).

It turned out it was because I was using sudo when installing things, and not for simple look-up activity, but since /usr/local/lib/node/.npm/.cache/ was owned by root, it could not write .cache.json there, and completion became uselessly slow. It took me a few hours figuring out why, and I think it's good form to print an error about it (without exiting), at least for purposes of completion.

One thing worth mentioning: any time there's stderr output which the script doesn't filter away, the command line the user was typing gets blown away to show all the stderr output (try: "npm init <tab>"). The cursor rests at the beginning of an empty line afterwards, instead of redrawing the prompt and command line typed. Sub-perfect but good enough for rare critical errors, I figured.

For that reason (stderr output breaking UX), I opted to make missing cache an error instead of warning, and set the completer's filter level to errors only, as there seemed to be non-critical expected things shown as warnings (specifically the "About to fetch users completion" message plus tons of JSON looked bad / unneccessary).
