### PR TITLE
use npm-registry-mock, fixes #3633

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ npm-debug.log
 /node_modules/ronn
 /node_modules/tap
 /node_modules/.bin
+/node_modules/npm-registry-mock
 /html/api/
 /html/doc/
 /man/

--- a/.npmignore
+++ b/.npmignore
@@ -10,6 +10,7 @@ npm-debug.log
 node_modules/ronn
 node_modules/tap
 node_modules/.bin
+node_modules/npm-registry-mock
 /npmrc
 /release/
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
   ],
   "devDependencies": {
     "ronn": "~0.3.6",
-    "tap": "~0.4.0"
+    "tap": "~0.4.0",
+    "npm-registry-mock": "~0.2.0"
   },
   "engines": {
     "node": ">=0.6",

--- a/test/tap/ignore-shrinkwrap.js
+++ b/test/tap/ignore-shrinkwrap.js
@@ -1,60 +1,58 @@
 var test = require("tap").test
 var npm = require("../../")
 var pkg = './ignore-shrinkwrap'
-var http = require("http")
 
+var mr = require("npm-registry-mock")
 
-var server, child
+var child
 var spawn = require("child_process").spawn
 var npm = require.resolve("../../bin/npm-cli.js")
 var node = process.execPath
 
-test("ignore-shrinkwrap: using the option", function(t) {
-  t.plan(1)
-  server = http.createServer(function (req, res) {
-    res.setHeader("content-type", "application/javascript")
-    switch (req.url) {
-      case "/shrinkwrap.js":
-        t.fail()
-        break
-      case "/package.js":
-        t.pass("package.json used")
+var customMocks = {
+  "get": {
+    "/package.js": [200, {"ente" : true}],
+    "/shrinkwrap.js": [200, {"ente" : true}]
+  }
+}
 
-    }
-    t.end()
-    this.close()
-    child.kill()
-    res.statusCode = 500
-    res.end('{"error":"Rocko Artischocko - oh oh oh oh!"}')
-  })
-  server.listen(1337, function() {
-    child = createChild(true)
+test("ignore-shrinkwrap: using the option", function(t) {
+  mr({port: 1337, mocks: customMocks}, function (s) {
+    s._server.on("request", function (req, res) {
+      switch (req.url) {
+        case "/shrinkwrap.js":
+          t.fail()
+          break
+        case "/package.js":
+          t.pass("package.json used")
+      }
+    })
+    var child = createChild(true)
+    child.on("close", function (m) {
+      s.close()
+      t.end()
+    })
   })
 })
 
 test("ignore-shrinkwrap: NOT using the option", function(t) {
-  t.plan(1)
-  server = http.createServer(function (req, res) {
-    res.setHeader("content-type", "application/javascript")
-    switch (req.url) {
-      case "/shrinkwrap.js":
-        t.pass("shrinkwrap used")
-        break
-      case "/package.js":
-        t.fail()
-
-    }
-    t.end()
-    this.close()
-    child.kill()
-    res.statusCode = 500
-    res.end('{"error":"Rocko Artischocko - oh oh oh oh!"}')
-  })
-  server.listen(1337, function() {
-    child = createChild(false)
+  mr({port: 1337, mocks: customMocks}, function (s) {
+    s._server.on("request", function (req, res) {
+      switch (req.url) {
+        case "/shrinkwrap.js":
+          t.pass("shrinkwrap used")
+          break
+        case "/package.js":
+          t.fail()
+      }
+    })
+    var child = createChild(false)
+    child.on("close", function (m) {
+      s.close()
+      t.end()
+    })
   })
 })
-
 
 function createChild (ignoreShrinkwrap) {
   var args
@@ -64,11 +62,10 @@ function createChild (ignoreShrinkwrap) {
     args = [npm, "install"]
   }
 
-  console.log(args)
-
   return spawn(node, args, {
     cwd: pkg,
     env: {
+      npm_config_registry: "http://localhost:1337",
       npm_config_cache_lock_stale: 1000,
       npm_config_cache_lock_wait: 1000,
       HOME: process.env.HOME,

--- a/test/tap/noargs-install-config-save.js
+++ b/test/tap/noargs-install-config-save.js
@@ -2,28 +2,29 @@ var test = require("tap").test
 var npm = require.resolve("../../bin/npm-cli.js")
 var osenv = require("osenv")
 var path = require("path")
-var http = require("http")
 var fs = require("fs")
 var rimraf = require("rimraf")
-var mkdirp = require('mkdirp')
+var mkdirp = require("mkdirp")
 
-var server, child
+var mr = require("npm-registry-mock")
+
+var child
 var spawn = require("child_process").spawn
 var node = process.execPath
 
-var pkg = process.env.npm_config_tmp || '/tmp'
-pkg += path.sep + 'noargs-install-config-save'
+var pkg = process.env.npm_config_tmp || "/tmp"
+pkg += path.sep + "noargs-install-config-save"
 
 function writePackageJson() {
   rimraf.sync(pkg)
   mkdirp.sync(pkg)
 
-  fs.writeFileSync(pkg + '/package.json', JSON.stringify({
+  fs.writeFileSync(pkg + "/package.json", JSON.stringify({
     "author": "Rocko Artischocko",
     "name": "noargs",
     "version": "0.0.0",
     "devDependencies": {
-      "underscore": "1.3.0"
+      "underscore": "1.3.1"
     }
   }), 'utf8')
 }
@@ -50,37 +51,29 @@ function createChild (args) {
 test("does not update the package.json with empty arguments", function (t) {
   writePackageJson()
   t.plan(1)
-  server = http.createServer(function (req, res) {
-    res.setHeader("content-type", "application/javascript")
-    res.statusCode = 200
-    res.end(JSON.stringify(require("./fixtures/underscore-1-3-3.json")))
+
+  mr(1337, function (s) {
+    var child = createChild([npm, "install"])
     child.on("close", function (m) {
       var text = JSON.stringify(fs.readFileSync(pkg + "/package.json", "utf8"))
       t.ok(text.indexOf('"dependencies') === -1)
+      s.close()
       t.end()
     })
-    this.close()
-  })
-  server.listen(1337, function() {
-    child = createChild([npm, "install"])
   })
 })
 
 test("updates the package.json (adds dependencies) with an argument", function (t) {
   writePackageJson()
   t.plan(1)
-  server = http.createServer(function (req, res) {
-    res.setHeader("content-type", "application/javascript")
-    res.statusCode = 200
-    res.end(JSON.stringify(require("./fixtures/underscore.json")))
+
+  mr(1337, function (s) {
+    var child = createChild([npm, "install", "underscore"])
     child.on("close", function (m) {
       var text = JSON.stringify(fs.readFileSync(pkg + "/package.json", "utf8"))
       t.ok(text.indexOf('"dependencies') !== -1)
+      s.close()
       t.end()
     })
-    this.close()
-  })
-  server.listen(1337, function () {
-    child = createChild([npm, "install", "underscore"])
   })
 })


### PR DESCRIPTION
This adds the new `npm-registry-mock` for testing. It's far away from complete, but it's easy to add new functionality whenever one needs a test.

See also #3633 
