### PR TITLE
Added .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.8"
+  - "0.9"
+  - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - "0.8"
   - "0.9"
   - "0.10"
+  - "0.11"
+matrix:
+  allow_failures:
+    - node-js: "0.11"


### PR DESCRIPTION
A `.travis.yml` is necessary for Travis CI to be able to run tests. This `.travis.yml` will run the `npm` tests against Node version `0.8`, `0.9`, and `0.10`.
