### PR TITLE
Fix zsh completion

### DIFF
--- a/lib/utils/completion.sh
+++ b/lib/utils/completion.sh
@@ -11,7 +11,7 @@ COMP_WORDBREAKS=${COMP_WORDBREAKS/=/}
 COMP_WORDBREAKS=${COMP_WORDBREAKS/@/}
 export COMP_WORDBREAKS
 
-if complete &>/dev/null; then
+if type complete &>/dev/null; then
   _npm_completion () {
     local si="$IFS"
     IFS=$'\n' COMPREPLY=($(COMP_CWORD="$COMP_CWORD" \
@@ -22,7 +22,18 @@ if complete &>/dev/null; then
     IFS="$si"
   }
   complete -F _npm_completion npm
-elif compctl &>/dev/null; then
+elif type compdef &>/dev/null; then
+  _npm_completion() {
+    si=$IFS
+    compadd -- $(COMP_CWORD=$((CURRENT-1)) \
+                 COMP_LINE=$BUFFER \
+                 COMP_POINT=0 \
+                 npm completion -- "${words[@]}" \
+                 2>/dev/null)
+    IFS=$si
+  }
+  compdef _npm_completion npm
+elif type compctl &>/dev/null; then
   _npm_completion () {
     local cword line point words si
     read -Ac words


### PR DESCRIPTION
Zsh completion seems completely broken. This commit provides completion for zsh's new completion system. It doesn't replace the existing old-style compctl support.
