### PR TITLE
Add git+file:// URL protocol

### DIFF
--- a/lib/utils/is-git-url.js
+++ b/lib/utils/is-git-url.js
@@ -8,6 +8,7 @@ function isGitUrl (url) {
     case "git+rsync:":
     case "git+ftp:":
     case "git+ssh:":
+    case "git+file:":
       return true
   }
 }


### PR DESCRIPTION
I added this to allow hosting private modules on a bare git repo, without needing to host that repo over HTTP or SSH.

I haven't run the full test suite yet as I'm behind a proxy which blocks git:// protocol, but other tests are passing.
