### PR TITLE
Exception when using a prefix with global install

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -317,7 +317,7 @@ function loadPrefix (npm, conf, cb) {
       , enumerable : true
       })
     // the prefix MUST exist, or else nothing works.
-    mkdir(p, null, null, null, true, next)
+    mkdir(p, npm.modes.exec, null, null, true, next)
   })
 
   findPrefix(gp, function (er, gp) {
@@ -327,7 +327,7 @@ function loadPrefix (npm, conf, cb) {
       , enumerable : true
       })
     // the prefix MUST exist, or else nothing works.
-    mkdir(gp, null, null, null, true, next)
+    mkdir(gp, npm.modes.exec, null, null, true, next)
   })
 
   var i = 2


### PR DESCRIPTION
Specifying a prefix for a global install results in a TypeError exception if the prefix directory does not already exist. An exception occurs with both Node 0.6.0 and Node 0.4.12, but with a slight difference between the two.

Example: npm install -g --prefix ./foo/bar abbrev

With Node 0.4.12:

```
npm ERR! TypeError: Bad argument
npm ERR!     at Object.mkdir (fs.js:356:11)
npm ERR!     at Object.GRACEFUL [as mkdir] (/Users/martinc/dev/src/github/npm/node_modules/graceful-fs/graceful-fs.js:38:6)
npm ERR!     at STATCB (/Users/martinc/dev/src/github/npm/lib/utils/mkdir-p.js:133:12)
npm ERR!     at cb (/Users/martinc/dev/src/github/npm/node_modules/graceful-fs/graceful-fs.js:36:9)
```

This is happening because a null value for the 'mode' argument to fs.mkdir() is not permitted in Node 0.4.x. (The default for modeNum is not used in most places in Node 0.4; that has been fixed in Node 0.6.)

With Node 0.6.0:

```
npm ERR! TypeError: Cannot call method 'toString' of null
npm ERR!     at done (/Users/martinc/dev/src/github/npm/lib/utils/mkdir-p.js:78:40)
npm ERR!     at S (/Users/martinc/dev/src/github/npm/lib/utils/mkdir-p.js:114:14)
npm ERR!     at MKDIRCB (/Users/martinc/dev/src/github/npm/lib/utils/mkdir-p.js:162:13)
npm ERR!     at Object.cb [as oncomplete] (/Users/martinc/dev/src/github/npm/node_modules/graceful-fs/graceful-fs.js:36:9)
```

In Node 0.6.x, it is permissible to pass null for the 'mode' argument to fs.mkdir(), but a log message in mkdir-p assumes that the mode value is non-null.

Passing a non-null 'mode' argument in the prefix-related mkdir calls fixes the problem. These appear to be the only places in npm that mkdir is called with a null mode.
