### PR TITLE
Work around install behind firewall/proxy server

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,7 +54,7 @@ if [ -z "$t" ]; then
   t="latest"
 fi
 
-url=`curl -s http://registry.npmjs.org/npm/$t \
+url=`curl -s -L http://registry.npmjs.org/npm/$t \
       | $egrep -o 'tarball":"[^"]+' \
       | head -n 1 \
       | $egrep -o 'http://.*'`


### PR DESCRIPTION
I ran into problem when trying to install npm behind firewall's proxy server.  Adding -L to curl worked around the issue.  Can you pull this simple patch?

Thanks
