### PR TITLE
Fix error Object.keys error

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -100,16 +100,15 @@ function shouldWarn(pkg, folder, global, cb) {
 
   readJson(path.resolve(cwd, "package.json"), function(er, topPkg) {
     if (er) return cb(er)
-
     var linkedPkg = path.basename(cwd)
       , currentPkg = path.basename(folder)
 
     // current searched package is the linked package on first call
     if (linkedPkg !== currentPkg) {
 
+      if (!topPkg.dependencies) return
       // don't generate a warning if it's listed in dependencies
       if (Object.keys(topPkg.dependencies).indexOf(currentPkg) === -1) {
-
         if (top && pkg.preferGlobal && !global) {
           log.warn("prefer global", pkg._id + " should be installed with -g")
         }


### PR DESCRIPTION
When I have a module with a package.json that has no dependencies
speacified and I do a `npm install {packagename}` there will be
an error thrown in the attempt to suppress a warning message
for global dependencies, which the package.json with no
dependencies does not have.

(Hot)- Fixes #3443
