### PR TITLE
Fix tap tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   ],
   "devDependencies": {
     "ronn": "~0.3.6",
-    "tap": "~0.2.5"
+    "tap": "~0.4.0"
   },
   "engines": {
     "node": ">=0.6",

--- a/test/tap/false_name.js
+++ b/test/tap/false_name.js
@@ -4,6 +4,7 @@ var test = require("tap").test
   , existsSync = fs.existsSync || path.existsSync
   , spawn = require("child_process").spawn
   , npm = require("../../")
+  , rimraf = require("rimraf")
 
 test("not every pkg.name can be required", function (t) {
   t.plan(1)
@@ -20,10 +21,8 @@ test("not every pkg.name can be required", function (t) {
 function setup (cb) {
   process.chdir(__dirname + "/false_name")
   npm.load(function () {
-    spawn("rm", [ "-rf", __dirname + "/false_name/node_modules" ])
-      .on("exit", function () {
-        fs.mkdirSync(__dirname + "/false_name/node_modules")
-        cb()
-      })
+    rimraf.sync(__dirname + "/false_name/node_modules")
+    fs.mkdirSync(__dirname + "/false_name/node_modules")
+    cb()
   })
 }


### PR DESCRIPTION
Before they would always be 0/1 tests, and a failure. Now they work as intended.
