### PR TITLE
first 2 characters of path-type config field chopped off when relative

### DIFF
--- a/lib/utils/ini.js
+++ b/lib/utils/ini.js
@@ -155,7 +155,7 @@ function parseField (f, k, emptyIsFalse) {
       f = path.join(process.env.HOME, f.substr(2))
     }
     if (f.charAt(0) !== "/") {
-      f = path.join(process.cwd(), f.substr(2))
+      f = path.join(process.cwd(), f.substr(0))
     }
   }
   return f


### PR DESCRIPTION
A config field of path type set as "foobar" wrongly becomes "/path/to/cwd/obar", path.join can handle paths prefixed with "./" and "../" so the first 2 characters shouldn't be removed.
