### PR TITLE
include process.pid in tmp dir to avoid collision with two npms in the same ms

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -261,7 +261,7 @@ function addRemoteTarball (u, shasum, name, cb_) {
   }
 
   log.verbose("addRemoteTarball", [u, shasum])
-  var tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
+  var tmp = path.join(npm.tmp, Date.now()+"-"+process.pid+"-"+Math.random(), "tmp.tgz")
   mkdir(path.dirname(tmp), function (er) {
     if (er) return cb(er)
     fetch(u, tmp, function (er) {


### PR DESCRIPTION
Seems extreme, but it could happen. I can simulate the problem with this script:

```
#!/usr/bin/bash
#
# "npm install $MODULE" 26 times as simultaneously as we can
#

DIR=2
rm -rf $DIR
DIRS="a b c d e f g h i j k l m n o p q r s t u v w x y z"

pids=""
NPMDEV="node cli.js"
MODULE="jsontool@3.2.0"
for d in $DIRS; do
        mkdir -p $DIR/$d
        (cd $DIR/$d;
                pwd;
                touch package.json;
                $NPMDEV --cache=`pwd`/cache install $MODULE
                )&
        pids="$pids $!"
done

for pid in $pids; do
        wait $pid
done  
```

Here is a failing case (without this patch):

```
[root@09f501c8-a9e6-11e1-bf82-2b368af2a8d7:~/tm/npm/tmp]$ ./stress2.sh 
/root/tm/npm/tmp/2/a
/root/tm/npm/tmp/2/b
/root/tm/npm/tmp/2/c
/root/tm/npm/tmp/2/d
/root/tm/npm/tmp/2/e
/root/tm/npm/tmp/2/f
/root/tm/npm/tmp/2/g
/root/tm/npm/tmp/2/h
/root/tm/npm/tmp/2/i
/root/tm/npm/tmp/2/j
/root/tm/npm/tmp/2/k
/root/tm/npm/tmp/2/l
/root/tm/npm/tmp/2/m
/root/tm/npm/tmp/2/n
/root/tm/npm/tmp/2/o
/root/tm/npm/tmp/2/p
/root/tm/npm/tmp/2/q
/root/tm/npm/tmp/2/r
/root/tm/npm/tmp/2/s
/root/tm/npm/tmp/2/t
/root/tm/npm/tmp/2/u
/root/tm/npm/tmp/2/v
/root/tm/npm/tmp/2/w
/root/tm/npm/tmp/2/x
/root/tm/npm/tmp/2/y
/root/tm/npm/tmp/2/z
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/3.2.0
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http npm 200 https://registry.npmjs.org/jsontool/3.2.0
http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http GET https://registry.npmjs.org/jsontool
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http GET https://registry.npmjs.org/jsontool
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http GET https://registry.npmjs.org/jsontool
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool/3.2.0
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm ERR! Error: ENOENT, open '/root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json'
npm ERR!  { [Error: ENOENT, open '/root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json']
npm ERR!   errno: 34,
npm ERR!   code: 'ENOENT',
npm ERR!   path: '/root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json' }
npm ERR! You may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>

npm ERR! System SunOS 5.11
npm ERR! command "node" "/root/tm/npm/cli.js" "--cache=/root/tm/npm/tmp/2/a/cache" "install" "jsontool@3.2.0"
npm ERR! cwd /root/tm/npm/tmp/2/a
npm ERR! node -v v0.6.19
npm ERR! npm -v 1.1.32
npm ERR! path /root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json
npm ERR! code ENOENT
npm ERR! message ENOENT, open '/root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json'
npm ERR! errno 34
npm ERR! 34 errno
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /root/tm/npm/tmp/2/a/npm-debug.log
npm ERR! not ok code undefined
npm ERR! not ok code 34
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
npm http GET https://registry.npmjs.org/jsontool
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
npm http GET https://registry.npmjs.org/jsontool
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
npm http 200 https://registry.npmjs.org/jsontool
npm http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
jsontool@3.2.0 node_modules/jsontool
└── jsontool@2.2.2
```

Here is the npm-debug.log from the failing one above:

```
[root@09f501c8-a9e6-11e1-bf82-2b368af2a8d7:~/tm/npm/tmp/2]$ cat a/npm-debug.log 
0 info it worked if it ends with ok
1 verbose cli [ 'node',
1 verbose cli   '/root/tm/npm/cli.js',
1 verbose cli   '--cache=/root/tm/npm/tmp/2/a/cache',
1 verbose cli   'install',
1 verbose cli   'jsontool@3.2.0' ]
2 info using npm@1.1.32
3 info using node@v0.6.19
4 verbose config file /root/.npmrc
5 verbose config file /root/opt/node-0.6/etc/npmrc
6 verbose config file /root/tm/npm/npmrc
7 verbose read json /root/tm/npm/tmp/2/a/package.json
8 verbose read json /root/tm/npm/tmp/2/a/package.json
9 verbose cache add [ 'jsontool@3.2.0', null ]
10 silly cache add name=undefined spec="jsontool@3.2.0" args=["jsontool@3.2.0",null]
11 verbose parsed url { pathname: 'jsontool@3.2.0',
11 verbose parsed url   path: 'jsontool@3.2.0',
11 verbose parsed url   href: 'jsontool@3.2.0' }
12 silly cache add name="jsontool" spec="3.2.0" args=["jsontool","3.2.0"]
13 verbose parsed url { pathname: '3.2.0', path: '3.2.0', href: '3.2.0' }
14 verbose addNamed [ 'jsontool', '3.2.0' ]
15 verbose addNamed [ '3.2.0', '3.2.0' ]
16 verbose url raw jsontool/3.2.0
17 verbose url resolving [ 'https://registry.npmjs.org/', './jsontool/3.2.0' ]
18 verbose url resolved https://registry.npmjs.org/jsontool/3.2.0
19 http GET https://registry.npmjs.org/jsontool/3.2.0
20 http 200 https://registry.npmjs.org/jsontool/3.2.0
21 silly registry.get cb [ 200,
21 silly registry.get   { vary: 'Accept',
21 silly registry.get     server: 'CouchDB/1.2.0 (Erlang OTP/R15B)',
21 silly registry.get     etag: '"2N5FHGUAR2MUZ8JEBNXOAO4DV"',
21 silly registry.get     date: 'Tue, 26 Jun 2012 23:43:23 GMT',
21 silly registry.get     'content-type': 'application/json',
21 silly registry.get     'content-length': '3459' } ]
22 verbose addRemoteTarball [ 'https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz',
22 verbose addRemoteTarball   '224d2a369f6c9820c5bf66ba4e473e87b1539203' ]
23 verbose fetch to= /root/tmp/npm-1340754203857/1340754203857-0.422616989351809/tmp.tgz
24 http GET https://registry.npmjs.org/jsontool/-/jsontool-3.2.0.tgz
25 silly shasum updated bytes 40960
26 silly shasum updated bytes 10
27 info shasum 224d2a369f6c9820c5bf66ba4e473e87b1539203
27 info shasum /root/tmp/npm-1340754203857/1340754203857-0.422616989351809/tmp.tgz
28 verbose tar unpack /root/tmp/npm-1340754203857/1340754203857-0.422616989351809/tmp.tgz
29 silly gunzTarPerm modes [ '755', '644' ]
30 silly gunzTarPerm extractEntry package.json
31 silly gunzTarPerm extractEntry .npmignore
32 silly gunzTarPerm extractEntry README.md
33 silly gunzTarPerm extractEntry LICENSE.txt
34 silly gunzTarPerm extractEntry docs/json.1
35 silly gunzTarPerm extractEntry docs/json.1.html
36 silly gunzTarPerm extractEntry docs/json.1.ronn
37 silly gunzTarPerm extractEntry lib/jsontool.js
38 silly gunzTarPerm extractEntry .gitmodules
39 silly gunzTarPerm extractEntry Makefile
40 silly gunzTarPerm extractEntry AUTHORS
41 silly gunzTarPerm extractEntry CHANGES.md
42 silly gunzTarPerm extractEntry support/update_json_parse.js
43 silly gunzTarPerm extractEntry support/cutarelease.py
44 silly gunzTarPerm extractEntry test/test.js
45 silly gunzTarPerm extractEntry test/invalid-json/cmd
46 silly gunzTarPerm extractEntry test/invalid-json/expected.exitCode
47 silly gunzTarPerm extractEntry test/invalid-json/input
48 silly gunzTarPerm extractEntry test/array-missing-keys/cmd
49 silly gunzTarPerm extractEntry test/array-missing-keys/expected.stdout
50 silly gunzTarPerm extractEntry test/array-processing/cmd
51 silly gunzTarPerm extractEntry test/array-processing/expected.stdout
52 silly gunzTarPerm extractEntry test/basic/cmd
53 silly gunzTarPerm extractEntry test/basic/expected.stdout
54 silly gunzTarPerm extractEntry test/basic/input
55 silly gunzTarPerm extractEntry test/conditionals/cmd
56 silly gunzTarPerm extractEntry test/conditionals/expected.stdout
57 silly gunzTarPerm extractEntry test/empty-lookup/cmd
58 silly gunzTarPerm extractEntry test/empty-lookup/expected.stdout
59 silly gunzTarPerm extractEntry test/empty-lookup/input
60 silly gunzTarPerm extractEntry test/executable/cmd
61 silly gunzTarPerm extractEntry test/executable/expected.stdout
62 silly gunzTarPerm extractEntry test/fickle-stdout/README.md
63 silly gunzTarPerm extractEntry test/fickle-stdout/cmd
64 silly gunzTarPerm extractEntry test/fickle-stdout/expected.stderr
65 silly gunzTarPerm extractEntry test/fickle-stdout/expected.stdout
66 silly gunzTarPerm extractEntry test/fickle-stdout/input
67 silly gunzTarPerm extractEntry test/flat-array-input/README.md
68 silly gunzTarPerm extractEntry test/flat-array-input/arrays-complex.input
69 silly gunzTarPerm extractEntry test/flat-array-input/arrays-on-same-line.input
70 silly gunzTarPerm extractEntry test/flat-array-input/arrays.input
71 silly gunzTarPerm extractEntry test/flat-array-input/cmd
72 silly gunzTarPerm extractEntry test/flat-array-input/dir/a.json
73 silly gunzTarPerm extractEntry test/flat-array-input/dir/b.json
74 silly gunzTarPerm extractEntry test/flat-array-input/dir/c.json
75 silly gunzTarPerm extractEntry test/flat-array-input/arrays-on-same-line-fail.input
76 silly gunzTarPerm extractEntry test/flat-array-input/mixed-objects-and-arrays.input
77 silly gunzTarPerm extractEntry test/flat-array-input/objects-complex.input
78 silly gunzTarPerm extractEntry test/flat-array-input/objects-on-same-line-fail.input
79 silly gunzTarPerm extractEntry test/flat-array-input/objects-on-same-line.input
80 silly gunzTarPerm extractEntry test/flat-array-input/objects.input
81 silly gunzTarPerm extractEntry test/flat-array-input/expected.stdout
82 silly gunzTarPerm extractEntry test/hyphen/cmd
83 silly gunzTarPerm extractEntry test/hyphen/expected.stdout
84 silly gunzTarPerm extractEntry test/hyphen/input
85 silly gunzTarPerm extractEntry test/argv/README.md
86 silly gunzTarPerm extractEntry test/argv/cmd
87 silly gunzTarPerm extractEntry test/argv/expected.stderr
88 silly gunzTarPerm extractEntry test/argv/expected.stdout
89 silly gunzTarPerm extractEntry test/json3/cmd
90 silly gunzTarPerm extractEntry test/json3/expected.stdout
91 silly gunzTarPerm extractEntry test/lookups/cmd
92 silly gunzTarPerm extractEntry test/lookups/expected.stderr
93 silly gunzTarPerm extractEntry test/lookups/expected.stdout
94 silly gunzTarPerm extractEntry test/Makefile
95 silly gunzTarPerm extractEntry test/multiargs/cmd
96 silly gunzTarPerm extractEntry test/multiargs/expected.stdout
97 silly gunzTarPerm extractEntry test/multiargs/input
98 silly gunzTarPerm extractEntry test/period/cmd
99 silly gunzTarPerm extractEntry test/period/expected.stdout
100 silly gunzTarPerm extractEntry test/period/input
101 silly gunzTarPerm extractEntry test/quiet/cmd
102 silly gunzTarPerm extractEntry test/quiet/expected.stdout
103 silly gunzTarPerm extractEntry test/quiet/input
104 silly gunzTarPerm extractEntry test/syntax-error/cmd
105 silly gunzTarPerm extractEntry test/syntax-error/expected.stderr
106 silly gunzTarPerm extractEntry test/syntax-error/expected.stdout
107 silly gunzTarPerm extractEntry test/syntax-error/input
108 silly gunzTarPerm extractEntry test/100-continue/cmd
109 silly gunzTarPerm extractEntry test/100-continue/expected.exitCode
110 silly gunzTarPerm extractEntry test/100-continue/expected.stdout
111 silly gunzTarPerm extractEntry test/100-continue/input
112 silly gunzTarPerm extractEntry test/undefined/cmd
113 silly gunzTarPerm extractEntry test/undefined/expected.exitCode
114 silly gunzTarPerm extractEntry test/undefined/expected.stderr
115 silly gunzTarPerm extractEntry test/undefined/expected.stdout
116 silly gunzTarPerm extractEntry test/undefined/input
117 silly gunzTarPerm extractEntry test/utf8/cmd
118 silly gunzTarPerm extractEntry test/utf8/expected.stdout
119 silly gunzTarPerm extractEntry test/utf8/input
120 silly gunzTarPerm extractEntry TODO.md
121 verbose read json /root/tmp/npm-1340754203857/1340754203857-0.422616989351809/package/package.json
122 verbose from cache /root/tmp/npm-1340754203857/1340754203857-0.422616989351809/package/package.json
123 verbose tar pack [ '/root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package.tgz',
123 verbose tar pack   '/root/tmp/npm-1340754203857/1340754203857-0.422616989351809/package' ]
124 verbose tarball /root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package.tgz
125 verbose folder /root/tmp/npm-1340754203857/1340754203857-0.422616989351809/package
126 verbose tar unpack /root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package.tgz
127 silly gunzTarPerm modes [ '755', '644' ]
128 silly gunzTarPerm extractEntry package.json
129 silly gunzTarPerm extractEntry .npmignore
130 silly gunzTarPerm extractEntry README.md
131 silly gunzTarPerm extractEntry LICENSE.txt
132 silly gunzTarPerm extractEntry support/update_json_parse.js
133 silly gunzTarPerm extractEntry support/cutarelease.py
134 silly gunzTarPerm extractEntry Makefile
135 silly gunzTarPerm extractEntry lib/jsontool.js
136 silly gunzTarPerm extractEntry docs/json.1
137 silly gunzTarPerm extractEntry docs/json.1.html
138 silly gunzTarPerm extractEntry docs/json.1.ronn
139 silly gunzTarPerm extractEntry AUTHORS
140 silly gunzTarPerm extractEntry test/test.js
141 silly gunzTarPerm extractEntry test/undefined/expected.stdout
142 silly gunzTarPerm extractEntry test/undefined/input
143 silly gunzTarPerm extractEntry test/undefined/expected.exitCode
144 silly gunzTarPerm extractEntry test/undefined/expected.stderr
145 silly gunzTarPerm extractEntry test/undefined/cmd
146 silly gunzTarPerm extractEntry test/period/expected.stdout
147 silly gunzTarPerm extractEntry test/period/cmd
148 silly gunzTarPerm extractEntry test/period/input
149 silly gunzTarPerm extractEntry test/Makefile
150 silly gunzTarPerm extractEntry test/quiet/cmd
151 silly gunzTarPerm extractEntry test/quiet/expected.stdout
152 silly gunzTarPerm extractEntry test/quiet/input
153 silly gunzTarPerm extractEntry test/invalid-json/input
154 silly gunzTarPerm extractEntry test/invalid-json/cmd
155 silly gunzTarPerm extractEntry test/invalid-json/expected.exitCode
156 silly gunzTarPerm extractEntry test/json3/expected.stdout
157 silly gunzTarPerm extractEntry test/json3/cmd
158 silly gunzTarPerm extractEntry test/argv/README.md
159 silly gunzTarPerm extractEntry test/argv/expected.stdout
160 silly gunzTarPerm extractEntry test/argv/cmd
161 silly gunzTarPerm extractEntry test/argv/expected.stderr
162 silly gunzTarPerm extractEntry test/executable/cmd
163 silly gunzTarPerm extractEntry test/executable/expected.stdout
164 silly gunzTarPerm extractEntry test/flat-array-input/README.md
165 silly gunzTarPerm extractEntry test/flat-array-input/arrays-on-same-line-fail.input
166 silly gunzTarPerm extractEntry test/flat-array-input/arrays-complex.input
167 silly gunzTarPerm extractEntry test/flat-array-input/mixed-objects-and-arrays.input
168 silly gunzTarPerm extractEntry test/flat-array-input/arrays.input
169 silly gunzTarPerm extractEntry test/flat-array-input/arrays-on-same-line.input
170 silly gunzTarPerm extractEntry test/flat-array-input/objects-on-same-line-fail.input
171 silly gunzTarPerm extractEntry test/flat-array-input/dir/c.json
172 silly gunzTarPerm extractEntry test/flat-array-input/dir/b.json
173 silly gunzTarPerm extractEntry test/flat-array-input/dir/a.json
174 silly gunzTarPerm extractEntry test/flat-array-input/objects-on-same-line.input
175 silly gunzTarPerm extractEntry test/flat-array-input/expected.stdout
176 silly gunzTarPerm extractEntry test/flat-array-input/objects-complex.input
177 silly gunzTarPerm extractEntry test/flat-array-input/objects.input
178 silly gunzTarPerm extractEntry test/flat-array-input/cmd
179 silly gunzTarPerm extractEntry test/utf8/expected.stdout
180 silly gunzTarPerm extractEntry test/utf8/cmd
181 silly gunzTarPerm extractEntry test/utf8/input
182 silly gunzTarPerm extractEntry test/basic/input
183 silly gunzTarPerm extractEntry test/basic/expected.stdout
184 silly gunzTarPerm extractEntry test/basic/cmd
185 silly gunzTarPerm extractEntry test/multiargs/expected.stdout
186 silly gunzTarPerm extractEntry test/multiargs/cmd
187 silly gunzTarPerm extractEntry test/multiargs/input
188 silly gunzTarPerm extractEntry test/100-continue/input
189 silly gunzTarPerm extractEntry test/100-continue/cmd
190 silly gunzTarPerm extractEntry test/100-continue/expected.exitCode
191 silly gunzTarPerm extractEntry test/100-continue/expected.stdout
192 silly gunzTarPerm extractEntry test/lookups/expected.stderr
193 silly gunzTarPerm extractEntry test/lookups/cmd
194 silly gunzTarPerm extractEntry test/lookups/expected.stdout
195 silly gunzTarPerm extractEntry test/empty-lookup/input
196 silly gunzTarPerm extractEntry test/empty-lookup/cmd
197 silly gunzTarPerm extractEntry test/empty-lookup/expected.stdout
198 silly gunzTarPerm extractEntry test/conditionals/expected.stdout
199 silly gunzTarPerm extractEntry test/conditionals/cmd
200 silly gunzTarPerm extractEntry test/fickle-stdout/README.md
201 silly gunzTarPerm extractEntry test/fickle-stdout/expected.stderr
202 silly gunzTarPerm extractEntry test/fickle-stdout/input
203 silly gunzTarPerm extractEntry test/fickle-stdout/cmd
204 silly gunzTarPerm extractEntry test/fickle-stdout/expected.stdout
205 silly gunzTarPerm extractEntry test/hyphen/cmd
206 silly gunzTarPerm extractEntry test/hyphen/input
207 silly gunzTarPerm extractEntry test/hyphen/expected.stdout
208 silly gunzTarPerm extractEntry test/array-processing/cmd
209 silly gunzTarPerm extractEntry test/array-processing/expected.stdout
210 silly gunzTarPerm extractEntry test/array-missing-keys/cmd
211 silly gunzTarPerm extractEntry test/array-missing-keys/expected.stdout
212 silly gunzTarPerm extractEntry test/syntax-error/expected.stderr
213 silly gunzTarPerm extractEntry test/syntax-error/cmd
214 silly gunzTarPerm extractEntry test/syntax-error/input
215 silly gunzTarPerm extractEntry test/syntax-error/expected.stdout
216 silly gunzTarPerm extractEntry .gitmodules
217 silly gunzTarPerm extractEntry CHANGES.md
218 silly gunzTarPerm extractEntry TODO.md
219 verbose read json /root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package/package.json
220 silly shasum updated bytes 40960
221 silly shasum updated bytes 696
222 info shasum 798f78376d029c904eda2a2db0722cae63850137
222 info shasum /root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package.tgz
223 verbose from cache /root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package/package.json
224 verbose chmod /root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package.tgz 644
225 verbose chown /root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package.tgz [ 0, 0 ]
226 silly resolved [ { name: 'jsontool',
226 silly resolved     description: 'a \'json\' command for massaging JSON on the command line',
226 silly resolved     version: '3.2.0',
226 silly resolved     repository: { type: 'git', url: 'git://github.com/trentm/json.git' },
226 silly resolved     author:
226 silly resolved      { name: 'Trent Mick',
226 silly resolved        email: 'trentm@gmail.com',
226 silly resolved        url: 'http://trentm.com' },
226 silly resolved     bin:
226 silly resolved      { json: './lib/jsontool.js',
226 silly resolved        json3: './lib/jsontool.js',
226 silly resolved        json2: './node_modules/.bin/json2' },
226 silly resolved     main: './lib/jsontool.js',
226 silly resolved     man: [ './man/man1/json.1' ],
226 silly resolved     scripts: { test: 'make test' },
226 silly resolved     engines: [ 'node >=0.4.0' ],
226 silly resolved     keywords: [ 'json', 'jsontool', 'filter', 'command', 'shell' ],
226 silly resolved     dependencies: { jsontool: '2.x' },
226 silly resolved     devDependencies: { 'uglify-js': '1.1.x', nodeunit: '0.7.x', ansidiff: '1.0' },
226 silly resolved     contributors: [ [Object], [Object] ],
226 silly resolved     readme: 'A "json" command for working with JSON on the command line. It is a\nsingle-file node.js script with no external deps (other than\n[node](https://github.com/joyent/node) itself). Here is a taste:\n\n    $ echo \'{"foo":"bar"}\' | json\n    {\n      "foo": "bar"\n    }\n    $ echo \'{"foo":"bar"}\' | json foo\n    bar\n\nUse it to:\n\n- pretty-print JSON to help read it\n- extract particular values (see `LOOKUPS` in usage)\n- get details on JSON syntax errors (handy for config files)\n- filter input JSON (see `-e` and `-c` options)\n\nFollow <a href="https://twitter.com/intent/user?screen_name=trentmick" target="_blank">@trentmick</a>\nfor updates to jsontool.\n\nSee <http://trentm.com/json> for full docs and many examples.\n\n\n# Installation\n\n1. Get [node](http://nodejs.org).\n\n2. `npm install -g jsontool`\n\n**OR manually**:\n\n2. Get the \'json\' script and put it on your PATH somewhere (it is a single file\n   with no external dependencies). For example:\n\n        cd ~/bin\n        curl -L https://github.com/trentm/json/raw/master/lib/jsontool.js > json\n        chmod 755 json\n\nYou should now have "json" on your PATH:\n\n    $ json --version\n    json 3.1.2\n\n\n# Test suite\n\n    make test\n\nYou can also limit (somewhat) which tests are run with the `TEST_ONLY` envvar,\ne.g.:\n\n    cd test && TEST_ONLY=executable nodeunit test.js\n\nI test against node 0.4, 0.6, 0.7 and (occassionally) node master.\n\n\n# License\n\nMIT (see the fine LICENSE.txt file).\n\n\n# Command-Line Usage\n\n    <something generating JSON on stdout> | json [OPTIONS] [LOOKUPS...]\n\nSee `json --help` output for full details.\n\n\n\n# Module Usage\n\nSince v1.3.1 you can use "jsontool" as a node.js module:\n\n    var jsontool = require(\'jsontool\');\n\nHowever, so far the module API isn\'t that useful and the CLI is the primary\nfocus.\n\n\n# Alternatives you might prefer\n\n- json:select: <http://jsonselect.org/>\n- jsonpipe: <https://github.com/dvxhouse/jsonpipe>\n- json-command: <https://github.com/zpoley/json-command>\n- JSONPath: <http://goessner.net/articles/JsonPath/>, <http://code.google.com/p/jsonpath/wiki/Javascript>\n- jsawk: <https://github.com/micha/jsawk>\n- jshon: <http://kmkeen.com/jshon/>\n',
226 silly resolved     _id: 'jsontool@3.2.0',
226 silly resolved     dist: { shasum: '798f78376d029c904eda2a2db0722cae63850137' },
226 silly resolved     _from: 'jsontool@3.2.0' } ]
227 info install jsontool@3.2.0 into /root/tm/npm/tmp/2/a
228 info installOne jsontool@3.2.0
229 verbose from cache /root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package/package.json
230 info /root/tm/npm/tmp/2/a/node_modules/jsontool unbuild
231 verbose read json /root/tm/npm/tmp/2/a/node_modules/jsontool/package.json
232 verbose tar unpack /root/tm/npm/tmp/2/a/cache/jsontool/3.2.0/package.tgz
233 silly gunzTarPerm modes [ '755', '644' ]
234 silly gunzTarPerm extractEntry package.json
235 silly gunzTarPerm extractEntry .npmignore
236 silly gunzTarPerm extractEntry README.md
237 silly gunzTarPerm extractEntry LICENSE.txt
238 silly gunzTarPerm extractEntry support/update_json_parse.js
239 silly gunzTarPerm extractEntry support/cutarelease.py
240 silly gunzTarPerm extractEntry Makefile
241 silly gunzTarPerm extractEntry lib/jsontool.js
242 silly gunzTarPerm extractEntry docs/json.1
243 silly gunzTarPerm extractEntry docs/json.1.html
244 silly gunzTarPerm extractEntry docs/json.1.ronn
245 silly gunzTarPerm extractEntry AUTHORS
246 silly gunzTarPerm extractEntry test/test.js
247 silly gunzTarPerm extractEntry test/undefined/expected.stdout
248 silly gunzTarPerm extractEntry test/undefined/input
249 silly gunzTarPerm extractEntry test/undefined/expected.exitCode
250 silly gunzTarPerm extractEntry test/undefined/expected.stderr
251 silly gunzTarPerm extractEntry test/undefined/cmd
252 silly gunzTarPerm extractEntry test/period/expected.stdout
253 silly gunzTarPerm extractEntry test/period/cmd
254 silly gunzTarPerm extractEntry test/period/input
255 silly gunzTarPerm extractEntry test/Makefile
256 silly gunzTarPerm extractEntry test/quiet/cmd
257 silly gunzTarPerm extractEntry test/quiet/expected.stdout
258 silly gunzTarPerm extractEntry test/quiet/input
259 silly gunzTarPerm extractEntry test/invalid-json/input
260 silly gunzTarPerm extractEntry test/invalid-json/cmd
261 silly gunzTarPerm extractEntry test/invalid-json/expected.exitCode
262 silly gunzTarPerm extractEntry test/json3/expected.stdout
263 silly gunzTarPerm extractEntry test/json3/cmd
264 silly gunzTarPerm extractEntry test/argv/README.md
265 silly gunzTarPerm extractEntry test/argv/expected.stdout
266 silly gunzTarPerm extractEntry test/argv/cmd
267 silly gunzTarPerm extractEntry test/argv/expected.stderr
268 silly gunzTarPerm extractEntry test/executable/cmd
269 silly gunzTarPerm extractEntry test/executable/expected.stdout
270 silly gunzTarPerm extractEntry test/flat-array-input/README.md
271 silly gunzTarPerm extractEntry test/flat-array-input/arrays-on-same-line-fail.input
272 silly gunzTarPerm extractEntry test/flat-array-input/arrays-complex.input
273 silly gunzTarPerm extractEntry test/flat-array-input/mixed-objects-and-arrays.input
274 silly gunzTarPerm extractEntry test/flat-array-input/arrays.input
275 silly gunzTarPerm extractEntry test/flat-array-input/arrays-on-same-line.input
276 silly gunzTarPerm extractEntry test/flat-array-input/objects-on-same-line-fail.input
277 silly gunzTarPerm extractEntry test/flat-array-input/dir/c.json
278 silly gunzTarPerm extractEntry test/flat-array-input/dir/b.json
279 silly gunzTarPerm extractEntry test/flat-array-input/dir/a.json
280 silly gunzTarPerm extractEntry test/flat-array-input/objects-on-same-line.input
281 silly gunzTarPerm extractEntry test/flat-array-input/expected.stdout
282 silly gunzTarPerm extractEntry test/flat-array-input/objects-complex.input
283 silly gunzTarPerm extractEntry test/flat-array-input/objects.input
284 silly gunzTarPerm extractEntry test/flat-array-input/cmd
285 silly gunzTarPerm extractEntry test/utf8/expected.stdout
286 silly gunzTarPerm extractEntry test/utf8/cmd
287 silly gunzTarPerm extractEntry test/utf8/input
288 silly gunzTarPerm extractEntry test/basic/input
289 silly gunzTarPerm extractEntry test/basic/expected.stdout
290 silly gunzTarPerm extractEntry test/basic/cmd
291 silly gunzTarPerm extractEntry test/multiargs/expected.stdout
292 silly gunzTarPerm extractEntry test/multiargs/cmd
293 silly gunzTarPerm extractEntry test/multiargs/input
294 silly gunzTarPerm extractEntry test/100-continue/input
295 silly gunzTarPerm extractEntry test/100-continue/cmd
296 silly gunzTarPerm extractEntry test/100-continue/expected.exitCode
297 silly gunzTarPerm extractEntry test/100-continue/expected.stdout
298 silly gunzTarPerm extractEntry test/lookups/expected.stderr
299 silly gunzTarPerm extractEntry test/lookups/cmd
300 silly gunzTarPerm extractEntry test/lookups/expected.stdout
301 silly gunzTarPerm extractEntry test/empty-lookup/input
302 silly gunzTarPerm extractEntry test/empty-lookup/cmd
303 silly gunzTarPerm extractEntry test/empty-lookup/expected.stdout
304 silly gunzTarPerm extractEntry test/conditionals/expected.stdout
305 silly gunzTarPerm extractEntry test/conditionals/cmd
306 silly gunzTarPerm extractEntry test/fickle-stdout/README.md
307 silly gunzTarPerm extractEntry test/fickle-stdout/expected.stderr
308 silly gunzTarPerm extractEntry test/fickle-stdout/input
309 silly gunzTarPerm extractEntry test/fickle-stdout/cmd
310 silly gunzTarPerm extractEntry test/fickle-stdout/expected.stdout
311 silly gunzTarPerm extractEntry test/hyphen/cmd
312 silly gunzTarPerm extractEntry test/hyphen/input
313 silly gunzTarPerm extractEntry test/hyphen/expected.stdout
314 silly gunzTarPerm extractEntry test/array-processing/cmd
315 silly gunzTarPerm extractEntry test/array-processing/expected.stdout
316 silly gunzTarPerm extractEntry test/array-missing-keys/cmd
317 silly gunzTarPerm extractEntry test/array-missing-keys/expected.stdout
318 silly gunzTarPerm extractEntry test/syntax-error/expected.stderr
319 silly gunzTarPerm extractEntry test/syntax-error/cmd
320 silly gunzTarPerm extractEntry test/syntax-error/input
321 silly gunzTarPerm extractEntry test/syntax-error/expected.stdout
322 silly gunzTarPerm extractEntry .gitmodules
323 silly gunzTarPerm extractEntry CHANGES.md
324 silly gunzTarPerm extractEntry TODO.md
325 verbose read json /root/tm/npm/tmp/2/a/node_modules/jsontool/package.json
326 info preinstall jsontool@3.2.0
327 verbose from cache /root/tm/npm/tmp/2/a/node_modules/jsontool/package.json
328 verbose readDependencies using package.json deps
329 verbose from cache /root/tm/npm/tmp/2/a/node_modules/jsontool/package.json
330 verbose readDependencies using package.json deps
331 verbose cache add [ 'jsontool@2.x', null ]
332 silly cache add name=undefined spec="jsontool@2.x" args=["jsontool@2.x",null]
333 verbose parsed url { pathname: 'jsontool@2.x',
333 verbose parsed url   path: 'jsontool@2.x',
333 verbose parsed url   href: 'jsontool@2.x' }
334 silly cache add name="jsontool" spec="2.x" args=["jsontool","2.x"]
335 verbose parsed url { pathname: '2.x', path: '2.x', href: '2.x' }
336 verbose addNamed [ 'jsontool', '2.x' ]
337 verbose addNamed [ null, '>=2.0.0- <3.0.0-' ]
338 silly addNameRange { name: 'jsontool', range: '>=2.0.0- <3.0.0-', hasData: false }
339 verbose url raw jsontool
340 verbose url resolving [ 'https://registry.npmjs.org/', './jsontool' ]
341 verbose url resolved https://registry.npmjs.org/jsontool
342 http GET https://registry.npmjs.org/jsontool
343 http 200 https://registry.npmjs.org/jsontool
344 silly registry.get cb [ 200,
344 silly registry.get   { vary: 'Accept',
344 silly registry.get     server: 'CouchDB/1.2.0 (Erlang OTP/R15B)',
344 silly registry.get     etag: '"2N5FHGUAR2MUZ8JEBNXOAO4DV"',
344 silly registry.get     date: 'Tue, 26 Jun 2012 23:43:26 GMT',
344 silly registry.get     'content-type': 'application/json',
344 silly registry.get     'content-length': '117990' } ]
345 silly addNameRange number 2 { name: 'jsontool', range: '>=2.0.0- <3.0.0-', hasData: true }
346 silly addNameRange versions [ 'jsontool',
346 silly addNameRange   [ '1.3.0',
346 silly addNameRange     '1.3.1',
346 silly addNameRange     '1.3.2',
346 silly addNameRange     '1.3.3',
346 silly addNameRange     '1.3.4',
346 silly addNameRange     '1.4.0',
346 silly addNameRange     '1.4.1',
346 silly addNameRange     '2.0.0',
346 silly addNameRange     '2.0.1',
346 silly addNameRange     '2.0.2',
346 silly addNameRange     '2.0.3',
346 silly addNameRange     '2.1.0',
346 silly addNameRange     '2.2.0',
346 silly addNameRange     '2.2.1',
346 silly addNameRange     '2.2.2',
346 silly addNameRange     '3.0.0',
346 silly addNameRange     '3.0.1',
346 silly addNameRange     '3.0.2',
346 silly addNameRange     '3.0.3',
346 silly addNameRange     '3.1.0',
346 silly addNameRange     '3.1.1',
346 silly addNameRange     '3.1.2',
346 silly addNameRange     '3.2.0' ] ]
347 verbose addRemoteTarball [ 'https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz',
347 verbose addRemoteTarball   '19d2a123a0408a12124d4a84f010c68bbb1f196c' ]
348 verbose fetch to= /root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/tmp.tgz
349 http GET https://registry.npmjs.org/jsontool/-/jsontool-2.2.2.tgz
350 silly shasum updated bytes 40960
351 silly shasum updated bytes 3629
352 info shasum 19d2a123a0408a12124d4a84f010c68bbb1f196c
352 info shasum /root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/tmp.tgz
353 verbose tar unpack /root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/tmp.tgz
354 silly gunzTarPerm modes [ '755', '644' ]
355 silly gunzTarPerm extractEntry package.json
356 silly gunzTarPerm extractEntry .npmignore
357 silly gunzTarPerm extractEntry README.md
358 silly gunzTarPerm extractEntry Makefile
359 silly gunzTarPerm extractEntry json.1.ronn
360 silly gunzTarPerm extractEntry lib/jsontool.js
361 silly gunzTarPerm extractEntry LICENSE.txt
362 silly gunzTarPerm extractEntry .gitmodules
363 silly gunzTarPerm extractEntry man/man1/json.1
364 silly gunzTarPerm extractEntry CHANGES.md
365 silly gunzTarPerm extractEntry deps/JSON-js/README
366 silly gunzTarPerm extractEntry deps/JSON-js/cycle.js
367 silly gunzTarPerm extractEntry deps/JSON-js/json.js
368 silly gunzTarPerm extractEntry deps/JSON-js/json2.js
369 silly gunzTarPerm extractEntry deps/JSON-js/json_parse.js
370 silly gunzTarPerm extractEntry deps/JSON-js/json_parse_state.js
371 silly gunzTarPerm extractEntry support/update_json_parse.js
372 silly gunzTarPerm extractEntry support/cutarelease.py
373 silly gunzTarPerm extractEntry test/test.js
374 silly gunzTarPerm extractEntry test/hyphen/cmd
375 silly gunzTarPerm extractEntry test/hyphen/expected.stdout
376 silly gunzTarPerm extractEntry test/hyphen/input
377 silly gunzTarPerm extractEntry test/array-missing-keys/cmd
378 silly gunzTarPerm extractEntry test/array-missing-keys/expected.stdout
379 silly gunzTarPerm extractEntry test/array-missing-keys/input
380 silly gunzTarPerm extractEntry test/array-processing/cmd
381 silly gunzTarPerm extractEntry test/array-processing/expected.stdout
382 silly gunzTarPerm extractEntry test/basic/cmd
383 silly gunzTarPerm extractEntry test/basic/expected.stdout
384 silly gunzTarPerm extractEntry test/basic/input
385 silly gunzTarPerm extractEntry test/empty-lookup/cmd
386 silly gunzTarPerm extractEntry test/empty-lookup/expected.stdout
387 silly gunzTarPerm extractEntry test/empty-lookup/input
388 silly gunzTarPerm extractEntry test/executable/cmd
389 silly gunzTarPerm extractEntry test/executable/expected.stdout
390 silly gunzTarPerm extractEntry test/fickle-stdout/README.md
391 silly gunzTarPerm extractEntry test/fickle-stdout/cmd
392 silly gunzTarPerm extractEntry test/fickle-stdout/expected.stderr
393 silly gunzTarPerm extractEntry test/fickle-stdout/expected.stdout
394 silly gunzTarPerm extractEntry test/fickle-stdout/input
395 silly gunzTarPerm extractEntry test/flat-array-input/README.md
396 silly gunzTarPerm extractEntry test/flat-array-input/arrays-complex.input
397 silly gunzTarPerm extractEntry test/flat-array-input/arrays-on-same-line.input
398 silly gunzTarPerm extractEntry test/flat-array-input/arrays.input
399 silly gunzTarPerm extractEntry test/flat-array-input/cmd
400 silly gunzTarPerm extractEntry test/flat-array-input/dir/a.json
401 silly gunzTarPerm extractEntry test/flat-array-input/dir/b.json
402 silly gunzTarPerm extractEntry test/flat-array-input/dir/c.json
403 silly gunzTarPerm extractEntry test/flat-array-input/arrays-on-same-line-fail.input
404 silly gunzTarPerm extractEntry test/flat-array-input/mixed-objects-and-arrays.input
405 silly gunzTarPerm extractEntry test/flat-array-input/objects-complex.input
406 silly gunzTarPerm extractEntry test/flat-array-input/objects-on-same-line-fail.input
407 silly gunzTarPerm extractEntry test/flat-array-input/objects-on-same-line.input
408 silly gunzTarPerm extractEntry test/flat-array-input/objects.input
409 silly gunzTarPerm extractEntry test/flat-array-input/expected.stdout
410 silly gunzTarPerm extractEntry test/argv/README.md
411 silly gunzTarPerm extractEntry test/argv/cmd
412 silly gunzTarPerm extractEntry test/argv/expected.stderr
413 silly gunzTarPerm extractEntry test/argv/expected.stdout
414 silly gunzTarPerm extractEntry test/invalid-json/cmd
415 silly gunzTarPerm extractEntry test/invalid-json/expected.exitCode
416 silly gunzTarPerm extractEntry test/invalid-json/input
417 silly gunzTarPerm extractEntry test/Makefile
418 silly gunzTarPerm extractEntry test/multiargs/cmd
419 silly gunzTarPerm extractEntry test/multiargs/expected.stdout
420 silly gunzTarPerm extractEntry test/multiargs/input
421 silly gunzTarPerm extractEntry test/period/cmd
422 silly gunzTarPerm extractEntry test/period/expected.stdout
423 silly gunzTarPerm extractEntry test/period/input
424 silly gunzTarPerm extractEntry test/quiet/cmd
425 silly gunzTarPerm extractEntry test/quiet/expected.stdout
426 silly gunzTarPerm extractEntry test/quiet/input
427 silly gunzTarPerm extractEntry test/syntax-error/cmd
428 silly gunzTarPerm extractEntry test/syntax-error/expected.stderr
429 silly gunzTarPerm extractEntry test/syntax-error/expected.stdout
430 silly gunzTarPerm extractEntry test/syntax-error/input
431 silly gunzTarPerm extractEntry test/100-continue/cmd
432 silly gunzTarPerm extractEntry test/100-continue/expected.exitCode
433 silly gunzTarPerm extractEntry test/100-continue/expected.stdout
434 silly gunzTarPerm extractEntry test/100-continue/input
435 silly gunzTarPerm extractEntry test/undefined/cmd
436 silly gunzTarPerm extractEntry test/undefined/expected.exitCode
437 silly gunzTarPerm extractEntry test/undefined/expected.stderr
438 silly gunzTarPerm extractEntry test/undefined/expected.stdout
439 silly gunzTarPerm extractEntry test/undefined/input
440 silly gunzTarPerm extractEntry test/utf8/cmd
441 silly gunzTarPerm extractEntry test/utf8/expected.stdout
442 silly gunzTarPerm extractEntry test/utf8/input
443 silly gunzTarPerm extractEntry TODO.md
444 verbose read json /root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json
445 verbose about to build /root/tm/npm/tmp/2/a/node_modules/jsontool
446 info /root/tm/npm/tmp/2/a/node_modules/jsontool unbuild
447 verbose from cache /root/tm/npm/tmp/2/a/node_modules/jsontool/package.json
448 info preuninstall jsontool@3.2.0
449 info uninstall jsontool@3.2.0
450 verbose true,/root/tm/npm/tmp/2/a/node_modules,/root/tm/npm/tmp/2/a/node_modules unbuild jsontool@3.2.0
451 verbose /root/tm/npm/tmp/2/a/node_modules/.bin,[object Object] binRoot
452 info postuninstall jsontool@3.2.0
453 error Error: ENOENT, open '/root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json'
453 error  { [Error: ENOENT, open '/root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json']
453 error   errno: 34,
453 error   code: 'ENOENT',
453 error   path: '/root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json' }
454 error You may report this log at:
454 error     <http://github.com/isaacs/npm/issues>
454 error or email it to:
454 error     <npm-@googlegroups.com>
455 error System SunOS 5.11
456 error command "node" "/root/tm/npm/cli.js" "--cache=/root/tm/npm/tmp/2/a/cache" "install" "jsontool@3.2.0"
457 error cwd /root/tm/npm/tmp/2/a
458 error node -v v0.6.19
459 error npm -v 1.1.32
460 error path /root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json
461 error code ENOENT
462 error message ENOENT, open '/root/tmp/npm-1340754203857/1340754207085-0.6197288541588932/package/package.json'
463 error errno 34
464 error 34 errno
465 verbose exit [ 34, true ]
```
