### PR TITLE
remove unused SPLIT_CHAR

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -14,9 +14,6 @@ if (typeof WScript !== "undefined") {
 // monkey-patch support for 0.6 child processes
 require('child-process-close')
 
-// FIXME there really ought to be a path.split in node core
-require("path").SPLIT_CHAR = process.platform === "win32" ? "\\" : "/"
-
 var EventEmitter = require("events").EventEmitter
   , npm = module.exports = new EventEmitter
   , config = require("./config.js")


### PR DESCRIPTION
`SPLIT_CHAR` is not used anymore:

```
(00:31:05) [robert@tequila-apple] ~/npm (master) $ git grep SPLIT_CHAR
lib/npm.js:require("path").SPLIT_CHAR = process.platform === "win32" ? "\\" : "/"
```

If it would be used, `require("path").sep` would replace it now.
