### PR TITLE
Cannot assume that the package.json has a dependencies object

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -108,7 +108,7 @@ function shouldWarn(pkg, folder, global, cb) {
     if (linkedPkg !== currentPkg) {
 
       // don't generate a warning if it's listed in dependencies
-      if (Object.keys(topPkg.dependencies).indexOf(currentPkg) === -1) {
+      if (Object.keys(topPkg.dependencies || {}).indexOf(currentPkg) === -1) {
 
         if (top && pkg.preferGlobal && !global) {
           log.warn("prefer global", pkg._id + " should be installed with -g")


### PR DESCRIPTION
There is probably a better way to fix this bug.
