### PR TITLE
Local support for 'bugs' and 'docs' commands

### DIFF
--- a/doc/api/bugs.md
+++ b/doc/api/bugs.md
@@ -12,8 +12,9 @@ bug tracker URL, and then tries to open it using the `--browser`
 config param.
 
 Like other commands, the first parameter is an array. This command only
-uses the first element, which is expected to be a package name with an
-optional version number.
+uses the first element if present, which is expected to be a package name with
+an optional version number. If no package name is passed and you are within a
+project directory, it will use the local package.json.
 
 This command will launch a browser, so this command may not be the most
 friendly for programmatic use.

--- a/doc/api/docs.md
+++ b/doc/api/docs.md
@@ -12,8 +12,9 @@ documentation URL, and then tries to open it using the `--browser`
 config param.
 
 Like other commands, the first parameter is an array. This command only
-uses the first element, which is expected to be a package name with an
-optional version number.
+uses the first element if present, which is expected to be a package name with
+an optional version number. If no package name is passed and you are within a
+project directory, it will use the local package.json.
 
 This command will launch a browser, so this command may not be the most
 friendly for programmatic use.

--- a/lib/bugs.js
+++ b/lib/bugs.js
@@ -1,12 +1,14 @@
 
 module.exports = bugs
 
-bugs.usage = "npm bugs <pkgname>"
+bugs.usage = "npm bugs [<pkgname>]"
 
 var npm = require("./npm.js")
   , registry = npm.registry
   , log = require("npmlog")
   , opener = require("opener")
+  , readJson = require("read-package-json")
+  , path = require("path")
 
 bugs.completion = function (opts, cb) {
   if (opts.conf.argv.remain.length > 2) return cb()
@@ -16,28 +18,42 @@ bugs.completion = function (opts, cb) {
 }
 
 function bugs (args, cb) {
-  if (!args.length) return cb(bugs.usage)
-  var n = args[0].split("@").shift()
-  registry.get(n + "/latest", 3600, function (er, d) {
-    if (er) return cb(er)
-    var bugs = d.bugs
-      , repo = d.repository || d.repositories
-      , url
-    if (bugs) {
-      url = (typeof bugs === "string") ? bugs : bugs.url
-    } else if (repo) {
-      if (Array.isArray(repo)) repo = repo.shift()
-      if (repo.hasOwnProperty("url")) repo = repo.url
-      log.verbose("repository", repo)
-      if (repo && repo.match(/^(https?:\/\/|git(:\/\/|@))github.com/)) {
-        url = repo.replace(/^git(@|:\/\/)/, "https://")
-                  .replace(/^https?:\/\/github.com:/, "https://github.com/")
-                  .replace(/\.git$/, '')+"/issues"
+  if (npm.config.get("global") && !args.length) return cb(bugs.usage)
+
+  if (!args.length) {
+    readJson(path.resolve(npm.prefix, "package.json"), function (er, d) {
+      if (er) {
+        return cb(er.code === "ENOENT" ? new Error("no package.json file found")
+                  : er)
       }
+      parseAndOpen(false, d, cb)
+    })
+  } else {
+    var n = args[0].split("@").shift()
+    registry.get(n + "/latest", 3600, function (er, d) {
+      if (er) return cb(er)
+      parseAndOpen(true, d, cb)
+    })
+  }
+}
+
+function parseAndOpen (named, data, cb) {
+  var url = data.bugs && data.bugs.url
+    , repo = data.repository || data.repositories
+  
+  if (!url && repo) {
+    if (Array.isArray(repo)) repo = repo.shift()
+    if (repo.hasOwnProperty("url")) repo = repo.url
+    log.verbose("repository", repo)
+    if (repo && repo.match(/^(https?:\/\/|git(:\/\/|@))github.com/)) {
+      url = repo.replace(/^git(@|:\/\/)/, "https://")
+          .replace(/^https?:\/\/github.com:/, "https://github.com/")
+          .replace(/\.git$/, "")+"/issues"
     }
-    if (!url) {
-      url = "https://npmjs.org/package/" + d.name
-    }
-    opener(url, { command: npm.config.get("browser") }, cb)
-  })
+  }
+  if (!url) {
+    if (named) url = "https://npmjs.org/package/" + data.name
+    else return cb(new Error("no url specified in package.json"))
+  }
+  opener(url, { command: npm.config.get("browser") }, cb)
 }

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,7 +1,14 @@
 
 module.exports = docs
 
-docs.usage = "npm docs <pkgname>"
+docs.usage = "npm docs [<pkgname>]"
+
+var npm = require("./npm.js")
+  , registry = npm.registry
+  , log = require("npmlog")
+  , opener = require("opener")
+  , readJson = require("read-package-json")
+  , path = require("path")
 
 docs.completion = function (opts, cb) {
   if (opts.conf.argv.remain.length > 2) return cb()
@@ -10,20 +17,46 @@ docs.completion = function (opts, cb) {
   })
 }
 
-var npm = require("./npm.js")
-  , registry = npm.registry
-  , log = require("npmlog")
-  , opener = require("opener")
-
 function docs (args, cb) {
-  if (!args.length) return cb(docs.usage)
-  var n = args[0].split("@").shift()
-  registry.get(n + "/latest", 3600, function (er, d) {
-    if (er) return cb(er)
-    var homepage = d.homepage
-      , repo = d.repository || d.repositories
-      , url = homepage ? homepage
-            : "https://npmjs.org/package/" + d.name
-    opener(url, { command: npm.config.get("browser") }, cb)
-  })
+  if (npm.config.get("global") && !args.length) return cb(docs.usage)
+
+  if (!args.length) {
+    readJson(path.resolve(npm.prefix, "package.json"), function (er, d) {
+      if (er) {
+        return cb(er.code === "ENOENT" ? new Error("no package.json file found")
+                  : er)
+      }
+      parseAndOpen(false, d, cb)
+    })
+  } else {
+    var n = args[0].split("@").shift()
+    registry.get(n + "/latest", 3600, function (er, d) {
+      if (er) return cb(er)
+      parseAndOpen(true, d, cb)
+    })
+  }
+}
+
+function parseAndOpen (named, data, cb) {
+  var homepage = data.homepage
+    , repo = data.repository || data.repositories
+    , url
+
+  if (homepage) {
+    url = homepage
+  } else if (repo) {
+    if (Array.isArray(repo)) repo = repo.shift()
+    if (repo.hasOwnProperty("url")) repo = repo.url
+    log.verbose("repository", repo)
+    if (repo && repo.match(/^(https?:\/\/|git(:\/\/|@))github.com/)) {
+      url = repo.replace(/^git(@|:\/\/)/, "https://")
+          .replace(/^https?:\/\/github.com:/, "https://github.com/")
+          .replace(/\.git$/, "")
+    }
+  }
+  if (!url) {
+    if (named) url = "https://npmjs.org/package/" + data.name
+    else return cb(new Error("no url specified in package.json"))
+  }
+  opener(url, { command: npm.config.get("browser") }, cb)
 }


### PR DESCRIPTION
Very minor edit to allow the a user to run the `docs`, `home`, `bugs`, `issues` commands without a package argument, in which case they will now attempt to use a local package.json. The attempt at deducing a URL when none is specified in package.json for GitHub projects has also been copied over appropriately to the docs command (previously only implemented in bugs).

Hopefully all OK.

Issue referenced: https://github.com/isaacs/npm/issues/3356
