### PR TITLE
Exit nonzero when ls returns no results.

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -63,6 +63,8 @@ function ls (args, silent, cb) {
     }
     console.log(out)
 
+    if (args.length && !data._found) process.exitCode = 1
+
     // if any errors were found, then complain and exit status 1
     if (lite.problems && lite.problems.length) {
       er = lite.problems.join('\n')

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -44,7 +44,7 @@ process.on("exit", function (code) {
 })
 
 function exit (code, noLog) {
-  exitCode = exitCode || code
+  exitCode = exitCode || process.exitCode || code
 
   var doExit = npm.config.get("_exit")
   log.verbose("exit", [code, doExit])


### PR DESCRIPTION
Running `npm ls -p arglebargle` does not show anything but exits 0.  It would be convenient if in that case it exited nonzero so that no results could be detected programmatically.

The first commit is a polyfill to make npm respect process.exitCode like node does now.
