### PR TITLE
Update documentation to reflect the commands used when opening a browser

### DIFF
--- a/doc/cli/bugs.md
+++ b/doc/cli/bugs.md
@@ -15,7 +15,7 @@ config param.
 
 ### browser
 
-* Default: OS X: `"open"`, others: `"google-chrome"`
+* Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 * Type: String
 
 The browser that is called by the `npm bugs` command to open websites.

--- a/doc/cli/config.md
+++ b/doc/cli/config.md
@@ -185,7 +185,7 @@ ostensibly Unix systems.
 
 ### browser
 
-* Default: OS X: `"open"`, others: `"google-chrome"`
+* Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 * Type: String
 
 The browser that is called by the `npm docs` command to open websites.

--- a/doc/cli/docs.md
+++ b/doc/cli/docs.md
@@ -16,7 +16,7 @@ config param.
 
 ### browser
 
-* Default: OS X: `"open"`, others: `"google-chrome"`
+* Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 * Type: String
 
 The browser that is called by the `npm docs` command to open websites.


### PR DESCRIPTION
Since we started using the `opener` module we no longer just use `google-chrome`.

/cc @domenic @isaacs
