### PR TITLE
Multiple registry support (re: #1401)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -48,6 +48,12 @@ config.completion = function (opts, cb) {
 // npm config list
 function config (args, cb) {
   var action = args.shift()
+
+  // Config for registry can be whitespace separated, support that here by treating them as one 'value'
+  if (action=='set' && args[0] === 'registry' && args.length >2){
+    args = [args[0], args.slice(1, args.length).join(' ')]
+  }
+
   switch (action) {
     case "set": return set(args[0], args[1], cb)
     case "get": return get(args[0], cb)
@@ -129,11 +135,17 @@ function set (key, val, cb) {
 }
 
 function get (key, cb) {
+  debugger;
   if (!key) return list(cb)
   if (key.charAt(0) === "_") {
     return cb(new Error("---sekretz---"))
   }
-  console.log(npm.config.get(key))
+  var val = npm.config.get(key)
+  // TODO: Add support to npmconf for whitespace separated URls..
+  if (val && val.indexOf('%20')!==-1){
+    val = val.replace('%20', ' ')
+  }
+  console.log(val)
   cb()
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -48,6 +48,12 @@ config.completion = function (opts, cb) {
 // npm config list
 function config (args, cb) {
   var action = args.shift()
+
+  // Config for registry can be whitespace separated, support that here by treating them as one 'value'
+  if (action=='set' && args[0] === 'registry' && args.length >2){
+    args = [args[0], args.slice(1, args.length).join(' ')]
+  }
+
   switch (action) {
     case "set": return set(args[0], args[1], cb)
     case "get": return get(args[0], cb)
@@ -129,11 +135,17 @@ function set (key, val, cb) {
 }
 
 function get (key, cb) {
+  debugger;
   if (!key) return list(cb)
   if (key.charAt(0) === "_") {
     return cb(new Error("---sekretz---"))
   }
-  console.log(npm.config.get(key))
+  var val = npm.config.get(key)
+  // TODO: Add support to npmconf for whitespace separated URls..
+  if (val.indexOf('%20')!==-1){
+    val = val.replace('%20', ' ')
+  }
+  console.log(val)
   cb()
 }
 

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -313,7 +313,52 @@ function load (npm, cli, cb) {
         } catch (e) { token = null }
       }
 
-      npm.registry = new RegClient(npm.config)
+      // split registries here, then pass each new RegClient a registry, cache, log config
+      var registries = npm.config.get('registry')
+      registries = registries.split(/%20+| /)
+
+      // TODO: npm.registry should be a RegManager, which looks after an array of npm.registries
+      npm.registries = []
+      var r
+      for (var i=0; i<registries.length; i++){
+        r = registries[i],
+        npm.registries.push(new RegClient({
+          cache: npm.config.get('cache'),
+          log : npm.config.get('log'),
+          registry : r
+        }));
+      }
+      var idx = 0
+      // TODO: This should be automatic, for key in registry...
+      npm.registry = {
+        conf : npm.registries[idx].conf,
+        adduser : npm.registries[idx].adduser,
+        get : function(){
+          // First attempt at overriding get function - long term this
+          // may not be enough. Maybe, the whole NPM install|search|whatever
+          // command needs to be retried from scratch if it's falling back to
+          // another registry..
+          var args = arguments,
+          me = this,
+          i, _cb
+          // Pluck out the callback from the arguments & intercept it
+          for (i=0; i<arguments.length; i++){
+            if (typeof arguments[i] == 'function'){
+              _cb = arguments[i]
+              arguments[i] = function(err, data){
+                if (err){
+                  me.conf = npm.registries[++idx].conf
+                  npm.registries[++idx].get.apply(me, args)
+                }
+                return _cb(err, data)
+              }
+            }
+          }
+          npm.registries[idx].get.apply(this, arguments)
+        },
+        request : npm.registries[idx].request,
+        log : npm.registries[idx].log
+      }
 
       // save the token cookie in the config file
       if (npm.registry.couchLogin) {

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -346,11 +346,14 @@ function load (npm, cli, cb) {
             if (typeof arguments[i] == 'function'){
               _cb = arguments[i]
               arguments[i] = function(err, data){
-                if (err){
-                  me.conf = npm.registries[++idx].conf
-                  npm.registries[++idx].get.apply(me, args)
+                // If the error is 'just' a 404, and there are registries still left to try, let's try them
+                if (err && err.code && err.code === "E404" && ++idx<npm.registries.length){
+                  me = npm.registries[idx]
+                  return npm.registries[idx].get.apply(me, args)
+                }else{
+                  // Either we've succeeded, we're out of registries, or it's an error we can't deal with
+                  return _cb(err, data)
                 }
-                return _cb(err, data)
               }
             }
           }

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -30,6 +30,7 @@ var EventEmitter = require("events").EventEmitter
   , slide = require("slide")
   , chain = slide.chain
   , RegClient = require("npm-registry-client")
+  , RegManager = require('./registry-manager.js')
 
 npm.config = {loaded: false}
 
@@ -313,7 +314,21 @@ function load (npm, cli, cb) {
         } catch (e) { token = null }
       }
 
-      npm.registry = new RegClient(npm.config)
+      // split registries here, then pass each new RegClient a registry, cache, log config
+      var registries = npm.config.get('registry')
+      registries = registries.split(/%20+| /)
+
+      npm.registries = []
+      var r
+      for (var i=0; i<registries.length; i++){
+        r = registries[i],
+        npm.registries.push(new RegClient({
+          cache: npm.config.get('cache'),
+          log : npm.config.get('log'),
+          registry : r
+        }));
+      }
+      npm.registry = new RegManager(npm.registries)
 
       // save the token cookie in the config file
       if (npm.registry.couchLogin) {

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -30,6 +30,7 @@ var EventEmitter = require("events").EventEmitter
   , slide = require("slide")
   , chain = slide.chain
   , RegClient = require("npm-registry-client")
+  , RegManager = require('./registry-manager.js')
 
 npm.config = {loaded: false}
 
@@ -328,40 +329,7 @@ function load (npm, cli, cb) {
           registry : r
         }));
       }
-      var idx = 0
-      // TODO: This should be automatic, for key in registry...
-      npm.registry = {
-        conf : npm.registries[idx].conf,
-        adduser : npm.registries[idx].adduser,
-        get : function(){
-          // First attempt at overriding get function - long term this
-          // may not be enough. Maybe, the whole NPM install|search|whatever
-          // command needs to be retried from scratch if it's falling back to
-          // another registry..
-          var args = arguments,
-          me = this,
-          i, _cb
-          // Pluck out the callback from the arguments & intercept it
-          for (i=0; i<arguments.length; i++){
-            if (typeof arguments[i] == 'function'){
-              _cb = arguments[i]
-              arguments[i] = function(err, data){
-                // If the error is 'just' a 404, and there are registries still left to try, let's try them
-                if (err && err.code && err.code === "E404" && ++idx<npm.registries.length){
-                  me = npm.registries[idx]
-                  return npm.registries[idx].get.apply(me, args)
-                }else{
-                  // Either we've succeeded, we're out of registries, or it's an error we can't deal with
-                  return _cb(err, data)
-                }
-              }
-            }
-          }
-          npm.registries[idx].get.apply(this, arguments)
-        },
-        request : npm.registries[idx].request,
-        log : npm.registries[idx].log
-      }
+      npm.registry = new RegManager(npm.registries);
 
       // save the token cookie in the config file
       if (npm.registry.couchLogin) {

--- a/lib/registry-manager.js
+++ b/lib/registry-manager.js
@@ -10,12 +10,12 @@ function RegManager(registries) {
   }
 
   var idx = 0,
-  firstRegistry = registries[0],
+  primaryRegistry = registries[0],
   i;
 
-  for (var key in firstRegistry){
+  for (var key in primaryRegistry){
     // No .hasOwnProperty check - we want the prototype chain!
-    this[key] = firstRegistry[key];
+    this[key] = primaryRegistry[key];
   }
   this.get = function(){
     // First attempt at overriding get function - long term this
@@ -23,7 +23,6 @@ function RegManager(registries) {
     // command needs to be retried from scratch if it's falling back to
     // another registry..
     var args = arguments,
-    me = this,
     i, _cb
     // Pluck out the callback from the arguments & intercept it
     for (i=0; i<arguments.length; i++){
@@ -32,8 +31,7 @@ function RegManager(registries) {
         arguments[i] = function(err, data){
           // If the error is 'just' a 404, and there are registries still left to try, let's try them
           if (err && err.code && err.code === "E404" && ++idx<registries.length){
-            me = registries[idx]
-            return registries[idx].get.apply(me, args)
+            return registries[idx].get.apply(registries[idx], args);
           }else{
             // Either we've succeeded, we're out of registries, or it's an error we can't deal with
             return _cb(err, data)

--- a/lib/registry-manager.js
+++ b/lib/registry-manager.js
@@ -1,0 +1,46 @@
+
+// Registry manager - makes npm.registry's functions allow a retry
+
+module.exports = RegManager
+
+
+function RegManager(registries) {
+  if (!registries || registries.length<1){
+    throw new Error("No registries have been supplied to the registry manager")
+  }
+
+  var idx = 0,
+  firstRegistry = registries[0],
+  i;
+
+  for (var key in firstRegistry){
+    // No .hasOwnProperty check - we want the prototype chain!
+    this[key] = firstRegistry[key];
+  }
+  this.get = function(){
+    // First attempt at overriding get function - long term this
+    // may not be enough. Maybe, the whole NPM install|search|whatever
+    // command needs to be retried from scratch if it's falling back to
+    // another registry..
+    var args = arguments,
+    me = this,
+    i, _cb
+    // Pluck out the callback from the arguments & intercept it
+    for (i=0; i<arguments.length; i++){
+      if (typeof arguments[i] == 'function'){
+        _cb = arguments[i]
+        arguments[i] = function(err, data){
+          // If the error is 'just' a 404, and there are registries still left to try, let's try them
+          if (err && err.code && err.code === "E404" && ++idx<registries.length){
+            me = registries[idx]
+            return registries[idx].get.apply(me, args)
+          }else{
+            // Either we've succeeded, we're out of registries, or it's an error we can't deal with
+            return _cb(err, data)
+          }
+        }
+      }
+    }
+    registries[idx].get.apply(this, arguments)
+  }
+}

--- a/lib/registry-manager.js
+++ b/lib/registry-manager.js
@@ -1,0 +1,44 @@
+
+// Registry manager - makes npm.registry's functions allow a retry
+
+module.exports = RegManager
+
+
+function RegManager(registries) {
+  if (!registries || registries.length<1){
+    throw new Error("No registries have been supplied to the registry manager")
+  }
+
+  var idx = 0,
+  primaryRegistry = registries[0],
+  i;
+
+  for (var key in primaryRegistry){
+    // No .hasOwnProperty check - we want the prototype chain!
+    this[key] = primaryRegistry[key];
+  }
+  this.get = function(){
+    // First attempt at overriding get function - long term this
+    // may not be enough. Maybe, the whole NPM install|search|whatever
+    // command needs to be retried from scratch if it's falling back to
+    // another registry..
+    var args = arguments,
+    i, _cb
+    // Pluck out the callback from the arguments & intercept it
+    for (i=0; i<arguments.length; i++){
+      if (typeof arguments[i] == 'function'){
+        _cb = arguments[i]
+        arguments[i] = function(err, data){
+          // If the error is 'just' a 404, and there are registries still left to try, let's try them
+          if (err && err.code && err.code === "E404" && ++idx<registries.length){
+            return registries[idx].get.apply(registries[idx], args);
+          }else{
+            // Either we've succeeded, we're out of registries, or it's an error we can't deal with
+            return _cb(err, data)
+          }
+        }
+      }
+    }
+    registries[idx].get.apply(this, arguments)
+  }
+}


### PR DESCRIPTION
This is my attempt at #1401, allowing whitespace separated registries to be specified in NPM Client. Still to be done from the numbered list in #1401 is 3), 5), 6), 7) - I'm not sure what 4) means (~/.npm/ is cache folder, right? So should it support caching from both registries?)

This pull request I think solves the main issue I've been having, which is there's no way to have a private instance of the registry which just contains private dependencies and doesn't replicate the full registry.npmjs.org. This allows there to be a 'fallback registry'

Review, comments, etc welcome! 
