### PR TITLE
Process node_modules during `npm init`

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -148,7 +148,10 @@ function init_ (data, folder, cb) {
       }
     )
     (function (cb) {
-      read({ prompt: "Would you like to process dependencies? ", default: "yes" }, function (er, ok) {
+      read({ prompt: "Would you like to process dependencies? "
+           , default: "yes" }
+           , function (er, ok) {
+
         if (er) return cb(er)
         if (ok.toLowerCase().charAt(0) !== "y") {
           return cb()
@@ -206,7 +209,8 @@ function dependencies (folder, data, cb) {
     (function (cb) {
       var count = 0
       folders.forEach(function (folder) {
-        fs.readFile('./node_modules/' + folder + '/package.json', 'utf8', function (er, json) {
+        var file = './node_modules/' + folder + '/package.json';
+        fs.readFile(file, 'utf8', function (er, json) {
           count += 1
 
           if (!er) {
@@ -224,36 +228,52 @@ function dependencies (folder, data, cb) {
         })
       })
     })
-    //TODO: search for each module discovered to ensure the module/version is available with npm
+    //TODO: search for each module discovered to ensure the module/version
+    //is available with npm
     (function (cb) {
       var count = 0
 
-      if (packages.length && !data.dependencies) {
-        data.dependencies = {}
+      if (packages.length) {
+        if (!data.dependencies) data.dependencies = {}
+        if (!data.devDependencies) data.devDependencies = {}
       }
 
       doWhile(function (next) {
         var package = packages[count]
+          , defaultAnswer = (data.devDependencies[package.name]) 
+              ? "dev" 
+              : "yes"
+          , prompt = ["Would you like to add the dependency"
+                     ,package.name
+                     ,"@"
+                     ,package.version
+                     ,"? [yes/no/dev]"
+          ].join(" ")
 
         count += 1
 
-        //TODO: check version also and ask to add this version if version is different?
-        if (!data.dependencies[package.name]) {
-          //TODO: offer more options for selecting version compatibility
-          read({ prompt: "Would you like to add the dependency: " + package.name + " @ " + package.version + "? ", default: "yes" }, function (er, ok) {
-            if (er) return cb(er)
-            if (ok.toLowerCase().charAt(0) !== "y") {
-              return next(count !== packages.length)
-            }
+        //TODO: offer more options for selecting version compatibility
+        read({ prompt: prompt, default: defaultAnswer }, function (er, ok) {
+          if (er) return cb(er)
 
-            data.dependencies[package.name] = package.version
+          switch (ok.toLowerCase().charAt(0)) {
+            case 'y' :
+              delete data.devDependencies[package.name]
+              data.dependencies[package.name] = package.version
+              break
+            case 'd' :
+              delete data.dependencies[package.name]
+              data.devDependencies[package.name] = package.version
+              break
+            case 'n' :
+              delete data.dependencies[package.name]
+              delete data.devDependencies[package.name]
+              break
+            default :
+          }
 
-            next(count !== packages.length)
-          })
-        }
-        else {
           next(count !== packages.length)
-        }
+        })
       }, function () {
         cb()
       })

--- a/lib/init.js
+++ b/lib/init.js
@@ -8,6 +8,7 @@ var read = require("read")
   , readJson = require("./utils/read-json.js")
   , fs = require("graceful-fs")
   , promiseChain = require("./utils/promise-chain.js")
+  , doWhile = require("./utils/do-while.js")
   , exec = require("./utils/exec.js")
   , semver = require("semver")
   , log = require("./utils/log.js")
@@ -146,6 +147,16 @@ function init_ (data, folder, cb) {
         (data.scripts = data.scripts || {}).test = t
       }
     )
+    (function (cb) {
+      read({ prompt: "Would you like to process dependencies? ", default: "yes" }, function (er, ok) {
+        if (er) return cb(er)
+        if (ok.toLowerCase().charAt(0) !== "y") {
+          return cb()
+        }
+
+        return dependencies(folder, data, cb)
+      })
+    })
     (cleanupPaths, [data, folder])
     (function (cb) {
       try { data = readJson.processJson(data) }
@@ -175,6 +186,77 @@ function init_ (data, folder, cb) {
       fs.writeFile( path.join(folder, "package.json")
                   , JSON.stringify(data, null, 2) + "\n"
                   , cb )
+    })
+    ()
+}
+
+// async - yes io
+function dependencies (folder, data, cb) {
+  var folders
+    , packages = []
+
+  promiseChain(cb)
+    (function (cb) {
+      fs.readdir(folder + '/node_modules', function (er, fo) {
+        folders = fo
+
+        cb()
+      })
+    })
+    (function (cb) {
+      var count = 0
+      folders.forEach(function (folder) {
+        fs.readFile('./node_modules/' + folder + '/package.json', 'utf8', function (er, json) {
+          count += 1
+
+          if (!er) {
+            try {
+              packages.push(JSON.parse(json))
+            }
+            catch (e) {
+              //parse failed, who cares?
+            }
+          }
+
+          if (count == folders.length) {
+            cb()
+          }
+        })
+      })
+    })
+    //TODO: search for each module discovered to ensure the module/version is available with npm
+    (function (cb) {
+      var count = 0
+
+      if (packages.length && !data.dependencies) {
+        data.dependencies = {}
+      }
+
+      doWhile(function (next) {
+        var package = packages[count]
+
+        count += 1
+
+        //TODO: check version also and ask to add this version if version is different?
+        if (!data.dependencies[package.name]) {
+          //TODO: offer more options for selecting version compatibility
+          read({ prompt: "Would you like to add the dependency: " + package.name + " @ " + package.version + "? ", default: "yes" }, function (er, ok) {
+            if (er) return cb(er)
+            if (ok.toLowerCase().charAt(0) !== "y") {
+              return next(count !== packages.length)
+            }
+
+            data.dependencies[package.name] = package.version
+
+            next(count !== packages.length)
+          })
+        }
+        else {
+          next(count !== packages.length)
+        }
+      }, function () {
+        cb()
+      })
     })
     ()
 }

--- a/lib/utils/do-while.js
+++ b/lib/utils/do-while.js
@@ -1,0 +1,34 @@
+module.exports = doWhile
+
+// usage:
+//
+// doWhile(function (next) {
+//   if (keepGoing) {
+//     return next(true)  //passing true will call this anonymous function again
+//   }
+//   else {
+//     return next(false) //passing false will call the second parameter to doWhile (the done function)
+//                        //or you could just call your callback here
+//   }
+// }
+// , function () {
+//   return cb()
+// })
+//
+
+function doWhile (fn, done) {
+  run(fn)
+  
+  function run (fn) {
+    process.nextTick(function() {
+      fn(function (cont) {
+        if (cont) {
+          run(fn)
+        }
+        else if (done) {
+          done()
+        }
+      })
+    })
+  }
+}


### PR DESCRIPTION
Here is a patch which enables processing of node_modules during `init`. This does the job but as I have noted with some TODO comments, I think there are some additional checks and features we could offer the user.  

Since I'm not very familiar with the npm codebase, I would like to get some comments regarding the current patch before I spend any more time on this.

Thanks!
