### PR TITLE
Encourage the same version everywhere (tilde begone)

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -325,10 +325,7 @@ function save (where, installed, tree, pretty, cb) {
         if (u && u.protocol) w[1] = t.from
         return w
       }).reduce(function (set, k) {
-        var rangeDescriptor = semver.valid(k[1]) &&
-                              semver.gte(k[1], "0.1.0")
-                            ? "~" : ""
-        set[k[0]] = rangeDescriptor + k[1]
+        set[k[0]] = k[1]
         return set
       }, {})
 


### PR DESCRIPTION
Its my opinion that `~` (and `>=`, `*`, et al.) are the bane of dependency management.  Since SemVer doesn't specify when people should release bugs, the only way people can guarantee that users of their software will get the same bugs that they depend on is to peg to specific versions.

I get the impression that `~` and the like are meant to either be kind to the internet (trying to download less) or reflect a foolhardy optimism that software developers will only fix bugs and not create new ones.

Making the `--save` and `--save-dev` options use fuzzy version matching means that in practice there is a lot of published software that is developed, tested, and deployed with unknown versions of dependencies.

Seeing 3defd7b2eebb05a4be99abd42f0e0a6c75010a21 (~ only in >= 1.0.0) is encouraging, but I'm guessing that  86a00019f72a2527d35a885a07f5e13459de33d4 (~ for 0.1.0 and above) means that the change suggested here won't necessarily meet with agreement.
