### PR TITLE
Make a copy of the cached objects we'll modify.

### DIFF
--- a/lib/utils/read-installed.js
+++ b/lib/utils/read-installed.js
@@ -125,14 +125,7 @@ function readInstalled_ (folder, parent, name, reqver, depth, maxDepth, cb) {
   })
 
   readJson(path.resolve(folder, "package.json"), function (er, data) {
-    obj = data
-
-    // make a copy to avoid undesirable changes to the cache
-    if (obj) {
-      obj = copy(obj)
-      if (obj.dependencies) obj.dependencies = copy(obj.dependencies)
-      if (obj.devDependencies) obj.devDependencies = copy(obj.devDependencies)
-    }
+    obj = copy(data)
 
     if (!parent) {
       obj = obj || true
@@ -278,8 +271,11 @@ function findUnmet (obj) {
 }
 
 function copy (obj) {
+  if (!obj || typeof obj !== 'object') return obj
+  if (Array.isArray(obj)) return obj.map(copy)
+
   var o = {}
-  for (var i in obj) o[i] = obj[i]
+  for (var i in obj) o[i] = copy(obj[i])
   return o
 }
 

--- a/lib/utils/read-installed.js
+++ b/lib/utils/read-installed.js
@@ -126,6 +126,14 @@ function readInstalled_ (folder, parent, name, reqver, depth, maxDepth, cb) {
 
   readJson(path.resolve(folder, "package.json"), function (er, data) {
     obj = data
+
+    // make a copy to avoid undesirable changes to the cache
+    if (obj) {
+      obj = copy(obj)
+      if (obj.dependencies) obj.dependencies = copy(obj.dependencies)
+      if (obj.devDependencies) obj.devDependencies = copy(obj.devDependencies)
+    }
+
     if (!parent) {
       obj = obj || true
       er = null
@@ -267,6 +275,12 @@ function findUnmet (obj) {
     })
   log.verbose([obj._id], "returning")
   return obj
+}
+
+function copy (obj) {
+  var o = {}
+  for (var i in obj) o[i] = obj[i]
+  return o
 }
 
 if (module === require.main) {


### PR DESCRIPTION
As suggested, avoid modifying the cached objects by making a copy of the objects we'll change.

Fixes #1753.
