### PR TITLE
npm 10.0.10 fails to update itself

### DIFF
--- a/lib/utils/find.js
+++ b/lib/utils/find.js
@@ -20,7 +20,7 @@ function find (dir, filter, depth, cb) {
 function findDir (filter, depth) { return function (dir, cb) {
   fs.lstat(dir, function (er, stats) {
     // don't include missing files, but don't abort either
-    if (er) return cb()
+    if (er) return cb(null, [])
     if (!stats.isDirectory()) return findFile(dir, filter, depth)("", cb)
     var found = []
     if (!filter || filter(dir, "dir")) found.push(dir+"/")


### PR DESCRIPTION
```
andreas@ubuntu:~$ npm update -g npm
npm ERR! TypeError: Cannot call method 'filter' of undefined
npm ERR!     at /home/andreas/.local/lib/node_modules/npm/lib/utils/load-package-defaults.js:64:15
npm ERR!     at cb (/home/andreas/.local/lib/node_modules/npm/lib/utils/async-map.js:51:11)
npm ERR!     at /home/andreas/.local/lib/node_modules/npm/lib/utils/find.js:23:20
npm ERR!     at cb (/home/andreas/.local/lib/node_modules/npm/lib/utils/graceful-fs.js:31:9)
npm ERR! Report this *entire* log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
npm ERR! 
npm ERR! System Linux 2.6.35-28-generic
npm ERR! command "node" "/home/andreas/.local/bin/npm" "update" "-g" "npm"
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/andreas/work/default-html/http-pub-production/npm-debug.log
npm not ok
andreas@ubuntu:~$ npm -v
1.0.10
```

I took a quick look at `/lib/utils/load-package-defaults.js` and the enclosed patch resolves the problem.

Best regards,
Papandreou
