### PR TITLE
update/outdated: don't access missing package info

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -144,7 +144,7 @@ function shouldUpdate (args, dir, dep, has, req, cb) {
   }
 
   function doIt (shouldHave) {
-    cb(null, [[ dir, dep, curr.version, shouldHave, req ]])
+    cb(null, [[ dir, dep, curr && curr.version, shouldHave, req ]])
   }
 
   if (args.length && args.indexOf(dep) === -1) {
@@ -159,11 +159,11 @@ function shouldUpdate (args, dir, dep, has, req, cb) {
 
     // check that the url origin hasn't changed (#1727) and that
     // there is no newer version available
-    var dFromUrl = url.parse(d._from).protocol
-    var cFromUrl = url.parse(curr.from).protocol
+    var dFromUrl = d._from && url.parse(d._from).protocol
+    var cFromUrl = curr && curr.from && url.parse(curr.from).protocol
 
-    if (dFromUrl && cFromUrl && d._from !== curr.from
-        || d.version !== has[dep].version)
+    if (!curr || dFromUrl && cFromUrl && d._from !== curr.from
+        || d.version !== curr.version)
       doIt(d.version)
     else
       skip()

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "devDependencies": {
     "ronn": "~0.3.6",
     "tap": "~0.4.0",
-    "npm-registry-mock": "~0.2.0"
+    "npm-registry-mock": "~0.3.0"
   },
   "engines": {
     "node": ">=0.6",

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -1,0 +1,32 @@
+var fs = require("fs")
+var test = require("tap").test
+var rimraf = require("rimraf")
+var npm = require("../../")
+
+var mr = require("npm-registry-mock")
+// config
+var port = 1331
+var address = "http://localhost:" + port
+var pkg = __dirname + '/outdated'
+
+test("it should not throw", function (t) {
+  rimraf.sync(pkg + "/node_modules")
+  process.chdir(pkg)
+
+  mr(port, function (s) {
+    npm.load({registry: address}, function () {
+      npm.install(".", function (err) {
+        npm.outdated(function (er, d) {
+          console.log(d)
+          s.close()
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  rimraf.sync(pkg + "/node_modules")
+  t.end()
+})

--- a/test/tap/outdated/index.js
+++ b/test/tap/outdated/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/test/tap/outdated/package.json
+++ b/test/tap/outdated/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bla",
+  "version": "0.0.1",
+  "main": "index.js",
+  "dependencies": {
+    "underscore": "1.3.1"
+  }
+}


### PR DESCRIPTION
If a dependency isn't currently installed, don't try to access
information about it.

Fixes #3820, a regression caused by #3798 and #3578
