### PR TITLE
Made the location of dotfiles honor XDG_CONFIG_HOME

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -29,7 +29,15 @@ completion.completion = function (opts, cb) {
     bashExists = !er
     next()
   })
+  fs.stat(path.resolve(process.env.XDG_CONFIG_HOME, "bashrc"), function (er, b) {
+    bashExists = !er
+    next()
+  })
   fs.stat(path.resolve(process.env.HOME, ".zshrc"), function (er, b) {
+    zshExists = !er
+    next()
+  })
+  fs.stat(path.resolve(process.env.XDG_CONFIG_HOME, "zshrc"), function (er, b) {
     zshExists = !er
     next()
   })

--- a/lib/utils/config-defs.js
+++ b/lib/utils/config-defs.js
@@ -74,6 +74,22 @@ var home = ( process.platform === "win32"
            ? process.env.USERPROFILE
            : process.env.HOME )
 
+var config_file = function(name, alt) {
+  var config = process.env.XDG_CONFIG_HOME;
+  if (config === undefined) {
+    return path.resolve(home || alt, "." + name);
+  }
+  return path.resolve(config || alt, name)
+}
+
+var cache_file = function(name) {
+  var cache = process.env.XDG_CACHE_HOME;
+  if (cache === undefined) {
+    return path.resolve(home || temp, "." + name);
+  }
+  return path.resolve(cache || temp, name)
+}
+
 if (home) process.env.HOME = home
 else home = temp
 
@@ -139,7 +155,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
 
     , cache : process.platform === "win32"
             ? path.resolve(process.env.APPDATA || home || temp, "npm-cache")
-            : path.resolve( home || temp, ".npm")
+            : cache_file("npm-cache", temp)
     , "cache-max": Infinity
     , "cache-min": 0
 
@@ -209,8 +225,8 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , usage : false
     , user : process.platform === "win32" ? 0 : "nobody"
     , username : ""
-    , userconfig : path.resolve(home, ".npmrc")
-    , userignorefile : path.resolve(home, ".npmignore")
+    , userconfig : config_file("npmrc")
+    , userignorefile : config_file("npmignore")
     , umask: 022
     , version : false
     , versions : false

--- a/node_modules/node-gyp/lib/node-gyp.js
+++ b/node_modules/node-gyp/lib/node-gyp.js
@@ -35,6 +35,14 @@ function gyp () {
   return new Gyp
 }
 
+function config_file(name) {
+  var config = process.env.XDG_CONFIG_FILE;
+  if (config !== undefined) {
+    return path.resolve(config, name);
+  }
+  return path.resolve(homeDir, "." + name);
+}
+
 function Gyp () {
   var me = this
 
@@ -42,7 +50,7 @@ function Gyp () {
   // TODO: make this configurable?
   //       see: https://github.com/TooTallNate/node-gyp/issues/21
   var homeDir = process.env.HOME || process.env.USERPROFILE
-  this.devDir = path.resolve(homeDir, '.node-gyp')
+  this.devDir = config_file("node-gyp")
 
   this.commands = {}
 


### PR DESCRIPTION
(And also XDG_CACHE_HOME)

The XDG specification allows users to specify configuration/data/cache locations so that their home directory need not be cluttered by a plethora of dotfiles (like `.npm` and `.npmrc`). npm should honor such settings.
