### PR TITLE
add "repo" command to attempt opening a package's repository in the browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ npm-debug.log
 /npm-*.tgz
 /node_modules/npm-registry-client/test/fixtures
 *.pyc
+node_modules/github-url-from-git

--- a/doc/api/repo.md
+++ b/doc/api/repo.md
@@ -1,0 +1,19 @@
+npm-repo(3) -- Open package repository page in the browser
+========================================================
+
+## SYNOPSIS
+
+    npm.commands.repo(package, callback)
+
+## DESCRIPTION
+
+This command tries to guess at the likely location of a package's
+repository URL, and then tries to open it using the `--browser`
+config param.
+
+Like other commands, the first parameter is an array. This command only
+uses the first element, which is expected to be a package name with an
+optional version number.
+
+This command will launch a browser, so this command may not be the most
+friendly for programmatic use.

--- a/doc/cli/repo.md
+++ b/doc/cli/repo.md
@@ -1,0 +1,26 @@
+npm-repo(1) -- Open package repository page in the browser
+========================================================
+
+## SYNOPSIS
+
+    npm repo <pkgname>
+
+## DESCRIPTION
+
+This command tries to guess at the likely location of a package's
+repository URL, and then tries to open it using the `--browser`
+config param.
+
+## CONFIGURATION
+
+### browser
+
+* Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+* Type: String
+
+The browser that is called by the `npm repo` command to open websites.
+
+## SEE ALSO
+
+* npm-docs(1)
+* npm-config(1)

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -146,6 +146,7 @@ var commandCache = {}
               , "edit"
               , "explore"
               , "docs"
+              , "repo"
               , "bugs"
               , "faq"
               , "root"

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -1,0 +1,29 @@
+
+module.exports = repo
+
+repo.usage = "npm repo <pkgname>"
+
+repo.completion = function (opts, cb) {
+  if (opts.conf.argv.remain.length > 2) return cb()
+  registry.get("/-/short", 60000, function (er, list) {
+    return cb(null, list || [])
+  })
+}
+
+var npm = require("./npm.js")
+  , registry = npm.registry
+  , log = require("npmlog")
+  , opener = require("opener")
+  , github = require('github-url-from-git')
+
+function repo (args, cb) {
+  if (!args.length) return cb(repo.usage)
+  var n = args[0].split("@").shift()
+  registry.get(n + "/latest", 3600, function (er, d) {
+    if (er) return cb(er)
+    var r = d.repository;
+    if (!r) return cb(new Error('no repository'));
+    var url = github(r.url);
+    opener(url, { command: npm.config.get("browser") }, cb)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "sha": "~1.0.1",
     "editor": "0.0.4",
     "child-process-close": "~0.1.1",
-    "npm-user-validate": "0.0.3"
+    "npm-user-validate": "0.0.3",
+    "github-url-from-git": "1.1.1"
   },
   "bundleDependencies": [
     "semver",


### PR DESCRIPTION
as per tweet. I wasn't sure if the node_modules/github-url-from-git should be checked in or not
