### PR TITLE
Add a colour-coded status column reflecting how recently module was updated

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -145,18 +145,19 @@ function prettify (data, args) {
   var longest = []
     , spaces
     , maxLen = npm.config.get("description")
-             ? [20, 60, 20, 20, Infinity]
-             : [20, 20, 20, Infinity]
+             ? [1, 20, 60, 20, 20, Infinity]
+             : [1, 20, 20, 20, Infinity]
     , headings = npm.config.get("description")
-               ? ["NAME", "DESCRIPTION", "AUTHOR", "DATE", "KEYWORDS"]
-               : ["NAME", "AUTHOR", "DATE", "KEYWORDS"]
+               ? [" ", "NAME", "DESCRIPTION", "AUTHOR", "DATE", "KEYWORDS"]
+               : [" ", "NAME", "AUTHOR", "DATE", "KEYWORDS"]
     , lines
     , searchsort = (npm.config.get("searchsort") || "NAME").toLowerCase()
-    , sortFields = { name: 0
-                   , description: 1
-                   , author: 2
-                   , date: 3
-                   , keywords: 4 }
+    , sortFields = { rating: 0
+                   , name: 1
+                   , description: 2
+                   , author: 3
+                   , date: 4
+                   , keywords: 5 }
     , searchRev = searchsort.charAt(0) === "-"
     , sortField = sortFields[searchsort.replace(/^\-+/, "")]
 
@@ -170,7 +171,11 @@ function prettify (data, args) {
       data.keywords = data.keywords.split(/[,\s]+/)
     }
     if (!Array.isArray(data.keywords)) data.keywords = []
-    var l = [ data.name
+      var rating = getRating(data.time)
+
+      var l = [
+              String(rating)
+            , data.name
             , data.description || ""
             , data.maintainers.join(" ")
             , data.time
@@ -221,7 +226,7 @@ function prettify (data, args) {
   return headings.map(function (h, i) {
     var space = Math.max(2, 3 + (longest[i] || 0) - h.length)
     return h + (new Array(space).join(" "))
-  }).join("").substr(0, cols).trim() + "\n" + lines.join("\n")
+  }).join("").substr(0, cols) + "\n" + lines.join("\n")
 
 }
 
@@ -254,9 +259,58 @@ function addColorMarker (str, arg, i) {
 }
 
 function colorize (line) {
+
+  // replace rating number (first char) with sexy color block
+  line = getRatingColor(line[0]) + line.slice(1)
+
   for (var i = 0; i < cl; i ++) {
     var m = i + 1
     line = line.split(String.fromCharCode(m)).join("\033["+colors[i]+"m")
   }
   return line.split("\u0000").join("\033[0m")
+}
+
+function getRating(dateString) {
+  // simple rating based on modified time
+  var aMonth = 1000 * 60 * 60 * 24 * 30 // a month (30 days) in milliseconds
+  var aYearAgo = new Date().getTime() - aMonth * 12
+  var oneMonthAgo = new Date().getTime() - aMonth * 1
+  var threeMonthsAgo = new Date().getTime() - aMonth * 3
+  var sixMonthsAgo = new Date().getTime() - aMonth * 6
+
+  var modified = new Date(dateString).getTime() || aYearAgo
+  if (modified > oneMonthAgo) {
+    return 1
+  } else if (modified > threeMonthsAgo) {
+    return 2
+  } else if (modified > sixMonthsAgo) {
+    return 3
+  } else if (modified > aYearAgo) {
+    return 4
+  } else {
+    return 5
+  }
+}
+
+function getRatingColor(rating) {
+  var color
+  switch(parseInt(rating)) {
+    case 1:
+      color = '\033[35;42m+' // green +
+      break
+    case 2:
+      color = '\033[42m ' // green
+      break
+    case 3:
+      color = '\033[43m ' // yellow
+      break
+    case 4:
+      color = '\033[41m ' // red
+      break
+    case 5:
+    default:
+      color = '\033[9;41m ' // red
+      break
+  }
+  return color + '\033[0m' // end
 }


### PR DESCRIPTION
This patch introduces an additional color coded 'status' column that reflects updated time.

Rationale: Although `npm search` probably isn't intended as a module discovery tool, it's usually the first tool I go to whenever I need to find something, and it gives me pretty good results. As with all node module search tools, evaluating the quality/suitability is a challenge when there are more than a few modules doing similar tasks.

In `npm search`, the only two metrics I currently have to evaluate the quality of a module is the author and the updated time. How recently module was updated has significant weight in the node community since the environment is advancing so fast, so being able to garner this information easily is important.

In its current output format the updated time is difficult to parse visually, and I've improved that by simplifying the date output format in #2303 but I believe we can do one better using an easily parsable color-coded status column. This could be extended to reflect more information in the future based on metrics as the information becomes available, eg stars, download count, etc.
