### PR TITLE
Add platform and arch to the default user-agent

### DIFF
--- a/doc/cli/config.md
+++ b/doc/cli/config.md
@@ -398,7 +398,7 @@ A proxy to use for outgoing https requests.
 
 ### user-agent
 
-* Default: npm/{npm.version} node/{process.version}
+* Default: node/{process.version} {process.platform} {process.arch}
 * Type: String
 
 Sets a User-Agent to the request header

--- a/node_modules/npm-registry-client/README.md
+++ b/node_modules/npm-registry-client/README.md
@@ -37,7 +37,7 @@ also be accepted.
 * `strict-ssl` {Boolean} Whether or not to be strict with SSL
   certificates.  Default = `true`
 * `user-agent` {String} User agent header to send.  Default =
-  `"node/{process.version}"`
+  `"node/{process.version} {process.platform} {process.arch}"`
 * `log` {Object} The logger to use.  Defaults to `require("npmlog")` if
   that works, otherwise logs are disabled.
 * `fetch-retries` {Number} Number of times to retry on GET failures.

--- a/node_modules/npmconf/config-defs.js
+++ b/node_modules/npmconf/config-defs.js
@@ -227,6 +227,8 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , "https-proxy" : process.env.HTTPS_PROXY || process.env.https_proxy ||
                       process.env.HTTP_PROXY || process.env.http_proxy || null
     , "user-agent" : "node/" + process.version
+                     + ' ' + process.platform
+                     + ' ' + process.arch
     , "rebuild-bundle" : true
     , registry : "https://registry.npmjs.org/"
     , rollback : true


### PR DESCRIPTION
I also made the documentation consistent. For now, the "npm/{version}" value is not in the user-agent. I am not sure what is the best way to tell npmconf the version of npm.
