### PR TITLE
Check both new and old locations for semver

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,7 +72,11 @@ cd "$TMP" \
       ret=$?
       if [ $ret -eq 0 ]; then
         req=`$node bin/read-package-json.js package.json engines.node`
-        $node node_modules/semver/bin/semver -v "$node_version" -r "$req"
+        if [ -e node_modules ]; then
+            $node node_modules/semver/bin/semver -v "$node_version" -r "$req"
+        else
+            $node bin/semver.js -v "$node_version" -r "$req"
+        fi
         ret=$?
       fi
       if [ $ret -ne 0 ]; then


### PR DESCRIPTION
Old versions (i.e. 0.2.19) won't install using install.sh with 'npm_install' set because install.sh is looking for semver in the new location under node_modules.

This patch checks for existence of node_modules, and if it doesn't exist, falls back to bin/semver.js
