### PR TITLE
Complex search with &|() ftw!

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "node_modules/which"]
 	path = node_modules/which
 	url = https://github.com/isaacs/node-which.git
+[submodule "node_modules/complex-search"]
+	path = node_modules/complex-search
+	url = git://github.com/thejh/node-complex-search.git

--- a/doc/search.md
+++ b/doc/search.md
@@ -7,4 +7,9 @@ npm-search(1) -- Search for packages
 
 ## DESCRIPTION
 
-Search the registry for packages matching the search terms.
+Search the registry for packages matching the search terms. It is possible to
+use the following special characters:
+
+ - | means OR
+ - & means AND (equivalent to whitespace between two words)
+ - () may be used for priority (default: parse left to right)

--- a/lib/search.js
+++ b/lib/search.js
@@ -6,6 +6,7 @@ var npm = require("../npm.js")
   , semver = require("semver")
   , output
   , log = require("./utils/log.js")
+  , Search = require("complex-search")
 
 search.usage = "npm search [some search terms ...]"
 
@@ -48,14 +49,14 @@ function search (args, silent, staleness, cb_) {
   searchexclude = searchexclude.map(function (s) {
     return s.toLowerCase()
   })
-  getFilteredData( staleness, opts, searchexclude, function (er, data) {
+  getFilteredData( staleness, opts, searchexclude, function (er, data, keywords) {
     // now data is the list of data that we want to show.
     // prettify and print it, and then provide the raw
     // data to the cb.
     if (er || silent) return cb_(er, data)
     function cb (er) { return cb_(er, data) }
     output = output || require("./utils/output.js")
-    output.write(prettify(data, args), cb)
+    output.write(prettify(data, args, keywords), cb)
   })
 }
 
@@ -63,22 +64,39 @@ function getFilteredData (staleness, args, notArgs, cb) {
   registry.get( "/-/all", null, staleness, false
               , true, function (er, data) {
     if (er) return cb(er)
-    return cb(null, filter(data, args, notArgs))
+    var filterResult = filter(data, args, notArgs)
+    return cb(null, filterResult[0], filterResult[1])
   })
 }
 
 function filter (data, args, notArgs) {
   // data={<name>:{package data}}
-  return Object.keys(data).map(function (d) {
+  var wordedData = Object.keys(data).map(function (d) {
     return data[d]
   }).filter(function (d) {
     return typeof d === "object"
-  }).map(stripData).map(getWords).filter(function (data) {
-    return filterWords(data, args, notArgs)
-  }).reduce(function (l, r) {
-    l[r.name] = r
-    return l
-  }, {})
+  }).map(stripData).map(getWords)
+  
+  var results
+  var search = new Search(args.join(" "), function (keys) {
+    results = keys.map(function(name) {
+      return wordedData.filter(function(package) {
+        return package.name === name
+      })[0]
+    })
+  })
+  search.keywords.forEach(function(keyword) {
+    search.provideKeywordData(keyword, wordedData.filter(function(package) {
+      return filterWords(package, [keyword], notArgs)
+    }).map(function(package) {
+      return package.name
+    }))
+  })
+  return [results.reduce(function (l, r) {
+      l[r.name] = r
+      return l
+    }, {})
+  , search.keywords]
 }
 
 function stripData (data) {
@@ -118,7 +136,7 @@ function filterWords (data, args, notArgs) {
   return true
 }
 
-function prettify (data, args) {
+function prettify (data, args, keywords) {
   try {
     var stdio = process.binding("stdio")
       , cols = stdio.isatty(stdio.stdoutFD) ?
@@ -176,8 +194,8 @@ function prettify (data, args) {
     return a === b ? 0 : a > b ? 1 : -1
   }).map(function (line) {
     // colorize!
-    args.forEach(function (arg, i) {
-      line = addColorMarker(line, arg, i)
+    keywords.forEach(function (keyword, i) {
+      line = addColorMarker(line, keyword, i)
     })
     return colorize(line).trim()
   })

--- a/man1/search.1
+++ b/man1/search.1
@@ -1,7 +1,7 @@
 .\" Generated with Ronnjs/v0.1
 .\" http://github.com/kapouer/ronnjs/
 .
-.TH "NPM\-SEARCH" "1" "July 2011" "" ""
+.TH "NPM\-SEARCH" "1" "August 2011" "" ""
 .
 .SH "NAME"
 \fBnpm-search\fR \-\- Search for packages
@@ -14,4 +14,17 @@ npm search [search terms \.\.\.]
 .fi
 .
 .SH "DESCRIPTION"
-Search the registry for packages matching the search terms\.
+Search the registry for packages matching the search terms\. It is possible to
+use the following special characters:
+.
+.IP "\(bu" 4
+| means OR
+.
+.IP "\(bu" 4
+& means AND (equivalent to whitespace between two words)
+.
+.IP "\(bu" 4
+() may be used for priority (default: parse left to right)
+.
+.IP "" 0
+


### PR DESCRIPTION
Here it is comink, complex search for npm!

Example:

```
$ node bin/npm.js search '(stream xml)|sax'
NAME            DESCRIPTION                                                AUTHOR      KEYWORDS
dom-js          XML DOM based on sax                                       =teknopaul
halfstreamxml   converts a stream of XML to a stream of objects            =thejh      XML stream SAX
readabilitySAX  the readability script ported to a sax parser              =feedic
sax                                                                        =isaacs
xml-stream      XML stream to JavaScript object converter based on Expat.  =dimituri   xml parser expat
$
```

`npm search foo bar` and `npm search 'foo bar'` give the same result.
