### PR TITLE
Tar has -z option to invoke gzip for you

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -167,17 +167,18 @@ function gunzTarPerm (tarball, tmp, dMode, fMode, uid, gid, cb) {
   //console.error(npm.config.get("gzipbin")+" --decompress --stdout "
   //  +tarball+" | "+npm.config.get("tar")+" -mvxpf - -o -C "
   //  +tmp)
-  pipe( spawn( npm.config.get("gzipbin")
-             , ["--decompress", "--stdout", tarball]
-             , process.env, false )
-      , spawn( npm.config.get("tar")
-             , ["-mvxpf", "-", "-o", "-C", tmp]
-             , process.env, false )
-      , function (er) {
+  log.verbose('gunzTarPerm')
+  exec(npm.config.get("tar")
+             , ["-mvxzpf", tarball, "-o", "-C", tmp]
+             , process.env, false
+      , function (er, code, stdout, stderr) {
           // if we're not doing ownership management,
           // then we're done now.
-          if (er) return log.er(cb,
+          if (er) {
+  		log.verbose(stderr, "stderr")
+			return log.er(cb,
             "Failed unpacking "+tarball)(er)
+		  }
           if (npm.config.get("unsafe-perm")) {
             if (!process.getuid || !process.getgid) return cb(er)
             uid = process.getuid()


### PR DESCRIPTION
The attached patch replaces spawn() call with exec() and spawns only tar instead of both tar and gzip.
