### PR TITLE
npm-bin returns an incorrect path

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -372,7 +372,7 @@ Object.defineProperty(npm, "prefix",
 Object.defineProperty(npm, "bin",
   { get : function () {
       if (npm.config.get("global")) return npm.globalBin
-      return path.resolve(npm.prefix, ".bin")
+      return path.resolve(npm.root, ".bin")
     }
   , enumerable : true
   })


### PR DESCRIPTION
npm-bin currently returns a path using the prefix instead of the root, i.e.
"./.bin" instead of "./node_modules/.bin".
