### PR TITLE
set permissions after git clone, fix #3117

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -408,7 +408,34 @@ function addRemoteGit (u, parsed, name, cb_) {
 
     p = path.join(npm.config.get("cache"), "_git-remotes", v)
 
-    checkGitDir(p, u, co, origUrl, cb)
+    checkGitDir(p, u, co, origUrl, function(er, data) {
+      chmodr(p, npm.modes.file, function(erChmod) {
+        if (er) return cb(er, data)
+        return cb(erChmod, data)
+      })
+    })
+  })
+}
+
+function chmodr(p, mode, cb) {
+  fs.chmod(p, mode, function(er) {
+    if (er) return cb(er)
+    fs.readdir(p, function(er, kids) {
+      if (er) return cb(er)
+      function next(er) {
+        if (er) return cb(er)
+        var kid = kids.shift()
+        if (!kid) return cb()
+        var kidPath = path.join(p, kid)
+        fs.stat(kidPath, function(er, stat) {
+          if (er) return cb(er)
+          if (stat.isDirectory())
+            return chmodr(kidPath, mode, next)
+          fs.chmod(kidPath, mode, next)
+        })
+      }
+      next()
+    })
   })
 }
 


### PR DESCRIPTION
This fixes 'npm cache clear' issues on Windows 7 that are due to git clone writing files marked as read only. You can reproduce this by using git: urls that get cloned in the cache folder.
