### PR TITLE
retry failed registry gets for more reliable 'npm install'

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -274,10 +274,10 @@ function add (args, cb) {
 }
 
 function fetchAndShaCheck (u, tmp, shasum, cb) {
-  fetch(u, tmp, function (er) {
+  fetch(u, tmp, function (er, response) {
     if (er) {
       log.error("fetch failed", u)
-      return cb(er)
+      return cb(er, response)
     }
     if (!shasum) return cb()
     // validate that the url we just downloaded matches the expected shasum.
@@ -323,8 +323,11 @@ function addRemoteTarball (u, shasum, name, cb_) {
       operation.attempt(function (currentAttempt) {
         log.info("retry", "fetch attempt " + currentAttempt
           + " at " + (new Date()).toLocaleTimeString())
-        fetchAndShaCheck(u, tmp, shasum, function (er) {
-          if (operation.retry(er)) {
+        fetchAndShaCheck(u, tmp, shasum, function (er, response) {
+          // Only retry on 408, 5xx or no `response`.
+          var statusCode = response && response.statusCode
+          var statusRetry = !statusCode || (statusCode === 408 || statusCode >= 500)
+          if (er && statusRetry && operation.retry(er)) {
             log.info("retry", "will retry, error on last attempt: " + er)
             return
           }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -75,6 +75,7 @@ var mkdir = require("mkdirp")
   , chownr = require("chownr")
   , lockFile = require("lockfile")
   , crypto = require("crypto")
+  , retry = require("retry")
 
 cache.usage = "npm cache add <tarball file>"
             + "\nnpm cache add <folder>"
@@ -272,6 +273,18 @@ function add (args, cb) {
   }
 }
 
+function fetchAndShaCheck (u, tmp, shasum, cb) {
+  fetch(u, tmp, function (er) {
+    if (er) {
+      log.error("fetch failed", u)
+      return cb(er)
+    }
+    if (!shasum) return cb()
+    // validate that the url we just downloaded matches the expected shasum.
+    sha.check(tmp, shasum, cb)
+  })
+}
+
 // Only have a single download action at once for a given url
 // additional calls stack the callbacks.
 var inFlightURLs = {}
@@ -299,14 +312,24 @@ function addRemoteTarball (u, shasum, name, cb_) {
     var tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
     mkdir(path.dirname(tmp), function (er) {
       if (er) return cb(er)
-      fetch(u, tmp, function (er) {
-        if (er) {
-          log.error("fetch failed", u)
-          return cb(er)
-        }
-        if (!shasum) return done()
-        // validate that the url we just downloaded matches the expected shasum.
-        sha.check(tmp, shasum, done)
+      // Tuned to spread 3 attempts over about a minute.
+      // See formula at <https://github.com/tim-kos/node-retry>.
+      var operation = retry.operation({
+        retries: 2,
+        factor: 10,
+        minTimeout: 10000,
+        maxTimeout: 60 * 1000
+      })
+      operation.attempt(function (currentAttempt) {
+        log.info("retry", "fetch attempt " + currentAttempt
+          + " at " + (new Date()).toLocaleTimeString())
+        fetchAndShaCheck(u, tmp, shasum, function (er) {
+          if (operation.retry(er)) {
+            log.info("retry", "will retry, error on last attempt: " + er)
+            return
+          }
+          done(er)
+        })
       })
     })
     function done (er) {

--- a/lib/utils/fetch.js
+++ b/lib/utils/fetch.js
@@ -25,17 +25,31 @@ function fetch (remote, local, headers, cb) {
 
 function fetch_ (remote, local, headers, cb) {
   var fstr = fs.createWriteStream(local, { mode : npm.modes.file })
+  var response = null
+  var calledback = false
   fstr.on("error", function (er) {
     fs.close(fstr.fd, function () {})
-    if (fstr._ERROR) return
+    if (calledback) return
+    calledback = true
     cb(fstr._ERROR = er)
   })
   fstr.on("open", function () {
-    makeRequest(remote, fstr, headers)
+    var req = makeRequest(remote, fstr, headers)
+    req.on("response", function (res) {
+      log.http(res.statusCode, remote)
+      response = res
+    })
   })
   fstr.on("close", function () {
-    if (fstr._ERROR) return
-    cb()
+    if (calledback) return
+    calledback = true
+    if (response && response.statusCode && response.statusCode >= 400) {
+      var er = new Error(response.statusCode + " "
+                        + require("http").STATUS_CODES[response.statusCode])
+      cb(fstr._ERROR = er, response)
+    } else {
+      cb(null, response)
+    }
   })
 }
 
@@ -64,8 +78,6 @@ function makeRequest (remote, fstr, headers) {
   req.on("error", function (er) {
     fstr.emit("error", er)
   })
-  req.on("response", function (res) {
-    log.http(res.statusCode, remote.href)
-  })
   req.pipe(fstr)
+  return req;
 }

--- a/node_modules/npm-registry-client/lib/request.js
+++ b/node_modules/npm-registry-client/lib/request.js
@@ -88,8 +88,11 @@ function regRequest (method, where, what, etag, nofollow, cb_) {
     self.log.info("retry", "registry request attempt " + currentAttempt
         + " at " + (new Date()).toLocaleTimeString())
     makeRequest.call(self, method, remote, where, what, etag, nofollow
-                     , function (er) {
-      if (operation.retry(er)) {
+                     , function (er, parsed, raw, response) {
+      // Only retry on 408, 5xx or no `response`.
+      var statusCode = response && response.statusCode
+      var statusRetry = !statusCode || (statusCode === 408 || statusCode >= 500)
+      if (er && statusRetry && operation.retry(er)) {
         self.log.info("retry", "will retry, error on last attempt: " + er)
         return
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "glob": "~3.1.9",
     "init-package-json": "0",
     "osenv": "0",
-    "lockfile": ">=0.2"
+    "lockfile": ">=0.2",
+    "retry": "~0.6.0"
   },
   "bundleDependencies": [
     "semver",


### PR DESCRIPTION
Retry up to 3 times in about a minute.

To test this I created https://github.com/trentm/npm-registry-proxy

```
# start the npm proxy that will (a) error twice for /:module and (b) once for /:module/-/:module-:version.tgz
cd /tmp
git clone https://github.com/trentm/npm-registry-proxy.git
cd npm-registry-proxy
node proxy.js
```

Then I tested against it like this:

```
mkdir -p /tmp/blah
cd /tmp/blah
touch package.json
rm -rf tmp/cache node_modules/bunyan && node ~/tm/npm/cli.js --loglevel=info --cache=`pwd`/tmp/cache --registry=http://localhost:8000/ install bunyan
```

Results:  https://gist.github.com/3008782

Isaac: Let's discuss if this looks good to you, then I can fix up this pull to do a separate PR against npm-registry-client for that part.  Also, how do you want the "retry" module dep added? Or do you want to handle that in separate commits?
