### PR TITLE
Handle general errors in `npm test`

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -6,6 +6,6 @@ var testCmd = require("./utils/lifecycle.js").cmd("test")
 function test (args, cb) {
   testCmd(args, function (er) {
     if (!er) return cb()
-    return cb("Test failed.  See above for more details.")
+    return cb(er.code ? "Test failed.  See above for more details." : er)
   })
 }

--- a/lib/utils/exec.js
+++ b/lib/utils/exec.js
@@ -53,11 +53,14 @@ function exec (cmd, args, env, takeOver, cwd, uid, gid, cb) {
   })
   cp.on("exit", function (code) {
     var er = null
-    if (code) er = new Error("`"+cmd
-                            +(args.length ? " "
-                                          + args.map(JSON.stringify).join(" ")
-                                          : "")
-                            +"` failed with "+code)
+    if (code) {
+      er = new Error("`"+cmd
+                    +(args.length ? " "
+                                  + args.map(JSON.stringify).join(" ")
+                                  : "")
+                    +"` failed with "+code)
+      er.code = code
+    }
     cb(er, code, stdout, stderr)
   })
   return cp


### PR DESCRIPTION
When creating a new package, I accidentally omitted required `version`
field in my `package.json`. `npm` only told me that test failed.
