### PR TITLE
Consistently use log.write instead of console.log

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,6 +1,7 @@
 module.exports = bin
 
 var npm = require("./npm.js")
+  , log = require("npmlog")
 
 bin.usage = "npm bin\nnpm bin -g\n(just prints the bin folder)"
 
@@ -9,7 +10,7 @@ function bin (args, silent, cb) {
   var b = npm.bin
     , PATH = (process.env.PATH || "").split(":")
 
-  if (!silent) console.log(b)
+  if (!silent) log.write(b + "\n")
   process.nextTick(cb.bind(this, null, b))
 
   if (npm.config.get("global") && PATH.indexOf(b) === -1) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -179,7 +179,7 @@ function linkBins (pkg, folder, parent, gtop, cb) {
           , out = npm.config.get("parseable")
                 ? dest + "::" + src + ":BINFILE"
                 : dest + " -> " + src
-        console.log(out)
+        log.write(out + "\n")
         cb()
       })
     })

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -159,9 +159,9 @@ function ls (args, cb) {
     prefix = "~" + prefix.substr(process.env.HOME.length)
   }
   ls_(args, npm.config.get("depth"), function (er, files) {
-    console.log(files.map(function (f) {
+    log.write(files.map(function (f) {
       return path.join(prefix, f)
-    }).join("\n").trim())
+    }).join("\n").trim() + "\n")
     cb(er, files)
   })
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -134,7 +134,7 @@ function get (key, cb) {
   if (key.charAt(0) === "_") {
     return cb(new Error("---sekretz---"))
   }
-  console.log(npm.config.get(key))
+  log.write(npm.config.get(key) + "\n")
   cb()
 }
 
@@ -251,7 +251,7 @@ function list (cb) {
          + "; HOME = " + process.env.HOME + "\n"
          + "; 'npm config ls -l' to show all defaults.\n"
 
-    console.log(msg)
+    log.write(msg + "\n")
     return cb()
   }
 
@@ -268,7 +268,7 @@ function list (cb) {
   })
   msg += "\n"
 
-  console.log(msg)
+  log.write(msg + "\n")
   return cb()
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -93,7 +93,7 @@ function install (args, cb_) {
       var tree = treeify(installed || [])
         , pretty = prettify(tree, installed).trim()
 
-      if (pretty) log.write(pretty)
+      if (pretty) log.write(pretty + "\n")
       save(where, installed, tree, pretty, cb_)
     })
   }

--- a/lib/link.js
+++ b/lib/link.js
@@ -152,7 +152,7 @@ function resultPrinter (pkg, src, dest, rp, cb) {
     return parseableOutput(dest, rp || src, cb)
   }
   if (rp === src) rp = null
-  console.log(where + " -> " + src + (rp ? " -> " + rp: ""))
+  log.write(where + " -> " + src + (rp ? " -> " + rp: "") + "\n")
   cb()
 }
 
@@ -164,6 +164,6 @@ function parseableOutput (dest, rp, cb) {
   // *just* print the target folder.
   // However, we don't actually ever read the version number, so
   // the second field is always blank.
-  console.log(dest + "::" + rp)
+  log.write(dest + "::" + rp + "\n")
   cb()
 }

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -58,7 +58,7 @@ function ls (args, silent, cb) {
     } else if (data) {
       out = makeArchy(bfs, long, dir)
     }
-    console.log(out)
+    log.write(out + "\n")
 
     // if any errors were found, then complain and exit status 1
     if (lite.problems && lite.problems.length) {

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -11,6 +11,7 @@ var npm = require("./npm.js")
   , chain = require("slide").chain
   , path = require("path")
   , cwd = process.cwd()
+  , log = require("npmlog")
 
 pack.usage = "npm pack <pkg>"
 
@@ -34,7 +35,7 @@ function printFiles (files, cb) {
   files = files.map(function (file) {
     return path.relative(cwd, file)
   })
-  console.log(files.join("\n"))
+  log.write(files.join("\n") + "\n")
   cb()
 }
 

--- a/lib/prefix.js
+++ b/lib/prefix.js
@@ -1,11 +1,12 @@
 module.exports = prefix
 
 var npm = require("./npm.js")
+  , log = require("npmlog")
 
 prefix.usage = "npm prefix\nnpm prefix -g\n(just prints the prefix folder)"
 
 function prefix (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
-  if (!silent) console.log(npm.prefix)
+  if (!silent) log.write(npm.prefix + "\n")
   process.nextTick(cb.bind(this, null, npm.prefix))
 }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -102,7 +102,7 @@ function publish_ (arg, data, isRetry, cachedir, cb) {
       })
     }
     if (er) return cb(er)
-    console.log("+ " + data._id)
+    log.write("+ " + data._id + "\n")
     cb()
   })
 }

