### PR TITLE
Fix for #1672

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -254,7 +254,7 @@ function gunzTarPerm (tarball, tmp, dMode, fMode, uid, gid, cb) {
           } else chown()
 
           function chown (er) {
-            if (er) return cb(er)
+            if (er && er.code !== "UNKNOWN") return cb(er)
             var mode = stat.isDirectory() ? dMode : fMode
               , oldMode = stat.mode & 0777
               , newMode = (oldMode | mode) & (~npm.modes.umask)
@@ -272,7 +272,7 @@ function gunzTarPerm (tarball, tmp, dMode, fMode, uid, gid, cb) {
         } else chown()
 
         function chown (er) {
-          if (er) return cb(er)
+          if (er && er.code !== "UNKNOWN") return cb(er)
           fs.readdir(tmp, function (er, folder) {
             folder = folder && folder.filter(function (f) {
               return f && !f.match(/^\._/)


### PR DESCRIPTION
I was experiencing the same issue as described here: https://github.com/isaacs/npm/issues/1672

I tracked it down to a problem with chmod when passing in a numerical group id. Probably a vmware fusion bug.

Do you know if anything else will ever generate an er.code of UNKNOWN? If not, this is a safe patch to apply. If yes, I will try and figure out a better condition to check.
