### PR TITLE
Set https-proxy to http by default in "utils/fetch.js"

### DIFF
--- a/lib/utils/fetch.js
+++ b/lib/utils/fetch.js
@@ -65,9 +65,10 @@ function makeRequest (remote, fstr, headers) {
       "Auth required and none provided. Please run 'npm adduser'"))
   }
 
-  var proxy = npm.config.get( remote.protocol === "https:"
-                            ? "https-proxy"
-                            : "proxy")
+  var proxy 
+  if (remote.protocol !== "https:" || !(proxy = npm.config.get("https-proxy"))) {
+    proxy = npm.config.get("proxy")
+  }
 
   var opts = { url: remote
              , proxy: proxy


### PR DESCRIPTION
When I set "proxy" property in config, but does not set "https-proxy", I have this error:

npm http GET https://registry.npmjs.org/wordwrap
npm http 200 https://registry.npmjs.org/wordwrap
npm http GET https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz
npm ERR! fetch failed https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz 

with this exception:
{ [Error: connect ENETUNREACH] code: 'ENETUNREACH', errno: 'ENETUNREACH', syscal
l: 'connect' }

I find in "utils/fetch.js" that that for HTTPS protocol by default does not use "proxy" property, and this cause error.

P.S. Sorry for my English :)  
