### PR TITLE
cannot use the custom registry whose port is not 80 because of the invalid 'Host' header.

### DIFF
--- a/lib/utils/fetch.js
+++ b/lib/utils/fetch.js
@@ -57,6 +57,7 @@ function fetchAndWrite (remote, fstr, headers, maxRedirects, redirects) {
       , agent: false
       }
   if (!opts.port) opts.port = opts.secure ? 443 : 80
+  else headers['host'] = remote.hostname + ":" + remote.port
 
   opts = proxyify(npm.config.get("proxy"), remote, opts)
   if (!opts) return cb(new Error("Bad proxy config: "+npm.config.get("proxy")))

--- a/lib/utils/registry/request.js
+++ b/lib/utils/registry/request.js
@@ -87,6 +87,8 @@ function request (method, where, what, etag, nofollow, cb_) {
     log.verbose(etag, "etag")
     headers[method === "GET" ? "if-none-match" : "if-match"] = etag
   }
+  if( remote.port ) headers['host'] = remote.hostname + ":" + remote.port;
+
   log.silly(headers, "headers")
 
   var opts = { method: method


### PR DESCRIPTION
Hello,

I set up my local npm registry referring to https://github.com/isaacs/npmjs.org .
I could be able to deploy couchapp and replicate documents from the public registry 
to the my local npm registry (http://localhost:5984/npm).
But I can not use registry operation commands such as npm publish, npm install, ... etc
with '--registry http://localhost:5984/' option.

I found that the latest npm (0.3.5) did not set the correct 'Host' header if the port of the given registry is not 80, so that registry rewrite rules were ignored.

I send you the fix patch for this issue.
Could you please confirm and merge it?

Thanks.
