### PR TITLE
Don't die on an empty repo url.

### DIFF
--- a/lib/bugs.js
+++ b/lib/bugs.js
@@ -28,7 +28,7 @@ function bugs (args, cb) {
     }
     if (repo) {
       if (Array.isArray(repo)) repo = repo.shift()
-      if (repo.url) repo = repo.url
+      if (repo.hasOwnProperty("url")) repo = repo.url
       log.verbose(repo, "repository")
       if (repo && repo.match(/^(https?:\/\/|git(:\/\/|@))github.com/)) {
         return open(repo.replace(/^git(@|:\/\/)/, "http://")

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -25,7 +25,7 @@ function docs (args, cb) {
     if (homepage) return open(homepage, cb)
     if (repo) {
       if (Array.isArray(repo)) repo = repo.shift()
-      if (repo.url) repo = repo.url
+      if (repo.hasOwnProperty("url")) repo = repo.url
       log.verbose(repo, "repository")
       if (repo) {
         return open(repo.replace(/^git(@|:\/\/)/, 'http://')


### PR DESCRIPTION
When the repo url is an empty string, the check for just (repo.url) is insufficient, and leads the code to later assume that the repo object is a string when it's not. The same issue is presents in 'npm docs' and 'npm bugs'. This patch addresses both. Fixes #2313.
