### PR TITLE
Report more details in the unsupported engine version error

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -713,7 +713,10 @@ function checkEngine (target, cb) {
   if (nodev && eng.node && !semver.satisfies(nodev, eng.node)
       || eng.npm && !semver.satisfies(npmv, eng.npm)) {
     if (strict) {
-      var er = new Error("Unsupported")
+      var er = new Error("Unsupported node version " + nodev
+               + " (required: " + eng.node
+               + ") or npm version " + npmv
+               + " (required: " + eng.npm + ")")
       er.code = "ENOTSUP"
       er.required = eng
       er.pkgid = target._id


### PR DESCRIPTION
Hi!

I had an npm error when trying to install the express example using Nodejitsu "jitsu" utility.

The error was extremely unhelpful:

```
error:   Error running command install
error:   Unsupported
error:   Error: Unsupported
error:       at checkEngine (/usr/lib/node_modules/jitsu/node_modules/npm/lib/install.js:681:14)
error:       at Array.0 (/usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/bind-actor.js:15:8)
error:       at LOOP (/usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/chain.js:15:14)
error:       at chain (/usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/chain.js:20:5)
error:       at installOne_ (/usr/lib/node_modules/jitsu/node_modules/npm/lib/install.js:658:3)
error:       at installOne (/usr/lib/node_modules/jitsu/node_modules/npm/lib/install.js:584:3)
error:       at /usr/lib/node_modules/jitsu/node_modules/npm/lib/install.js:471:9
error:       at /usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/async-map.js:54:35
error:       at Array.forEach (native)
error:       at /usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/async-map.js:54:11
info:    Nodejitsu not ok
```

With my change, the error message is much more informative and I've immediately discovered that I were using too much of a cutting edge node version:

```
error:   Error running command install
error:   Unsupported node version 0.8.2 (required: >= 0.4.1 < 0.7.0) or npm version 1.1.16 (required: undefined)
error:   Error: Unsupported node version 0.8.2 (required: >= 0.4.1 < 0.7.0) or npm version 1.1.16 (required: undefined)
error:       at checkEngine (/usr/lib/node_modules/jitsu/node_modules/npm/lib/install.js:680:14)
error:       at Array.0 (/usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/bind-actor.js:15:8)
error:       at LOOP (/usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/chain.js:15:14)
error:       at chain (/usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/chain.js:20:5)
error:       at installOne_ (/usr/lib/node_modules/jitsu/node_modules/npm/lib/install.js:658:3)
error:       at installOne (/usr/lib/node_modules/jitsu/node_modules/npm/lib/install.js:584:3)
error:       at /usr/lib/node_modules/jitsu/node_modules/npm/lib/install.js:471:9
error:       at /usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/async-map.js:54:35
error:       at Array.forEach (native)
error:       at /usr/lib/node_modules/jitsu/node_modules/npm/node_modules/slide/lib/async-map.js:54:11
info:    Nodejitsu not ok
```
