### PR TITLE
improved search sorting?

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -128,9 +128,10 @@ function prettify (data, args) {
   var longest = []
     , spaces
     , maxLen = [20, 60, 20]
-  return Object.keys(data).map(function (d) {
+
+  return sortData(Object.keys(data).map(function (d) {
     return data[d]
-  }).map(function (data) {
+  }), args).map(function (data) {
     // turn a pkg data into a string
     // [name,who,desc,targets,keywords] tuple
     // also set longest to the longest name
@@ -165,8 +166,6 @@ function prettify (data, args) {
       }
       return s + spaces[i].substr(len)
     }).join(" ").substr(0, cols)
-  }).sort(function (a, b) {
-    return a === b ? 0 : a > b ? 1 : -1
   }).map(function (line) {
     // colorize!
     args.forEach(function (arg, i) {
@@ -174,6 +173,57 @@ function prettify (data, args) {
     })
     return colorize(line)
   }).join("\n")
+}
+
+function sortData (data, args) {
+  var regex
+    , sorted = []
+    , priority = [ "name", "keywords", "description" ]
+    , args = args.map(function (arg) {
+      return escapeRegExp(arg)
+    })
+
+  //args as exact phrase for name
+  regexp = new RegExp("^" + args.join("\\s") + "$")
+  sortByRegExp(regexp, data, sorted, ["name"])
+
+  //args as phrase anywhere
+  regexp = new RegExp("\\b" + args.join("\\s") + "\\b", "i")
+  sortByRegExp(regexp, data, sorted, priority)
+
+  //args as keywords anywhere (ex: useful for case when express matches expresso)
+  regexp = new RegExp("\\b" + args.join("\\b\|\\b") + "\\b", "i")
+  sortByRegExp(regexp, data, sorted, priority)
+
+  //we don't really care about relevance at this point :P
+  return sorted.concat(data)
+}
+
+function sortByRegExp (regex, data, sorted, priority) {
+  for (var i = 0; i < priority.length; i++) {
+    var p = priority[i]
+    for (var j = 0; j < data.length; j++) {
+      if (typeof data[j][p] == "string" && regex.test(data[j][p])) {
+        sorted.push(data.splice(j, 1)[0])
+        j--
+      } else if (data[j][p] && typeof data[j][p] != "string") {
+        for (var m = 0; m < data[j][p].length; m++) {
+          if (regex.test(data[j][p][m])) {
+            sorted.push(data.splice(j, 1)[0])
+            j--
+            break
+          }
+        }
+      }
+    }
+  }
+}
+
+function escapeRegExp (string) {
+  // Credit: XRegExp 0.6.1 (c) 2007-2008 Steven Levithan <http://stevenlevithan.com/regex/xregexp/> MIT License
+  return string.replace(/[-[\]{}()*+?.\\^$|,#\s]/g, function(match){
+    return "\\" + match
+  })
 }
 
 var colors = [31, 33, 32, 36, 34, 35 ]


### PR DESCRIPTION
This is my proposal to making the npm search results a little easier to consume... to do that, I propose doing these 3 small things:

1) bubble up terms which are an exact phrase match for an entire name.

```
npm search express
```

here, the "express" package should be the first result i think... (it's not currently)

2) bubble up args with complete phrase matches in the the name, keywords, or description.

```
 npm search on express
```

I think "blog engine on express" should be ranked higher than "on load for express" (it's not currently)

3) bubble up individual args as complete words in the name, keywords, or description.

```
npm search express
```

Currently one of the first matches for the term "express" is a match based on "expresso"... i'd rather this was lower in the results.

Let me know what you think -- and if i totally sucked it up at writing the codez... 
