### PR TITLE
Use git repo/ tarball for "npm update" rather than npm repo

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -138,7 +138,7 @@ function shouldUpdate (args, dir, dep, has, req, cb) {
   }
 
   function doIt (shouldHave) {
-    cb(null, [[ dir, dep, has[dep], shouldHave ]])
+    cb(null, [[ dir, dep, has[dep], shouldHave, req ]])
   }
 
   if (args.length && args.indexOf(dep) === -1) {

--- a/lib/update.js
+++ b/lib/update.js
@@ -27,12 +27,16 @@ function update (args, cb) {
     if (er) return cb(er)
 
     asyncMap(outdated, function (ww, cb) {
-      // [[ dir, dep, has, want ]]
+      // [[ dir, dep, has, want, req ]]
       var where = ww[0]
         , dep = ww[1]
         , want = ww[3]
         , what = dep + "@" + want
+        , req = ww[4]
+        , url = require('url')
 
+      // use the initial installation method (repo, tar, git) for updating
+      if (url.parse(req).protocol) what = req
       npm.commands.install(where, what, cb)
     }, cb)
   })


### PR DESCRIPTION
This would fix #2374 and #2419 (which seems to be [incorrectly closed](https://github.com/isaacs/npm/issues/1727#issuecomment-17426135) as a dupe of #1727).

Instead of checking whether the original source (git/ https? tarball) has an update available, but then only considering the npm repository for the update, this PR will update from the source instead.

I'm open for ideas whether the PR should be changed so that it checks the npm repo either first, or as a fallback, but as npm checks **the source** to see whether an update is available, it makes little sense to retrieve the update from the npm repository.
