### PR TITLE
Removed superfluous and erroneous node-gyp command replacement

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -86,14 +86,6 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
   if (packageLifecycle) {
     // define this here so it's available to all scripts.
     env.npm_lifecycle_script = pkg.scripts[stage]
-    // if the command is "node-gyp <args>", then call ours instead.
-    try {
-      var ourGyp = require.resolve("node-gyp/bin/node-gyp.js")
-    } catch (er) {
-      return cb(new Error("No gyp installed with npm"))
-    }
-    var gyp = path.execPath + " " + JSON.stringify(ourGyp)
-    pkg.scripts[stage] = pkg.scripts[stage].replace(/^node-gyp( |$)/, gyp)
   }
 
   if (failOk) {


### PR DESCRIPTION
`lib/utils/lifecycle.js` has a codeblock which is supposed to replace a package.json script call such as `node-gyp configure` with `path/to/node full/path/of/node-gyp configure`.

The original code:

``` js
env.npm_lifecycle_script = pkg.scripts[stage]
// if the command is "node-gyp <args>", then call ours instead.
try {
    var ourGyp = require.resolve("node-gyp/bin/node-gyp.js")
} catch (er) {
    return cb(new Error("No gyp installed with npm"))
}
var gyp = path.execPath + " " + JSON.stringify(ourGyp)
pkg.scripts[stage] = pkg.scripts[stage].replace(/^node-gyp( |$)/, gyp)
```

Two things seem to be off here:
- `env.npm_lifecycle_script`, which is what is actually being executed later, is assigned before the replacement.
- `path.execPath` is undefined. I'm guessing it should have been `process.execPath`.

Furthermore, this replacement doesn't seem to have any meaning in either case, as the PATH environment variable is updated a few lines up, favoring the locally bundled version of node-gyp prior to anything else. That means that a script referencing `node-gyp` should hit the right version anyhow.
