### PR TITLE
`logstream` option to replace removed `logfd`

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -263,6 +263,7 @@ function load (npm, conf, cb) {
     ini.resolveConfigs(conf, function (er) {
       log.level = npm.config.get("loglevel")
       log.heading = "npm"
+      log.stream = npm.config.get("logstream")
       switch (npm.config.get("color")) {
         case "always": log.enableColor(); break
         case false: log.disableColor(); break

--- a/lib/utils/config-defs.js
+++ b/lib/utils/config-defs.js
@@ -165,6 +165,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , json: false
     , link: false
     , loglevel : "http"
+    , logstream : process.stderr
     , long : false
     , message : "%s"
     , "node-version" : process.version
@@ -249,6 +250,7 @@ exports.types =
   , json: Boolean
   , link: Boolean
   , loglevel : ["silent","win","error","warn","http","info","verbose","silly"]
+  , logstream : Stream
   , long : Boolean
   , message: String
   , "node-version" : [null, semver]

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -10,6 +10,7 @@ var log = require("npmlog")
   , chain = require("slide").chain
   , constants = require("constants")
   , output = require("./output.js")
+  , Stream = require("stream").Stream
   , PATH = "PATH"
 
 // windows calls it's path "Path" usually, but this is not guaranteed.
@@ -260,6 +261,7 @@ function makeEnv (data, prefix, env) {
       return
     }
     var value = ini.get(i)
+    if (value instanceof Stream) return
     if (!value) value = ""
     else if (typeof value !== "string") value = JSON.stringify(value)
 


### PR DESCRIPTION
We've been using the `logfd` option via the npm API in Ender (see [here](https://github.com/ender-js/Ender/blob/1.0-wip/lib/repository.js#L79-82)) to redirect output to a temporary file which is deleted if there are no errors. Now with the new _npmlog_ package we can't do that and `logfd` is (almost) completely removed from npm without a replacement. `outfd` still works fine but now we get `stderr` from npmlog that we can't capture.

This PR is pretty simple, it simply allows a `logstream` option which is passed to npmlog via `log.stream =`. Defaults to `process.stderr` just like npmlog.

Cheers!
