### PR TITLE
Fix assignment of repo in init command

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -99,7 +99,7 @@ function init_ (data, folder, cb) {
           , function (er, r) {
               if (er) return cb(er)
               if (r !== "none") {
-                data.repository = (data.repository || {}).url = r
+                (data.repository = (data.repository || {})).url = r
               }
               cb()
             }


### PR DESCRIPTION
In the init command, the code for setting the repo works, but only accidentally. The defaultRepo function constructs the correct repo object, but this is then clobbered and replaced by a string. The processJson function sees that a string has been provided instead of an object, and reconstructs the object again. (You can see the bug in action by temporarily changing the repo type string in defaultRepo; the type will still be "git" when the package.json contents are created.)
