### PR TITLE
Exclude peerDependencies of devDependencies from shrinkwrap

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -32,21 +32,20 @@ function shrinkwrap_ (pkginfo, silent, dev, cb) {
                        +pkginfo.problems.join("\n")))
   }
 
-  if (!dev) {
-    // remove dev deps unless the user does --dev
-    getExcludes(function(er, exclude) {
-      if (er) return cb(er)
-
-      exclude.forEach(function (dep) {
-        log.warn("shrinkwrap", "Excluding devDependency: %s", dep)
-        delete pkginfo.dependencies[dep]
-      })
-
-      save(pkginfo, silent, cb)
-    })
-  } else {
+  if (!dev)
     return save(pkginfo, silent, cb)
-  }
+
+  // remove dev deps unless the user does --dev
+  getExcludes(function(er, exclude) {
+    if (er) return cb(er)
+
+    exclude.forEach(function (dep) {
+      log.warn("shrinkwrap", "Excluding devDependency: %s", dep)
+      delete pkginfo.dependencies[dep]
+    })
+
+    save(pkginfo, silent, cb)
+  })
 }
 
 function getExcludes(cb) {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -8,6 +8,7 @@ var npm = require("./npm.js")
   , fs = require("fs")
   , path = require("path")
   , readJson = require("read-package-json")
+  , readInstalled = require("read-installed")
 
 shrinkwrap.usage = "npm shrinkwrap"
 
@@ -33,22 +34,52 @@ function shrinkwrap_ (pkginfo, silent, dev, cb) {
 
   if (!dev) {
     // remove dev deps unless the user does --dev
-    readJson(path.resolve(npm.prefix, "package.json"), function (er, data) {
-      if (er)
-        return cb(er)
-      if (data.devDependencies) {
-        Object.keys(data.devDependencies).forEach(function (dep) {
-          log.warn("shrinkwrap", "Excluding devDependency: %s", dep)
-          delete pkginfo.dependencies[dep]
-        })
-      }
+    getExcludes(function(er, exclude) {
+      if (er) return cb(er)
+
+      exclude.forEach(function (dep) {
+        log.warn("shrinkwrap", "Excluding devDependency: %s", dep)
+        delete pkginfo.dependencies[dep]
+      })
+
       save(pkginfo, silent, cb)
     })
   } else {
-    save(pkginfo, silent, cb)
+    return save(pkginfo, silent, cb)
   }
 }
 
+function getExcludes(cb) {
+
+  var exclude = []
+    , depth = npm.config.get("depth")
+    , dir = path.resolve(npm.dir, "..")
+
+  // exclude devDependencies
+  readJson(path.resolve(npm.prefix, "package.json"), function (er, data) {
+    if (er) return cb(er)
+
+    if (data.devDependencies)
+      exclude = [].concat(Object.keys(data.devDependencies))
+
+    // exclude peerDependencies of devDependencies
+    readInstalled(dir, depth, log.warn, function (er, data) {
+      if (er) return cb(er)
+
+      if (data.devDependencies) {
+        var deps = data.dependencies || {};
+        for (name in deps)
+          if (name in data.devDependencies && deps[name].peerDependencies)
+            exclude = exclude.concat(Object.keys(deps[name].peerDependencies))
+      }
+
+      // return unique excludes
+      cb(null, exclude.filter(function(elem, pos) {
+        return exclude.indexOf(elem) === pos
+      }))
+    })
+  })
+}
 
 function save (pkginfo, silent, cb) {
   try {


### PR DESCRIPTION
If dev dependency has deps in `peerDependency` field they go to shrinkwrap file, what isn't correct I believe. This PR is addressing this issue.
