### PR TITLE
Fix #3598 - npm does not warn at installations

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -161,7 +161,7 @@ function install (args, cb_) {
     // initial "family" is the name:version of the root, if it's got
     // a package.json file.
     var jsonFile = path.resolve(where, "package.json")
-    readJson(jsonFile, true, function (er, data) {
+    readJson(jsonFile, log.warn, function (er, data) {
       if (er
           && er.code !== "ENOENT"
           && er.code !== "ENOTDIR") return cb(er)


### PR DESCRIPTION
This is a regression.

Before with broken fields:

```
(23:30:39) [robert@tequila-apple] ~/footest $ npm install https://github.com/robertkowalski/foo-private/tarball/master
npm http GET https://github.com/robertkowalski/foo-private/tarball/master
npm http 200 https://github.com/robertkowalski/foo-private/tarball/master
foo-private@0.0.0 node_modules/foo-private
```

Fixed:

```
(23:27:53) [robert@tequila-apple] ~/footest $ npm install https://github.com/robertkowalski/foo-private/tarball/master
npm WARN package.json footest@0.0.0 No description
npm WARN package.json footest@0.0.0 No repository field.
npm WARN package.json footest@0.0.0 No README data
npm http GET https://github.com/robertkowalski/foo-private/tarball/master
npm http 200 https://github.com/robertkowalski/foo-private/tarball/master
foo-private@0.0.0 node_modules/foo-private
```
