### PR TITLE
npm i module misses new line at the end

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -93,7 +93,7 @@ function install (args, cb_) {
       var tree = treeify(installed || [])
         , pretty = prettify(tree, installed).trim()
 
-      if (pretty) log.write(pretty)
+      if (pretty) log.write(pretty + "\n")
       save(where, installed, tree, pretty, cb_)
     })
   }


### PR DESCRIPTION
run `npm i npm -g && npm i some module` 

For example

``` sh
$ npm i continuable-mongo
npm http GET https://registry.npmjs.org/continuable-mongo
npm http 304 https://registry.npmjs.org/continuable-mongo
npm http GET https://registry.npmjs.org/continuable-cache
npm http GET https://registry.npmjs.org/through
npm http GET https://registry.npmjs.org/individual
npm http 304 https://registry.npmjs.org/through
npm http 304 https://registry.npmjs.org/continuable-cache
npm http 304 https://registry.npmjs.org/individual
npm http GET https://registry.npmjs.org/global
npm http 304 https://registry.npmjs.org/global
npm WARN package.json ctype@0.5.2 No repository field.
npm WARN package.json assert-plus@0.1.2 No repository field.
npm WARN package.json uglify-js@2.2.5 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
npm WARN package.json callsite@1.0.0 No repository field.
continuable-mongo@0.1.7 node_modules/continuable-mongo
├── continuable-cache@0.1.1
├── through@2.3.4
└── individual@0.1.1 (global@0.1.5)raynos at raynos-Latitude-E5530-non-vPro in ~/Documents/class-page on master*
```

This is with the latest version of npm.

I think it may be because of https://github.com/isaacs/npm/commit/ba010c537002e20209dd8751b2becb32dfb0d29d

console.log probably puts a `'\n'` at the end and `log.write` probably does not.

I've done the "simple" fix of putting a "\n" in the place where I would expect one for install.js, this problem might be larger or have a better solution!
