### PR TITLE
Fix installation issues due to lock race conditions

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1096,8 +1096,12 @@ function LockFile(path) {
 LockFile.prototype.unlock = function(cb) {
   var self = this
 
-  if (!this.locked)
-    return cb()
+  if (!this.locked) {
+    console.trace()
+    console.warn('LockFile.unlock() called twice for '+this.path)
+    if (cb) cb()
+    return
+  }
 
   lockFile.unlock(this.path, function(er) {
     self.locked = false

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -55,7 +55,6 @@ cache.read = read
 cache.clean = clean
 cache.unpack = unpack
 cache.lock = lock
-cache.unlock = unlock
 
 var mkdir = require("mkdirp")
   , exec = require("./utils/exec.js")
@@ -292,6 +291,8 @@ function fetchAndShaCheck (u, tmp, shasum, cb) {
 // additional calls stack the callbacks.
 var inFlightURLs = {}
 function addRemoteTarball (u, shasum, name, cb_) {
+  var lockFile
+
   if (typeof cb_ !== "function") cb_ = name, name = ""
   if (typeof cb_ !== "function") cb_ = shasum, shasum = null
 
@@ -305,17 +306,19 @@ function addRemoteTarball (u, shasum, name, cb_) {
       data._from = u
       data._resolved = u
     }
-    unlock(u, function () {
-      var c
-      while (c = iF.shift()) c(er, data)
-      delete inFlightURLs[u]
-    })
+    if (lockFile)
+      lockFile.unlock()
+    var c
+    while (c = iF.shift()) c(er, data)
+    delete inFlightURLs[u]
   }
 
   var tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
 
-  lock(u, function (er) {
+  lock(u, function (er, lo) {
     if (er) return cb(er)
+
+    lockFile = lo
 
     log.verbose("addRemoteTarball", [u, shasum])
     mkdir(path.dirname(tmp), function (er) {
@@ -364,23 +367,27 @@ function addRemoteTarball_(u, tmp, shasum, cb) {
 function addRemoteGit (u, parsed, name, cb_) {
   if (typeof cb_ !== "function") cb_ = name, name = null
 
+  var lockFile
+
   if (!inFlightURLs[u]) inFlightURLs[u] = []
   var iF = inFlightURLs[u]
   iF.push(cb_)
   if (iF.length > 1) return
 
   function cb (er, data) {
-    unlock(u, function () {
-      var c
-      while (c = iF.shift()) c(er, data)
-      delete inFlightURLs[u]
-    })
+    if (lockFile)
+      lockFile.unlock()
+    var c
+    while (c = iF.shift()) c(er, data)
+    delete inFlightURLs[u]
   }
 
   var p, co // cachePath, git-ref we want to check out
 
-  lock(u, function (er) {
+  lock(u, function (er, lo) {
     if (er) return cb(er)
+
+    lockFIle = lo
 
     // figure out what we should check out.
     var co = parsed.hash && parsed.hash.substr(1) || "master"
@@ -538,6 +545,8 @@ function addNamed (name, x, data, cb_) {
   if (typeof cb_ !== "function") cb_ = data, data = null
   log.verbose("addNamed", [name, x])
 
+  var lockFile
+
   var k = name + "@" + x
   if (!inFlightNames[k]) inFlightNames[k] = []
   var iF = inFlightNames[k]
@@ -546,16 +555,18 @@ function addNamed (name, x, data, cb_) {
 
   function cb (er, data) {
     if (data && !data._fromGithub) data._from = k
-    unlock(k, function () {
-      var c
-      while (c = iF.shift()) c(er, data)
-      delete inFlightNames[k]
-    })
+    if (lockFile)
+      lockFile.unlock()
+    var c
+    while (c = iF.shift()) c(er, data)
+    delete inFlightNames[k]
   }
 
   log.verbose("addNamed", [semver.valid(x), semver.validRange(x)])
-  lock(k, function (er, fd) {
+  lock(k, function (er, lo) {
     if (er) return cb(er)
+
+    lockFile = lo
 
     var fn = ( null !== semver.valid(x) ? addNameVersion
              : null !== semver.validRange(x) ? addNameRange
@@ -741,25 +752,30 @@ function addNameVersion (name, ver, data, cb) {
 function addLocal (p, name, cb_) {
   if (typeof cb_ !== "function") cb_ = name, name = ""
 
+  var lockFile
+
   function cb (er, data) {
-    unlock(p, function () {
-      if (er) {
-        // if it doesn't have a / in it, it might be a
-        // remote thing.
-        if (p.indexOf("/") === -1 && p.charAt(0) !== "."
-           && (process.platform !== "win32" || p.indexOf("\\") === -1)) {
-          return addNamed(p, "", cb_)
-        }
-        log.error("addLocal", "Could not install %s", p)
-        return cb_(er)
+    if (lockFile)
+      lockFile.unlock()
+    if (er) {
+      // if it doesn't have a / in it, it might be a
+      // remote thing.
+      if (p.indexOf("/") === -1 && p.charAt(0) !== "."
+         && (process.platform !== "win32" || p.indexOf("\\") === -1)) {
+        return addNamed(p, "", cb_)
       }
-      if (data && !data._fromGithub) data._from = p
-      return cb_(er, data)
-    })
+      log.error("addLocal", "Could not install %s", p)
+      return cb_(er)
+    }
+    if (data && !data._fromGithub) data._from = p
+    return cb_(er, data)
   }
 
-  lock(p, function (er) {
+  lock(p, function (er, lo) {
     if (er) return cb(er)
+
+    lockFile = lo
+
     // figure out if this is a folder or file.
     fs.stat(p, function (er, s) {
       if (er) {
@@ -902,28 +918,31 @@ function addPlacedTarball_ (p, name, uid, gid, cb) {
   // and fire cb with the json data.
   var target = path.dirname(p)
     , folder = path.join(target, "package")
+    , lockFile
 
-  lock(folder, function (er) {
+  lock(folder, function (er, lo) {
     if (er) return cb(er)
+    lockFile = lo
     rmUnpack()
   })
 
   function rmUnpack () {
     rm(folder, function (er) {
-      unlock(folder, function () {
-        if (er) {
-          log.error("addPlacedTarball", "Could not remove %j", folder)
-          return cb(er)
-        }
-        thenUnpack()
-      })
+      if (lockFile)
+        lockFile.unlock()
+      if (er) {
+        log.error("addPlacedTarball", "Could not remove %j", folder)
+        return cb(er)
+      }
+      thenUnpack()
     })
   }
 
   function thenUnpack () {
     tar.unpack(p, folder, null, null, uid, gid, function (er) {
       if (er) {
-        log.error("addPlacedTarball", "Could not unpack %j to %j", p, target)
+        log.error("addPlacedTarball", "Could not unpack %j to %j", p, target, er.stack)
+        console.log(er.stack)
         return cb(er)
       }
       // calculate the sha of the file that we just unpacked.
@@ -1070,6 +1089,22 @@ function lockFileName (u) {
   return path.resolve(npm.config.get("cache"), h + "-" + c + ".lock")
 }
 
+function LockFile(path) {
+  this.path = path
+  this.locked = true
+}
+LockFile.prototype.unlock = function(cb) {
+  var self = this
+
+  if (!this.locked)
+    return cb()
+
+  lockFile.unlock(this.path, function(er) {
+    self.locked = false
+    if (cb) cb(er)
+  })
+}
+
 var madeCache = false
 function lock (u, cb) {
   // the cache dir needs to exist already for this.
@@ -1085,10 +1120,10 @@ function lock (u, cb) {
                , wait: npm.config.get("cache-lock-wait") }
     var lf = lockFileName(u)
     log.verbose("lock", u, lf)
-    lockFile.lock(lf, opts, cb)
+    lockFile.lock(lf, opts, function(er) {
+      if (er) return cb(er)
+      return cb(null, new LockFile(lf))
+    })
   }
 }
 
-function unlock (u, cb) {
-  lockFile.unlock(lockFileName(u), cb)
-}

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -10,7 +10,6 @@ var npm = require("../npm.js")
   , readJson = require("read-package-json")
   , cache = require("../cache.js")
   , lock = cache.lock
-  , unlock = cache.unlock
   , myUid = process.getuid && process.getuid()
   , myGid = process.getgid && process.getgid()
   , tar = require("tar")
@@ -46,13 +45,16 @@ function pack (targetTarball, folder, pkg, dfc, cb) {
 }
 
 function pack_ (targetTarball, folder, pkg, cb_) {
+  var tbLock
+
   function cb (er) {
-    unlock(targetTarball, function () {
-      return cb_(er)
-    })
+    if (tbLock)
+      tbLock.unlock(function () {})
+    return cb_(er)
   }
-  lock(targetTarball, function (er) {
+  lock(targetTarball, function (er, lo) {
     if (er) return cb(er)
+    tbLock = lo
 
     new Packer({ path: folder, type: "Directory", isDirectory: true })
       .on("error", function (er) {
@@ -101,16 +103,28 @@ function unpack (tarball, unpackTarget, dMode, fMode, uid, gid, cb) {
 function unpack_ ( tarball, unpackTarget, dMode, fMode, uid, gid, cb_ ) {
   var parent = path.dirname(unpackTarget)
     , base = path.basename(unpackTarget)
+  var tarballLock
+    , targetLock
 
   function cb (er) {
-    unlock(unpackTarget, function () {
-      return cb_(er)
-    })
+    if (tarballLock)
+      tarballLock.unlock(function() {})
+  
+    if (targetLock)
+      targetLock.unlock(function() {})
+
+    return cb_(er)
   }
 
-  lock(unpackTarget, function (er) {
+  lock(tarball, function (er, lo) {
     if (er) return cb(er)
-    rmGunz()
+    tarballLock = lo
+
+    lock(unpackTarget, function (er, lo) {
+      if (er) return cb(er)
+      targetLock = lo
+      rmGunz()
+    })
   })
 
   function rmGunz () {


### PR DESCRIPTION
- add lock() on the tarball in unpack()
- use lockfile from https://github.com/isaacs/lockfile/pull/1
- use only the LockObjects from lock() to unlock() locks
- check whether we got locks in callbacks

This fixes issues with tar pack() and unpack(), where npm would simultaneously start packing and unpacking a tarball, resulting in a corrupted tar to get unpacked, finally crashing npm when it tried to readJson(). I believe this fix will also fix many of the ELIFECYCLE et al issues, where the workaround was simply to rerun npm install.
