### PR TITLE
Fixing failure when make script is rerun after a previous failure

### DIFF
--- a/scripts/doc-build.sh
+++ b/scripts/doc-build.sh
@@ -7,7 +7,7 @@ set -o errexit
 set -o pipefail
 
 if ! [ -x node_modules/.bin/ronn ]; then
-  if [ -f .building_ronn ]; then
+  if [ -f .building_ronn -a $(ps --no-headers -p $(cat .building_ronn) | wc -l) != 0 ]; then
     while [ -f .building_ronn ]; do
       sleep 1
     done

--- a/scripts/doc-build.sh
+++ b/scripts/doc-build.sh
@@ -7,7 +7,7 @@ set -o errexit
 set -o pipefail
 
 if ! [ -x node_modules/.bin/ronn ]; then
-  if [ -f .building_ronn -a $(ps --no-headers -p $(cat .building_ronn) | wc -l) != 0 ]; then
+  if [ -f .building_ronn -a $(ps --no-headers -p $(cat .building_ronn) 2> /dev/null | wc -l) != 0 ]; then
     while [ -f .building_ronn ]; do
       sleep 1
     done


### PR DESCRIPTION
Fixing the issue where the make script fails to continue when a previous run of the make had failed. More details here: https://github.com/isaacs/npm/issues/1616#issuecomment-2612367
