### PR TITLE
Fix bug in prettyWhere calculation

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -714,7 +714,7 @@ function resultList (target, where, parentId) {
 function installOne_ (target, where, context, cb) {
   var nm = path.resolve(where, "node_modules")
     , targetFolder = path.resolve(nm, target.name)
-    , prettyWhere = path.relative(process.cwd, where)
+    , prettyWhere = path.relative(process.cwd(), where)
     , parent = context.parent
 
   if (prettyWhere === ".") prettyWhere = null


### PR DESCRIPTION
It was using `process.cwd`, not `process.cwd()`.
