### PR TITLE
Replace node command in scripts with full path to the currently executing node binary

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -84,6 +84,8 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
   var packageLifecycle = pkg.scripts && pkg.scripts.hasOwnProperty(stage)
 
   if (packageLifecycle) {
+    // if the command is "node <args>", then point to the current executable instead.
+    pkg.scripts[stage] = pkg.scripts[stage].replace(/^node( |$)/, process.execPath + ' ')
     // define this here so it's available to all scripts.
     env.npm_lifecycle_script = pkg.scripts[stage]
     // if the command is "node-gyp <args>", then call ours instead.


### PR DESCRIPTION
For some platforms, build systems and broken package managers, etc., the `node` binary may not be available in the environment path. When executing `node foo` from a package.json script, it would be beneficial to have 'node' replaced with the full path of the currently executing node binary.
