### PR TITLE
Fix "npm ls"-using tests on Windows.

### DIFF
--- a/test/packages/npm-test-peer-deps-invalid/test.js
+++ b/test/packages/npm-test-peer-deps-invalid/test.js
@@ -7,7 +7,7 @@ delete process.env.npm_config_depth
 
 var npm = process.env.npm_execpath
 
-require("child_process").exec(npm + " ls --json", {
+require("child_process").execFile(process.execPath, [npm, "ls", "--json"], {
     env: process.env, cwd: process.cwd() },
     function (err, stdout, stderr) {
 

--- a/test/packages/npm-test-peer-deps/test.js
+++ b/test/packages/npm-test-peer-deps/test.js
@@ -7,7 +7,7 @@ delete process.env.npm_config_depth
 
 var npm = process.env.npm_execpath
 
-require("child_process").exec(npm + " ls --json", {
+require("child_process").execFile(process.execPath, [npm, "ls", "--json"], {
     env: process.env, cwd: process.cwd() },
     function (err, stdout, stderr) {
 

--- a/test/packages/npm-test-shrinkwrap/test.js
+++ b/test/packages/npm-test-shrinkwrap/test.js
@@ -7,7 +7,7 @@ delete process.env.npm_config_depth
 
 var npm = process.env.npm_execpath
 
-require("child_process").exec(npm + " ls --json", {
+require("child_process").execFile(process.execPath, [npm, "ls", "--json"], {
     stdio: "pipe", env: process.env, cwd: process.cwd() },
     function (err, stdout, stderr) {
   if (err) throw err


### PR DESCRIPTION
exec doesn't work well when there are spaces in the path, like in the default installs of Node.js on Windows into Program Files.
