### PR TITLE
Less package json change

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -29,10 +29,13 @@ function version (args, silent, cb_) {
       })
       v.npm = npm.version
       var hasTrailingNewline = (/\n\n$/).test(data)
+      var indent = data.toString('utf8').match(/^[ \t]+/m)
+      var indentSize = indent ? indent[0] : 2
       try {
         data = JSON.parse(data.toString())
         data.format = {
-          hasTrailingNewline: hasTrailingNewline
+          hasTrailingNewline: hasTrailingNewline,
+          indent: indentSize
         }
       } catch (er) {
         data = null
@@ -105,8 +108,9 @@ function checkGit (data, cb) {
 function write (data, cb) {
   if (!data.format) { data.format = {} }
   var endingNewlines = data.format.hasTrailingNewline ? "\n\n" : "\n"
+  var indent = data.format.indent || 2
   delete data.format
   fs.writeFile( path.join(process.cwd(), "package.json")
-              , new Buffer(JSON.stringify(data, null, 2) + endingNewlines)
+              , new Buffer(JSON.stringify(data, null, indent) + endingNewlines)
               , cb )
 }

--- a/lib/version.js
+++ b/lib/version.js
@@ -28,8 +28,12 @@ function version (args, silent, cb_) {
         v[k] = process.versions[k]
       })
       v.npm = npm.version
+      var hasTrailingNewline = (/\n\n$/).test(data)
       try {
         data = JSON.parse(data.toString())
+        data.format = {
+          hasTrailingNewline: hasTrailingNewline
+        }
       } catch (er) {
         data = null
       }
@@ -99,7 +103,10 @@ function checkGit (data, cb) {
 }
 
 function write (data, cb) {
+  if (!data.format) { data.format = {} }
+  var endingNewlines = data.format.hasTrailingNewline ? "\n\n" : "\n"
+  delete data.format
   fs.writeFile( path.join(process.cwd(), "package.json")
-              , new Buffer(JSON.stringify(data, null, 2) + "\n")
+              , new Buffer(JSON.stringify(data, null, 2) + endingNewlines)
               , cb )
 }


### PR DESCRIPTION
`npm version` changes my entire package.json file by stripping trailing newlines, as well as reindenting it with 2 spaces. This change preserves the trailing newline as well as the original "tabs or N spaces" indentation.
