### PR TITLE
Pass file args to stdin to avoid exec arg limit.

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -68,7 +68,7 @@ function packFiles (targetTarball, parent, files, pkg, cb) {
     //   | gzip {tarball} > targetTarball
     var target = fs.createWriteStream(targetTarball)
       , unPacked = false
-      , args = [ "-cvf", "-"].concat(files)
+      , args = [ "-cv", "--files-from=-"]
       , tarEnv = {}
     for (var i in process.env) {
       tarEnv[i] = process.env[i]
@@ -86,6 +86,11 @@ function packFiles (targetTarball, parent, files, pkg, cb) {
                     , ["--stdout"] , null, false, parent )
       , errState
     tar.name = "tar -cvf - <file list elided>"
+    // Don't write all in one go, we may exceed net's kPoolSize.
+    files.forEach(function (file) {
+      tar.stdin.write(file + "\n")
+    });
+    tar.stdin.end()
     pipe(tar, gzip, function (er) {
       //clearTimeout(gzipTimeout)
       if (errState) return

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -89,7 +89,7 @@ function packFiles (targetTarball, parent, files, pkg, cb) {
     // Don't write all in one go, we may exceed net's kPoolSize.
     files.forEach(function (file) {
       tar.stdin.write(file + "\n")
-    });
+    })
     tar.stdin.end()
     pipe(tar, gzip, function (er) {
       //clearTimeout(gzipTimeout)


### PR DESCRIPTION
YUI is a beast. When trying to package it, I get an error:

```
execvp(): Argument list too long
npm ERR! tar -cvf - <file list elided> 
npm ERR! Failed creating the tarball.
```

This patch uses GNU tar's `--files-from=-` to instead pass file args to tar's stdin. Tested on OS X only.
