### PR TITLE
cache: handle git-submodules in git-dependencies

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -364,9 +364,9 @@ function addRemoteTarball_(u, tmp, shasum, cb) {
 // 2. checkGitDir(cacheDir) ? 4. : 3. (rm cacheDir if necessary)
 // 3. git clone u cacheDir
 // 4. git fetch -a origin (cwd: cacheDir)
-// 7. git checkout <git-ref> (cwd: cacheDir)
-// 8. git submodule update --init --recursive (cwd: cacheDir)
-// 9. addLocalDirectory(cacheDir)
+// 5. git checkout <git-ref> (cwd: cacheDir)
+// 6. git submodule update --init --recursive (cwd: cacheDir)
+// 7. addLocalDirectory(cacheDir)
 function addRemoteGit (u, parsed, name, cb_) {
   if (typeof cb_ !== "function") cb_ = name, name = null
 
@@ -390,6 +390,7 @@ function addRemoteGit (u, parsed, name, cb_) {
 
     // figure out what we should check out.
     var co = parsed.hash && parsed.hash.substr(1) || "master"
+    co = "origin/"+co
     // git is so tricky!
     // if the path is like ssh://foo:22/some/path then it works, but
     // it needs the ssh://

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -362,10 +362,11 @@ function addRemoteTarball_(u, tmp, shasum, cb) {
 
 // 1. cacheDir = path.join(cache,'_git-remotes',sha1(u))
 // 2. checkGitDir(cacheDir) ? 4. : 3. (rm cacheDir if necessary)
-// 3. git clone --mirror u cacheDir
-// 4. cd cacheDir && git fetch -a origin
-// 5. git archive /tmp/random.tgz
-// 6. addLocalTarball(/tmp/random.tgz) <gitref> --format=tar --prefix=package/
+// 3. git clone u cacheDir
+// 4. git fetch -a origin (cwd: cacheDir)
+// 7. git checkout <git-ref> (cwd: cacheDir)
+// 8. git submodule update --init --recursive (cwd: cacheDir)
+// 9. addLocalDirectory(cacheDir)
 function addRemoteGit (u, parsed, name, cb_) {
   if (typeof cb_ !== "function") cb_ = name, name = null
 
@@ -435,7 +436,7 @@ function checkGitDir (p, u, co, origUrl, cb) {
       stdoutTrimmed = (stdout + "\n" + stderr).trim()
       if (er || u !== stdout.trim()) {
         log.warn( "`git config --get remote.origin.url` returned "
-                + "wrong result ("+u+")", stdoutTrimmed )
+                + "wrong result (" + u + ")", stdoutTrimmed )
         return rm(p, function (er){
           if (er) return cb(er)
           cloneGitRemote(p, u, co, origUrl, cb)
@@ -450,7 +451,8 @@ function checkGitDir (p, u, co, origUrl, cb) {
 function cloneGitRemote (p, u, co, origUrl, cb) {
   mkdir(p, function (er) {
     if (er) return cb(er)
-    exec( npm.config.get("git"), ["clone", "--mirror", u, p], gitEnv(), false
+    exec( npm.config.get("git"), ["clone", "-n", u, p]
+        , gitEnv(), false
         , function (er, code, stdout, stderr) {
       stdout = (stdout + "\n" + stderr).trim()
       if (er) {
@@ -468,20 +470,15 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
   var archive = ["fetch", "-a", "origin"]
   var resolve = ["rev-list", "-n1", co]
   var env = gitEnv()
-
-  var errState = null
-  var n = 0
   var resolved = null
-  var tmp
 
   exec(git, archive, env, false, p, function (er, code, stdout, stderr) {
     stdout = (stdout + "\n" + stderr).trim()
     if (er) {
-      log.error("git fetch -a origin ("+u+")", stdout)
+      log.error("git fetch -a origin (" + u + ")", stdout)
       return cb(er)
     }
-    log.verbose("git fetch -a origin ("+u+")", stdout)
-    tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
+    log.verbose("git fetch -a origin (" + u + ")", stdout)
     resolveHead()
   })
 
@@ -497,30 +494,38 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
       parsed.hash = stdout
       resolved = url.format(parsed)
       log.verbose('resolved git url', resolved)
-      next()
+      checkout()
     })
   }
-
-  function next () {
-    mkdir(path.dirname(tmp), function (er) {
-      if (er) return cb(er)
-      var gzip = zlib.createGzip({ level: 9 })
-      var git = npm.config.get("git")
-      var args = ["archive", co, "--format=tar", "--prefix=package/"]
-      var out = fs.createWriteStream(tmp)
-      var env = gitEnv()
-      cb = once(cb)
-      var cp = spawn(git, args, { env: env, cwd: p })
-      cp.on("error", cb)
-      cp.stderr.on("data", function(chunk) {
-        log.silly(chunk.toString(), "git archive")
-      })
-
-      cp.stdout.pipe(gzip).pipe(out).on("close", function() {
-        addLocalTarball(tmp, function(er, data) {
-          if (data) data._resolved = resolved
-          cb(er, data)
-        })
+  
+  function checkout () {
+    exec( git, ["checkout", co], env, false, p
+        , function(er, code, stdout, stderr) {
+      stdout = (stdout + "\n" + stderr).trim()
+      if (er) {
+        log.error( "Failed checking out git-ref " + co + " in " 
+                 + tmp + " (" + u + ")", stderr )
+        return cb(er)
+      }
+      log.verbose("git checkout " + co + " (" + u + ")", stdout)
+      updateSubmodules()
+    })
+  }
+  
+  function updateSubmodules () {
+    exec( git, ["submodule", "-q", "update", "--init", "--recursive"]
+        , env, false, p
+        , function(er, code, stdout, stderr) {
+      stdout = (stdout + "\n" + stderr).trim()
+      if (er) {
+        log.error( "Failed updating submodules in " 
+                 + tmp + " (" + u + ")", stderr )
+        return cb(er)
+      }
+      log.verbose("git submodule update --init --recursive (" + u + ")", stdout)
+      addLocalDirectory(p, function(er, data){
+        if (data) data._resolved = resolved
+        cb(er, data)   
       })
     })
   }
@@ -1057,7 +1062,8 @@ function addLocalDirectory (p, name, shasum, cb) {
   if (typeof cb !== "function") cb = name, name = ""
   // if it's a folder, then read the package.json,
   // tar it to the proper place, and add the cache tar
-  if (p.indexOf(npm.cache) === 0) return cb(new Error(
+  var isGitCache = p.indexOf(path.join(npm.cache, '_git-remotes')) === 0
+  if (!isGitCache && p.indexOf(npm.cache) === 0) return cb(new Error(
     "Adding a cache directory to the cache will make the world implode."))
   readJson(path.join(p, "package.json"), function (er, data) {
     er = needName(er, data)


### PR DESCRIPTION
Fix #1876

this is another approach besides #3343

here i replace `git archive -> addLocalTarball()` with `git checkout && git submodule update --init --recursive -> addLocalDirectory()`. `_git-remotes` is not bare anymore so we can update git-submodules in it and dont need to clone into a tmp-directory.

```
1. cacheDir = path.join(cache,'_git-remotes',sha1(u))
2. checkGitDir(cacheDir) ? 4. : 3. (rm cacheDir if necessary)
3. git clone u cacheDir
4. git fetch -a origin (cwd: cacheDir)
5. git checkout <git-ref> (cwd: cacheDir)
6. git submodule update --init --recursive (cwd: cacheDir)
7. addLocalDirectory(cacheDir)
```
