### PR TITLE
Default version and auther info from config for `npm init`. 

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -249,6 +249,34 @@ user.
 
 The gzip binary
 
+### init.version 
+
+* Default: "0.0.0"
+* Type: String
+
+The value `npm init` should use by default for the package version.
+
+### init.author.name
+
+* Default: "0.0.0"
+* Type: String
+
+The value `npm init` should use by default for the package author's name.
+
+### init.author.email
+
+* Default: "0.0.0"
+* Type: String
+
+The value `npm init` should use by default for the package author's email.
+
+### init.author.url
+
+* Default: "0.0.0"
+* Type: String
+
+The value `npm init` should use by default for the package author's homepage.
+
 ### logfd
 
 * Default: stderr file descriptor

--- a/lib/init.js
+++ b/lib/init.js
@@ -24,6 +24,11 @@ function init (args, cb) {
 
   readJson(path.join(folder, "package.json"), function (er, data) {
     if (er) data = {}
+    data.author = data.author || {
+      name: npm.config.get('init.author.name'),
+      email: npm.config.get('init.author.email'),
+      url: npm.config.get('init.author.url')
+    };
     init_(data, folder, function (er) {
       npm.config.set("loglevel", ll)
       if (!er) log(path.join(folder, "package.json"), "written")
@@ -215,6 +220,8 @@ function defaultVersion (folder, data, cb) {
   exec("git", ["describe", "--tags"], process.env, false, folder,
        function (er, code, out) {
     out = (out || "").trim()
+    if (semver.valid(out)) return cb(null, out)
+    out = npm.config.get("init.version");
     if (semver.valid(out)) return cb(null, out)
     return cb(null, "0.0.0")
   })

--- a/lib/utils/config-defs.js
+++ b/lib/utils/config-defs.js
@@ -34,6 +34,10 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , globalconfig : path.resolve(process.execPath, "..", "..", "etc", "npmrc")
     , group : process.env.SUDO_GID || process.getgid()
     , gzipbin : process.env.GZIPBIN || "gzip"
+    , 'init.version' : '0.0.0'
+    , 'init.author.name' : ''
+    , 'init.author.email' : ''
+    , 'init.author.url' : ''
     , logfd : stdio.stderrFD
     , loglevel : "warn"
     , long : false
@@ -86,6 +90,10 @@ exports.types =
   , globalconfig : path
   , group : [String, Number]
   , gzipbin : String
+  , 'init.version' : String
+  , 'init.author.name' : String
+  , 'init.author.email' : String
+  , 'init.author.url' : String
   , logfd : [Number, Stream]
   , loglevel : ["silent","win","error","warn","info","verbose","silly"]
   , long : Boolean


### PR DESCRIPTION
Read the initial value of a package's `version`, `author.name`,
`author.email` and `author.url` properties from .npmrc when
running `npm init`, allowing the user to set defaults for
these fields.
