### PR TITLE
If `dependencies` is not set, default to empty object

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -176,6 +176,7 @@ function readDependencies (context, where, opts, cb) {
           , function (er, data) {
     if (er)  return cb(er)
 
+    if (!data.dependencies) data.dependencies = {};
     if (opts && opts.dev) {
       Object.keys(data.devDependencies || {}).forEach(function (k) {
         data.dependencies[k] = data.devDependencies[k]


### PR DESCRIPTION
Fixes crash when package only has `devDependencies` field.
