### PR TITLE
Standardize the 'bugs' field in package.json.

### DIFF
--- a/doc/cli/json.md
+++ b/doc/cli/json.md
@@ -96,6 +96,23 @@ been published somewhere else, and spit at you.
 
 Literally.  Spit.  I'm so not kidding.
 
+## bugs
+
+The url to your project's issue tracker and / or the email address to which
+issues should be reported. These are helpful for people who encounter issues
+with your package.
+
+It should look like this:
+
+    { "url" : "http://github.com/owner/project/issues"
+    , "email" : "project@hostname.com"
+    }
+
+You can specify either one or both values. If you want to provide only a url,
+you can specify the value for "bugs" as a simple string instead of an object.
+
+If a url is provided, it will be used by the `npm bugs` command.
+
 ## people fields: author, contributors
 
 The "author" is one person.  "contributors" is an array of people.  A "person"

--- a/lib/bugs.js
+++ b/lib/bugs.js
@@ -24,11 +24,7 @@ function bugs (args, cb) {
       , repo = d.repository || d.repositories
     if (bugs) {
         if (typeof bugs === "string") return open(bugs, cb)
-        if (bugs.url) bugs = bugs.url
-        else if (bugs.web) bugs = bugs.web
-        else if (bugs.name && /^http/.test(bugs.name)) bugs = bugs.name
-        else bugs = null
-        if (bugs) return open(bugs, cb)
+        if (bugs.url) return open(bugs.url, cb)
     }
     if (repo) {
       if (Array.isArray(repo)) repo = repo.shift()

--- a/lib/utils/read-json.js
+++ b/lib/utils/read-json.js
@@ -181,6 +181,20 @@ function typoWarn (json) {
     }
   })
 
+  // bugs typos
+  var bugsTypos = { "web": "url"
+                  , "name": "url"
+                  }
+
+  if (typeof json.bugs === "object") {
+    Object.keys(bugsTypos).forEach(function (d) {
+      if (json.bugs.hasOwnProperty(d)) {
+        log.warn( "package.json: bugs['" + d + "'] should probably be "
+                + "bugs['" + bugsTypos[d] + "']", json._id)
+        }
+    })
+  }
+
   // script typos
   var scriptTypos = { "server": "start" }
   if (json.scripts) Object.keys(scriptTypos).forEach(function (d) {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   , "url" : "https://github.com/isaacs/npm"
   }
 , "bugs" :
-  { "mail" : "npm-@googlegroups.com"
-  , "web" : "http://github.com/isaacs/npm/issues"
+  { "email" : "npm-@googlegroups.com"
+  , "url" : "http://github.com/isaacs/npm/issues"
   }
 , "directories" : { "doc" : "./doc"
                   , "man" : "./man"


### PR DESCRIPTION
Per the discussion on the mailing list:
- Document the field in doc/cli/json.md
- Make lib/utils/read-json.md complain about a typo
- Have lib/bugs.js only respect the "official" form
