### PR TITLE
More helpful instruction for install using sudo on a 'notroot' server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ To say "yes" to the 0.x cleanup, but skip the prompt:
 
     curl http://npmjs.org/install.sh | clean=yes sh
 
-If you get permission errors, you'll need to **run** the script as root.
+If you get permission errors, you'll either need to **run** the script as root,
 (Note, just putting `sudo` in front of the `curl` will **fetch** the script
-as root.)
+as root.) or run `curl http://npmjs.org/install.sh | sudo sh`
 
 ### Slightly Fancier
 


### PR DESCRIPTION
...  Yes, if you are getting errors, you now know that sudo 'curl ... | sh' does not work... helpful to suggest running 'curl ... | sudo sh' instead, which has worked for several people. 
re: http://stackoverflow.com/questions/6752873/node-js-npm-install-fails
