### PR TITLE
Docs: fix formatting in folders.md example

### DIFF
--- a/doc/cli/folders.md
+++ b/doc/cli/folders.md
@@ -157,21 +157,21 @@ In this case, we might expect a folder structure like this:
     +-- node_modules
         +-- blerg (1.2.5) <---[A]
         +-- bar (1.2.3) <---[B]
-        |   +-- node_modules
-        |   |   `-- baz (2.0.2) <---[C]
-        |   |       `-- node_modules
-        |   |           `-- quux (3.2.0)
-        |   `-- asdf (2.3.4)
+        |   `-- node_modules
+        |       +-- baz (2.0.2) <---[C]
+        |       |   `-- node_modules
+        |       |       `-- quux (3.2.0)
+        |       `-- asdf (2.3.4)
         `-- baz (1.2.3) <---[D]
             `-- node_modules
                 `-- quux (3.2.0) <---[E]
 
-Since foo depends directly on bar@1.2.3 and baz@1.2.3, those are
+Since foo depends directly on `bar@1.2.3` and `baz@1.2.3`, those are
 installed in foo's `node_modules` folder.
 
 Even though the latest copy of blerg is 1.3.7, foo has a specific
 dependency on version 1.2.5.  So, that gets installed at [A].  Since the
-parent installation of blerg satisfie's bar's dependency on blerg@1.x,
+parent installation of blerg satisfies bar's dependency on `blerg@1.x`,
 it does not install another copy under [B].
 
 Bar [B] also has dependencies on baz and asdf, so those are installed in
@@ -179,11 +179,11 @@ bar's `node_modules` folder.  Because it depends on `baz@2.x`, it cannot
 re-use the `baz@1.2.3` installed in the parent `node_modules` folder [D],
 and must install its own copy [C].
 
-Underneath bar, the `baz->quux->bar` dependency creates a cycle.
-However, because `bar` is already in `quux`'s ancestry [B], it does not
+Underneath bar, the `baz -> quux -> bar` dependency creates a cycle.
+However, because bar is already in quux's ancestry [B], it does not
 unpack another copy of bar into that folder.
 
-Underneath `foo->baz` [D], quux's [E] folder tree is empty, because its
+Underneath `foo -> baz` [D], quux's [E] folder tree is empty, because its
 dependency on bar is satisfied by the parent folder copy installed at [B].
 
 For a graphical breakdown of what is installed where, use `npm ls`.


### PR DESCRIPTION
In the cycles example, fix structure so that asdf is within bar's
node_modules, rather than directly in bar.

Also tried to make the code-span formatting a bit more consistent
in that section as it was kinda all over the place.
