### PR TITLE
Add newline after package.json generated by npm version.

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -63,6 +63,6 @@ function checkGit (data, cb) {
 }
 function write (data, cb) {
   fs.writeFile( path.join(process.cwd(), "package.json")
-              , new Buffer(JSON.stringify(data, null, 2))
+              , new Buffer(JSON.stringify(data, null, 2) + "\n")
               , cb )
 }


### PR DESCRIPTION
When you invoke `npm version [newversion]` npm updates the `package.json` file of a package.

The problem is, that it does not add a newline character at the end of the file. Vim always adds a newline character at the end of a file. This way, if you look at the diff after editing `package.json` with vim, you see this:

``` diff
…
-}
\ No newline at end of file
+}
```

My patch fixes this by adding a newline after the package.json created by npm.
