### PR TITLE
Exception when attempting to remove non-owner

### DIFF
--- a/lib/owner.js
+++ b/lib/owner.js
@@ -134,7 +134,7 @@ function rm (user, pkg, cb) {
           return !match
         })
     if (!found) {
-      log("Not a package owner: "+u.name+" <"+u.email+">", "owner rm")
+      log("Not a package owner: "+user, "owner rm")
       return false
     }
     if (!m.length) return new Error(


### PR DESCRIPTION
For 'npm owner rm', commit 2b39dff0a8245a6a323a5bcbbed2c16a7696bb8c causes a null user to be passed to mutate, which in turn causes a null user to be passed to the mutation. If the user to be removed was not a package owner, this null user value is dereferenced when attempting to report the failure.
