### PR TITLE
install.sh : -o (aka --no-same-owner) argument added to tar

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -85,7 +85,7 @@ if [ $ret -ne 0 ]; then
 fi
 
 cd "$TMP" \
-  && curl -s -L "$url" | gzip --decompress --stdout | $tar -xf - \
+  && curl -s -L "$url" | gzip --decompress --stdout | $tar -xof - \
   && cd * \
   && (node_version=`"$node" --version 2>&1`
       ret=$?


### PR DESCRIPTION
On running sh install.sh from windows/cygwin the following error is received:

tar: package/node_modules/nopt/examples/my-program.js: Cannot change ownership to uid 24561, gid 20: Invalid argument

This can be worked around by changing line 88 of install.sh to include the -o (aka --no-same-owner) argument for tar.

From the tar docs http://www.gnu.org/software/tar/manual/tar.html#SEC40 "--no-same-owner : When extracting an archive, do not attempt to preserve the owner specified in the tar archive. This the default behavior for ordinary users."

I assume that as it is default for 'ordinary users', it won't change the behaviour on any other OS (i.e. *nix) but will fix the issue with cygwin.
