### PR TITLE
Added ENOTDIR check to install.js->targetResolver

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -139,7 +139,7 @@ function read (name, ver, forceBypass, cb) {
   }
 
   readJson(jsonFile, function (er, data) {
-    if (er && er.code !== "ENOENT") return cb(er)
+    if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     if (er) return addNamed(name, ver, c)
     deprCheck(data)
     c(er, data)
@@ -712,7 +712,7 @@ function addNameVersion (name, ver, data, cb) {
       if (!er) readJson( path.join( npm.cache, name, ver
                                   , "package", "package.json" )
                        , function (er, data) {
-          if (er && er.code !== "ENOENT") return cb(er)
+          if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
           if (er) return fetchit()
           return cb(null, data)
         })

--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -265,7 +265,7 @@ function readInstalled (dir, counter, parent, cb) {
   })
 
   readJson(path.resolve(dir, "package.json"), function (er, data) {
-    if (er && er.code !== "ENOENT") return cb(er)
+    if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     if (er) return cb() // not a package, probably.
     counter[data.name] = counter[data.name] || 0
     counter[data.name]++

--- a/lib/install.js
+++ b/lib/install.js
@@ -148,7 +148,7 @@ function install (args, cb_) {
     // initial "family" is the name:version of the root, if it's got
     // a package.json file.
     readJson(path.resolve(where, "package.json"), function (er, data) {
-      if (er && er.code !== "ENOENT") return cb(er)
+      if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
       if (er) data = null
       var context = { family: {}
                     , ancestors: {}
@@ -456,7 +456,7 @@ function installManyTop_ (what, where, context, cb) {
       return path.resolve(nm, p, "package.json")
     }), function (jsonfile, cb) {
       readJson(jsonfile, function (er, data) {
-        if (er && er.code !== "ENOENT") return cb(er)
+        if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
         if (er) return cb(null, [])
         return cb(null, [[data.name, data.version]])
       })
@@ -657,7 +657,7 @@ function localLink (target, where, context, cb) {
     , parent = context.parent
 
   readJson(jsonFile, function (er, data) {
-    if (er && er.code !== "ENOENT") return cb(er)
+    if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     if (er || data._id === target._id) {
       if (er) {
         install( path.resolve(npm.globalDir, "..")

--- a/lib/install.js
+++ b/lib/install.js
@@ -538,7 +538,7 @@ function targetResolver (where, context, deps) {
     if (er) return alreadyInstalledManually = []
     asyncMap(inst, function (pkg, cb) {
       readJson(path.resolve(nm, pkg, "package.json"), function (er, d) {
-        if (er && er.code !== "ENOENT") return cb(er)
+        if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
         // error means it's not a package, most likely.
         if (er) return cb(null, [])
 

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -76,7 +76,7 @@ function outdated_ (args, dir, parentHas, cb) {
 
   var deps = null
   readJson(path.resolve(dir, "package.json"), function (er, d) {
-    if (er && er.code !== "ENOENT") return cb(er)
+    if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     deps = (er) ? true : (d.dependencies || {})
     return next()
   })
@@ -90,7 +90,7 @@ function outdated_ (args, dir, parentHas, cb) {
     asyncMap(pkgs, function (pkg, cb) {
       var jsonFile = path.resolve(dir, "node_modules", pkg, "package.json")
       readJson(jsonFile, function (er, d) {
-        if (er && er.code !== "ENOENT") return cb(er)
+        if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
         cb(null, er ? [] : [[d.name, d.version]])
       })
     }, function (er, pvs) {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -32,7 +32,7 @@ function publish (args, isRetry, cb) {
   var arg = args[0]
   // if it's a local folder, then run the prepublish there, first.
   readJson(path.resolve(arg, "package.json"), function (er, data) {
-    if (er && er.code !== "ENOENT") return cb(er)
+    if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     // error is ok.  could be publishing a url or tarball
     // however, that means that we will not have automatically run
     // the prepublish script, since that gets run when adding a folder

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -25,7 +25,7 @@ runScript.completion = function (opts, cb) {
     // or a package, in which case, complete against its scripts
     var json = path.join(npm.prefix, "package.json")
     return readJson(json, function (er, d) {
-      if (er && er.code !== "ENOENT") return cb(er)
+      if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
       if (er) d = {}
       var scripts = Object.keys(d.scripts || {})
       console.error("local scripts", scripts)
@@ -36,7 +36,7 @@ runScript.completion = function (opts, cb) {
       var pkgDir = path.resolve( pref, "node_modules"
                                , argv[2], "package.json" )
       readJson(pkgDir, function (er, d) {
-        if (er && er.code !== "ENOENT") return cb(er)
+        if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
         if (er) d = {}
         var scripts = Object.keys(d.scripts || {})
         return cb(null, scripts)
@@ -57,7 +57,7 @@ runScript.completion = function (opts, cb) {
 
   if (npm.config.get("global")) scripts = [], next()
   else readJson(path.join(npm.prefix, "package.json"), function (er, d) {
-    if (er && er.code !== "ENOENT") return cb(er)
+    if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     d = d || {}
     scripts = Object.keys(d.scripts || {})
     next()

--- a/lib/uninstall.js
+++ b/lib/uninstall.js
@@ -30,7 +30,7 @@ function uninstall (args, cb) {
   // remove this package from the global space, if it's installed there
   if (npm.config.get("global")) return cb(uninstall.usage)
   readJson(path.resolve(npm.prefix, "package.json"), function (er, pkg) {
-    if (er && er.code !== "ENOENT") return cb(er)
+    if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     if (er) return cb(uninstall.usage)
     uninstall_( [pkg.name]
               , npm.dir

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -56,7 +56,7 @@ function unpublish (args, cb) {
     // read the package name and version out of that.
     var cwdJson = path.join(process.cwd(), "package.json")
     return readJson(cwdJson, function (er, data) {
-      if (er && er.code !== "ENOENT") return cb(er)
+      if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
       if (er) return cb("Usage:\n"+unpublish.usage)
       gotProject(data.name, data.version, cb)
     })


### PR DESCRIPTION
We had a repo which shipped with a node_modules directory, and inside this directory was a .gitignore file.

This led to `npm install` attempting to install the .gitignore file as a package. This made npm hang, instead of erroring out, as there was no handling for ENOTDIR and the default error handler didn't act correctly. This bug was introduced in npm v.1.1.71, roughly in commit 00f781f6. (This is presumably also the issue shown in #3058)

This pull request adds an ENOTDIR check next to the ENOENT check, thus correctly handing any non-directory files that already exist in the node_modules directory.

There may need to be more checks for other places - or the problem may in fact be the error handler, not targetResolver.

Let me know if there's anything I can help with!
