### PR TITLE
xmas tree's size

### DIFF
--- a/lib/xmas.js
+++ b/lib/xmas.js
@@ -42,7 +42,7 @@ w("\n")
     w("| "+x+" |")
     for (var i = 1; i < H; i ++) w(" ")
   }
-})(20)
+})(Number(args[0]) || 20)
 w("\n\n")
 log.win("Happy Xmas, Noders!", "loves you", cb)
 }


### PR DESCRIPTION
`npm xmas` makes fixed size tree, but `xmas.js` can make various size trees.

This commit use 2nd argument.
for example, we can make [smaller tree](http://cdn-ak.f.st-hatena.com/images/fotolife/s/sugyan/20111225/20111225011717.png) by `npm xmas 10`
