### PR TITLE
Convert Unix paths to Windows paths for scripts if platform is win32

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -1,4 +1,3 @@
-
 exports = module.exports = lifecycle
 exports.cmd = cmd
 
@@ -94,6 +93,11 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
   if (packageLifecycle) {
     // define this here so it's available to all scripts.
     env.npm_lifecycle_script = pkg.scripts[stage]
+
+    if (process.platform === "win32") {
+      // change / to \\
+      env.npm_lifecycle_script = env.npm_lifecycle_script.replace(/\//g, '\\');
+    }
   }
 
   if (failOk) {


### PR DESCRIPTION
I was having problems running a script defined in package.json on a Windows box.  This is a quick change to allow `npm run-script` to use scripts defined with Unix paths, by changing  '/' to '\' in the script command.
