### PR TITLE
Fixed typo in docs/faq.md

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -58,7 +58,7 @@ This is not recommended.
 
 `npm search`
 
-Arguments are greps.  `npm ls jsdom` shows jsdom packages.
+Arguments are greps.  `npm search jsdom` shows jsdom packages.
 
 ## How do I update npm?
 


### PR DESCRIPTION
`npm ls jsdom` => `npm search jsdom`
