### PR TITLE
Add ability to change 'v' prefix when tagging with `npm version`

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -60,18 +60,17 @@ function version (args, silent, cb_) {
 
     fs.stat(path.join(process.cwd(), ".git"), function (er, s) {
       function cb (er) {
-        if (!er && !silent) console.log("v" + newVer)
         cb_(er)
       }
 
       var doGit = !er && s.isDirectory()
       if (!doGit) return write(data, cb)
-      else checkGit(data, cb)
+      else checkGit(data, silent, cb)
     })
   })
 }
 
-function checkGit (data, cb) {
+function checkGit (data, silent, cb) {
   exec( npm.config.get("git"), ["status", "--porcelain"], process.env, false
       , function (er, code, stdout, stderr) {
     var lines = stdout.trim().split("\n").filter(function (line) {
@@ -86,13 +85,25 @@ function checkGit (data, cb) {
       var message = npm.config.get("message").replace(/%s/g, data.version)
         , sign = npm.config.get("sign-git-tag")
         , flag = sign ? "-sm" : "-am"
+        // 1: --version-prefix=""
+        // 2: --version-prefix
+        // 3: --version-prefix="<something>"
+        // 4: versionPrefix: ""
+        // 5: versionPrefix: "<something>"
+        // 6: "v"
+        , newVer = ((npm.config.get("version-prefix") === 0 // 1
+                   || npm.config.get("version-prefix") === true /* 2 */) ? ""
+                   : npm.config.get("version-prefix") // 3
+                   || (data.versionPrefix === "" /* 4 */ ? ""
+                   : data.versionPrefix /* 5 */ || "v" /* 6 */)) + data.version
+      if (!silent) console.log(newVer)
       chain
         ( [ [ exec, npm.config.get("git")
             , ["add","package.json"], process.env, false ]
           , [ exec, npm.config.get("git")
             , ["commit", "-m", message ], process.env, false ]
           , [ exec, npm.config.get("git")
-            , ["tag", "v"+data.version, flag, message], process.env, false ] ]
+            , ["tag", newVer, flag, message], process.env, false ] ]
         , cb )
     })
   })

--- a/lib/version.js
+++ b/lib/version.js
@@ -52,9 +52,9 @@ function version (args, silent, cb_) {
       return cb_(er)
     }
 
-		var newVer = semver.valid(args[0])
-		if (!newVer) newVer = semver.inc(data.version, args[0])
-		if (!newVer) return cb_(version.usage)
+    var newVer = semver.valid(args[0])
+    if (!newVer) newVer = semver.inc(data.version, args[0])
+    if (!newVer) return cb_(version.usage)
     if (data.version === newVer) return cb_(new Error("Version not changed"))
     data.version = newVer
 


### PR DESCRIPTION
Currently, `npm version <semver>` (or its variants) increases package's version, `git commit`, and then `git tag` it as `v{version}`. Although, some projects (eg. [jquery](https://github.com/jquery/jquery), or [backbone](https://github.com/documentcloud/backbone)) don't use the `v{version}` pattern to tag its releases. This change allows one to customize the "v" prefix as described below.

In the command line:

```
$ npm version <semver> --version-prefix="<prefix>"
```

In the `packages.json`:

```
  versionPrefix: "<prefix>"
```

Although this is not a critical issue (or not even an issue at all), it would be a good thing to have.
