### PR TITLE
doc: Mention --nodedir in npm install documentation

### DIFF
--- a/doc/cli/install.md
+++ b/doc/cli/install.md
@@ -168,6 +168,9 @@ local space in some cases.
 The `--no-bin-links` argument will prevent npm from creating symlinks for
 any binaries the package might contain.
 
+The `--nodedir=/path/to/node/source` argument will allow npm to find the
+node source code so that npm can compile native modules.
+
 See `npm-config(1)`.  Many of the configuration params have some
 effect on installation, since that's most of what npm does.
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -27,6 +27,8 @@ install.usage = "npm install"
               + "\nIf no argument is supplied and ./npm-shrinkwrap.json is "
               + "\npresent, installs dependencies specified in the shrinkwrap."
               + "\nOtherwise, installs dependencies from ./package.json."
+              + "\n\nOptions
+              + "\n\n--nodedir=/path/to/node/source"
 
 install.completion = function (opts, cb) {
   // install can complete to a folder with a package.json, or any package.


### PR DESCRIPTION
It's hard to find documentation about --nodedir. This makes it a little easier.

See also the [PR I originally opened against node](https://github.com/joyent/node/pull/5575).
