### PR TITLE
Rewrite of login/adduser to allow private registries and protected user dbs

### DIFF
--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -123,7 +123,7 @@ function save (c, u, cb) {
   }
 
   // save existing configs, but yank off for this PUT
-  registry.adduser(u.u, u.p, u.e, function (er) {
+  registry.adduser(u.u, u.p, u.e, registry.couchLogin, function (er) {
     if (er) return cb(er)
     registry.username = u.u
     registry.password = u.p

--- a/node_modules/npm-registry-client/index.js
+++ b/node_modules/npm-registry-client/index.js
@@ -51,12 +51,16 @@ function RegClient (conf) {
 
   var auth = this.conf.get('_auth')
   var alwaysAuth = this.conf.get('always-auth')
+  // if we're always authing, then we just send the
+  // user/pass on every thing. otherwise, create a
+  // session (if we have auth then with token), and use that.
   if (auth && !alwaysAuth && registry) {
-    // if we're always authing, then we just send the
-    // user/pass on every thing.  otherwise, create a
-    // session, and use that.
     var token = this.conf.get('_token')
     this.couchLogin = new CouchLogin(registry, token)
+  } else if (registry && !alwaysAuth) {
+    this.couchLogin = new CouchLogin(registry)
+  }
+  if (this.couchLogin) {
     this.couchLogin.proxy = this.conf.get('proxy')
     this.couchLogin.strictSSL = this.conf.get('strict-ssl')
     this.couchLogin.ca = this.conf.get('ca')

--- a/node_modules/npm-registry-client/index.js
+++ b/node_modules/npm-registry-client/index.js
@@ -50,14 +50,10 @@ function RegClient (conf) {
   if (!conf.get('cache')) throw new Error("Cache dir is required")
 
   var auth = this.conf.get('_auth')
-  var alwaysAuth = this.conf.get('always-auth')
-  // if we're always authing, then we just send the
-  // user/pass on every thing. otherwise, create a
-  // session (if we have auth then with token), and use that.
-  if (auth && !alwaysAuth && registry) {
+  if (auth && registry) {
     var token = this.conf.get('_token')
     this.couchLogin = new CouchLogin(registry, token)
-  } else if (registry && !alwaysAuth) {
+  } else if (registry) {
     this.couchLogin = new CouchLogin(registry)
   }
   if (this.couchLogin) {

--- a/node_modules/npm-registry-client/lib/adduser.js
+++ b/node_modules/npm-registry-client/lib/adduser.js
@@ -6,7 +6,7 @@ function sha (s) {
   return crypto.createHash("sha1").update(s).digest("hex")
 }
 
-function adduser (username, password, email, cb) {
+function adduser (username, password, email, couch, cb) {
 
   password = ("" + (password || "")).trim()
   if (!password) return cb(new Error("No password supplied."))
@@ -58,52 +58,58 @@ function adduser (username, password, email, cb) {
     return s
   }, {})
 
-  this.log.verbose("adduser", "before first PUT", logObj)
+  this.log.verbose("adduser", "before couch login", logObj)
 
-  this.request('PUT'
-    , '/-/user/org.couchdb.user:'+encodeURIComponent(username)
-    , userobj
-    , function (error, data, json, response) {
-        // if it worked, then we just created a new user, and all is well.
-        // but if we're updating a current record, then it'll 409 first
-        if (error && !this.conf.get('_auth')) {
-          // must be trying to re-auth on a new machine.
-          // use this info as auth
-          var b = new Buffer(username + ":" + password)
-          this.conf.set('_auth', b.toString("base64"))
-          this.conf.set('username', username)
-          this.conf.set('_password', password)
+  var auth = {name : username, password : password}
+
+  couch.login(auth, function (error, response, json) {
+
+    // if we find a user we will get a 200, if not let us try to create one
+    if (response && (response.statusCode === 401
+            || response.statusCode === 200)) {
+      this.log.verbose("response.statusCode ", response.statusCode)
+      this.log.verbose("json-data ", JSON.stringify(json))
+      // if we get a 401 we need to to create the user and we will stop
+      if(response.statusCode === 401) {
+        /* if the user db is passwd protected and we reach here we need to
+         * check whether we are admin prior to be able to create new user
+         * re-instate previous auth/token/etc.*/
+        this.conf.set('_token', pre.token)
+        if (this.couchLogin) {
+          this.couchLogin.token = pre.token
+          if (this.couchLogin.tokenSet) {
+            this.couchLogin.tokenSet(pre.token)
+          }
         }
+        this.conf.set('username', pre.username)
+        this.conf.set('_password', pre.password)
+        this.conf.set('_auth', pre.auth)
+        return this.request('PUT'
+        , '/-/user/org.couchdb.user:'+encodeURIComponent(username)
+        , userobj
+        , cb)
+      }
+      // let us save the auth when we enter here
+      var b = new Buffer(username + ":" + password)
+      this.conf.set('_auth', b.toString("base64"))
+      this.conf.set('username', username)
+      this.conf.set('_password', password)
+      this.conf.save("user")
+      // if we reach here we have are done
+      return this.request('GET'
+        , '/-/user/org.couchdb.user:'+encodeURIComponent(username)
+        , cb)
+    } else {
+      return cb(error, json, json, response)
+    }
+  }.bind(this))
 
-        if (!error || !response || response.statusCode !== 409) {
-          return cb(error, data, json, response)
-        }
-
-        this.log.verbose("adduser", "update existing user")
-        return this.request('GET'
-          , '/-/user/org.couchdb.user:'+encodeURIComponent(username)
-          , function (er, data, json, response) {
-              if (er || data.error) {
-                return cb(er, data, json, response)
-              }
-              Object.keys(data).forEach(function (k) {
-                if (!userobj[k]) {
-                  userobj[k] = data[k]
-                }
-              })
-              this.log.verbose("adduser", "userobj", logObj)
-              this.request('PUT'
-                , '/-/user/org.couchdb.user:'+encodeURIComponent(username)
-                  + "/-rev/" + userobj._rev
-                , userobj
-                , cb )
-            }.bind(this))
-      }.bind(this))
 }
 
 function done (cb, pre) {
   return function (error, data, json, response) {
-    if (!error && (!response || response.statusCode === 201)) {
+    if (!error &&
+     (!response || response.statusCode === 201|| response.statusCode === 200)) {
       return cb(error, data, json, response)
     }
 
@@ -126,10 +132,17 @@ function done (cb, pre) {
     }
     if (response
         && (response.statusCode === 401 || response.statusCode === 403)) {
-      this.log.warn("adduser", "Incorrect username or password\n"
+      this.log.warn("adduser", "Incorrect username or password\n\n"
               +"You can reset your account by visiting:\n"
               +"\n"
-              +"    http://admin.npmjs.org/reset\n")
+              +"    https://admin.npmjs.org/reset\n")
+    } else if (response
+        && response.statusCode === 404) {
+      this.log.warn("adduser", "Insufficient rights to add the user\n\n"
+              +"You need to contact the admin " 
+              +"of the private registry to create your account\n"
+              +"public registry visit:\n\n"
+              +"    https://npmjs.org/signup\n")
     }
 
     return cb(error)

--- a/node_modules/npm-registry-client/lib/adduser.js
+++ b/node_modules/npm-registry-client/lib/adduser.js
@@ -21,6 +21,9 @@ function adduser (username, password, email, couch, cb) {
     "Sorry, ':' chars are not allowed in passwords.\n"+
     "See <https://issues.apache.org/jira/browse/COUCHDB-969> for why."))
 
+  var defaultRolesString = this.conf.get("defaultRoles")
+    , defaultRoles = (defaultRolesString)? defaultRolesString.split(','):[]
+
   var salt = crypto.randomBytes(30).toString('hex')
     , userobj =
       { name : username
@@ -29,7 +32,7 @@ function adduser (username, password, email, couch, cb) {
       , email : email
       , _id : 'org.couchdb.user:'+username
       , type : "user"
-      , roles : []
+      , roles : defaultRoles  
       , date: new Date().toISOString()
       }
 
@@ -139,7 +142,7 @@ function done (cb, pre) {
     } else if (response
         && response.statusCode === 404) {
       this.log.warn("adduser", "Insufficient rights to add the user\n\n"
-              +"You need to contact the admin " 
+              +"You need to become or contact the admin " 
               +"of the private registry to create your account\n"
               +"public registry visit:\n\n"
               +"    https://npmjs.org/signup\n")


### PR DESCRIPTION
fixes https://github.com/isaacs/npmjs.org/issues/117
- Enabling private repos by passing the couch object to addUser to not do the work twice
- using couch login instead of a put
- enabling to create new user if you have been admin before
- adding note if a 404 occurs - an indicator for a private rep
- enabling defaultRoles to be configured instead on an empty array
  - this allows to create new user with default roles defined 
    - in .npmrc `defaultRoles = devs,clients`
    - in cli `npm adduser -defaultRoles=devs,clients`
  - if not defined in the config we use the current value
- pointing out that you as well can login as an admin user
