### PR TITLE
Windows command echoing

### DIFF
--- a/lib/utils/cmd-shim.js
+++ b/lib/utils/cmd-shim.js
@@ -92,7 +92,7 @@ function writeShim_ (from, to, prog, args, cb) {
         + "  " + prog + " " + args + " " + target + " %*\r\n"
         + ")"
   } else {
-    cmd = prog + " " + args + " " + target + " %*\r\n"
+    cmd = "@" + prog + " " + args + " " + target + " %*\r\n"
   }
 
   cmd = ":: Created by npm, please don't edit manually.\r\n" + cmd


### PR DESCRIPTION
Avoid echoing command on the cli by adding a preceding "@" (when no shebang is defined)

Adresses #2915
