### PR TITLE
`npm init && npm install --save anyLibrary` error

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -101,6 +101,8 @@ function shouldWarn(pkg, folder, global, cb) {
   readJson(path.resolve(cwd, "package.json"), function(er, topPkg) {
     if (er) return cb(er)
 
+    topPkg.dependencies = topPkg.dependencies || {}
+
     var linkedPkg = path.basename(cwd)
       , currentPkg = path.basename(folder)
 


### PR DESCRIPTION
`npm init && npm install --save anyLibrary` fails with error:

npm ERR! TypeError: Object.keys called on non-object
npm ERR!     at Function.keys (native)
npm ERR!     at /usr/local/lib/node_modules/npm/lib/build.js:111:18

This is because `npm init` does not add a `dependencies` property in package.json by default.

Line 111 of build.js is:

```
      if (Object.keys(topPkg.dependencies).indexOf(currentPkg) === -1) {
```
