### PR TITLE
Add link support for Windows

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -29,13 +29,6 @@ link.completion = function (opts, cb) {
 }
 
 function link (args, cb) {
-  if (process.platform === "win32") {
-    var e = new Error("npm link not supported on windows")
-    e.code = "ENOTSUP"
-    e.errno = require("constants").ENOTSUP
-    return cb(e)
-  }
-
   if (npm.config.get("global")) {
     return cb(new Error("link should never be --global.\n"
                        +"Please re-run this command with --local"))

--- a/node_modules/graceful-fs/graceful-fs.js
+++ b/node_modules/graceful-fs/graceful-fs.js
@@ -2,6 +2,7 @@
 // fs operations wait until some have closed before trying to open more.
 
 var fs = require("fs")
+  , exec = require("child_process").exec
 
 // there is such a thing as TOO graceful.
 if (fs.open === gracefulOpen) return
@@ -271,5 +272,12 @@ if (process.platform === "win32") {
       }
       cb(er)
     })
+  }
+}
+
+// for symlink on windows, use mklink /j instead
+if (process.platform === "win32") {
+  fs.symlink = function (linkdata, path, callback) {
+    exec('mklink /j "' + path + '" "' + linkdata + '"', callback);
   }
 }


### PR DESCRIPTION
We can substitute "mklink /j" for `fs.symlink` for Windows until symlink is fully supported in node core.
