### PR TITLE
#2453 ssh is not always the default

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -298,7 +298,6 @@ function addRemoteGit (u, parsed, name, cb_) {
   var co = parsed.hash && parsed.hash.substr(1) || "master"
   u = u.replace(/^git\+/, "")
        .replace(/#.*$/, "")
-       .replace(/^ssh:\/\//, "") // ssh is the default anyway
   log.verbose([u, co], "addRemoteGit")
 
   var tmp = path.join(npm.tmp, Date.now()+"-"+Math.random())


### PR DESCRIPTION
 See `man git clone` on at least Ubuntu 10.10 and 12.04.

```
       For local repositories, also supported by git natively, the following
       syntaxes may be used:

       ·   /path/to/repo.git/

       ·    file:///path/to/repo.git/

       These two syntaxes are mostly equivalent, except the former implies
       --local option.
```
