### PR TITLE
Only use tilde range descriptor when package >=1.0 

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -233,7 +233,8 @@ function save (where, installed, tree, pretty, cb) {
         //log.warn(k, "k")
         return tree[k].what.split("@")
       }).reduce(function (set, k) {
-        set[k[0]] = "~" + k[1]
+        var rangeDescriptor = semver.gte(k[1], "1.0.0") ? "~" : '';
+        set[k[0]] = rangeDescriptor + k[1]
         return set
       }, {})
 


### PR DESCRIPTION
Problem: When using `install --save`, npm prefixed the installed
package version with the tilde range descriptor. This makes sense
for packages that follow semver and have reached 1.0.0. But for
packages < 1.0.0 semver allows APIs to change freely, so those
should be packaged with the exact version that was installed,
as implemented by this patch.
