### PR TITLE
add the directory containing the `node` executable currently running to the PATH for lifestyle scripts

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -78,6 +78,10 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
   // the bundled one will be used for installing things.
   pathArr.unshift(path.join(__dirname, "..", "..", "bin", "node-gyp-bin"))
 
+  // add the directory containing the `node` executable currently running, so
+  // that any lifecycle script that invoke "node" will execute this same one.
+  pathArr.unshift(path.dirname(process.execPath))
+
   if (env[PATH]) pathArr.push(env[PATH])
   env[PATH] = pathArr.join(process.platform === "win32" ? ";" : ":")
 


### PR DESCRIPTION
Fixes #2680.
