### PR TITLE
Implement warnings for local package.json

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -162,7 +162,7 @@ function install (args, cb_) {
     // initial "family" is the name:version of the root, if it's got
     // a package.json file.
     var jsonFile = path.resolve(where, "package.json")
-    readJson(jsonFile, true, function (er, data) {
+    readJson(jsonFile, log.warn, true, function (er, data) {
       if (er
           && er.code !== "ENOENT"
           && er.code !== "ENOTDIR") return cb(er)
@@ -238,6 +238,7 @@ function readDependencies (context, where, opts, cb) {
   var wrap = context ? context.wrap : null
 
   readJson( path.resolve(where, "package.json")
+          , log.warn
           , function (er, data) {
     if (er)  return cb(er)
 


### PR DESCRIPTION
This warns people with missing fields in their package.json
but will not warn if the dependencies of the local project are
missing something in their package.json
