### PR TITLE
Make postpublish script to be run on cwd.

### DIFF
--- a/doc/cli/scripts.md
+++ b/doc/cli/scripts.md
@@ -9,8 +9,10 @@ following scripts:
 * prepublish:
   Run BEFORE the package is published.  (Also run on local `npm
   install` without any arguments.)
-* publish, postpublish:
-  Run AFTER the package is published.
+* publish:
+  Run AFTER the package is published on a directory which contains cached copy of directory from which `npm publish` was run.
+* postpublish
+  Run AFTER the package is published on a directory from which `npm publish` was run.
 * preinstall:
   Run BEFORE the package is installed
 * install, postinstall:

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -42,8 +42,8 @@ function publish (args, isRetry, cb) {
   })
 }
 
-function cacheAddPublish (arg, didPre, isRetry, cb) {
-  npm.commands.cache.add(arg, function (er, data) {
+function cacheAddPublish (dir, didPre, isRetry, cb) {
+  npm.commands.cache.add(dir, function (er, data) {
     if (er) return cb(er)
     log.silly("publish", data)
     var cachedir = path.resolve( npm.cache
@@ -52,9 +52,9 @@ function cacheAddPublish (arg, didPre, isRetry, cb) {
                                , "package" )
     chain
       ( [ !didPre && [lifecycle, data, "prepublish", cachedir]
-        , [publish_, arg, data, isRetry, cachedir]
+        , [publish_, dir, data, isRetry, cachedir]
         , [lifecycle, data, "publish", cachedir]
-        , [lifecycle, data, "postpublish", cachedir] ]
+        , [lifecycle, data, "postpublish", dir] ]
       , cb )
   })
 }


### PR DESCRIPTION
1. Having `publish` and `postpublish` identical is not very cool.
2. Having both of them executed on CACHED directory is absolutely not cool and useless.

Use case: CoffeeScript compilation.
1. I don’t want to store CoffeeScript-compiled JS output in repository.
2. I want compiled js to be published on NPM (with `prepublish` script).
3. I want users of git (pre-release) version of my package to be able to have coffeescript automatically compiled even though I don’t want to store coffee output in repo.
4. I don’t want `postinstall` to be executed for npm users because it’s buggy and stuff.

How:
1. `npm prepublish`: compile coffee, remove `scripts.postinstall` from `package.json`.
2. `npm postpublish`: bring back `scripts.postinstall` to `package.json`.
3. `npm postinstall`: compile coffee (only done for git users).

Used in https://github.com/paulmillr/chokidar.

Closes gh-2550, gh-2315.
