### PR TITLE
show better error message for proxy users

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -225,6 +225,7 @@ function errorHandler (er) {
     break
 
   case "ENOTFOUND":
+  case "ETIMEDOUT":
     log.error("network", [er.message
               ,"This is most likely not a problem with npm itself"
               ,"and is related to network connectivity."


### PR DESCRIPTION
This will hopefully enable the npm users behind a proxy to help
themselves in case of a proxy/network issue.
