### PR TITLE
Cache git remotes

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -77,6 +77,7 @@ var mkdir = require("mkdirp")
   , lockFile = require("lockfile")
   , crypto = require("crypto")
   , retry = require("retry")
+  , zlib = require("zlib")
 
 cache.usage = "npm cache add <tarball file>"
             + "\nnpm cache add <folder>"
@@ -341,9 +342,12 @@ function addRemoteTarball (u, shasum, name, cb_) {
   })
 }
 
-// For now, this is kind of dumb.  Just basically treat git as
-// yet another "fetch and scrub" kind of thing.
-// Clone to temp folder, then proceed with the addLocal stuff.
+// 1. cacheDir = path.join(cache,'_git-remotes',sha1(u))
+// 2. checkGitDir(cacheDir) ? 4. : 3. (rm cacheDir if necessary)
+// 3. git clone --mirror u cacheDir
+// 4. cd cacheDir && git fetch -a origin
+// 5. git archive /tmp/random.tgz
+// 6. addLocalTarball(/tmp/random.tgz) <gitref> --format=tar --prefix=package/
 function addRemoteGit (u, parsed, name, cb_) {
   if (typeof cb_ !== "function") cb_ = name, name = null
 
@@ -360,11 +364,13 @@ function addRemoteGit (u, parsed, name, cb_) {
     })
   }
 
+  var p, co // cachePath, git-ref we want to check out
+  
   lock(u, function (er) {
     if (er) return cb(er)
 
     // figure out what we should check out.
-    var co = parsed.hash && parsed.hash.substr(1) || "master"
+    co = parsed.hash && parsed.hash.substr(1) || "master"
     // git is so tricky!
     // if the path is like ssh://foo:22/some/path then it works, but
     // it needs the ssh://
@@ -378,32 +384,91 @@ function addRemoteGit (u, parsed, name, cb_) {
       u = u.replace(/^ssh:\/\//, "")
     }
 
+    var v = crypto.createHash("sha1").update(u).digest("hex")
+
     log.verbose("addRemoteGit", [u, co])
 
-    var tmp = path.join(npm.tmp, Date.now()+"-"+Math.random())
-    mkdir(path.dirname(tmp), function (er) {
+    p = path.join(npm.config.get("cache"), "_git-remotes", v)
+
+    checkGitDir()
+  })
+
+  function checkGitDir () {
+    fs.stat(p, function(er, s) {
+      if (er) return cloneRemote()
+      if (!s.isDirectory()) return rm(p, function(er){
+          if (er) return cb(er)
+          cloneRemote()
+        })
+      exec( npm.config.get("git"), ["config", "--get", "remote.origin.url"]
+          , gitEnv(), false, p, function(er, code, stdout, stderr) {
+        stdoutTrimmed = (stdout + "\n" + stderr).trim()
+        if (er) {
+          log.warn( "git config --get remote.config.url returned wrong result "
+                  + "("+u+")", stdoutTrimmed )
+          return rm(p, function(err){
+            if (err) return cb(err)
+            cloneRemote()
+          })
+        }
+        log.verbose("git config --get remote.config.url ("+u+")", stdoutTrimmed)
+        if (u != stdout.trim()) return rm(p, function(err){
+            if (err) return cb(err)
+            cloneRemote(p)
+          })
+        archiveRemote()
+      })
+    })
+  }
+
+  function cloneRemote () {
+    mkdir(p, function (er) {
       if (er) return cb(er)
-      exec( npm.config.get("git"), ["clone", u, tmp], gitEnv(), false
+      exec( npm.config.get("git"), ["clone", "--mirror", u, p], gitEnv(), false
           , function (er, code, stdout, stderr) {
         stdout = (stdout + "\n" + stderr).trim()
         if (er) {
           log.error("git clone " + u, stdout)
           return cb(er)
         }
-        log.verbose("git clone "+u, stdout)
-        exec( npm.config.get("git"), ["checkout", co], gitEnv(), false, tmp
-            , function (er, code, stdout, stderr) {
-          stdout = (stdout + "\n" + stderr).trim()
-          if (er) {
-            log.error("git checkout " + co, stdout)
-            return cb(er)
-          }
-          log.verbose("git checkout " + co, stdout)
-          addLocalDirectory(tmp, cb)
-        })
+        log.verbose("git clone " + u, stdout)
+        archiveRemote(p)
       })
     })
-  })
+  }
+
+  function archiveRemote () {
+    exec( npm.config.get("git"), ["fetch", "-a", "origin"], gitEnv(), false, p
+        , function (er, code, stdout, stderr) {
+      stdout = (stdout + "\n" + stderr).trim()
+      if (er) {
+        log.error("git fetch -a origin ("+u+")", stdout)
+        return cb(er)
+      }
+      log.verbose("git fetch -a origin ("+u+")", stdout)
+      var tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
+      mkdir( path.dirname(tmp), function (er) {
+        if (er) return cb(er)
+        var gzip = zlib.createGzip()
+        var out = fs.createWriteStream(tmp)
+        var cp = exec( npm.config.get("git")
+                     , ["archive", co, "--format=tar", "--prefix=package/"]
+                     , gitEnv(), false, p
+                     , function (er, code, stdout, stderr) {
+          if (er) {
+            log.error( "git archive " + co + " ("+u+")"
+                     , (stdout + "\n" + stderr).trim())
+            return cb(er)
+          }
+          log.verbose("git archive " + co + " ("+u+")")
+          cp.on('close', function(){
+            addLocalTarball(tmp, cb)
+          })
+        })
+        cp.stdout.pipe(gzip).pipe(out)
+      })
+    })
+  }
 }
 
 


### PR DESCRIPTION
right now `npm install git+ssh://foo.com/bar.git#v0.0.1` will (see https://github.com/isaacs/npm/blob/master/lib/cache.js#L280-326 ):
- clone the git-repo into `/tmp/random`
- then it will checkout the gitref `v0.0.1`
- then it will run `addLocalDirectory(/tmp/random)`

this patch will make it do (u is the git-remote):
1. path.exists(cache+'/.gitRemotes/'+sha1(u)) ? 3. : 2.
2. git clone --bare u cache/.gitRemotes/sha1(u)
3. cd cache/.gitRemotes/sha1(u) && git fetch
4. git clone cache/.gitRemotes/sha1(u) /tmp/random
5. cd /tmp/random && git checkout gitref
6. addLocalDirectory(/tmp/random)

that way npm only needs to clone repositories (per git-remote) 1 time and will use `git fetch` after that
