### PR TITLE
Exclude any dependencies which may be added, but are not extraneous

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -510,6 +510,7 @@ function makeList_ (dir, pkg, exList, dfc, cb) {
 function filterNodeModules (files, pkg) {
   var bd = pkg.bundleDependencies || pkg.bundledDependencies || []
     , deps = Object.keys(pkg.dependencies || {})
+             .filter(function (key) { return !pkg.dependencies[key].extraneous })
              .concat(Object.keys(pkg.devDependencies || {}))
   return files.filter(function (f) {
     f = f.replace(/\/$/, "")


### PR DESCRIPTION
[fix] Exclude any dependencies which may be added, but are not extraneous
