### PR TITLE
search performance improvements

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -62,14 +62,22 @@ function getFilteredData (staleness, args, notArgs, cb) {
   var leftToRun = args.length;
   var aggregateData = {};
   
+  // if there are no search terms, call the callback with no data
+  if(args.length == 0)
+    return cb(null, filter(aggregateData, args, notArgs))
+  
+  // for each search term, fire off a search. 
+  // When all of the calls have returned, invoke the callback with the
+  // aggregate data
   args.forEach(function(it) {
-      registry.get("/-/search/\"" + it + "\"/\"" + it + "\"/25", null, staleness, function (er, data) {
-        if (er) return cb(er)
-        Object.keys(data).forEach(function(key) {
-            aggregateData[key] = data[key];
-        });
-        if(--leftToRun == 0)
-            return cb(null, filter(aggregateData, args, notArgs))
+    var searchUri = "/-/search/\"" + it + "\"/\"" + it + "\"/25";
+    registry.get(searchUri, null, staleness, function (er, data) {
+      if (er) return cb(er)
+      Object.keys(data).forEach(function(key) {
+        aggregateData[key] = data[key];
+      });
+      if(--leftToRun == 0)
+        return cb(null, filter(aggregateData, args, notArgs))
       })      
   });
 }

--- a/lib/search.js
+++ b/lib/search.js
@@ -70,7 +70,7 @@ function getFilteredData (staleness, args, notArgs, cb) {
   // When all of the calls have returned, invoke the callback with the
   // aggregate data
   args.forEach(function(it) {
-    var searchUri = "/-/search/\"" + it + "\"/\"" + it + "\"/25";
+    var searchUri = "/-/search/\"" + it + "\"/\"" + it + "ZZZZZZZZZZZZZZZ\"/25";
     registry.get(searchUri, null, staleness, function (er, data) {
       if (er) return cb(er)
       Object.keys(data).forEach(function(key) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -6,7 +6,8 @@ var npm = require("../npm")
   , semver = require("semver")
   , output
   , log = require("./utils/log")
-
+  , underscore = require("underscore")
+  
 search.usage = "npm search [some search terms ...]"
 
 search.completion = function (opts, cb) {
@@ -59,10 +60,17 @@ function search (args, silent, staleness, cb_) {
 }
 
 function getFilteredData (staleness, args, notArgs, cb) {
-  registry.get("/-/all", null, staleness, function (er, data) {
-    if (er) return cb(er)
-    return cb(null, filter(data, args, notArgs))
-  })
+  var leftToRun = args.length;
+  var aggregateData = {};
+  
+  args.forEach(function(it) {
+      registry.get("/-/search/\"" + it + "\"/\"" + it + "\"/25", null, staleness, function (er, data) {
+        if (er) return cb(er)
+        aggregateData = underscore.extend(data, aggregateData);
+        if(--leftToRun == 0)
+            return cb(null, filter(aggregateData, args, notArgs))
+      })      
+  });
 }
 
 function filter (data, args, notArgs) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -66,7 +66,9 @@ function getFilteredData (staleness, args, notArgs, cb) {
   args.forEach(function(it) {
       registry.get("/-/search/\"" + it + "\"/\"" + it + "\"/25", null, staleness, function (er, data) {
         if (er) return cb(er)
-        aggregateData = underscore.extend(data, aggregateData);
+        Object.keys(data).forEach(function(key) {
+            aggregateData[key] = data[key];
+        });
         if(--leftToRun == 0)
             return cb(null, filter(aggregateData, args, notArgs))
       })      

--- a/lib/search.js
+++ b/lib/search.js
@@ -6,7 +6,6 @@ var npm = require("../npm")
   , semver = require("semver")
   , output
   , log = require("./utils/log")
-  , underscore = require("underscore")
   
 search.usage = "npm search [some search terms ...]"
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   { "semver" : "1"
   , "abbrev" : "1"
   , "nopt" : "1"
-  , "node-uuid" : "1.1" }
+  , "node-uuid" : "1.1"
+  , "underscore" : "1" }
 , "bundleDependencies" : [ "semver", "abbrev", "nopt" ]
 , "devDependencies" : { "ronn" : "" }
 , "engines" : { "node" : "0.4 || 0.5", "npm" : "1" }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   { "semver" : "1"
   , "abbrev" : "1"
   , "nopt" : "1"
-  , "node-uuid" : "1.1"
-  , "underscore" : "1" }
+  , "node-uuid" : "1.1"}
 , "bundleDependencies" : [ "semver", "abbrev", "nopt" ]
 , "devDependencies" : { "ronn" : "" }
 , "engines" : { "node" : "0.4 || 0.5", "npm" : "1" }


### PR DESCRIPTION
complement to this pull request to npmjs. These changes are dependent on each other, though registry changes will work with an older npm client.

https://github.com/isaacs/npmjs.org/pull/7

wired in the new search route.
I also added a dependency for underscore, not particularly registry, but use of _.extend is nice.

Mike
