### PR TITLE
"npm config edit" with empty config results in ENOENT error

### DIFF
--- a/lib/utils/ini.js
+++ b/lib/utils/ini.js
@@ -209,20 +209,11 @@ function saveConfig (which, cb) {
   saveConfigfile
     ( configList.get(which + "config")
     , configList.list[TRANS[which]]
-    , which === "user" ? 0600 : 0644
-    , function (er) {
-        if (er || which !== "user" || !process.getuid) return cb(er)
-        var uid = process.env.SUDO_UID !== undefined
-                ? process.env.SUDO_UID : process.getuid()
-          , gid = process.env.SUDO_GID !== undefined
-                ? process.env.SUDO_GID : process.getgid()
-        fs.chown(configList.get(which + "config"), +uid, +gid, function (e) {
-          cb(e && e.code !== "ENOENT" ? e : undefined)
-        } )
-      } )
+    , which
+    , cb )
 }
 
-function saveConfigfile (file, config, mode, cb) {
+function saveConfigfile (file, config, which, cb) {
   encryptAuth(config, function () { // ignore errors
     var data = {}
     Object.keys(config).forEach(function (k) {
@@ -230,16 +221,25 @@ function saveConfigfile (file, config, mode, cb) {
     })
     data = ini.stringify(data)
     return (data.trim())
-         ? writeConfigfile(file, data, mode, cb)
+         ? writeConfigfile(file, data, which, cb)
          : rmConfigfile(file, cb)
   })
 }
-function writeConfigfile (configfile, data, mode, cb) {
+function writeConfigfile (configfile, data, which, cb) {
   fs.writeFile
     ( configfile, data, "utf8"
     , function (er) {
         if (er) log(er, "Failed saving "+configfile, cb)
-        else if (mode) fs.chmod(configfile, mode, cb)
+        else if (which) {
+          fs.chmod(configfile, which === "user" ? 0600 : 0644, function (e) {
+            if (e || which !== "user" || !process.getuid) return cb(e)
+            var uid = process.env.SUDO_UID !== undefined
+                    ? process.env.SUDO_UID : process.getuid()
+              , gid = process.env.SUDO_GID !== undefined
+                    ? process.env.SUDO_GID : process.getgid()
+            fs.chown(configList.get(which + "config"), +uid, +gid, cb)
+          })
+        }
         else cb()
       }
     )

--- a/lib/utils/ini.js
+++ b/lib/utils/ini.js
@@ -216,7 +216,9 @@ function saveConfig (which, cb) {
                 ? process.env.SUDO_UID : process.getuid()
           , gid = process.env.SUDO_GID !== undefined
                 ? process.env.SUDO_GID : process.getgid()
-        fs.chown(configList.get(which + "config"), +uid, +gid, cb)
+        fs.chown(configList.get(which + "config"), +uid, +gid, function (e) {
+          cb(e.code === "ENOENT" ? undefined : e)
+        } )
       } )
 }
 

--- a/lib/utils/ini.js
+++ b/lib/utils/ini.js
@@ -217,7 +217,7 @@ function saveConfig (which, cb) {
           , gid = process.env.SUDO_GID !== undefined
                 ? process.env.SUDO_GID : process.getgid()
         fs.chown(configList.get(which + "config"), +uid, +gid, function (e) {
-          cb(e.code === "ENOENT" ? undefined : e)
+          cb(e && e.code !== "ENOENT" ? e : undefined)
         } )
       } )
 }


### PR DESCRIPTION
"npm config edit" with empty config results in ENOENT error rather than an editor.

When there are no user-specified config entries, the user config file is removed in rmConfigfile - obviously attempting to chown it in the callback after this will fail but that shouldn't stop the editor from opening.
