### PR TITLE
submodules in a git url are now updated pre-build

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -458,7 +458,7 @@ function cloneGitRemote (p, u, co, origUrl, silent, cb) {
     if (er) return cb(er)
 
     var git = npm.config.get("git")
-    var args = [ "clone", "--mirror", u, p ]
+    var args = [ "clone", "--recursive", '--branch', co, u, p ]
     var env = gitEnv()
 
     // check for git
@@ -493,18 +493,36 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
   var errState = null
   var n = 0
   var resolved = null
-  var tmp
+
+  logCmd = function(args, stdout, level) {
+    if (typeof level == 'undefined' || level == null) {
+      level = 'verbose'
+    }
+    log[level]('git ' + args.join(' ') + ' (' + u + ')')
+  }
 
   exec(git, archive, {cwd: p, env: env}, function (er, stdout, stderr) {
     stdout = (stdout + "\n" + stderr).trim()
     if (er) {
-      log.error("git fetch -a origin ("+u+")", stdout)
+      logCmd(archive, stdout, 'error')
       return cb(er)
     }
-    log.verbose("git fetch -a origin ("+u+")", stdout)
-    tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
-    resolveHead()
+    log.verbose(archive, stdout)
+    checkout()
   })
+
+  function checkout () {
+    var args = ["checkout", co]
+    exec(git, args, {cwd: p, env: env}, function(er, stdout, stderr) {
+      stdout = (stdout + "\n" + stderr).trim()
+      if (er) {
+        log.error( "Failed checking out git-ref " + co + " (" + u + ")", stderr )
+        return cb(er)
+      }
+      logCmd(args, stdout)
+    })
+    resolveHead()
+  }
 
   function resolveHead () {
     exec(git, resolve, {cwd: p, env: env}, function (er, stdout, stderr) {
@@ -513,7 +531,7 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
         log.error("Failed resolving git HEAD (" + u + ")", stderr)
         return cb(er)
       }
-      log.verbose("git rev-list -n1 " + co, stdout)
+      logCmd(resolve, stdout)
       var parsed = url.parse(origUrl)
       parsed.hash = stdout
       resolved = url.format(parsed)
@@ -528,32 +546,15 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
       resolved = spr.join(parsed.host)
 
       log.verbose('resolved git url', resolved)
-      next()
+      pack()
     })
   }
 
-  function next () {
-    mkdir(path.dirname(tmp), function (er) {
-      if (er) return cb(er)
-      var gzip = zlib.createGzip({ level: 9 })
-      var git = npm.config.get("git")
-      var args = ["archive", co, "--format=tar", "--prefix=package/"]
-      var out = fs.createWriteStream(tmp)
-      var env = gitEnv()
-      cb = once(cb)
-      var cp = spawn(git, args, { env: env, cwd: p })
-      cp.on("error", cb)
-      cp.stderr.on("data", function(chunk) {
-        log.silly(chunk.toString(), "git archive")
+  function pack () {
+      addLocalDirectory(p, function(er, data){
+        if (data) data._resolved = resolved
+        cb(er, data)   
       })
-
-      cp.stdout.pipe(gzip).pipe(out).on("close", function() {
-        addLocalTarball(tmp, function(er, data) {
-          if (data) data._resolved = resolved
-          cb(er, data)
-        })
-      })
-    })
   }
 }
 
@@ -1105,7 +1106,8 @@ function addLocalDirectory (p, name, shasum, cb) {
   if (typeof cb !== "function") cb = name, name = ""
   // if it's a folder, then read the package.json,
   // tar it to the proper place, and add the cache tar
-  if (p.indexOf(npm.cache) === 0) return cb(new Error(
+  var isGitCache = p.indexOf(path.join(npm.cache, '_git-remotes')) === 0
+  if (!isGitCache && p.indexOf(npm.cache) === 0) return cb(new Error(
     "Adding a cache directory to the cache will make the world implode."))
   var strict = p.indexOf(npm.tmp) !== 0
                 && p.indexOf(npm.cache) !== 0


### PR DESCRIPTION
The problem this solves is not being able to build dependencies included
as git urls in `package.json` that have git-submodules themselves.

This fix uses `git clone --recursive` (with working-tree) instead of
`git archive` to package such dependencies as node_modules. It's not as
clean, leaving behind working-trees and taking up more space, but I
don't think it can get much better until git-archive supports submodules
natively.

I also saw a lot of senseless coupling of the log messages with the
commands being run, so included a `logCmd` function to make logging the
git commands more maintainable. I've only made use of it in the scope of
my changes, but something similar should be used throughout the file, if
not the entire module.

This is largely based on the work that was started here:
[https://github.com/isaacs/npm/pull/3343](https://github.com/isaacs/npm/pull/3343)
[https://github.com/isaacs/npm/pull/3344](https://github.com/isaacs/npm/pull/3344)
