### PR TITLE
--skip-installed flag for `npm install`

### DIFF
--- a/doc/cli/config.md
+++ b/doc/cli/config.md
@@ -716,6 +716,13 @@ using `-s` to add a signature.
 Note that git requires you to have set up GPG keys in your git configs
 for this to work properly.
 
+### skip-installed
+
+* Default: true
+* Type: Boolean
+
+Whether to skip installation if a requested package already exists in the node_modules directory.
+
 ### strict-ssl
 
 * Default: true

--- a/doc/cli/config.md
+++ b/doc/cli/config.md
@@ -718,7 +718,7 @@ for this to work properly.
 
 ### skip-installed
 
-* Default: true
+* Default: false
 * Type: Boolean
 
 Whether to skip installation if a requested package already exists in the node_modules directory.

--- a/doc/cli/install.md
+++ b/doc/cli/install.md
@@ -7,7 +7,7 @@ npm-install(1) -- Install a package
     npm install <tarball file>
     npm install <tarball url>
     npm install <folder>
-    npm install <name> [--save|--save-dev|--save-optional]
+    npm install <name> [--save|--save-dev|--save-optional] [--skip-installed]
     npm install <name>@<tag>
     npm install <name>@<version>
     npm install <name>@<version range>
@@ -67,7 +67,7 @@ after packing it up into a tarball (b).
 
           npm install https://github.com/indexzero/forever/tarball/v0.5.6
 
-* `npm install <name> [--save|--save-dev|--save-optional]`:
+* `npm install <name> [--save|--save-dev|--save-optional] [--skip-installed]`:
 
     Do a `<name>@<tag>` install, where `<tag>` is the "tag" config. (See
     `npm-config(1)`.)
@@ -79,7 +79,7 @@ after packing it up into a tarball (b).
 
           npm install sax
 
-    `npm install` takes 3 exclusive, optional flags which save or update
+    `npm install` takes 3 exclusive, optional save flags which save or update
     the package version in your main package.json:
 
     * `--save`: Package will appear in your `dependencies`.
@@ -93,6 +93,10 @@ after packing it up into a tarball (b).
           npm install sax --save
           npm install node-tap --save-dev
           npm install dtrace-provider --save-optional
+
+    `npm install` also takes an optional `--skip-installed` flag which will
+    cause npm to skip installation if a requested package already exists in the
+    node_modules directory.
 
 
     **Note**: If there is a file or folder named `<name>` in the current

--- a/lib/install.js
+++ b/lib/install.js
@@ -479,7 +479,7 @@ function installMany (what, where, context, cb) {
     // what is a list of things.
     // resolve each one.
     asyncMap( what
-            , targetResolver(where, context, d)
+            , targetResolver(what, where, context, d)
             , function (er, targets) {
 
       if (er) return cb(er)
@@ -511,25 +511,39 @@ function installMany (what, where, context, cb) {
   })
 }
 
-function targetResolver (where, context, deps) {
-  var alreadyInstalledManually = context.explicit ? [] : null
+function targetResolver (what, where, context, deps) {
+  var skipInstalled = npm.config.get("skip-installed")
+    , alreadyInstalledManually = context.explicit && !skipInstalled ? [] : null
     , nm = path.resolve(where, "node_modules")
     , parent = context.parent
     , wrap = context.wrap
 
-  if (!context.explicit) fs.readdir(nm, function (er, inst) {
+  if (!context.explicit || skipInstalled) fs.readdir(nm, function (er, inst) {
     if (er) return alreadyInstalledManually = []
     asyncMap(inst, function (pkg, cb) {
       readJson(path.resolve(nm, pkg, "package.json"), function (er, d) {
         // error means it's not a package, most likely.
         if (er) return cb(null, [])
 
-        // if it's a bundled dep, then assume that anything there is valid.
-        // otherwise, make sure that it's a semver match with what we want.
-        var bd = parent.bundleDependencies
-        if (bd && bd.indexOf(d.name) !== -1 ||
-            semver.satisfies(d.version, deps[d.name] || "*")) {
-          return cb(null, d.name)
+        if (skipInstalled) {
+          // for a --skip-installed install we test the available packages
+          // against what's in node_modules, allowing for semver matching
+          // which even allows for cmds like:
+          //   npm install 'pkg@>=0.1.0' --skip-installed
+          if (what.some(function (w) {
+               return new RegExp("^" + d.name + "(@|$)").test(w) &&
+                 semver.satisfies(d.version, w.split("@")[1] || "*")
+              })) {
+            return cb(null, d.name)
+          }
+        } else {
+          // if it's a bundled dep, then assume that anything there is valid.
+          // otherwise, make sure that it's a semver match with what we want.
+          var bd = parent.bundleDependencies
+          if (bd && bd.indexOf(d.name) !== -1 ||
+              semver.satisfies(d.version, deps[d.name] || "*")) {
+            return cb(null, d.name)
+          }
         }
 
         // something is there, but it's not satisfactory.  Clobber it.

--- a/node_modules/npmconf/config-defs.js
+++ b/node_modules/npmconf/config-defs.js
@@ -239,6 +239,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , searchsort: "name"
     , shell : osenv.shell()
     , "sign-git-tag": false
+    , "skip-installed": false
     , "strict-ssl": true
     , tag : "latest"
     , tmp : temp
@@ -331,6 +332,7 @@ exports.types =
                 , "keywords", "-keywords" ]
   , shell : String
   , "sign-git-tag": Boolean
+  , "skip-installed": Boolean
   , "strict-ssl": Boolean
   , tag : String
   , tmp : path


### PR DESCRIPTION
I don't have tests for this because I couldn't see how to work them in to the existing test structure as this is just an extra flag for `npm install`, if you'd like tests then could you point me in the right direction to get started?

`npm install <package1> [<package2>...] --skip-installed` will act a little like a plain `npm install` does on a directory with a _package.json_, that is, it'll skip any packages that already exist in the _node_modules_ directory:

```
$ npm install foo bar
$ # → foo and bar installed into node_modules
$ npm install foo bar --skip-installed
$ # → nothing is done, they are already there
$ npm install foo bar baz --skip-installed
$ # → baz installed into node_modules
```

Additionally, semver matching is performed so you can do it by version, and even semver ranges (basically it's all passed to `semver.satisies, so you can do:

```
$ npm install foo@0.0.5
$ # → foo@0.0.5 installed to node_modules
$ npm install foo@0.0.5 --skip-installed
$ # → nothing happens
$ npm install foo@0.0.6 --skip-installed
$ # → foo@0.0.6 installed to node_modules
$ npm install 'foo@>=0.0.4' --skip-installed
$ # → nothing happens
$ npm install 'foo@>=0.0.10' --skip-installed
$ # → foo@* (latest) installed to node_modules
```

The main reason I want this is for use via the API in Ender so we can do `ender build pkg1 pkg2 pkg3` and have it act like a plain `npm install`, i.e. not install anything if it's already there. But it's also very handy as a command line option, particularly when installation can be slow (like down here in AU where the latency kills us).
