### PR TITLE
Multi-registry support

### DIFF
--- a/lib/utils/npm-registry-client/get.js
+++ b/lib/utils/npm-registry-client/get.js
@@ -118,7 +118,9 @@ function get_ (uri, timeout, cache, stat, data, nofollow, staleOk, cb) {
     }
   }
 
+	console.log(uri);
   GET(uri, etag, nofollow, function (er, remoteData, raw, response) {
+	console.log(uri);
     if (response) {
       log.silly([response.statusCode, response.headers], "get cb")
       if (response.statusCode === 304 && etag) {

--- a/lib/utils/npm-registry-client/request.js
+++ b/lib/utils/npm-registry-client/request.js
@@ -19,7 +19,7 @@ var npm = require("../../npm.js")
   , request = require("request")
   , getAgent = require("../get-agent.js")
 
-function regRequest (method, where, what, etag, nofollow, cb_) {
+function regRequest (method, where, what, etag, nofollow, cb_, registries) {
   if (typeof cb_ !== "function") cb_ = nofollow, nofollow = false
   if (typeof cb_ !== "function") cb_ = etag, etag = null
   if (typeof cb_ !== "function") cb_ = what, what = null
@@ -29,18 +29,24 @@ function regRequest (method, where, what, etag, nofollow, cb_) {
   // Since there are multiple places where an error could occur,
   // don't let the cb be called more than once.
   var errState = null
-  function cb (er) {
-    if (errState) return
-    if (er) errState = er
-    cb_.apply(null, arguments)
-  }
+
+  var registries = registries || reg()
+  if (registries instanceof Error) return cb(registries)
+
+  cb = (function(method, where, what, eteg, nofollow, cb_, registries) {
+    return function cb (er) {
+      if(er && registries.length > 0) {
+        return regRequest(method, where, what, etag, nofollow, cb_, registries);
+	  }
+      if (errState) return
+      if (er) errState = er
+      cb_.apply(null, arguments)
+    }
+  })(method, where, what, etag, nofollow, cb_, registries);
 
   if (where.match(/^\/?favicon.ico/)) {
     return cb(new Error("favicon.ico isn't a package, it's a picture."))
   }
-
-  var registry = reg()
-  if (registry instanceof Error) return cb(registry)
 
   var adduserChange = /^\/?-\/user\/org\.couchdb\.user:([^\/]+)\/-rev/
     , adduserNew = /^\/?-\/user\/org\.couchdb\.user:([^\/]+)/
@@ -66,8 +72,9 @@ function regRequest (method, where, what, etag, nofollow, cb_) {
       return encodeURIComponent(p)
     }).join("/")
     if (q) where += "?" + q
-    log.verbose([registry, where], "url resolving")
-    where = url.resolve(registry, where)
+    var registryUrl = registries.shift();
+    log.verbose([registryUrl, where], "url resolving")
+    where = url.resolve(registryUrl, where)
     log.verbose(where, "url resolved")
   }
 
@@ -233,11 +240,16 @@ function upload (where, filename, etag, nofollow, cb) {
 }
 
 function reg () {
-  var r = npm.config.get("registry")
-  if (!r) {
+  var rs = npm.config.get("registry").split(",");
+
+  if (!rs || rs.length === 0) {
     return new Error("Must define registry URL before accessing registry.")
   }
-  if (r.substr(-1) !== "/") r += "/"
-  npm.config.set("registry", r)
-  return r
+
+  rs.forEach(function(r,i) {
+    if (rs[i].substr(-1) !== "/") rs[i] += "/"
+  });
+
+  npm.config.set("registry", rs.join(","))
+  return rs;
 }


### PR DESCRIPTION
Adds support in the form comma seperated urls in npmrc

registry = http://some.probably.local.couch.db/registry,http://isaacs.iriscouch.com

if there is a failure (say 404) it will try again with the next until
there are no more

Hopefully this fits into the original flow. It took me a while to figure out whats what.
