### PR TITLE
Support publishing private packages, if desired

### DIFF
--- a/doc/cli/config.md
+++ b/doc/cli/config.md
@@ -534,6 +534,18 @@ this as true.
 
 A proxy to use for outgoing http requests.
 
+### publish-privates
+
+* Default: false
+* Type: Boolean
+
+When set to false, npm will refuse to publish private packages (those
+having "private":true in package.json). When set to true, npm will
+publish private packages.
+
+Note, the official npm registry does not accept private packages. This
+feature requires a custom registry server.
+
 ### rebuild-bundle
 
 * Default: true

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -72,9 +72,16 @@ function publish_ (arg, data, isRetry, cachedir, cb) {
   }
 
   delete data.modules
-  if (data.private) return cb(new Error
-    ("This package has been marked as private\n"
-    +"Remove the 'private' field from the package.json to publish it."))
+  if (data.private) {
+    if (npm.config.get("publish-privates")) {
+      log.info("publish", "Publishing a private package")
+    } else {
+      return cb(new Error
+        ("This package has been marked as private\n"
+        +"To publish it, remove the 'private' field from its"
+        +" package.json, or `npm config set publish-privates true`"))
+    }
+  }
 
   // pre-build
   var bd = data.scripts

--- a/lib/utils/config-defs.js
+++ b/lib/utils/config-defs.js
@@ -180,6 +180,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , "https-proxy" : process.env.HTTPS_PROXY || process.env.https_proxy ||
                       process.env.HTTP_PROXY || process.env.http_proxy || null
     , "user-agent" : "npm/" + npm.version + " node/" + process.version
+    , "publish-privates" : false
     , "rebuild-bundle" : true
     , registry : "https://registry.npmjs.org/"
     , rollback : true


### PR DESCRIPTION
This is pretty simple.

```
npm config set publish-privates true
```

Or, edit an individual package.json

```
"publishConfig": {"publish-privates": true}
```

Voila. Now npm will `log.info()` a message but otherwise let it happen. I think the official registry should ban all private packages though.
