### PR TITLE
Configurable number of spaces for indent

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -314,7 +314,7 @@ function save (where, installed, tree, pretty, cb) {
       }
     })
 
-    data = JSON.stringify(data, null, 2) + "\n"
+    data = JSON.stringify(data, null, npm.config.get('indent') || 2) + "\n"
     fs.writeFile(saveTarget, data, function (er) {
       cb(er, installed, tree, pretty)
     })
@@ -350,7 +350,7 @@ function prettify (tree, installed) {
        return o
     })
 
-    return JSON.stringify(tree, null, 2)
+    return JSON.stringify(tree, null, npm.config.get('indent') || 2)
   }
   if (npm.config.get("parseable")) return parseable(installed)
 
@@ -891,7 +891,7 @@ function write (target, targetFolder, context, cb_) {
         , null, null, user, group ]
       , [ fs, "writeFile"
         , path.resolve(targetFolder, "package.json")
-        , JSON.stringify(target, null, 2) + "\n" ]
+        , JSON.stringify(target, null, npm.config.get('indent') || 2) + "\n" ]
       , [ lifecycle, target, "preinstall", targetFolder ]
       , function (cb) {
           if (!target.bundleDependencies) return cb()

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -30,7 +30,7 @@ function shrinkwrap_ (pkginfo, silent, cb) {
                        +pkginfo.problems.join("\n")))
   }
   try {
-    var swdata = JSON.stringify(pkginfo, null, 2) + "\n"
+    var swdata = JSON.stringify(pkginfo, null, npm.config.get('indent') || 2) + "\n"
   } catch (er) {
     log.error("shrinkwrap", "Error converting package info to json")
     return cb(er)

--- a/lib/uninstall.js
+++ b/lib/uninstall.js
@@ -120,7 +120,7 @@ function saver (args, nm, cb_) {
         }
       }
 
-      fs.writeFile(pj, JSON.stringify(pkg, null, 2) + "\n", function (er) {
+      fs.writeFile(pj, JSON.stringify(pkg, null, npm.config.get('indent') || 2) + "\n", function (er) {
         return cb_(er, data)
       })
     })

--- a/lib/version.js
+++ b/lib/version.js
@@ -100,6 +100,6 @@ function checkGit (data, cb) {
 
 function write (data, cb) {
   fs.writeFile( path.join(process.cwd(), "package.json")
-              , new Buffer(JSON.stringify(data, null, 2) + "\n")
+              , new Buffer(JSON.stringify(data, null, npm.config.get('indent') || 2) + "\n")
               , cb )
 }

--- a/lib/view.js
+++ b/lib/view.js
@@ -191,7 +191,7 @@ function printData (data, name, cb) {
       if (showVersions || showFields || typeof d !== "string") {
         d = cleanup(data[v][f])
         d = npm.config.get("json")
-          ? JSON.stringify(d, null, 2)
+          ? JSON.stringify(d, null, npm.config.get('indent') || 2)
           : util.inspect(d, false, 5, npm.color)
       } else if (typeof d === "string" && npm.config.get("json")) {
         d = JSON.stringify(d)


### PR DESCRIPTION
I'm a big fan of `npm install --save` but tend to use 4 spaces for indenting (whereas npm uses 2).  I added a config option (`indent`) which allows this to be changed.  If this is something you're interested in merging into npm I'll submit another pull request to npmconf setting the default `indent` value to 2 (and eliminate all the `npm.config.get('indent') || 2` here).
