### PR TITLE
Fix spawn error handling in exec util

### DIFF
--- a/lib/utils/exec.js
+++ b/lib/utils/exec.js
@@ -45,14 +45,14 @@ function exec (cmd, args, env, takeOver, cwd, uid, gid, cb) {
   var stdout = ""
     , stderr = ""
     , cp = spawn(cmd, args, env, takeOver, cwd, uid, gid)
-    , onclose
   cp.stdout && cp.stdout.on("data", function (chunk) {
     if (chunk) stdout += chunk
   })
   cp.stderr && cp.stderr.on("data", function (chunk) {
     if (chunk) stderr += chunk
   })
-  cp.on("close", onclose = function (code) {
+
+  function onclose (code) {
     var er = null
     if (code) er = new Error("`"+cmd
                             +(args.length ? " "
@@ -60,7 +60,8 @@ function exec (cmd, args, env, takeOver, cwd, uid, gid, cb) {
                                           : "")
                             +"` failed with "+code)
     cb(er, code, stdout, stderr)
-  })
+  }
+  cp.on("close", onclose);
   cp.on("error", function (err) {
     onclose(err.code || "UNKNOWN_SPAWN_ERROR");
   })

--- a/lib/utils/exec.js
+++ b/lib/utils/exec.js
@@ -45,13 +45,14 @@ function exec (cmd, args, env, takeOver, cwd, uid, gid, cb) {
   var stdout = ""
     , stderr = ""
     , cp = spawn(cmd, args, env, takeOver, cwd, uid, gid)
+    , onclose
   cp.stdout && cp.stdout.on("data", function (chunk) {
     if (chunk) stdout += chunk
   })
   cp.stderr && cp.stderr.on("data", function (chunk) {
     if (chunk) stderr += chunk
   })
-  cp.on("close", function (code) {
+  cp.on("close", onclose = function (code) {
     var er = null
     if (code) er = new Error("`"+cmd
                             +(args.length ? " "
@@ -59,6 +60,9 @@ function exec (cmd, args, env, takeOver, cwd, uid, gid, cb) {
                                           : "")
                             +"` failed with "+code)
     cb(er, code, stdout, stderr)
+  })
+  cp.on("error", function (err) {
+    onclose(err.code || "UNKNOWN_SPAWN_ERROR");
   })
   return cp
 }


### PR DESCRIPTION
It appears that eventual errors coming from `child_process.spawn` are not handled within _utils/exec.js_. In some scenarios it causes immediate crashes

This mishandling is a source of #3243 issue. After this patch is applied, compilation with Node v0.10.0 goes fine as it was with Node v0.8.22.
