### PR TITLE
Do not ignore GIT_PROXY_COMMAND on install

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -414,7 +414,7 @@ function gitEnv () {
   if (gitEnv_) return gitEnv_
   gitEnv_ = {}
   for (var k in process.env) {
-    if (k.match(/^GIT/)) continue
+    if (!~['GIT_PROXY_COMMAND'].indexOf(k) && k.match(/^GIT/)) continue
     gitEnv_[k] = process.env[k]
   }
   return gitEnv_


### PR DESCRIPTION
That's just a small patch introducing a whitelist for ignored GIT environment variables.
I hardcoded it currently, tell me if you prefer another way of setting it.
