### PR TITLE
Issue with symlinked modules

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -174,15 +174,21 @@ function linkBins (pkg, folder, parent, gtop, cb) {
       if (er) return cb(er)
       // bins should always be executable.
       // XXX skip chmod on windows?
-      fs.chmod(path.resolve(folder, pkg.bin[b]), npm.modes.exec, function (er) {
-        if (er || !gtop) return cb(er)
-        var dest = path.resolve(binRoot, b)
-          , src = path.resolve(folder, pkg.bin[b])
-          , out = npm.config.get("parseable")
-                ? dest + "::" + src + ":BINFILE"
-                : dest + " -> " + src
-        console.log(out)
-        cb()
+      fs.lstat(folder, function (er,stat) {
+        if (!stat.isSymbolicLink) {
+          fs.chmod(path.resolve(folder, pkg.bin[b]), npm.modes.exec, function (er) {
+            if (er || !gtop) return cb(er)
+            var dest = path.resolve(binRoot, b)
+              , src = path.resolve(folder, pkg.bin[b])
+              , out = npm.config.get("parseable")
+                    ? dest + "::" + src + ":BINFILE"
+                    : dest + " -> " + src
+            console.log(out)
+            cb()
+          })
+        } else {
+          cb()
+        }
       })
     })
   }, cb)


### PR DESCRIPTION
This diff causes npm to skip chown'ing symlinked node modules as modules installed with npm -g that contain a "bin" entry in package.json should already have correct permissions.

Example: 
sudo npm install -g node-gyp
cd /tmp
npm link node-gyp
npm ERR! Error: EPERM, chmod '/tmp/node_modules/node-gyp/bin/node-gyp.js'
