### PR TITLE
Avoid trying to simultaneously install invalid peer dependencies.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -711,6 +711,13 @@ function resultList (target, where, parentId) {
          , target._from ]
 }
 
+var installOnesInProgress = Object.create(null); // name => install locations
+
+function isIncompatibleInstallOneInProgress(target, where) {
+  return target.name in installOnesInProgress &&
+         installOnesInProgress[target.name].indexOf(where) !== -1
+}
+
 function installOne_ (target, where, context, cb) {
   var nm = path.resolve(where, "node_modules")
     , targetFolder = path.resolve(nm, target.name)
@@ -719,6 +726,20 @@ function installOne_ (target, where, context, cb) {
 
   if (prettyWhere === ".") prettyWhere = null
 
+  if (isIncompatibleInstallOneInProgress(target, where)) {
+    var prettyTarget = path.relative(process.cwd(), targetFolder)
+
+    // just call back, with no error; the error will be detected in the final
+    // check for peer-invalid dependencies
+    return cb()
+  }
+
+  if (!(target.name in installOnesInProgress)) {
+    installOnesInProgress[target.name] = []
+  }
+  installOnesInProgress[target.name].push(where)
+  var indexOfIOIP = installOnesInProgress[target.name].length - 1
+
   chain
     ( [ [checkEngine, target]
       , [checkPlatform, target]
@@ -726,7 +747,10 @@ function installOne_ (target, where, context, cb) {
       , [checkGit, targetFolder]
       , [write, target, targetFolder, context] ]
     , function (er, d) {
+        installOnesInProgress[target.name].splice(indexOfIOIP, 1)
+
         if (er) return cb(er)
+
         d.push(resultList(target, where, parent && parent._id))
         cb(er, d)
       }


### PR DESCRIPTION
Helps fix #3079: now an error will _never_ be thrown, instead of the confusing ENOTEMPTY/ENOENT shitstorm that we saw in #3047.

It remains to make an error _always_ be thrown, but this is a good first step. We should never try to install a package twice, concurrently, into the same place, even when there are conflicting peer dependencies.
