### PR TITLE
make cmd-shim a separate package

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -16,7 +16,7 @@ var npm = require("./npm.js")
   , readJson = require("read-package-json")
   , link = require("./utils/link.js")
   , linkIfExists = link.ifExists
-  , cmdShim = require("./utils/cmd-shim.js")
+  , cmdShim = require("cmd-shim")
   , cmdShimIfExists = cmdShim.ifExists
   , asyncMap = require("slide").asyncMap
 

--- a/node_modules/cmd-shim/.npmignore
+++ b/node_modules/cmd-shim/.npmignore
@@ -1,0 +1,16 @@
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+
+pids
+logs
+results
+
+npm-debug.log
+
+node_modules

--- a/node_modules/cmd-shim/README.md
+++ b/node_modules/cmd-shim/README.md
@@ -1,0 +1,47 @@
+# cmd-shim
+
+The cmd-shim used in npm.  Currently npm has this code inlined.  It wasn not originally written by me; I simply copied it from the npm repository.
+
+## Installation
+
+```
+npm install cmd-shim
+```
+
+## API
+
+### cmdShim(from, to, cb)
+
+Create a cmd shim at `to` for the command line program at `from`.  e.g.
+
+```javascript
+var cmdShim = require('cmd-shim');
+cmdShim(__dirname + '/cli.js', '/usr/bin/command-name', function (err) {
+  if (err) throw err;
+});
+```
+
+### cmdShim.ifExists(from, to, cb)
+
+The same as above, but will just continue if the file does not exist.  Source:
+
+```javascript
+function cmdShimIfExists (from, to, cb) {
+  fs.stat(from, function (er) {
+    if (er) return cb()
+    cmdShim(from, to, cb)
+  })
+}
+```
+
+## Logging
+
+By default, [npmlog](https://npmjs.org/package/npmlog) is used for logging.  Log messages are written by default if it fails to write to the output directory.  You can disable the logging by calling:
+
+```javascript
+require('npmlog').level('silent');
+```
+
+## License
+
+MIT

--- a/node_modules/cmd-shim/index.js
+++ b/node_modules/cmd-shim/index.js
@@ -18,7 +18,6 @@ var fs = require("graceful-fs")
   , rm = require("rimraf")
   , log = require("npmlog")
   , path = require("path")
-  , npm = require("../npm.js")
   , shebangExpr = /^#\!\s*(?:\/usr\/bin\/env)?\s*([^ \t]+)(.*)$/
 
 function cmdShimIfExists (from, to, cb) {

--- a/node_modules/cmd-shim/package.json
+++ b/node_modules/cmd-shim/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "cmd-shim",
+  "version": "1.0.0",
+  "description": "Used in npm for command line application support",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ForbesLindesay/cmd-shim.git"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "graceful-fs": "~1.2.0",
+    "rimraf": "2",
+    "mkdirp": "~0.3.3",
+    "slide": "1",
+    "npmlog": "0"
+  },
+  "readme": "# cmd-shim\r\n\r\nThe cmd-shim used in npm.  Currently npm has this code inlined.  It wasn not originally written by me; I simply copied it from the npm repository.\r\n\r\n## Installation\r\n\r\n```\r\nnpm install cmd-shim\r\n```\r\n\r\n## API\r\n\r\n### cmdShim(from, to, cb)\r\n\r\nCreate a cmd shim at `to` for the command line program at `from`.  e.g.\r\n\r\n```javascript\r\nvar cmdShim = require('cmd-shim');\r\ncmdShim(__dirname + '/cli.js', '/usr/bin/command-name', function (err) {\r\n  if (err) throw err;\r\n});\r\n```\r\n\r\n### cmdShim.ifExists(from, to, cb)\r\n\r\nThe same as above, but will just continue if the file does not exist.  Source:\r\n\r\n```javascript\r\nfunction cmdShimIfExists (from, to, cb) {\r\n  fs.stat(from, function (er) {\r\n    if (er) return cb()\r\n    cmdShim(from, to, cb)\r\n  })\r\n}\r\n```\r\n\r\n## Logging\r\n\r\nBy default, [npmlog](https://npmjs.org/package/npmlog) is used for logging.  Log messages are written by default if it fails to write to the output directory.  You can disable the logging by calling:\r\n\r\n```javascript\r\nrequire('npmlog').level('silent');\r\n```\r\n\r\n## License\r\n\r\nMIT",
+  "readmeFilename": "README.md",
+  "_id": "cmd-shim@1.0.0",
+  "_from": "cmd-shim@~1.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "once": "~1.1.1",
     "npmconf": "0",
     "opener": "~1.3.0",
-    "chmodr": "~0.1.0"
+    "chmodr": "~0.1.0",
+    "cmd-shim": "~1.0.0"
   },
   "bundleDependencies": [
     "semver",
@@ -107,7 +108,8 @@
     "once",
     "npmconf",
     "opener",
-    "chmodr"
+    "chmodr",
+    "cmd-shim"
   ],
   "devDependencies": {
     "ronn": "~0.3.6",


### PR DESCRIPTION
I've separated cmd-shim so it's a [separate package](https://github.com/ForbesLindesay/cmd-shim).  I'm happy to change the license/add @isaacs as a maintainer etc. if that makes this easier to merge.
