### PR TITLE
Add docs for license entry in package.json

### DIFF
--- a/doc/cli/json.md
+++ b/doc/cli/json.md
@@ -118,6 +118,27 @@ you can specify the value for "bugs" as a simple string instead of an object.
 
 If a url is provided, it will be used by the `npm bugs` command.
 
+## license
+
+You should specify a license for your package so that people know how they are
+permitted to use it, and any restrictions you're placing on it.
+
+The simplest way, assuming you're using a common license such as BSD or MIT, is
+to just specify the name of the license you're using, like this:
+
+    { "license" : "BSD" }
+
+If you have more complex licensing terms, or you want to provide more detail
+in your package.json file, you can use the more verbose plural form, like this:
+
+    "licenses" : [
+      { "type" : "MyLicense"
+      , "url" : "http://github.com/user/repo/path/to/license"
+      }
+    ]
+
+It's also a good idea to include a license file at the top level in your repo.
+
 ## people fields: author, contributors
 
 The "author" is one person.  "contributors" is an array of people.  A "person"


### PR DESCRIPTION
The `license` entry is commonly used in package.json but currently isn't documented. Add docs for the simple form and also the more complex form for people who may have more complex needs.
