### PR TITLE
README tutorial missing `git submodule` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ If that fails, try this:
 ```bash
 git clone http://github.com/isaacs/npm.git
 cd npm
+git submodule init
+git submodule update
 sudo make install
 ```
 


### PR DESCRIPTION
this trivial patch make the "if that doesn't work" instructions work.
