### PR TITLE
Fixes the init.author.* settings when doing npm init

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -27,7 +27,14 @@ function init (args, cb) {
     ,"Press ^C at any time to quit."
     ].join("\n"))
 
-  initJson(dir, initFile, npm.config.get(), function (er, data) {
+  var config = npm.config.list.reduce(function(prev, list) {
+    return prev.concat(Object.keys(list))
+  }, []).reduce(function (s, k) {
+    s[k] = npm.config.get(k)
+    return s
+  }, {})
+
+  initJson(dir, initFile, config, function (er, data) {
     log.resume()
     log.silly('package data', data)
     log.info('init', 'written successfully')

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "read-package-json": "~0.3.0",
     "read-installed": "0",
     "glob": "~3.1.21",
-    "init-package-json": "0.0.6",
+    "init-package-json": "0.0.7",
     "osenv": "0",
     "lockfile": "~0.3.0",
     "retry": "~0.6.0",


### PR DESCRIPTION
The init.author.\* settings in .npmrc were broken (ignored when running `npm init`). 

This fixes the issue by pulling in the config options explicitly since I couldn't find a `config-chain` method to do that - npm.config.get() without params returns undefined which is why this broke.

Bump up init-package-json as well, since it was out of date, 0.0.7 was released 6 months ago, cf: https://github.com/isaacs/init-package-json 
