### PR TITLE
Improve npm.config handling of true/false/null/undefined and empty values.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -98,10 +98,14 @@ function del (key, cb) {
 }
 
 function set (key, val, cb) {
-  if (val === undefined && key.indexOf("=") !== -1) {
-    var k = key.split("=")
-    key = k.shift()
-    val = k.join("=")
+  if (val === undefined) {
+    if (key.indexOf("=") !== -1) {
+      var k = key.split("=")
+      key = k.shift()
+      val = k.join("=")
+    } else {
+      val = ""
+    }
   }
   key = key.trim()
   val = val.trim()

--- a/lib/utils/ini.js
+++ b/lib/utils/ini.js
@@ -110,7 +110,13 @@ function parseField (f, k) {
   // type can be an array or single thing.
   var isPath = -1 !== [].concat(parseArgs.types[k]).indexOf(path)
   f = (""+f).trim()
-  if (f === "") f = true
+  if (f === "") return f = true
+  switch (f) {
+    case "true": return f = true
+    case "false": return f = false
+    case "null": return f = null
+    case "undefined": return f = undefined
+  }
   if (isPath) {
     if (f.substr(0, 2) === "~/" && process.env.HOME) {
       f = path.join(process.env.HOME, f.substr(2))
@@ -118,12 +124,6 @@ function parseField (f, k) {
     if (f.charAt(0) !== "/") {
       f = path.join(process.cwd(), f.substr(2))
     }
-  }
-  switch (f) {
-    case "true": f = true; break
-    case "false": f = false; break
-    case "null": f = null; break
-    case "undefined": f = undefined; break
   }
   return f
 }


### PR DESCRIPTION
This patch fixes the following three `node config` behaviors.
### When setting a config param to a boolean value, unwanted path interpolation happens.

Moving the true/false/null/undefined handling to happen before path interpolation fixes this:

```
> npm config --loglevel=win set binroot false
npm ok  
> npm config --loglevel=win get binroot
/home/chromakode/lse
npm ok
```
### Setting a config param to an empty string breaks npm:

```
> npm config --loglevel=win set binroot ""
npm ok  
> npm --help
>
```

This was an unfortunate case where npm dies before logging config is loaded, causing it to quit without any output. What's actually happening is that [lib/utils/ini.js:113](https://github.com/isaacs/npm/blob/b1faed0054831173f6c476cce5b599944184b48a/lib/utils/ini.js#L113) defaults the value `f = true`, and then `f.substr(0, 2)` fails (undefined on a boolean) on line 115.
### Setting a config param to an empty value throws a TypeError:

```
> npm config set binroot 
npm info it worked if it ends with ok
npm info using npm@0.3.15
npm info using node@v0.4.2
npm ERR! TypeError: Cannot call method 'trim' of undefined
npm ERR!     at set (/home/chromakode/Apps/source/node/npm/lib/config.js:107:13)
...
```

The patch changes the behavior of `config set key` to default an empty value to "", which then gets interpreted as `true` by `parseField`.

Thanks,  
-M
