### PR TITLE
Treat a "No compatible version found" error as ENOTSUP

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -363,7 +363,7 @@ function addNameTag (name, tag, cb) {
 
   registry.get(name, function (er, data, json, response) {
     if (er) return cb(er)
-    engineFilter(data)
+    var filtered = engineFilter(data)
     if (data["dist-tags"] && data["dist-tags"][tag]
         && data.versions[data["dist-tags"][tag]]) {
       var ver = data["dist-tags"][tag]
@@ -372,7 +372,7 @@ function addNameTag (name, tag, cb) {
     if (!explicit && Object.keys(data.versions).length) {
       return addNameRange(name, "*", data, cb)
     }
-    return cb(installTargetsError(tag, data))
+    return cb(installTargetsError(tag, data, filtered))
   })
 }
 
@@ -382,14 +382,17 @@ function engineFilter (data) {
 
   if (!nodev || npm.config.get("force")) return data
 
+  var filtered = {}
   Object.keys(data.versions || {}).forEach(function (v) {
     var eng = data.versions[v].engines
     if (!eng) return
     if (eng.node && !semver.satisfies(nodev, eng.node)
         || eng.npm && !semver.satisfies(npmv, eng.npm)) {
+      filtered[v] = eng
       delete data.versions[v]
     }
   })
+  return filtered
 }
 
 function addNameRange (name, range, data, cb) {
@@ -401,6 +404,7 @@ function addNameRange (name, range, data, cb) {
 
   log.silly([name, range, !!data], "name, range, hasData")
 
+  var filtered = null
   if (data) return next()
   registry.get(name, function (er, d, json, response) {
     if (er) return cb(er)
@@ -410,7 +414,7 @@ function addNameRange (name, range, data, cb) {
 
   function next () {
     log.silly([name, range, !!data], "name, range, hasData 2")
-    engineFilter(data)
+    filtered = engineFilter(data)
 
     if (npm.config.get("registry")) return next_()
 
@@ -435,7 +439,7 @@ function addNameRange (name, range, data, cb) {
     // find the max satisfying version.
     var ms = semver.maxSatisfying(Object.keys(data.versions || {}), range)
     if (!ms) {
-      return cb(installTargetsError(range, data))
+      return cb(installTargetsError(range, data, filtered))
     }
 
     // if we don't have a registry connection, try to see if
@@ -473,10 +477,16 @@ function cachedFilter (data, range, cb) {
   })
 }
 
-function installTargetsError (requested, data) {
+function installTargetsError (requested, data, engines) {
   var targets = Object.keys(data["dist-tags"]).filter(function (f) {
     return (data.versions || {}).hasOwnProperty(f)
   }).concat(Object.keys(data.versions || {}))
+
+  Object.keys(engines || {}).forEach(function (v) {
+    if (!semver.satisfies(v, requested)) {
+      delete engines[v]
+    }
+  })
 
   requested = data.name + (requested ? "@'" + requested + "'" : "")
 
@@ -485,8 +495,12 @@ function installTargetsError (requested, data) {
           : "No valid targets found.\n"
           + "Perhaps not compatible with your version of node?"
 
-  return new Error( "No compatible version found: "
+  var er = new Error( "No compatible version found: "
                   + requested + "\n" + targets)
+  er.errno = npm.ENOTSUP
+  er.required = engines
+  er.pkgid = requested
+  return er
 }
 
 function addNameVersion (name, ver, data, cb) {


### PR DESCRIPTION
Currently, when an installation dependency can't be satisfied, npm directs users to submit the log here and treat it as an npm bug. This patch should make it more apparent that the problem is with the package being installed or its dependencies instead.

Example output of npm before patch:

<pre>
npm ERR! Error: No compatible version found: sqlite3@'&gt;=2.0.17- &lt;2.1.0-'
npm ERR! Valid install targets:
npm ERR! ["2.0.0","2.0.1","2.0.2","2.0.3","2.0.4","2.0.5","2.0.6","2.0.7","2.0.8","2.0.9","2.0.10","2.0.11","2.0.12","2.0.13","2.0.14","2.0.15","2.1.0","2.1.1"]
npm ERR!     at installTargetsError (/home/user/.nave/installed/0.6.5/lib/node_modules/npm/lib/cache.js:429:10)
npm ERR!     at /home/user/.nave/installed/0.6.5/lib/node_modules/npm/lib/cache.js:411:17
npm ERR!     at Object.saved [as oncomplete] (/home/user/.nave/installed/0.6.5/lib/node_modules/npm/lib/utils/npm-registry-client/get.js:136:7)
npm ERR! Report this *entire* log at:
npm ERR!     &lt;http://github.com/isaacs/npm/issues&gt;
npm ERR! or email it to:
npm ERR!     &lt;npm-@googlegroups.com&gt;
</pre>


Example output of npm after patch:

<pre>
npm ERR! No compatible version found: sqlite3@'&gt;=2.0.17- &lt;2.1.0-'
npm ERR! Valid install targets:
npm ERR! ["2.0.0","2.0.1","2.0.2","2.0.3","2.0.4","2.0.5","2.0.6","2.0.7","2.0.8","2.0.9","2.0.10","2.0.11","2.0.12","2.0.13","2.0.14","2.0.15","2.1.0","2.1.1"]
npm ERR! Not compatible with your version of node/npm: sqlite3@'&gt;=2.0.17- &lt;2.1.0-'
npm ERR! Required: {"2.0.17":{"node":"&gt;=0.2.4 &lt;0.5"},"2.0.18":{"node":"&gt;=0.2.4 &lt;0.5"}}
npm ERR! Actual:   {"npm":"1.1.0-alpha-6","node":"0.6.5"}
</pre>


Related issues:

<ul>
<li>#1309</li>
<li>#1527</li>
<li>#1589</li>
<li>#1617</li>
<li>#1669</li>
<li>#1680</li>
<li>#1684</li>
<li>#1687</li>
<li>#1690</li>
<li>#1692</li>
<li>#1747</li>
<li>#1748 - original patch created</li>
<li>#1762 - unmet npm requirement</li>
<li>#1791</li>
<li>#1804</li>
<li>#1810</li>
<li>#1831</li>
<li>#1836</li>
<li>#1878</li>
<li>#1885</li>
<li>#1948</li>
</ul>
