### PR TITLE
Add GIT_SSH to list of environment variables to copy

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -414,7 +414,7 @@ function gitEnv () {
   if (gitEnv_) return gitEnv_
   gitEnv_ = {}
   for (var k in process.env) {
-    if (!~['GIT_PROXY_COMMAND'].indexOf(k) && k.match(/^GIT/)) continue
+    if (!~['GIT_PROXY_COMMAND','GIT_SSH'].indexOf(k) && k.match(/^GIT/)) continue
     gitEnv_[k] = process.env[k]
   }
   return gitEnv_


### PR DESCRIPTION
Allows for the `GIT_SSH` environment variable to be passed along to git for use by `git+ssh` resources.
#3008
