### PR TITLE
Improved error message when runScript command is omitted

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -67,6 +67,7 @@ runScript.completion = function (opts, cb) {
 }
 
 function runScript (args, cb) {
+  if (!args.length) return cb(runScript.usage)
   var pkgdir = args.length === 1 ? process.cwd()
              : path.resolve(npm.dir, args[0])
     , cmd = args.pop()


### PR DESCRIPTION
This addresses the ugly error message seen in #2757, using the same check and usage response as other commands such as _star_.
