### PR TITLE
ignore logfd/outfd streams in makeEnv()

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -247,6 +247,10 @@ function makeEnv (data, prefix, env) {
       return
     }
     var value = ini.get(i)
+    if (/^(log|out)fd$/.test(i) && typeof value === "object") {
+      // not an fd, a stream
+      return
+    }
     if (!value) value = ""
     else if (typeof value !== "string") value = JSON.stringify(value)
 


### PR DESCRIPTION
[Streams are allowed as logfd and outfd](https://github.com/isaacs/npm/blob/master/lib/utils/output.js#L120-123) and work in most places, but not for `npm.install` which gets us to `makeEnv()` in lifecycle.js where outfd and/or logfd are passed to `JSON.stringify()` which fails on circular references (and is nonsense for Streams).

I believe that the appropriate thing to do is just ignore them in `makeEnv()` when they are Streams.
