### PR TITLE
Avoid install failure from that the `treeify` get null

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -77,7 +77,7 @@ function install (args, cb_) {
 
     output = output || require("./utils/output.js")
 
-    var tree = treeify(installed)
+    var tree = treeify(installed || [])
       , pretty = prettify(tree, installed).trim()
 
     if (pretty) output.write(pretty, afterWrite)


### PR DESCRIPTION
As you can see at [here](https://github.com/isaacs/npm/blob/1977584a975db9fbc2cd36b34ea2e4743f465dd4/lib/install.js#L622) a failure from an optional dependency eats an error. It cause a problem by that both of `err` and `installedWhat` could be null at same time if the optional package was an only package which needed to be installed.
