### PR TITLE
Windows path fix

### DIFF
--- a/bin/node-gyp-bin/node-gyp.cmd
+++ b/bin/node-gyp-bin/node-gyp.cmd
@@ -1,1 +1,1 @@
-node "%~dp0\..\..\node_modules\node-gyp\bin\node-gyp.js" %*
+node "%~dp0..\..\node_modules\node-gyp\bin\node-gyp.js" %*

--- a/bin/npm.cmd
+++ b/bin/npm.cmd
@@ -1,6 +1,6 @@
 :: Created by npm, please don't edit manually.
-@IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
+@IF EXIST "%~dp0node.exe" (
+  "%~dp0node.exe" "%~dp0node_modules\npm\bin\npm-cli.js" %*
 ) ELSE (
-  node "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
+  node "%~dp0node_modules\npm\bin\npm-cli.js" %*
 )

--- a/lib/utils/cmd-shim.js
+++ b/lib/utils/cmd-shim.js
@@ -67,22 +67,22 @@ function writeShim_ (from, to, prog, args, cb) {
   shTarget = shTarget.split("\\").join("/")
   args = args || ""
   if (!prog) {
-    prog = "\"%~dp0\\" + target + "\""
+    prog = "\"%~dp0" + target + "\""
     shProg = "\"$basedir/" + shTarget + "\""
     args = ""
     target = ""
     shTarget = ""
   } else {
-    longProg = "\"%~dp0\\" + prog + ".exe\""
+    longProg = "\"%~dp0" + prog + ".exe\""
     shLongProg = "\"$basedir/" + prog + "\""
-    target = "\"%~dp0\\" + target + "\""
+    target = "\"%~dp0" + target + "\""
     shTarget = "\"$basedir/" + shTarget + "\""
   }
 
-  // @IF EXIST "%~dp0\node.exe" (
-  //   "%~dp0\node.exe" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
+  // @IF EXIST "%~dp0node.exe" (
+  //   "%~dp0node.exe" "%~dp0node_modules\npm\bin\npm-cli.js" %*
   // ) ELSE (
-  //   node "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
+  //   node "%~dp0node_modules\npm\bin\npm-cli.js" %*
   // )
   var cmd
   if (longProg) {

--- a/node_modules/node-gyp/legacy/tools/gyp/gyp.bat
+++ b/node_modules/node-gyp/legacy/tools/gyp/gyp.bat
@@ -2,4 +2,4 @@
 @rem Use of this source code is governed by a BSD-style license that can be
 @rem found in the LICENSE file.
 
-@python "%~dp0/gyp" %*
+@python "%~dp0gyp" %*

--- a/node_modules/node-gyp/legacy/tools/gyp/samples/samples.bat
+++ b/node_modules/node-gyp/legacy/tools/gyp/samples/samples.bat
@@ -2,4 +2,4 @@
 @rem Use of this source code is governed by a BSD-style license that can be
 @rem found in the LICENSE file.
 
-@python %~dp0/samples %*
+@python %~dp0samples %*


### PR DESCRIPTION
`%~dp0` already ends with a backslash. So, for instance, we should have `"%~dp0node.exe"` instead of `"%~dp0\node.exe"`
