### PR TITLE
fix #2187 set terminal columns to Infinity if 0

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -137,7 +137,8 @@ function prettify (data, args) {
       , stdout = process.stdout
       , cols = !tty.isatty(stdout.fd) ? Infinity
              : stdout._handle ? stdout._handle.getWindowSize()[0]
-             : tty.getWindowSize()[1]
+             : process.stdout.getWindowSize()[0] 
+      cols = (cols == 0) ? Infinity : cols
   } catch (ex) { cols = Infinity }
 
   // name, desc, author, keywords


### PR DESCRIPTION
In some cases (like emacs shell, process.stdout.getWindowSize() returns [0,0])  
In these cases, we should default to infinity because if cols == 0 blank lines are displayed.         

I tested this fix in a xterm-color, xterm, vt102, vt100, vt52, rxvt, dtterm, ansi, emacs shell, and emacs terminal.                                                                                                  

process.stdout.getWindowSize()[0]  
I set the array index to 0 here because the c++ source code in node (file tty_wrap.cc) for GetWindowSize is                                         

a->Set(0, Integer::New(width));  
a->Set(1, Integer::New(height)); 

and we want the columns (width), not the rows(height).

Further justification for this fix:                                   

the c++ source for tty.isatty just a guess. The node definition for IsTTY in tty_wrap.cc is

```
return uv_guess_handle(fd) == UV_TTY ? v8::True() : v8::False();     
```
