### PR TITLE
Fix EPIPE workaround for Darwin

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -145,10 +145,19 @@ function completion (args, cb) {
   cb()
 }
 
-function dumpScript (cb) {
+function dumpScript (cb_) {
   var fs = require("graceful-fs")
     , path = require("path")
     , p = path.resolve(__dirname, "utils/completion.sh")
+
+  // The Darwin patch below results in callbacks first for the write and then
+  // for the error handler, so make sure we only call our callback once.
+  var cbCalled = false
+  function cb (er) {
+    if (cbCalled) return
+    cbCalled = true
+    cb_.apply(null, arguments)
+  }
 
   fs.readFile(p, "utf8", function (er, d) {
     if (er) return cb(er)
@@ -166,7 +175,7 @@ function dumpScript (cb) {
       // Really, one should not be tossing away EPIPE errors, or any
       // errors, so casually.  But, without this, `. <(npm completion)`
       // can never ever work on OS X.
-      if (er.errno === require("constants").EPIPE) er = null
+      if (er.errno === "EPIPE") er = null
       cb(er)
     })
 


### PR DESCRIPTION
The current workaround for the EPIPE error on Darwin, when running `. <(npm completion)`, does not work because the errno that comes back from Node is actually a string, rather than the numeric error code it's being compared against. This patch fixes that test.

With the test fixed, there's another error, because we call our callback twice. The first time is when we get called back from write(), and the second when we process the EPIPE error. Thus the patch includes code to ensure that we only call our callback once.
