### PR TITLE
Add `npm linkall` command

### DIFF
--- a/doc/api/linkall.md
+++ b/doc/api/linkall.md
@@ -1,0 +1,13 @@
+npm-linkall(3) -- Symlink all dependencies
+==========================================
+
+## SYNOPSIS
+
+    npm.commands.linkall(callback)
+
+## DESCRIPTION
+
+`linkall` reads list of dependencies of the package and links all available
+global packages which are depended on into local `node_modules` directory.
+
+This is useful during development or when dealing with many private packages.

--- a/doc/cli/linkall.md
+++ b/doc/cli/linkall.md
@@ -1,0 +1,13 @@
+npm-linkall(1) -- Symlink a package folder
+==========================================
+
+## SYNOPSIS
+
+    npm linkall (in package folder)
+
+## DESCRIPTION
+
+`linkall` reads list of dependencies of the package and links all available
+global packages which are depended on into local `node_modules` directory.
+
+This is useful during development or when dealing with many private packages.

--- a/lib/linkall.js
+++ b/lib/linkall.js
@@ -1,0 +1,31 @@
+var npm = require("./npm.js")
+  , asyncMap = require("slide").asyncMap
+  , readJson = require("./utils/read-json.js")
+  , fs = require("graceful-fs")
+
+module.exports = linkall
+
+linkall.usage = "npm linkall (in package dir)"
+
+function linkall (args, cb) {
+  fs.readdir(npm.globalDir, function (er, files) {
+    if (er) return cb(er)
+    files = files.filter(function (f) {
+      return f[0] !== "."
+    })
+
+    readJson("package.json", function (er, pkg) {
+      if (er) return cb(er)
+
+      var deps = Object.keys(pkg.dependencies)
+      if (!npm.config.get("production")) {
+        deps = deps.concat(Object.keys(pkg.devDependencies))
+      }
+
+      asyncMap(files, function (f, cb_) {
+        if (deps.indexOf(f) === -1) return cb_()
+        npm.commands.link(f, cb_)
+      }, cb)
+    })
+  })
+}

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -123,6 +123,7 @@ var commandCache = {}
 
               , "rebuild"
               , "link"
+              , "linkall"
 
               , "publish"
               , "star"


### PR DESCRIPTION
`npm linkall` reads `dependencies` and `devDependencies` (unless running
in production environment) and links all globally installed packages
which are included in dependencies.

This feature is useful in development or when using many private packages.

Documentation included.

Feel free to squash these commits.
