### PR TITLE
`npm set` errs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -113,6 +113,10 @@ function del (key, cb) {
 }
 
 function set (key, val, cb) {
+  if (key === undefined) {
+    console.log(config.usage)
+    return cb()
+  }
   if (val === undefined) {
     if (key.indexOf("=") !== -1) {
       var k = key.split("=")


### PR DESCRIPTION
issue #2239

pull request fixes bug: `cannot call method indexOf undefined`

logs out config usage if key is undefined in set method.

The issue states 'it would be good if it told you that you entered an invalid command'

I felt it would be better to log out config usage being as no command was entered at all in this case.
perhaps I should slim it down to just the `npm config set` usage?
