### PR TITLE
Dependencies as local directories

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -186,6 +186,8 @@ function add (args, cb) {
     return cb(new Error(usage))
   }
   if (pkg && ver) return addNamed(pkg, ver, cb)
+  var m
+  if (m = pkg.match(/^local:\/\/(.+)$/)) pkg = m[1]
   if (pkg.match(/^https?:\/\//)) return addRemoteTarball(pkg, cb)
   else addLocal(pkg, cb)
 }

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -118,6 +118,7 @@ function ugly (data) {
        + ":" + (data._id || "")
        + ":" + (data.realPath !== data.path ? data.realPath : "")
        + (data.extraneous ? ":EXTRANEOUS" : "")
+       + (data.local ? ":LOCAL" : "")
        + (data.invalid ? ":INVALID" : "")
 }
 
@@ -143,6 +144,9 @@ function format (data, long, prefix, dir) {
   }
   if (data.extraneous && rel !== ".") {
     l += "\033[32;40mextraneous\033[0m "
+  }
+  if (data.local && rel !== ".") {
+    l += "\033[32;40mlocal\033[0m "
   }
   if (!long || !data._id) return l
   var extras = []

--- a/lib/utils/read-installed.js
+++ b/lib/utils/read-installed.js
@@ -151,6 +151,10 @@ function readInstalled_ (folder, parent, name, reqver, depth, maxDepth, cb) {
       obj = {dependencies:{}}
       installed.forEach(function (i) { obj.dependencies[i] = "*" })
     }
+    if (reqver && reqver.indexOf('local://') === 0) {
+        reqver = null
+        obj.local = true
+    }
     if (name && obj.name !== name) obj.invalid = true
     obj.realName = name || obj.name
     obj.dependencies = obj.dependencies || {}


### PR DESCRIPTION
Hi, I've just added support for dependencies as local directories relative to current package directory.
It is very handy when you use 'npm' as a project deployment helper. In this case, sometimes there are local libraries (for example, git submodules) which are not pushed to npm registry, but it's convenient to specify them as dependencies and install like other registry-packages in one shot.

Example package.json:

```
{
    ...
    "dependencies": {
        "fibers": "local://submodules/fibers",
        "express": "2.2.1"
    }
    ...
}
```

So, it will install fibers the same way like if we run "npm install submodules/fibers" from a project root.

```
$ npm ls
myapp@0.0.1 /path/to/myapp
├── fibers@0.2.4 local 
└── express@2.2.1
```

Additionally, it would be very useful to do something like "npm link" from local packages.
What's your opinion on it, guys?
