### PR TITLE
Correctly process "|| true" as a script argument for Windows

### DIFF
--- a/lib/utils/exec.js
+++ b/lib/utils/exec.js
@@ -1,4 +1,3 @@
-
 module.exports = exec
 exec.spawn = spawn
 exec.pipe = pipe
@@ -13,6 +12,9 @@ var log = require("./log.js")
   , constants = require("constants")
 
 function exec (cmd, args, env, takeOver, cwd, uid, gid, cb) {
+  // Windows hack to support "true" as a cmd
+  (cmd === 'cmd') && (typeof args[1] === 'string') && (args[1] = args[1].replace(/\|\| *true$/i, '|| exit 0'));
+  
   if (typeof cb !== "function") cb = gid, gid = null
   if (typeof cb !== "function") cb = uid, uid = null
   if (typeof cb !== "function") cb = cwd, cwd = null


### PR DESCRIPTION
In Windows, there is no "true" command available from cmd.  This cripples scripts like "node-waf configure build || true", which (reportedly) works fine on Linux.  See issue isaacs/npm/#1625.

So instead we replace instances of "|| true" with "|| exit 0" on Windows, which does the same thing.

(It might be better to create a "true.cmd" with contents `exit 0`, and put this somewhere in the path variable, but the attached hack works fine.)
