### PR TITLE
Discover newer versions of dependencies than package.json allows

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -89,7 +89,7 @@ function outdated_ (args, dir, parentHas, cb) {
   fs.readdir(path.resolve(dir, "node_modules"), function (er, pkgs) {
     if (er) {
       has = Object.create(parentHas)
-      //TODO what to do here?
+      runNpmView(has)
       return next()
     }
     asyncMap(pkgs, function (pkg, cb) {
@@ -99,17 +99,8 @@ function outdated_ (args, dir, parentHas, cb) {
       })
     }, function (er, pvs) {
       if (er) return cb(er)
-	  has = Object.create(parentHas)
-      discoverNew(has, function (er, result) {
-        for (var key in result) {
-	  var newest = key.split("@")
-          var currentVersion = has[newest[0]]
-          var newestVersion = newest[1]
-          if (semver.gt(newestVersion, currentVersion)) {
-            cb(null, [[dir, newest[0], currentVersion, currentVersion, newestVersion]])        
-          }
-        }
-      })
+      has = Object.create(parentHas)
+      runNpmView(has)
       pvs.forEach(function (pv) { 
         has[pv[0]] = pv[1]
       })
@@ -117,20 +108,21 @@ function outdated_ (args, dir, parentHas, cb) {
     })
   })
 
-  function dump (obj) {
-    var out = '';
-    for (var i in obj) {	
-      out += i + ": " + obj[i] + "\n";
-    }
-    console.log("*** dumping***\n")
-  }
-
-  function discoverNew (has, cb) {
+  function runNpmView (has) {
     var keys = []
     for (var key in has) {
         keys.push(key)	  
     }
-    npm.commands.view(["mkdirp"], true, cb)
+    npm.commands.view(["mkdirp"], true, function (er, result) {
+        for (var key in result) {
+          var newest = key.split("@")
+          var currentVersion = has[newest[0]]
+          var newestVersion = newest[1]
+          if (semver.gt(newestVersion, currentVersion)) {
+            cb(null, [[dir, newest[0], currentVersion, currentVersion, newestVersion]])        
+          }
+        }    
+      })
   }
 
   function next () {

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -49,11 +49,16 @@ function makePretty (p) {
     , dir = path.resolve(p[0], "node_modules", dep)
     , has = p[2]
     , want = p[3]
+    , newerVersion = p[4]
+  var depStatus = has ? (dep + "@" + has) : "MISSING"
+  if (newerVersion) {
+    depStatus = "OUTDATED("+newerVersion+" available)"	  
+  }
   if (parseable) {
     var str = dir
     if (npm.config.get("long")) {
       str += ":" + dep + "@" + want
-           + ":" + (has ? (dep + "@" + has) : "MISSING")
+           + ":" + depStatus
     }
     return str
   }
@@ -62,7 +67,7 @@ function makePretty (p) {
     dir = relativize(dir, process.cwd()+"/x")
   }
   return dep + "@" + want + " " + dir
-       + " current=" + (has || "MISSING")
+       + " current=" + (depStatus || has || "MISSING")
 }
 
 function outdated_ (args, dir, parentHas, cb) {
@@ -84,22 +89,49 @@ function outdated_ (args, dir, parentHas, cb) {
   fs.readdir(path.resolve(dir, "node_modules"), function (er, pkgs) {
     if (er) {
       has = Object.create(parentHas)
+      //TODO what to do here?
       return next()
     }
     asyncMap(pkgs, function (pkg, cb) {
-      readJson( path.resolve(dir, "node_modules", pkg, "package.json")
+      readJson(path.resolve(dir, "node_modules", pkg, "package.json")
               , function (er, d) {
         cb(null, er ? [] : [[d.name, d.version]])
       })
     }, function (er, pvs) {
       if (er) return cb(er)
-      has = Object.create(parentHas)
-      pvs.forEach(function (pv) {
+	  has = Object.create(parentHas)
+      discoverNew(has, function (er, result) {
+        for (var key in result) {
+	  var newest = key.split("@")
+          var currentVersion = has[newest[0]]
+          var newestVersion = newest[1]
+          if (semver.gt(newestVersion, currentVersion)) {
+            cb(null, [[dir, newest[0], currentVersion, currentVersion, newestVersion]])        
+          }
+        }
+      })
+      pvs.forEach(function (pv) { 
         has[pv[0]] = pv[1]
       })
       next()
     })
   })
+
+  function dump (obj) {
+    var out = '';
+    for (var i in obj) {	
+      out += i + ": " + obj[i] + "\n";
+    }
+    console.log("*** dumping***\n")
+  }
+
+  function discoverNew (has, cb) {
+    var keys = []
+    for (var key in has) {
+        keys.push(key)	  
+    }
+    npm.commands.view(["mkdirp"], true, cb)
+  }
 
   function next () {
     if (!has || !deps) return
@@ -145,3 +177,4 @@ function shouldUpdate (args, dir, dep, has, req, cb) {
     return (er || d.version === has[dep]) ? skip() : doIt(d.version)
   })
 }
+

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -50,10 +50,14 @@ function makePretty (p) {
     , dir = path.resolve(p[0], "node_modules", dep)
     , has = p[2]
     , want = p[3]
-    , newerVersion = p[4]
+    , newer = p[4]
   var depStatus = has ? (dep + "@" + has) : "MISSING"
-  if (newerVersion) {
-    depStatus = "OUTDATED("+newerVersion+" available)"	  
+  if (newer) {
+    if (semver.lte(newer, want)) {
+      depStatus = "CANUPDATE("+newer+" available)"
+    } else {
+      depStatus = "OUTDATED("+newer+" available)"	  
+    }
   }
   if (parseable) {
     var str = dir
@@ -113,15 +117,12 @@ function outdated_ (args, dir, parentHas, cb) {
         var depName = Object.keys(dep)[0]
         get(depName, function (er, doc) {
           var versions = Object.keys(doc.versions)
-          //TODO check if doc.version is lways ordered
           var newest = versions[versions.length-1]
 	  cb_(null, {"name": depName, "current": dep[depName], "newest": newest})
         })
       }, function (er, results) {
         results.forEach(function (dep) {
-            if (semver.gt(dep.newest, dep.current)) {
-              //TODO why pass dep.current two times? is it correct?
-	      //TODO why the double square parens?
+            if (semver.gte(dep.newest, dep.current)) {
               cb(null, [[dir, dep.name, dep.current, dep.current, dep.newest]])        
             }      		    
           })

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -27,6 +27,7 @@ var path = require("path")
   , log = require("./utils/log.js")
   , semver = require("semver")
   , relativize = require("./utils/relativize.js")
+  , get = require("./utils/npm-registry-client/get.js")
 
 function outdated (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
@@ -82,6 +83,7 @@ function outdated_ (args, dir, parentHas, cb) {
   var deps = null
   readJson(path.resolve(dir, "package.json"), function (er, d) {
     deps = (er) ? true : d.dependencies
+    discoverNew(deps)
     return next()
   })
 
@@ -89,7 +91,6 @@ function outdated_ (args, dir, parentHas, cb) {
   fs.readdir(path.resolve(dir, "node_modules"), function (er, pkgs) {
     if (er) {
       has = Object.create(parentHas)
-      runNpmView(has)
       return next()
     }
     asyncMap(pkgs, function (pkg, cb) {
@@ -100,7 +101,6 @@ function outdated_ (args, dir, parentHas, cb) {
     }, function (er, pvs) {
       if (er) return cb(er)
       has = Object.create(parentHas)
-      runNpmView(has)
       pvs.forEach(function (pv) { 
         has[pv[0]] = pv[1]
       })
@@ -108,21 +108,25 @@ function outdated_ (args, dir, parentHas, cb) {
     })
   })
 
-  function runNpmView (has) {
-    var keys = []
-    for (var key in has) {
-        keys.push(key)	  
-    }
-    npm.commands.view(["mkdirp"], true, function (er, result) {
-        for (var key in result) {
-          var newest = key.split("@")
-          var currentVersion = has[newest[0]]
-          var newestVersion = newest[1]
-          if (semver.gt(newestVersion, currentVersion)) {
-            cb(null, [[dir, newest[0], currentVersion, currentVersion, newestVersion]])        
-          }
-        }    
-      })
+  function discoverNew (deps) {
+    asyncMap(deps, function (dep, cb_) {
+        var depName = Object.keys(dep)[0]
+        get(depName, function (er, doc) {
+          var versions = Object.keys(doc.versions)
+          //TODO check if doc.version is lways ordered
+          var newest = versions[versions.length-1]
+	  cb_(null, {"name": depName, "current": dep[depName], "newest": newest})
+        })
+      }, function (er, results) {
+        results.forEach(function (dep) {
+            if (semver.gt(dep.newest, dep.current)) {
+              //TODO why pass dep.current two times? is it correct?
+	      //TODO why the double square parens?
+              cb(null, [[dir, dep.name, dep.current, dep.current, dep.newest]])        
+            }      		    
+          })
+      }
+    )
   }
 
   function next () {


### PR DESCRIPTION
The reference issue is https://github.com/isaacs/npm/issues/1428

Newer packages are looked for when issuing a npm outdated on the project.
If a newer package is discovered then there are two options, basing on the package.json:
- the newer is not allowed, in the message OUTDATED is showed
- the newer is allowed, in the message CANUPDATE is showed 

In both cases the newer version discovered is showed.

Let me know if I made any kind of mistake here, such as this is not what was expected or if there are bugs I've not spotted.

Cheers.
