### PR TITLE
Patch for Git bash on Windows issue

### DIFF
--- a/lib/utils/cmd-shim.js
+++ b/lib/utils/cmd-shim.js
@@ -1,4 +1,4 @@
-// XXX Todo: 
+// XXX Todo:
 // On windows, create a .cmd file.
 // Read the #! in the file to see what it uses.  The vast majority
 // of the time, this will be either:
@@ -43,7 +43,7 @@ function cmdShim (from, to, cb) {
 }
 
 function writeShim (from, to, cb) {
-  // make a cmd file
+  // make a cmd file and a sh script
   // First, check if the bin is a #! of some sort.
   // If not, then assume it's something that'll be compiled, or some other
   // sort of script, and just call it directly.
@@ -59,16 +59,22 @@ function writeShim (from, to, cb) {
 }
 
 function writeShim_ (from, to, prog, args, cb) {
-  var target = relativize(from, to).split("/").join("\\")
+  var shTarget = relativize(from, to)
+    , target = shTarget.split("/").join("\\")
     , longProg
+    , shProg
+    , shLongProg
   args = args || ""
   if (!prog) {
     prog = "\"%~dp0\\" + target + "\""
+    shProg = "\"$NODE_DIR/" + shTarget + "\""
     args = ""
     target = ""
   } else {
     longProg = "\"%~dp0\"\\\"" + prog + ".exe\""
+    shLongProg = "\"$NODE_DIR/" + prog + ".exe\""
     target = "\"%~dp0\\" + target + "\""
+    shTarget = "\"$NODE_DIR/" + shTarget + "\""
   }
 
   // @IF EXIST "%~dp0"\"node.exe" (
@@ -89,10 +95,41 @@ function writeShim_ (from, to, prog, args, cb) {
 
   cmd = ":: Created by npm, please don't edit manually.\r\n" + cmd
 
+  // #!/bin/sh
+  // pushd "$(dirname "$0")" > /dev/null
+  // NODE_DIR=`pwd -P`
+  // popd > /dev/null
+  //
+  // if [ -f "$NODE_DIR/node.exe" ]; then
+  //  "$NODE_DIR/node.exe" "$NODE_DIR/node_modules/npm/bin/npm-cli.js" "$*"
+  // else
+  //  node "$NODE_DIR/node_modules/npm/bin/npm-cli.js" "$*"
+  // fi
+  var sh = "#!/bin/sh\n"
+         + ""
+         + "pushd \"$(dirname \"$0\")\" > /dev/null\n"
+         + "NODE_DIR=`pwd -P`\n"
+         + "popd > /dev/null\n\n"
+  if (shLongProg) {
+    sh = sh + "if [ -f "+shLongProg+" ]; then\n"
+       + "  " + shLongProg + " " + args + " " + shTarget + " $*\n"
+       + "else \n"
+       + "  " + shProg + " " + args + " " + shTarget + " $*\n"
+  } else {
+    sh = shProg + " " + args + " " + shTarget + " $*\n"
+  }
+
   fs.writeFile(to + ".cmd", cmd, "utf8", function (er) {
     if (er) {
       log.warn("Could not write "+to+".cmd", "cmdShim")
+      cb(er)
+    } else {
+      fs.writeFile(to, sh, "utf8", function (er) {
+        if (er) {
+          log.warn("Could not write "+to, "shShim")
+        }
+        cb(er)
+      }
     }
-    cb(er)
   })
 }

--- a/lib/utils/cmd-shim.js
+++ b/lib/utils/cmd-shim.js
@@ -129,7 +129,7 @@ function writeShim_ (from, to, prog, args, cb) {
           log.warn("Could not write "+to, "shShim")
         }
         cb(er)
-      }
+      })
     }
   })
 }

--- a/lib/utils/cmd-shim.js
+++ b/lib/utils/cmd-shim.js
@@ -127,8 +127,11 @@ function writeShim_ (from, to, prog, args, cb) {
       fs.writeFile(to, sh, "utf8", function (er) {
         if (er) {
           log.warn("Could not write "+to, "shShim")
-        }
-        cb(er)
+          cb(er)
+        } else {
+          fs.chmod(to, 0755, function (er) {
+            cb(er)
+          })
       })
     }
   })


### PR DESCRIPTION
This is a patch for issue #1763 and node-issue [#2406](https://github.com/joyent/node/issues/2406).

This adds another shim for MSYS/Git Bash on Windows just like the cmd shims.

This is an example of the npm shim:

``` bash
#!/bin/sh

pushd "$(dirname "$0")" > /dev/null
NODE_DIR=`pwd -P`
popd > /dev/null

if [ -f "$NODE_DIR/node.exe" ]; then
  "$NODE_DIR/node.exe" "$NODE_DIR/node_modules/npm/bin/npm-cli.js" $*
else
  node "$NODE_DIR/node_modules/npm/bin/npm-cli.js" $*
fi
```

For the `pushd`-`popd` thing at the top, see http://stackoverflow.com/questions/4774054/reliable-way-to-get-the-full-path-to-a-bash-script/4774063#4774063.

Please verify that this really writes the shim files. For some reason, I couldn't test it on my machine. When I run something like `npm build .` in my local npm folder, nothing (not even the .cmd-shims) are being rewritten.

Alternatively you could also provide me some information on how to test this.
