### PR TITLE
Remove uneeded line

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -149,7 +149,6 @@ function gunzTarPerm (tarball, target, dMode, fMode, uid, gid, cb_) {
     if (c[0] === 0x1F &&
         c[1] === 0x8B &&
         c[2] === 0x08) {
-      var extracter = tar.Extract(extractOpts)
       fst
         .pipe(zlib.Unzip())
         .on("error", log.er(cb, "unzip error "+tarball))


### PR DESCRIPTION
I couldn't find anywhere else `extracter` being used but where it was defined. The function is again called to pipe the stream to it but I don't they are related, unless if you call it twice, it works faster!!! :P
