### PR TITLE
Sort output of fs.readdir to ensure an ordered command list

### DIFF
--- a/scripts/index-build.js
+++ b/scripts/index-build.js
@@ -12,6 +12,7 @@ fs.readdir(api, done("api"))
 
 function done (which) { return function (er, docs) {
   if (er) throw er
+  docs.sort()
   if (which === "api") apidocs = docs
   else clidocs = docs
 


### PR DESCRIPTION
The order of entries returned by fs.readdir varies across OSes. To ensure that the generated index lists commands in alpha order, we need to sort the output of that function.
