### PR TITLE
Use registry auth for fetching tarball.

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -733,7 +733,11 @@ function addNameVersion (name, ver, data, cb) {
       // use the same protocol as the registry.
       // https registry --> https tarballs.
       var tb = url.parse(dist.tarball)
-      tb.protocol = url.parse(npm.config.get("registry")).protocol
+        , registry = url.parse(npm.config.get("registry"))
+      tb.protocol = registry.protocol
+      if (registry.auth) {
+        tb.auth = registry.auth
+      }
       delete tb.href
       tb = url.format(tb)
       // only add non-shasum'ed packages if --forced.


### PR DESCRIPTION
When I use npm with a private registry where the registry is secured, i.e. registry config has authentication details like this in .npmrc:
    registry = http://user:pass@host:5984/registry/_design/app/_rewrite

npm request the module doc using the above registry config (with auth info), but the auth info is then ignored while fetching the tarball:
npm http GET http://user:pass@host:5984/registry/_design/app/_rewrite/inflection
npm http 200 http://user:pass@host:5984/registry/_design/app/_rewrite/inflection
npm http 401 http://host:5984/registry/_design/app/_rewrite/inflection/-/inflection-1.2.5.tgz
npm ERR! fetch failed http://host:5984/registry/_design/app/_rewrite/inflection/-/inflection-1.2.5.tgz

This patch passes the auth info to the tarball url. Here's the log after the fix:
npm http GET http://user:pass@host:5984/registry/_design/app/_rewrite/inflection/-/inflection-1.2.5.tgz
npm http 200 http://user:pass@host:5984/registry/_design/app/_rewrite/inflection/-/inflection-1.2.5.tgz
