### PR TITLE
Fix git dependency URL updating

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -672,6 +672,7 @@ function targetResolver (where, context, deps) {
           data &&
           !context.explicit &&
           context.family[data.name] === data.version &&
+          !data._resolved &&
           !npm.config.get("force")) {
         log.info("already installed", data.name + "@" + data.version)
         return cb(null, [])


### PR DESCRIPTION
This addresses issue #1727. The change ensures that git dependencies will always update by checking for `_resolved`.
