### PR TITLE
NPM shrinkwrap should not strip out devDependency if it's also listed under dependency

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -38,6 +38,11 @@ function shrinkwrap_ (pkginfo, silent, dev, cb) {
         return cb(er)
       if (data.devDependencies) {
         Object.keys(data.devDependencies).forEach(function (dep) {
+          if (data.dependencies && data.dependencies[dep]) {
+            // do not exclude the dev dependency if it's also listed as a dependency
+            continue
+          }
+
           log.warn("shrinkwrap", "Excluding devDependency: %s", dep)
           delete pkginfo.dependencies[dep]
         })


### PR DESCRIPTION
This is specific to this kind of situation:
dependency:
   moduleA: '*'
devDependency:
   moduleA: 'git+ssh://blahblah'

The same module is listed in both dependency and devDependency, with the dev dependency pointing to the source of the module. In my situation, we have minified and coffee-script compiled modules and unminified coffee-script source.

For dev setup, we just npm install
For build process, we npm install in production mode and then npm shrinkwraps. We would prefer that shrinkwrap doesn't strip out devDependencies that are also listed as dependency.