--- a/lib/rebuild.js
+++ b/lib/rebuild.js
@@ -30,9 +30,9 @@ function rebuild (args, cb) {
 function cleanBuild (folders, set, cb) {
   npm.commands.build(folders, function (er) {
     if (er) return cb(er)
-    console.log(folders.map(function (f) {
+    log.write(folders.map(function (f) {
       return set[f] + " " + f
-    }).join("\n"))
+    }).join("\n") + "\n")
     cb()
   })
 }

--- a/lib/root.js
+++ b/lib/root.js
@@ -1,11 +1,12 @@
 module.exports = root
 
 var npm = require("./npm.js")
+  , log = require("npmlog")
 
 root.usage = "npm root\nnpm root -g\n(just prints the root folder)"
 
 function root (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
-  if (!silent) console.log(npm.dir)
+  if (!silent) log.write(npm.dir + "\n")
   process.nextTick(cb.bind(this, null, npm.dir))
 }

--- a/lib/search.js
+++ b/lib/search.js
@@ -4,6 +4,7 @@ module.exports = exports = search
 var npm = require("./npm.js")
   , registry = npm.registry
   , semver = require("semver")
+  , log = require("npmlog")
 
 search.usage = "npm search [some search terms ...]"
 
@@ -51,7 +52,7 @@ function search (args, silent, staleness, cb) {
     // prettify and print it, and then provide the raw
     // data to the cb.
     if (er || silent) return cb(er, data)
-    console.log(prettify(data, args))
+    log.write(prettify(data, args) + "\n")
     cb(null, data)
   })
 }

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -41,7 +41,7 @@ function shrinkwrap_ (pkginfo, silent, cb) {
   fs.writeFile(file, swdata, function (er) {
     if (er) return cb(er)
     if (silent) return cb(null, pkginfo)
-    console.log("wrote npm-shrinkwrap.json")
+    log.write("wrote npm-shrinkwrap.json\n")
     cb(null, pkginfo)
   })
 }

--- a/lib/star.js
+++ b/lib/star.js
@@ -24,7 +24,7 @@ function star (args, cb) {
   asyncMap(args, function (pkg, cb) {
     registry.star(pkg, using, function (er, data, raw, req) {
       if (!er) {
-        console.log(s + " "+pkg)
+        log.write(s + " "+pkg+"\n")
         log.verbose("star", data)
       }
       cb(er, data, raw, req)

--- a/lib/stars.js
+++ b/lib/stars.js
@@ -19,7 +19,7 @@ function stars (args, cb) {
       log.warn('stars', 'user has not starred any packages.')
     } else {
       data.rows.forEach(function(a) {
-        console.log(a.value)
+        log.write(a.value + "\n")
       })
     }
     cb()

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -67,7 +67,7 @@ function unpublish (args, cb) {
 function gotProject (project, version, cb_) {
   function cb (er) {
     if (er) return cb_(er)
-    console.log("- " + project + (version ? "@" + version : ""))
+    log.write("- " + project + (version ? "@" + version : "") + "\n")
     cb_()
   }
 

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -148,7 +148,7 @@ function runPackageLifecycle (pkg, env, wd, unsafe, cb) {
   var note = "\n> " + pkg._id + " " + stage + " " + wd
            + "\n> " + cmd + "\n"
 
-  console.log(note)
+  log.write(note + "\n")
 
   var conf = { cwd: wd, env: env, customFds: [ 0, 1, 2] }
   var proc = spawn(sh, [shFlag, cmd], conf)

--- a/lib/version.js
+++ b/lib/version.js
@@ -37,7 +37,7 @@ function version (args, silent, cb_) {
       if (data && data.name && data.version) {
         v[data.name] = data.version
       }
-      console.log(v)
+      log.write(v + "\n")
       return cb_()
     }
 
@@ -61,7 +61,7 @@ function version (args, silent, cb_) {
 
     fs.stat(path.join(process.cwd(), ".git"), function (er, s) {
       function cb (er) {
-        if (!er && !silent) console.log("v" + newVer)
+        if (!er && !silent) log.write("v" + newVer + "\n")
         cb_(er)
       }
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -203,7 +203,7 @@ function printData (data, name, cb) {
     })
   })
 
-  console.log(msg)
+  log.write(msg + "\n")
   cb(null, data)
 }
 function cleanup (data) {

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -1,6 +1,7 @@
 module.exports = whoami
 
 var npm = require("./npm.js")
+  , log = require("npmlog")
 
 whoami.usage = "npm whoami\n(just prints the 'username' config)"
 
@@ -8,6 +9,6 @@ function whoami (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
   var me = npm.config.get("username")
   msg = me ? me : "Not authed.  Run 'npm adduser'"
-  if (!silent) console.log(msg)
+  if (!silent) log.write(msg + "\n")
   process.nextTick(cb.bind(this, null, me))
 }


### PR DESCRIPTION
Found a couple more places where console.log could be swapped for log.write when working with the logstream option.

This also fixes a bug in my previous pr (#3434) where install output was missing a newline at the end.
