### PR TITLE
Fix documentation for default prefix

### DIFF
--- a/doc/cli/config.md
+++ b/doc/cli/config.md
@@ -357,10 +357,10 @@ Operates in "global" mode, so that packages are installed into the
 `prefix` folder instead of the current working directory.  See
 `npm-folders(1)` for more on the differences in behavior.
 
-* packages are installed into the `prefix/node_modules` folder, instead of the
+* packages are installed into the `{prefix}/node_modules` folder, instead of the
   current working directory.
-* bin files are linked to `prefix/bin`
-* man pages are linked to `prefix/share/man`
+* bin files are linked to `{prefix}/bin`
+* man pages are linked to `{prefix}/share/man`
 
 ### globalconfig
 
@@ -568,7 +568,7 @@ standard output.
 
 ### prefix
 
-* Default: node's process.installPrefix
+* Default: see npm-folders(1)
 * Type: path
 
 The location to install global items.  If set on the command line, then


### PR DESCRIPTION
The documentation as it stands says the default for `prefix` is process.installPrefix, a variable that doesn't even exist today. The "prefix Configuration" section of folders(1) does a pretty good job of explaining it, so I've kicked the explanation over to that.
