### PR TITLE
Bug when HOME has a trailing slash

### DIFF
--- a/lib/utils/ini.js
+++ b/lib/utils/ini.js
@@ -152,7 +152,7 @@ function unParseField (f, k) {
   if (isPath) {
     if (typeof process.env.HOME !== 'undefined') {
       if (process.env.HOME.substr(-1) === "/") {
-        process.env.HOME = process.env.HOME(0, process.env.HOME.length-1)
+        process.env.HOME = process.env.HOME.slice(0, process.env.HOME.length-1)
       }
       if (f.indexOf(process.env.HOME) === 0) {
         f = "~"+f.substr(process.env.HOME.length)


### PR DESCRIPTION
There's a bug in the ini code when the HOME environment variable has a trailing slash. Somehow a slice() call was missed, and the code tries to call HOME as a function.
