### PR TITLE
FIx Srinkwrap for project with no dependencies

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -211,7 +211,7 @@ function readDependencies (context, where, opts, cb) {
         rv[key] = data[key]
       })
       rv.dependencies = {}
-      Object.keys(newwrap.dependencies).forEach(function (key) {
+      Object.keys(newwrap.dependencies || {}).forEach(function (key) {
         var w = newwrap.dependencies[key]
         rv.dependencies[key] = w.from || w.version
       })

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -38,7 +38,7 @@ function shrinkwrap_ (pkginfo, silent, cb) {
   }
 
   var file = path.resolve(npm.prefix, "npm-shrinkwrap.json")
-
+console.log("data", swdata);
   fs.writeFile(file, swdata, function (er) {
     if (er) return cb(er)
     if (silent) return cb(null, pkginfo)


### PR DESCRIPTION
Hi, I do propose this to fix https://github.com/isaacs/npm/issues/2336#issuecomment-5012235
Two commit , the first one to fix the problem.
The second one to add dependencies objects in npm-shrinkwrap.json file even if there is no dependencies
