### PR TITLE
getting npm link to work on windows

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -29,13 +29,6 @@ link.completion = function (opts, cb) {
 }
 
 function link (args, cb) {
-  if (process.platform === "win32") {
-    var e = new Error("npm link not supported on windows")
-    e.code = "ENOTSUP"
-    e.errno = require("constants").ENOTSUP
-    return cb(e)
-  }
-
   if (npm.config.get("global")) {
     return cb(new Error("link should never be --global.\n"
                        +"Please re-run this command with --local"))

--- a/lib/utils/link.js
+++ b/lib/utils/link.js
@@ -25,6 +25,6 @@ function link (from, to, gently, cb) {
     ( [ [fs, "stat", from]
       , [rm, to, gently]
       , [mkdir, path.dirname(to)]
-      , [fs, "symlink", relativize(from, to), to] ]
+      , [fs, "symlink", relativize(from, to), to, 'dir'] ]
     , cb)
 }


### PR DESCRIPTION
there still some issues left
- when you dont run it as Admin you get `Error: UNKNOWN` when you exec npm link
- when you have already linked it you get following error
  <pre>Error: EACCES, permission denied 'NodeDir/node_modules/moduleName'
  Please try running this command again as root/Administrator.</pre>
- npm unlink doesn't work
