### PR TITLE
Suggest use process substitution to load npm completions 

### DIFF
--- a/doc/completion.md
+++ b/doc/completion.md
@@ -3,16 +3,18 @@ npm-completion(1) -- Tab Completion for npm
 
 ## SYNOPSIS
 
-    npm completion >> ~/.bashrc
-    npm completion >> ~/.zshrc
+    . <(npm completion)
 
 ## DESCRIPTION
 
-Sets up a function that enables tab-completion in all npm commands.
+Enables tab-completion in all npm commands.  The synopsis above
+loads the completions into your current shell.  Adding it to
+your ~/.bashrc or ~/.zshrc will make the completions available
+everywhere.
 
-You may of course also pipe the relevant script to a file such as
-`/usr/local/etc/bash_completion.d/npm` if you have a system that will
-read that file for you.
+You may of course also pipe the output of npm completion to a file
+such as `/usr/local/etc/bash_completion.d/npm` if you have a system
+that will read that file for you.
 
 When `COMP_CWORD`, `COMP_LINE`, and `COMP_POINT` are defined in the
 environment, `npm completion` acts in "plumbing mode", and outputs


### PR DESCRIPTION
It's hard to agree with npm putting bunch of code into .(ba|z)shrc files.
It's messy and will get out of date.
