### PR TITLE
Support Graceful Restarts

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -80,9 +80,8 @@ function runScript (args, cb) {
 function run (pkg, wd, cmd, cb) {
   var cmds = []
   if (!pkg.scripts) pkg.scripts = {}
-  if (cmd === "restart") {
+  if (!pkg.scripts.restart && cmd === "restart") {
     cmds = ["prestop","stop","poststop"
-           ,"restart"
            ,"prestart","start","poststart"]
   } else {
     cmds = [cmd]


### PR DESCRIPTION
isaacs/npm#1999

npm restart currently runs prestop, stop, poststop, restart, prestart, start, poststart.  According to the docs, and the original intention of the feature, a restart script should be able to be provided so the application can choose to restart their service gracefully (see isaacs/npm#184) instead of issueing a full stop/start.

```
Note: npm restart will run the stop and start scripts if no restart script is provided.
```

A full stop/start should only happen if a restart script is not provided.
