### PR TITLE
ls: show git urls in parentheses

### DIFF
--- a/doc/cli/ls.md
+++ b/doc/cli/ls.md
@@ -22,7 +22,11 @@ For example, running `npm ls promzard` in npm's source tree will show:
     └─┬ init-package-json@0.0.4
       └── promzard@0.1.5
 
-It will show print out extraneous, missing, and invalid packages.
+It will print out extraneous, missing, and invalid packages.
+
+If a project specifies git urls for dependencies these are shown
+in parentheses after the name@version to make it easier for users to
+recognize potential forks of a project.
 
 When run as `ll` or `la`, it shows extended information by default.
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -82,6 +82,7 @@ var mkdir = require("mkdirp")
   , zlib = require("zlib")
   , chmodr = require("chmodr")
   , which = require("which")
+  , isGitUrl = require("./utils/is-git-url.js")
 
 cache.usage = "npm cache add <tarball file>"
             + "\nnpm cache add <folder>"
@@ -261,15 +262,11 @@ function add (args, cb) {
     case "http:":
     case "https:":
       return addRemoteTarball(spec, null, name, cb)
-    case "git:":
-    case "git+http:":
-    case "git+https:":
-    case "git+rsync:":
-    case "git+ftp:":
-    case "git+ssh:":
-      //p.protocol = p.protocol.replace(/^git([^:])/, "$1")
-      return addRemoteGit(spec, p, name, false, cb)
+
     default:
+      if (isGitUrl(p.protocol))
+        return addRemoteGit(spec, p, name, false, cb)
+
       // if we have a name and a spec, then try name@spec
       // if not, then try just spec (which may try name@"" if not found)
       if (name) {

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -13,6 +13,8 @@ var npm = require("./npm.js")
   , path = require("path")
   , archy = require("archy")
   , semver = require("semver")
+  , url = require("url")
+  , isGitUrl = require("./utils/is-git-url.js")
 
 ls.usage = "npm ls"
 
@@ -84,7 +86,6 @@ function alphasort (a, b) {
 function getLite (data, noname) {
   var lite = {}
     , maxDepth = npm.config.get("depth")
-    , url = require("url")
 
   if (!noname && data.name) lite.name = data.name
   if (data.version) lite.version = data.version
@@ -262,6 +263,13 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
               + (color ? "\033[0m" : "")
   }
 
+  // add giturl to name@version
+  if (data._resolved) {
+    var p = url.parse(data._resolved)
+    if (isGitUrl(p.protocol))
+      out.label += " (" + data._resolved + ")"
+  }
+
   if (long) {
     if (dir === data.path) out.label += "\n" + dir
     out.label += "\n" + getExtras(data, dir)
@@ -285,7 +293,6 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
 
 function getExtras (data, dir) {
   var extras = []
-    , url = require("url")
 
   if (data.description) extras.push(data.description)
   if (data.repository) extras.push(data.repository.url)

--- a/lib/utils/is-git-url.js
+++ b/lib/utils/is-git-url.js
@@ -1,0 +1,13 @@
+module.exports = isGitUrl
+
+function isGitUrl (url) {
+  switch (url) {
+    case "git:":
+    case "git+http:":
+    case "git+https:":
+    case "git+rsync:":
+    case "git+ftp:":
+    case "git+ssh:":
+      return true
+  }
+}


### PR DESCRIPTION
If a project specifies git urls for dependencies these are shown
in parentheses after the name@version to make it easier for
users to recognize potential forks of a project.

Fixes #3570
