### PR TITLE
Try to use `xdg-open` as a browser on Linux

### DIFF
--- a/lib/utils/config-defs.js
+++ b/lib/utils/config-defs.js
@@ -4,6 +4,7 @@
 var path = require("path")
   , url = require("url")
   , Stream = require("stream").Stream
+  , whichSync = require("which").sync
   , semver = require("semver")
   , stableFamily = semver.parse(process.version)
   , os = require("os")
@@ -95,6 +96,14 @@ Object.defineProperty(exports, "defaults", {get: function () {
     }
   }
 
+  var browser = process.platform === "darwin" ? "open"
+              : process.platform === "win32" ? "start" : null;
+
+  if (process.platform === "linux") {
+    try { browser = whichSync("xdg-open") }
+    catch (_) { browser = "google-chrome" }
+  }
+
   return defaults =
     { "always-auth" : false
 
@@ -114,10 +123,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
            + os.release() )
 
       // are there others?
-    , browser : process.platform === "darwin" ? "open"
-              : process.platform === "win32" ? "start"
-              : "google-chrome"
-
+    , browser : browser
     , ca : // the npm CA certificate.
       "-----BEGIN CERTIFICATE-----\n"+
       "MIIChzCCAfACCQDauvz/KHp8ejANBgkqhkiG9w0BAQUFADCBhzELMAkGA1UEBhMC\n"+


### PR DESCRIPTION
`xdg-open` is a command similar to `open` - it tries to find a preferred
command to open a resource with. However, it isn't present on some
machines (depending on window manager/desktop environment), thus we have
to check for it's existance with `which`.
