### PR TITLE
npm outdated

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -109,6 +109,15 @@ function outdated_ (args, dir, parentHas, cb) {
         return l
       }, {})
     }
+
+    // if the user has specifically requested to update
+    // an extraneous package, go ahead and do that
+    Object.keys(has).forEach(function (k){
+      if (~args.indexOf(k)) {
+        deps[k] = '*'
+      }
+    })
+
     // now get what we should have, based on the dep.
     // if has[dep] !== shouldHave[dep], then cb with the data
     // otherwise dive into the folder


### PR DESCRIPTION
if user specifically asks if a package is outdated that has been installed, but is extraneous, report it. useful for `npm update <package>` when package is not yet in package.json, but package.json exists

Not sure if this is the exact way this ought to be handled, but here's the use case: https://gist.github.com/1238813
