### PR TITLE
Create symlink if dependency has preferred name different than package name

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -796,6 +796,7 @@ function maybeGithub (p, name, er, cb) {
     if (er2) return cb(er)
     data._from = u
     data._fromGithub = true
+    data._preferredName = name;
     return cb(null, data)
   })
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -776,6 +776,7 @@ function installOne_ (target, where, context, cb) {
     , targetFolder = path.resolve(nm, target.name)
     , prettyWhere = path.relative(process.cwd(), where)
     , parent = context.parent
+    , targetSymlink = target._preferredName && path.resolve(nm, target._preferredName)
 
   if (prettyWhere === ".") prettyWhere = null
 
@@ -798,7 +799,8 @@ function installOne_ (target, where, context, cb) {
       , [checkPlatform, target]
       , [checkCycle, target, context.ancestors]
       , [checkGit, targetFolder]
-      , [write, target, targetFolder, context] ]
+      , [write, target, targetFolder, context]
+      , [symlink, targetFolder, targetSymlink] ]
     , function (er, d) {
         installOnesInProgress[target.name].splice(indexOfIOIP, 1)
 
@@ -1023,6 +1025,12 @@ function write (target, targetFolder, context, cb_) {
         chain(actions, cb)
       })
     })
+}
+
+function symlink (targetFolder, targetSymlink, cb) {
+  if(!targetSymlink || targetFolder === targetSymlink) return cb()
+
+  fs.symlink(targetFolder, targetSymlink, cb)
 }
 
 function installManyAndBuild (deps, targetFolder, context, cb) {


### PR DESCRIPTION
This commit allows us have packages compatible with Component, solves Issue #3144.

The commit creates a symlink if package.json defines a dependency with a preferred name different than the NPM package name, like following;

``` json
"dependencies": {
  "foo": "azer/foo"
}
```

When the NPM registry name of the project located at  github.com/azer/foo is not foo:

``` json
{
  "name": "azer-foo-component"
}
```
