### PR TITLE
Recommend to turn off antivirus software on Windows during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,18 @@ If you decide not to update the PATH, and put the node.exe file in
 `C:\node\node.exe`, then the npm executable will end up `C:\node\npm.cmd`,
 and you'll have to type `C:\node\npm <command>` to use it.
 
-### Step 3: Install git
+### Step 3: Turn off antivirus software (highly recommended)
+
+Turn off antivirus software, it may lock some folders during npm installation
+
+### Step 4: Install git
 
 If you don't already have git,
 [install it](https://git.wiki.kernel.org/index.php/MSysGit:InstallMSysGit).
 
 Run `git --version` to make sure that it's at least version 1.7.6.
 
-### Step 4: install npm
+### Step 5: install npm
 
 Lastly, **after** node.exe, git, and your %PATH% have *all* been set up
 properly, install npm itself:


### PR DESCRIPTION
It seems that antivirus software (at least Microsoft Security Essentials) breaks npm installation on windows. It locks some files and `tar` fails on line 178 https://github.com/isaacs/npm/blob/master/lib/utils/tar.js#L178

I have the following error, but I don't know which error message was return by OS, because it's in Russian and after some reencodings it was converted to something unreadable

<pre>npm ERR! couldn't unpack C:\Users\BETALB~1.HYP\AppData\Local\Temp\npm-1320659412171\1320659412171-0.21731988084502518\tmp.tgz to C:\Users\BETALB~1.HYP\AppData\Local\Temp\npm-1320659412171\1320659412171-0.21731988084502518\contents
npm ERR! Error: UNKNOWN, �������� ������� ���������.
npm ERR!  'C:/Users/BETALB~1.HYP/AppData/Local/Temp/npm-1320659412171/1320659412171-0.21731988084502518/contents/___package.npm/package'
npm ERR! Report this *entire* log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
npm ERR!
npm ERR! System Windows_NT 6.1.7601
npm ERR! command "node" "D:\\betalb\\nodejs\\npm\\cli.js" "install" "npm" "-gf"
npm ERR! cwd D:\betalb\nodejs\npm
npm ERR! node -v v0.6.0
npm ERR! npm -v 1.0.104
npm ERR! path C:/Users/BETALB~1.HYP/AppData/Local/Temp/npm-1320659412171/1320659412171-0.21731988084502518/contents/___package.npm/package
npm ERR! code UNKNOWN
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     D:\betalb\nodejs\npm\npm-debug.log
npm not ok</pre>


So as a quick fix I propose to recommend turing off Antivirus software while installing npm
