### PR TITLE
Make `npm docs Raynos/after` work

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -20,10 +20,9 @@ function docs (args, cb) {
   var npmName = project.split("@").shift()
   registry.get(project + "/latest", 3600, function (er, d) {
     if (er) {
-      var githubParts = project.split("/")
-      if (githubParts.length !== 2) return cb(er)
+      if (project.split("/").length !== 2) return cb(er)
       
-      var url = "https://github.com/" + githubParts + "#readme"
+      var url = "https://github.com/" + project + "#readme"
       return opener(url, { command: npm.config.get("browser") }, cb)
     }
 

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -18,7 +18,7 @@ function docs (args, cb) {
   if (!args.length) return cb(docs.usage)
   var project = args[0]
   var npmName = project.split("@").shift()
-  registry.get(n + "/latest", 3600, function (er, d) {
+  registry.get(project + "/latest", 3600, function (er, d) {
     if (er) {
       var githubParts = project.split("/")
       if (githubParts.length !== 2) return cb(er)

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,4 +1,3 @@
-
 module.exports = docs
 
 docs.usage = "npm docs <pkgname>"
@@ -17,9 +16,17 @@ var npm = require("./npm.js")
 
 function docs (args, cb) {
   if (!args.length) return cb(docs.usage)
-  var n = args[0].split("@").shift()
+  var project = args[0]
+  var npmName = project.split("@").shift()
   registry.get(n + "/latest", 3600, function (er, d) {
-    if (er) return cb(er)
+    if (er) {
+      var githubParts = project.split("/")
+      if (githubParts.length !== 2) return cb(er)
+      
+      var url = "https://github.com/" + githubParts + "#readme"
+      return opener(url, { command: npm.config.get("browser") }, cb)
+    }
+
     var homepage = d.homepage
       , repo = d.repository || d.repositories
       , url = homepage ? homepage


### PR DESCRIPTION
when using git namespace dependencies in package.json which expand to either public or private git uris.

It would be nice if `npm docs {{githubNamespace}}` opened the github page for that project. 

This is very useful for private git dependencies because it means I can use `npm docs` as a uniform documentation opener between public npm dependencies and git uris
