### PR TITLE
Use env to locate bash

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # set configurations that will be "sticky" on this system,
 # surviving npm self-updates.

--- a/scripts/clean-old.sh
+++ b/scripts/clean-old.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # look for old 0.x cruft, and get rid of it.
 # Should already be sitting in the npm folder.

--- a/scripts/doc-build.sh
+++ b/scripts/doc-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $DEBUG != "" ]]; then
   set -x


### PR DESCRIPTION
Fix problem with building FreeBSD (which installs bash in
/usr/local/bin). Related to #445.
