### PR TITLE
Add file:// support

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -261,6 +261,8 @@ function add (args, cb) {
     case "git+ssh:":
       //p.protocol = p.protocol.replace(/^git([^:])/, "$1")
       return addRemoteGit(spec, p, name, cb)
+    case "file:":
+      return addLocal(p.path, cb)
     default:
       // if we have a name and a spec, then try name@spec
       // if not, then try just spec (which may try name@"" if not found)


### PR DESCRIPTION
I wanted to be able to `npm install file:///Users/gregp/code/connect` and use a similar construction in my `package.json`.

This patch assumes that the cache.js addLocal function (https://github.com/gregrperkins/npm/blob/master/lib/cache.js#L629-664) will handle strings like `/c:/example/path.js` properly, since the windows file uri scheme should look like `file:///c:/example/path.js` per http://en.wikipedia.org/wiki/File_URI_scheme#Windows .
