### PR TITLE
Package name should not include version (in docs command).

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -18,7 +18,7 @@ var exec = require("./utils/exec.js")
 function docs (args, cb) {
   if (!args.length) return cb(docs.usage)
   var n = args[0].split("@").shift()
-  registry.get(args[0], "latest", 3600, function (er, d) {
+  registry.get(n, "latest", 3600, function (er, d) {
     if (er) return cb(er)
     var homepage = d.homepage
       , repo = d.repository || d.repositories


### PR DESCRIPTION
The code is already there to split name and version, but then wasn't being used.
