### PR TITLE
Quote paths passed to child_process.exec in tests.

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -72,8 +72,8 @@ function exec (cmd, shouldFail, cb) {
   // special: replace 'node' with the current execPath,
   // and 'npm' with the thing we installed.
   var cmdShow = cmd
-  cmd = cmd.replace(/^npm /, path.resolve(npmPath, "npm") + " ")
-  cmd = cmd.replace(/^node /, process.execPath + " ")
+  cmd = cmd.replace(/^npm /, "\"" + path.resolve(npmPath, "npm") + "\" ")
+  cmd = cmd.replace(/^node /, "\"" + process.execPath + "\" ")
 
   child_process.exec(cmd, {env: env}, function (er, stdout, stderr) {
     if (stdout) {


### PR DESCRIPTION
This is necessary on Windows; otherwise you get

```
2> 'c:\PROGRAM' is not recognized as an internal or external command,
2> operable program or batch file.
```

since Node/npm are in "C:\Program Files (x86)\nodejs", which has spaces in it.

---

I don't know if this works on POSIX, so someone should test that before merging.

An alternative would be to use `child_process.execFile`, but then you'd have to distinguish between the command and the arguments to the command, which is not currently done.
