### PR TITLE
Early return in build.js shouldWarn didn't call cb

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -107,7 +107,7 @@ function shouldWarn(pkg, folder, global, cb) {
     // current searched package is the linked package on first call
     if (linkedPkg !== currentPkg) {
 
-      if (!topPkg.dependencies) return
+      if (!topPkg.dependencies) return cb()
 
       // don't generate a warning if it's listed in dependencies
       if (Object.keys(topPkg.dependencies).indexOf(currentPkg) === -1) {


### PR DESCRIPTION
The recent fix https://github.com/isaacs/npm/commit/3da8cbab211748287cb98517bb813750becfb1de
did not call the cb
