### PR TITLE
`npm version` with message

### DIFF
--- a/doc/cli/config.md
+++ b/doc/cli/config.md
@@ -84,6 +84,7 @@ The following shorthands are parsed on the command-line:
 * `-ddd`: `--loglevel silly`
 * `-g`: `--global`
 * `-l`: `--long`
+* `-m`: `--message`
 * `-p`, `--porcelain`: `--parseable`
 * `-reg`: `--registry`
 * `-v`: `--version`
@@ -384,6 +385,13 @@ also "color" and "loglevel".
 * Type: Boolean
 
 Show extended information in `npm ls`
+
+### message
+* Default: null
+* Type: [null, String]
+
+Commit message which is used by `npm version` when creating version commit.
+When null, "version <version>" is used.
 
 ### node-version
 

--- a/doc/cli/version.md
+++ b/doc/cli/version.md
@@ -3,7 +3,7 @@ npm-version(1) -- Bump a package version
 
 ## SYNOPSIS
 
-    npm version <newversion>
+    npm version <newversion> [--message/-m commit-message]
 
 ## DESCRIPTION
 
@@ -12,6 +12,8 @@ data back to the package.json file.
 
 If run in a git repo, it will also create a version commit and tag, and
 fail if the repo is not clean.
+If supplied with `--message`/`-m` command line option, npm will use
+it as a commit message when creating a version commit.
 
 ## SEE ALSO
 

--- a/lib/utils/config-defs.js
+++ b/lib/utils/config-defs.js
@@ -126,6 +126,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , loglevel : "warn"
     , logprefix : process.platform !== "win32"
     , long : false
+    , message : null
     , "node-version" : process.version
     , npaturl : "http://npat.npmjs.org/"
     , npat : false
@@ -255,6 +256,7 @@ exports.shorthands =
   , "no-desc" : ["--no-description"]
   , "local" : ["--no-global"]
   , l : ["--long"]
+  , m : ["--message"]
   , p : ["--parseable"]
   , porcelain : ["--parseable"]
   , g : ["--global"]

--- a/lib/version.js
+++ b/lib/version.js
@@ -11,7 +11,8 @@ var exec = require("./utils/exec.js")
   , log = require("./utils/log.js")
   , npm = require("../npm.js")
 
-version.usage = "npm version <newversion>\n(run in package dir)\n"
+version.usage = "npm version <newversion> [--message/-m commit-message]"
+              + "\n(run in package dir)\n"
               + "'npm -v' or 'npm --version' to print npm version "
               + "("+npm.version+")\n"
               + "'npm view <pkg> version' to view a package's "
@@ -48,7 +49,8 @@ function checkGit (data, cb) {
       if (er) return cb(er)
       chain
         ( [ [ exec, "git", ["add","package.json"], process.env, false ]
-          , [ exec, "git", ["commit", "-m", "version "+data.version]
+          , [ exec, "git", ["commit", "-m"
+                           , npm.config.get("message")||"version "+data.version]
             , process.env, false ]
           , [ exec, "git", ["tag", "v"+data.version], process.env, false ] ]
         , cb )


### PR DESCRIPTION
Add `message` option, letting user choose what commit message he wants to use when creating version commit.
