### PR TITLE
WARN if npm-shrinkwrap.json is present

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -85,6 +85,11 @@ function install (args, cb_) {
   // the /path/to/node_modules/..
   var where = path.resolve(npm.dir, "..")
 
+  // output a message if shrinkwrap is present
+  if(path.resolve(where, "npm-shrinkwrap.json")) {
+    log.warn("install", "using npm-shrinkwrap.json");
+  }
+
   // internal api: install(where, what, cb)
   if (arguments.length === 3) {
     where = args
@@ -98,6 +103,8 @@ function install (args, cb_) {
       return path.resolve(a) !== where
     })
   }
+
+
 
   mkdir(where, function (er, made) {
     if (er) return cb(er)
@@ -213,7 +220,6 @@ function readDependencies (context, where, opts, cb) {
       } catch (ex) {
         return cb(ex)
       }
-
       log.info("shrinkwrap", "file %j", wrapfile)
       var rv = {}
       Object.keys(data).forEach(function (key) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -104,8 +104,6 @@ function install (args, cb_) {
     })
   }
 
-
-
   mkdir(where, function (er, made) {
     if (er) return cb(er)
     // install dependencies locally by default,
@@ -220,6 +218,7 @@ function readDependencies (context, where, opts, cb) {
       } catch (ex) {
         return cb(ex)
       }
+
       log.info("shrinkwrap", "file %j", wrapfile)
       var rv = {}
       Object.keys(data).forEach(function (key) {


### PR DESCRIPTION
This small patch outputs a warning if npm-shrinkwrap.json is present. This is generally useful for informing the user that the shrinkwrap file has been picked up. In particular it is useful for cloud providers which dump the console output and where the user may not know if shrinkwrap is supported.
