### PR TITLE
npm run as root leaves root-owned folders in ~/.npm

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -705,6 +705,8 @@ function addPlacedTarball_ (p, name, uid, gid, cb) {
                 && parseInt(gid, 10) === gid) {
               log.verbose([f, uid, gid], "chown")
               fs.chown(f, uid, gid, cb)
+              log.verbose([target, uid, gid], "chown")
+              fs.chown(target, uid, gid, cb)
             } else {
               log.verbose([f, uid, gid], "not chowning, invalid uid/gid")
               cb()

--- a/lib/config.js
+++ b/lib/config.js
@@ -113,6 +113,10 @@ function del (key, cb) {
 }
 
 function set (key, val, cb) {
+  if (key === undefined) {
+    console.log(config.usage)
+    return cb()
+  }
   if (val === undefined) {
     if (key.indexOf("=") !== -1) {
       var k = key.split("=")


### PR DESCRIPTION
Addressing issue #2264

The only changes I made were adding 2 lines in the following commit to chown the target dir.
https://github.com/gradus/npm/commit/858f573daea5bc37b2d495835d488afa18c21e2e

Apologizing for my terrible git-fu.
`git fetch` and `git merge` added extraneous commits in this pull request.

Not sure if this covers all cases where running npm as root is leaving root-owned folders in .npm, but it does cover the example specifically documented in issue #2264
