### PR TITLE
Add npm-exec(1) as command for executing dependency executables

### DIFF
--- a/doc/api/exec.md
+++ b/doc/api/exec.md
@@ -1,0 +1,13 @@
+npm-exec(1) -- Execute a dependency supplied binary
+==================================================
+
+## SYNOPSIS
+
+    npm.exec(executable [, arguments])
+
+## DESCRIPTION
+
+This command will execute a executable from the executables made available by
+your package.json dependencies in the current working directory.
+Zero or more arguments to the executable may be supplied after the
+executable name.

--- a/doc/cli/exec.md
+++ b/doc/cli/exec.md
@@ -1,0 +1,15 @@
+npm-exec(1) -- Execute a dependency supplied executable
+=======================================================
+
+## SYNOPSIS
+
+    npm exec <executable>
+    npm exec <executable> -- <executable_arguments>
+
+## DESCRIPTION
+
+This command will execute an executable from the executables made available by
+your package.json dependencies in the current working directory.
+Arguments to the executable may be supplied after "--".
+
+

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,0 +1,30 @@
+module.exports = exec
+
+var child_process = require("child_process")
+  , fs = require("fs")
+  , path = require("path")
+
+exec.usage = "npm exec <executable>"
+           + "\nnpm exec <executable> -- <executable_arguments>"
+
+function exec(args, cb) {
+  if (!args.length) return cb(exec.usage);
+  var cwd = process.cwd()
+    , executable_dir = cwd + "/node_modules/.bin/"
+    , executable = path.basename(args[0])
+    , fullpath = executable_dir + executable
+    , executable_args = args.slice(1)
+    , child
+
+  if (!fs.existsSync(fullpath)) return cb("Unable to find: " + fullpath);
+
+  child = child_process.spawn(fullpath, executable_args, { cwd: cwd, env: process.env, stdio: [0,1,2] })
+
+  child.on('error', function(error) {
+    cb(error)
+  })
+
+  child.on('exit', function() {
+    cb(null)
+  })
+}

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -3,28 +3,33 @@ module.exports = exec
 var child_process = require("child_process")
   , fs = require("fs")
   , path = require("path")
+  , npm = require("./npm.js")
 
 exec.usage = "npm exec <executable>"
            + "\nnpm exec <executable> -- <executable_arguments>"
 
 function exec(args, cb) {
   if (!args.length) return cb(exec.usage);
-  var cwd = process.cwd()
-    , executable_dir = cwd + "/node_modules/.bin/"
+
+  var executable_dir = npm.bin
     , executable = path.basename(args[0])
-    , fullpath = executable_dir + executable
+    , fullpath = path.join(executable_dir, executable)
     , executable_args = args.slice(1)
     , child
 
-  if (!fs.existsSync(fullpath)) return cb("Unable to find: " + fullpath);
+  fs.exists(fullpath, function(exists) {
+    if (exists) {
+      child = child_process.spawn(fullpath, executable_args, { stdio: [0,1,2] })
 
-  child = child_process.spawn(fullpath, executable_args, { cwd: cwd, env: process.env, stdio: [0,1,2] })
+      child.on('error', function(error) {
+        cb(error)
+      })
 
-  child.on('error', function(error) {
-    cb(error)
-  })
-
-  child.on('exit', function() {
-    cb(null)
+      child.on('exit', function() {
+        cb(null)
+      })
+    } else {
+      cb("Unable to find: " + executable + " in " + executable_dir)
+    }
   })
 }

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -121,6 +121,7 @@ var commandCache = {}
               , "submodule"
               , "pack"
               , "dedupe"
+              , "exec"
 
               , "rebuild"
               , "link"


### PR DESCRIPTION
There is always the chance that this functionality already exists in npm, if so, just close this and point me to it, thanks. This is intended to reproduce the basic functionality of `bundle exec` in npm.

There is a very good chance this is incomplete or incorrect in some way or another, but it works for the specific use case that it was written for: `npm exec mocha -- --colors test/file.test.js`.

There is also the question of how this should be handled from an API perspective. Should npm.exec use the directory of the package that it is referenced from or the package that it is referenced in? i.e.: I use npm.exec to execute an executable in my node_modules directory and the executable that is being executed wants to use npm.exec to execute an executable in it's own node_modules folder.

Hopefully, this commit will get the ball rolling on this discussion.

references #1543
