### PR TITLE
Update npm-faq.md

### DIFF
--- a/doc/misc/npm-faq.md
+++ b/doc/misc/npm-faq.md
@@ -83,7 +83,7 @@ tl;dr
 * Check `node_modules` into git for things you **deploy**, such as
   websites and apps.
 * Do not check `node_modules` into git for libraries and modules
-  intended to be reused.
+  intended to be reused or apps installed using `npm install`.
 * Use npm to manage dependencies in your dev environment, but not in
   your deployment scripts.
 


### PR DESCRIPTION
Clarify that some "apps" shouldn't have the node_modules folder in their git repo.

We found that a little confusing (see https://github.com/FredrikNoren/ungit/pull/135) because some websites/webapps are more like libraries in this regard. They have a large userbase to test and install them with updated packages, report bugs, and they use npm for deployment.
