### PR TITLE
"bundle exec" style exec command

### DIFF
--- a/doc/cli/exec.md
+++ b/doc/cli/exec.md
@@ -1,4 +1,4 @@
-npm-exec(1) -- Add local package binaries to path and execute command
+npm-exec(1) -- Execute command using local package bin
 ====================================
 
 ## SYNOPSIS

--- a/doc/cli/exec.md
+++ b/doc/cli/exec.md
@@ -1,0 +1,15 @@
+npm-exec(1) -- Add local package binaries to path and execute command
+====================================
+
+## SYNOPSIS
+
+    npm exec
+
+## DESCRIPTION
+
+Adds the local package bin path (eg. node_modules/.bin) before executing the
+command.
+
+## SEE ALSO
+
+* npm-bin(1)

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -5,9 +5,10 @@ var npm = require("./npm.js")
 
 exec.usage = "npm exec <command>\n(execute command using local package bin)"
 
+exec.completion = require("./utils/completion/local-bin.js")
+
 function exec (args, cb) {
-  var path = require("path")
-    , b = npm.bin
+  var b = npm.bin
     , exec = require("child_process").exec
 
   if (args.length == 0) return cb("Usage:\n"+exec.usage)

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -9,23 +9,30 @@ exec.usage = "npm exec <command>\n(execute command using local package bin)"
 
 exec.completion = require("./utils/completion/local-bin.js")
 
-function exec (args, cb) {
-  var b = npm.bin, cmd
-
+function exec(args, cb) {
   if (args.length == 0) return cb("Usage:\n"+exec.usage)
-  var cmd;
-  if (process.platform.match(/win/))
+  var b = npm.bin, cmd, o = ""
+  var isWin = process.platform.match(/win/)
+
+  // Create an OS specific call
+  if (isWin)
     cmd = "SET OLDPATH=%PATH% & SET PATH=" + b + ";%PATH% & " +
       args.join(" ") + " & SET PATH=%OLDPATH%"
   else
     cmd = "PATH=" + b + ":$PATH " + args.join(" ")
+
   p = cp.exec(cmd, function(error, stdout, stderr) {
-    cb()
+    // Return all captured output
+    cb(null, o)
   })
   p.stdout.on('data', function(data) {
+    // Capture stdout output and output to screen
     console.log(data.toString().replace(/\n$/, ''))
+    o += data.toString()
   })
   p.stderr.on('data', function(data) {
+    // Capture stderr output and output to screen
     console.error(data.toString().replace(/\n$/, ''))
+    o += data.toString()
   })
 }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -3,16 +3,18 @@ module.exports = exec
 var npm = require("./npm.js")
   , output = require("./utils/output.js")
 
-exec.usage = "npm exec\n(add local package binaries to path and execute command)"
+exec.usage = "npm exec <command>\n(execute command using local package bin)"
 
 function exec (args, cb) {
   var path = require("path")
     , b = npm.bin
-    , PATH = (process.env.PATH || "").split(":")
     , exec = require("child_process").exec
 
+  if (args.length == 0) return cb("Usage:\n"+exec.usage)
   var cmd = "PATH=" + b + ":$PATH " + args.join(" ")
   exec(cmd, function (error, stdout, stderr) {
-    output.write(stdout, function (er) { cb(er, stdout) })
+    if (error !== null) return cb(stderr.replace(/\n$/, ''))
+    var o = stdout.replace(/\n$/, '')
+    output.write(o, function (er) { cb(er, o) })
   })
 }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,0 +1,18 @@
+module.exports = exec
+
+var npm = require("./npm.js")
+  , output = require("./utils/output.js")
+
+exec.usage = "npm exec\n(add local package binaries to path and execute command)"
+
+function exec (args, cb) {
+  var path = require("path")
+    , b = npm.bin
+    , PATH = (process.env.PATH || "").split(":")
+    , exec = require("child_process").exec
+
+  var cmd = "PATH=" + b + ":$PATH " + args.join(" ")
+  exec(cmd, function (error, stdout, stderr) {
+    output.write(stdout, function (er) { cb(er, stdout) })
+  })
+}

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -2,18 +2,24 @@ module.exports = exec
 
 var npm = require("./npm.js")
   , output = require("./utils/output.js")
+  , cp = require("child_process")
+  , os = require("os")
 
 exec.usage = "npm exec <command>\n(execute command using local package bin)"
 
 exec.completion = require("./utils/completion/local-bin.js")
 
 function exec (args, cb) {
-  var b = npm.bin
-    , exec = require("child_process").exec
+  var b = npm.bin, cmd
 
   if (args.length == 0) return cb("Usage:\n"+exec.usage)
-  var cmd = "PATH=" + b + ":$PATH " + args.join(" ")
-  exec(cmd, function (error, stdout, stderr) {
+  var cmd;
+  if (process.platform.match(/win/))
+    cmd = "SET OLDPATH=%PATH% & SET PATH=" + b + ";%PATH% & " +
+      args.join(" ") + " & SET PATH=%OLDPATH%"
+  else
+    cmd = "PATH=" + b + ":$PATH " + args.join(" ")    
+  cp.exec(cmd, function (error, stdout, stderr) {
     if (error !== null) return cb(stderr.replace(/\n$/, ''))
     var o = stdout.replace(/\n$/, '')
     output.write(o, function (er) { cb(er, o) })

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -18,10 +18,14 @@ function exec (args, cb) {
     cmd = "SET OLDPATH=%PATH% & SET PATH=" + b + ";%PATH% & " +
       args.join(" ") + " & SET PATH=%OLDPATH%"
   else
-    cmd = "PATH=" + b + ":$PATH " + args.join(" ")    
-  cp.exec(cmd, function (error, stdout, stderr) {
-    if (error !== null) return cb(stderr.replace(/\n$/, ''))
-    var o = stdout.replace(/\n$/, '')
-    output.write(o, function (er) { cb(er, o) })
+    cmd = "PATH=" + b + ":$PATH " + args.join(" ")
+  p = cp.exec(cmd, function(error, stdout, stderr) {
+    cb()
+  })
+  p.stdout.on('data', function(data) {
+    console.log(data.toString().replace(/\n$/, ''))
+  })
+  p.stderr.on('data', function(data) {
+    console.error(data.toString().replace(/\n$/, ''))
   })
 }

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -156,6 +156,7 @@ var commandCache = {}
               , "restart"
               , "run-script"
               , "completion"
+              , "exec"
               ]
   , plumbing = [ "build"
                , "unbuild"

--- a/lib/utils/completion/local-bin.js
+++ b/lib/utils/completion/local-bin.js
@@ -1,0 +1,19 @@
+module.exports = localBin
+
+var npm = require("../../npm.js")
+  , find = require("../find.js")
+  , path = require("path")
+
+function localBin (filter, cb) {
+  var b = npm.bin;
+  path.exists(b, function(exists) {
+    // Return if there is no local bin dir
+    if (!exists) return cb(null, [])
+    // Search local bin for files
+    find(b, null, 1, function(er, files) {
+      return cb(null, (files || []).map(function(f) {
+        return f.replace(b + '/', '')
+      }))
+    })
+  })
+}


### PR DESCRIPTION
I've created a new command to execute commands using local binaries before global ones.  The command auto completes based on which binaries are available in the node_modules/.bin.

Examples:
npm exec jasmine-node spec
npm exec jake build

Tested under Linux (arch) and Windows 7.  I don't have an OSX machine to try it out on though.
