### PR TITLE
Truncate description to maxLen to get neater npm search output

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -177,6 +177,11 @@ function prettify (data, args) {
             , (data.keywords || []).join(" ")
             ]
     l.forEach(function (s, i) {
+      // limit description to maxLen.
+      // Remember to change this when changing/reordering columns
+      if (s.length > maxLen[i] && i == 1) {
+        s = l[i] = s.substring(0, maxLen[i] - 1) + '>'
+      }
       var len = s.length
       longest[i] = Math.min(maxLen[i] || Infinity
                            ,Math.max(longest[i] || 0, len))


### PR DESCRIPTION
This truncates the description to maxLen (currently 60 chars).

Currently, the date and keywords are often pushed way off to the side by long descriptions, making reading the updated time and keywords sometimes impossible.
