### PR TITLE
better error message for proxy users, fixes #3415

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -215,6 +215,16 @@ function errorHandler (er) {
     log.error("peerinvalid", [er.message].concat(peerErrors).join("\n"))
     break
 
+  case "ENOTFOUND":
+    log.error("network", [er.message
+              ,"This is most likely not a problem with npm itself"
+              ,"and is related to network connectivity."
+              ,"In most cases you are behind a proxy or have bad network settings."
+              ,"\nIf you are behind a proxy, please make sure that the"
+              ,"'proxy' config is set properly.  See: 'npm help config'"
+              ].join("\n"))
+    break
+
   case "ENOTSUP":
     if (er.required) {
       log.error("notsup", [er.message


### PR DESCRIPTION
This fixes #3415 (proxy users are getting errors that they can't interpret) which currently results in an increased need for support.

Here is a preview of the message:

```
(01:22:20) [robert@tequila-apple] ~/npm (master *) $ npm install foo2
npm http GET http://registry.npmjs.org/foo2
npm http GET http://registry.npmjs.org/foo2
npm http GET http://registry.npmjs.org/foo2
npm ERR! network getaddrinfo ENOTFOUND
npm ERR! network This is most likely not a problem with npm itself
npm ERR! network and is related to network connectivity.
npm ERR! network In most cases you are behind a proxy or have bad network settings.
npm ERR! network
npm ERR! network If you are behind a proxy, please make sure that the
npm ERR! network 'proxy' config is set properly.  See: 'npm help config'

npm ERR! System Darwin 12.3.0
npm ERR! command "node" "/usr/local/bin/npm" "install" "foo2"
npm ERR! cwd /Users/robert/npm
npm ERR! node -v v0.10.4
npm ERR! npm -v 1.2.19
npm ERR! syscall getaddrinfo
npm ERR! code NETWORK
npm ERR! errno ENOTFOUND
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/robert/npm/npm-debug.log
npm ERR! not ok code 0
```
