### PR TITLE
Increase space for name from 20 to 30 characters.

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -145,8 +145,8 @@ function prettify (data, args) {
   var longest = []
     , spaces
     , maxLen = npm.config.get("description")
-             ? [20, 60, 20, 20, Infinity]
-             : [20, 20, 20, Infinity]
+             ? [30, 60, 20, 20, Infinity]
+             : [30, 20, 20, Infinity]
     , headings = npm.config.get("description")
                ? ["NAME", "DESCRIPTION", "AUTHOR", "DATE", "KEYWORDS"]
                : ["NAME", "AUTHOR", "DATE", "KEYWORDS"]


### PR DESCRIPTION
Many name lengths are > than the 20 characters allotted to them. This helps tidy up the formatting of the columns in `npm search` results.
