### PR TITLE
npm.commands.uninstall() doesn't return anything in the callback

### DIFF
--- a/lib/uninstall.js
+++ b/lib/uninstall.js
@@ -39,6 +39,7 @@ function uninstall (args, cb) {
 }
 
 function uninstall_ (args, nm, cb) {
+  var o = uninstallOutput(args, nm)
   asyncMap(args, function (arg, cb) {
     // uninstall .. should not delete /usr/local/lib/node_modules/..
     var p = path.join(path.resolve(nm), path.join("/", arg))
@@ -51,10 +52,17 @@ function uninstall_ (args, nm, cb) {
         log.warn(arg, "Not installed in "+nm)
         return cb(null, [])
       }
-      cb(null, p)
+      cb(null, p, o)
     })
   }, function (er, folders) {
     if (er) return cb(er)
     asyncMap(folders, npm.commands.unbuild, cb)
   })
+}
+
+function uninstallOutput (args, nm) {
+  for (var i = 0; i < args.length; i++) {
+    var p = path.join(path.resolve(nm), path.join("/", args[i]))
+    log.warn(p, "uninstalling")
+  }
 }


### PR DESCRIPTION
referencing issue #1754

This commit will cause `npm uninstall <module>` to output `npm warn uninstalling /path/to/module`
