### PR TITLE
#472: Adds support for os and cpu fields in package.json

### DIFF
--- a/doc/cli/json.md
+++ b/doc/cli/json.md
@@ -428,7 +428,7 @@ node that your stuff works on:
     { "engines" : { "node" : ">=0.1.27 <0.1.30" } }
 
 And, like with dependencies, if you don't specify the version (or if you
-specify "*" as the version), then any version of node will do.
+specify "\*" as the version), then any version of node will do.
 
 If you specify an "engines" field, then npm will require that "node" be
 somewhere on that list. If "engines" is omitted, then npm will just assume
@@ -444,27 +444,30 @@ are capable of properly installing your program.  For example:
 You can specify which operating systems your
 module will run on:
 
-    { "os" : [ "darwin", "linux" ] }
+    "os" : [ "darwin", "linux" ]
 
 You can also blacklist instead of whitelist operating systems,
 just prepend the blacklisted os with a '!':
 
-    { "os" : [ "!win32" ] }
+    "os" : [ "!win32" ]
 
-The host operating system is determined by `process.platform()`
+The host operating system is determined by `process.platform`
+
+It is allowed to both blacklist, and whitelist, although there isn't any
+good reason to do this.
 
 ## cpu
 
 If your code only runs on certain cpu architectures,
 you can specify which ones.
 
-    { "cpu" : [ "x64", "sparc" ] }
+    "cpu" : [ "x64", "ia32" ]
 
 Like the `os` option, you can also blacklist architectures:
 
-    { "cpu" : [ "!x64", "!sparc" ] }
+    "cpu" : [ "!arm", "!mips" ]
 
-The host architecture is determined by `process.arch()`
+The host architecture is determined by `process.arch`
 
 ## preferGlobal
 

--- a/doc/cli/json.md
+++ b/doc/cli/json.md
@@ -439,6 +439,33 @@ are capable of properly installing your program.  For example:
 
     { "engines" : { "npm" : "~1.0.20" } }
 
+## os
+
+You can specify which operating systems your
+module will run on:
+
+    { "os" : [ "darwin", "linux" ] }
+
+You can also blacklist instead of whitelist operating systems,
+just prepend the blacklisted os with a '!':
+
+    { "os" : [ "!win32" ] }
+
+The host operating system is determined by `process.platform()`
+
+## cpu
+
+If your code only runs on certain cpu architectures,
+you can specify which ones.
+
+    { "cpu" : [ "x64", "sparc" ] }
+
+Like the `os` option, you can also blacklist architectures:
+
+    { "cpu" : [ "!x64", "!sparc" ] }
+
+The host architecture is determined by `process.arch()`
+
 ## preferGlobal
 
 If your package is primarily a command-line application that should be

--- a/lib/install.js
+++ b/lib/install.js
@@ -606,6 +606,7 @@ function installOne_ (target, where, context, cb) {
 
   chain
     ( [ [checkEngine, target]
+      , [checkPlatform, target]
       , [checkCycle, target, context.ancestors]
       , [checkGit, targetFolder]
       , [write, target, targetFolder, context] ]
@@ -635,6 +636,58 @@ function checkEngine (target, cb) {
   return cb()
 }
 
+function checkPlatform (target, cb) {
+  var platform = process.platform
+    , arch = process.arch
+    , osOk = true
+    , cpuOk = true
+    , force = npm.config.get("force")
+
+  if (force) {
+    return cb()
+  }
+
+  if (target.os) {
+    osOk = checkList(platform, target.os)
+  }
+  if (target.cpu) {
+    cpuOk = checkList(arch, target.cpu)
+  }
+  if (!osOk || !cpuOk) {
+    var er = new Error("Unsupported")
+    er.errno = npm.EBADPLATFORM
+    er.os = target.os || ['any']
+    er.cpu = target.cpu || ['any']
+    er.pkgid = target._id
+    return cb(er)
+  }
+  return cb()
+}
+
+function checkList (value, list) {
+  var tmp
+    , match = false
+    , blc = 0
+  if (typeof list === "string") {
+    list = [list]
+  }
+  if (list.length === 1 && list[0] === "any") {
+    return true;
+  }
+  for (var i = 0; i < list.length; ++i) {
+    tmp = list[i]
+    if (tmp[0] === '!') {
+      tmp = tmp.slice(1)
+      if (tmp === value) {
+        return false;
+      }
+      ++blc
+    } else {
+      match = match || tmp === value
+    }
+  }
+  return match || blc === list.length
+}
 
 function checkCycle (target, ancestors, cb) {
   // there are some very rare and pathological edge-cases where

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -40,6 +40,7 @@ npm.EJSONPARSE = {}
 npm.EISGIT = {}
 npm.ECYCLE = {}
 npm.ENOTSUP = {}
+npm.EBADPLATFORM = {}
 
 // HACK for windows
 if (process.platform === "win32") {

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -159,6 +159,17 @@ function errorHandler (er) {
               ].join("\n"))
     break
 
+  case npm.EBADPLATFORM:
+    er.code = "EBADPLATFORM"
+    log.error([er.message
+              ,"Not compatible with your operating system or architecture: "+er.pkgid
+              ,"Valid OS:    "+er.os.join(",")
+              ,"Valid Arch:  "+er.cpu.join(",")
+              ,"Actual OS:   "+process.platform
+              ,"Actual Arch: "+process.arch
+              ].join("\n"))
+    break
+
   case "EEXIST":
   case constants.EEXIST:
     log.error([er.message

--- a/test/packages/npm-test-platform-all/package.json
+++ b/test/packages/npm-test-platform-all/package.json
@@ -1,0 +1,5 @@
+{"name":"npm-test-platform"
+,"version":"9.9.9-9"
+,"homepage":"http://www.zombo.com/",
+,"os":["darwin","linux","win32","solaris","haiku","sunos","freebsd","openbsd","netbsd"]
+,"cpu":["arm","mips","ia32","x64","sparc"]}

--- a/test/packages/npm-test-platform/package.json
+++ b/test/packages/npm-test-platform/package.json
@@ -1,0 +1,5 @@
+{"name":"npm-test-platform"
+,"version":"9.9.9-9"
+,"homepage":"http://www.youtube.com/watch?v=dQw4w9WgXcQ"
+,"os":["!this_is_not_a_real_os", "!neither_is_this"]
+,"cpu":["!this_is_not_a_real_cpu","!this_isnt_either"]}


### PR DESCRIPTION
This patch adds support for os and cpu fields in pacakge.json. It allows whitelisting or blacklisting operating systems and cpu architectures.

There was some discussion about using semver or minimatch on os versions, but it seems like the os version would rarely be a factor, and much more likely compiler and library versions, which would be handled by a makefile; so I elected to only handle platform types, such as `win32` or `darwin`.

I added some documentation to doc/cli/json.md to explain how to use the options.
