### PR TITLE
dedupe: respect --tag

### DIFF
--- a/doc/cli/npm-dedupe.md
+++ b/doc/cli/npm-dedupe.md
@@ -47,6 +47,10 @@ registry.
 
 This feature is experimental, and may change in future versions.
 
+The `--tag` argument will apply to all of the affected dependencies. If a
+tag with the given name exists, the tagged version is preferred over newer
+versions.
+
 ## SEE ALSO
 
 * npm-ls(1)

--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -152,7 +152,9 @@ For example:
 
     npm install sax@">=0.1.0 <0.2.0" bench supervisor
 
-The `--tag` argument will apply to all of the specified install targets.
+The `--tag` argument will apply to all of the specified install targets. If a
+tag with the given name exists, the tagged version is preferred over newer
+versions.
 
 The `--force` argument will force npm to fetch remote resources even if a
 local copy exists on disk.

--- a/doc/cli/npm-tag.md
+++ b/doc/cli/npm-tag.md
@@ -10,9 +10,24 @@ npm-tag(1) -- Tag a published version
 Tags the specified version of the package with the specified tag, or the
 `--tag` config if not specified.
 
+A tag can be used when installing packages as a reference to a version instead
+of using a specific version number:
+
+    npm install <name>@<tag>
+
+When installing dependencies, a preferred tagged version may be specified:
+
+    npm install --tag <tag>
+
+This also applies to `npm dedupe`.
+
+Publishing a package always sets the "latest" tag to the published version.
+
 ## SEE ALSO
 
 * npm-publish(1)
+* npm-install(1)
+* npm-dedupe(1)
 * npm-registry(7)
 * npm-config(1)
 * npm-config(7)

--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -248,7 +248,14 @@ function findVersions (npm, summary, cb) {
     npm.registry.get(name, function (er, data) {
       var regVersions = er ? [] : Object.keys(data.versions)
       var locMatch = bestMatch(versions, ranges)
-      var regMatch = bestMatch(regVersions, ranges)
+      var regMatch;
+      var tag = npm.config.get("tag");
+      var distTags = data["dist-tags"];
+      if (distTags && distTags[tag] && data.versions[distTags[tag]]) {
+        regMatch = distTags[tag]
+      } else {
+        regMatch = bestMatch(regVersions, ranges)
+      }
 
       cb(null, [[name, has, loc, locMatch, regMatch, locs]])
     })


### PR DESCRIPTION
I'm doing this in my release script:

```
$ npm install --tag release
$ npm dedupe
```

This causes npm to look into the package.json for modules it wants to move to find the best version. If a newer version is in the registry, npm will install the new version.

With this patch, `npm dedupe --tag release` prefers the tagged version if available.
