### PR TITLE
Issue #890 - Allow node_modules to contain non-packages  

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -109,9 +109,9 @@ function rebuildBundles (pkg, folder, parent, gtop, cb) {
       return function (cb) {
         if (build._didBuild[file]) return cb()
         log.verbose(file, "rebuild bundle")
-        // if not a dir, then don't do it.
-        fs.lstat(file, function (er, st) {
-          if (er || !st.isDirectory()) return cb()
+        // if file is not a package dir, then don't do it.
+        fs.lstat(path.resolve(file, "package.json"), function (er, st) {
+          if (er) return cb()
           build_(false)(file, cb)
         })
     }}).concat(cb))


### PR DESCRIPTION
Change `rebuildBundles` so that it only tryies to re-build dirs that have `package.json` in them. Fix for [issue #890](https://github.com/isaacs/npm/issues/890)
