### PR TITLE
Solves reduce on undefined when (optional) dependency failed to install

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -378,7 +378,7 @@ function treeify (installed) {
 // where/node_modules to the family object.
 function installManyTop (what, where, context, cb_) {
   function cb (er, d) {
-    if (context.explicit || er) return cb_(er, d)
+    if (context.explicit || er) return cb_(er, d || [])
     // since this wasn't an explicit install, let's build the top
     // folder, so that `npm install` also runs the lifecycle scripts.
     npm.commands.build([where], false, true, function (er) {


### PR DESCRIPTION
Can be reproduced by trying to install [connect-redis](https://github.com/visionmedia/connect-redis) on Windows which has hiredis as an optional dependency.

Line 381 throws `TypeError: Cannot call method 'reduce' of undefined`

So when `d` is not defined, pass an empty array instead.
