### PR TITLE
install.sh compatible with other OSs (that don't ship with GNU Grep)

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -172,7 +172,7 @@ function gunzTarPerm (tarball, tmp, dMode, fMode, uid, gid, cb) {
              , ["--decompress", "--stdout", tarball]
              , process.env, false )
       , spawn( npm.config.get("tar")
-             , ["-mvxpf", "-", "--no-same-owner", "-C", tmp]
+             , ["xfmopv", "-", "-C", tmp]
              , process.env, false )
       , function (er) {
           // if we're not doing ownership management,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,17 +45,12 @@ fi
 
 BACK="$PWD"
 
-# sniff for gtar/gegrep/gmake
+# sniff for gtar/gmake
 # use which, but don't trust it very much.
 
 tar="${TAR}"
 if [ -z "$tar" ]; then
   tar=tar
-fi
-
-egrep=`which gegrep 2>&1`
-if [ $? -ne 0 ] || ! [ -x $egrep ]; then
-  egrep=egrep
 fi
 
 make=`which gmake 2>&1`
@@ -73,9 +68,9 @@ if [ -z "$t" ]; then
 fi
 
 url=`curl -s -L http://registry.npmjs.org/npm/$t \
-      | $egrep -o 'tarball":"[^"]+' \
-      | head -n 1 \
-      | $egrep -o 'http://.*'`
+    | sed -re 's/^.+tarball\"\:\"//' \
+    | sed -re 's/tgz.+/tgz/'`
+
 echo "fetching: $url" >&2
 
 ret=$?


### PR DESCRIPTION
Modified install.sh to use 'sed' instead of 'egrep' to improve compatibility with non-gnu greps.
Tested on OpenBSD, and ArchLinux.  Should work fine on any linux distro and most BSDs.  Will _probably_ work fine with Solaris.
