### PR TITLE
npm seach date format more easily scannable

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -194,6 +194,11 @@ function prettify (data, args) {
     return aa === bb ? 0
          : aa < bb ? (searchRev ? 1 : -1)
          : (searchRev ? -1 : 1)
+
+  }).map(function (line) {
+    line[3] = formatDate(line[3])
+    return line
+
   }).map(function (line) {
     return line.map(function (s, i) {
       spaces = spaces || longest.map(function (n) {
@@ -259,4 +264,11 @@ function colorize (line) {
     line = line.split(String.fromCharCode(m)).join("\033["+colors[i]+"m")
   }
   return line.split("\u0000").join("\033[0m")
+}
+
+function formatDate(age) {
+  var date = new Date(age)
+  if (isNaN(date.getTime())) return age
+  var formattedDate = date.toDateString().slice(4) // chop off day
+  return formattedDate
 }


### PR DESCRIPTION
Currently, it's difficult to scan the release dates for modules in npm search. This converts the old `2011-12-16 23:35` format to a more easily readable `Dec 16 2011` format. 

I have removed the release time information since in 99% of cases it's probably not as important as the date itself. If you feel time info is important, I will modify patch to include it.
