### PR TITLE
Discover new versions with outdated

### DIFF
--- a/doc/cli/npm-outdated.md
+++ b/doc/cli/npm-outdated.md
@@ -10,6 +10,10 @@ npm-outdated(1) -- Check for outdated packages
 This command will check the registry to see if any (or, specific) installed
 packages are currently outdated.
 
+The resulting field 'wanted' shows the latest version according to the
+version specified in the package.json, the field 'latest' the very latest
+version of the package.
+
 ## SEE ALSO
 
 * npm-update(1)

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -45,6 +45,7 @@ function makePretty (p) {
     , dir = path.resolve(p[0], "node_modules", dep)
     , has = p[2]
     , want = p[3]
+    , latest = p[4]
 
   // XXX add --json support
   // Should match (more or less) the output of ls --json
@@ -61,8 +62,10 @@ function makePretty (p) {
   if (!npm.config.get("global")) {
     dir = path.relative(process.cwd(), dir)
   }
-  return dep + "@" + want + " " + dir
+  return dep + " " + dir
        + " current=" + (has || "MISSING")
+       + " wanted=" + want
+       + " latest=" + latest
 }
 
 function outdated_ (args, dir, parentHas, cb) {
@@ -143,29 +146,35 @@ function shouldUpdate (args, dir, dep, has, req, cb) {
              , cb )
   }
 
-  function doIt (shouldHave) {
-    cb(null, [[ dir, dep, curr && curr.version, shouldHave, req ]])
+  function doIt (wanted, latest) {
+    cb(null, [[ dir, dep, curr && curr.version, wanted, latest, req ]])
   }
 
   if (args.length && args.indexOf(dep) === -1) {
     return skip()
   }
 
-  // so, we can conceivably update this.  find out if we need to.
-  cache.add(dep, req, function (er, d) {
-    // if this fails, then it means we can't update this thing.
-    // it's probably a thing that isn't published.
-    if (er) return skip()
+  var registry = npm.registry
+  // search for the latest package
+  registry.get(dep + "/latest", function (er, l) {
+    if (er) return cb()
+    // so, we can conceivably update this.  find out if we need to.
+    cache.add(dep, req, function (er, d) {
+      // if this fails, then it means we can't update this thing.
+      // it's probably a thing that isn't published.
+      if (er) return skip()
 
-    // check that the url origin hasn't changed (#1727) and that
-    // there is no newer version available
-    var dFromUrl = d._from && url.parse(d._from).protocol
-    var cFromUrl = curr && curr.from && url.parse(curr.from).protocol
+      // check that the url origin hasn't changed (#1727) and that
+      // there is no newer version available
+      var dFromUrl = d._from && url.parse(d._from).protocol
+      var cFromUrl = curr && curr.from && url.parse(curr.from).protocol
 
-    if (!curr || dFromUrl && cFromUrl && d._from !== curr.from
-        || d.version !== curr.version)
-      doIt(d.version)
-    else
-      skip()
+      if (!curr || dFromUrl && cFromUrl && d._from !== curr.from
+          || d.version !== curr.version
+          || d.version !== l.version)
+        doIt(d.version, l.version)
+      else
+        skip()
+    })
   })
 }

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "devDependencies": {
     "ronn": "~0.3.6",
     "tap": "~0.4.0",
-    "npm-registry-mock": "~0.3.0"
+    "npm-registry-mock": "~0.4.0"
   },
   "engines": {
     "node": ">=0.6",

--- a/test/tap/outdated-new-versions.js
+++ b/test/tap/outdated-new-versions.js
@@ -1,0 +1,27 @@
+var test = require("tap").test
+var npm = require("../../")
+
+var mr = require("npm-registry-mock")
+
+// config
+var port = 1331
+var address = "http://localhost:" + port
+var pkg = __dirname + '/outdated-new-versions'
+
+
+test("dicovers new versions in outdated", function (t) {
+  process.chdir(pkg)
+
+  mr(port, function (s) {
+    npm.load({registry: address}, function () {
+      npm.outdated(function (er, d) {
+        t.equal("1.5.1", d[0][4])
+        // tests devDependencies,
+        // depends on #3863 - 427ea5ef75c7a29899c0faf98c32f0653a0bec0e
+        // t.equal("2.27.0", d[1][4])
+        s.close()
+        t.end()
+      })
+    })
+  })
+})

--- a/test/tap/outdated-new-versions/package.json
+++ b/test/tap/outdated-new-versions/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "new-versions-with-outdated",
+  "author": "Rockbert",
+  "version": "0.0.0",
+  "dependencies": {
+    "underscore": "~1.3.1"
+  },
+  "devDependencies": {
+    "request": "~0.9.0"
+  }
+}


### PR DESCRIPTION
Add versions that are not matching the version specified in the
package.json as 'latest'.
Show versions that are specified by the package.json as 'wanted'

Fixes #1428
