### PR TITLE
Fixed: npm was re-fetching tarballs on every `npm install`

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -602,12 +602,12 @@ function installMany (what, where, context, cb) {
 }
 
 function targetResolver (where, context, deps) {
-  var alreadyInstalledManually = context.explicit ? [] : null
+  var alreadyInstalledManually = context.explicit || npm.config.get("force") ? [] : null
     , nm = path.resolve(where, "node_modules")
     , parent = context.parent
     , wrap = context.wrap
 
-  if (!context.explicit) fs.readdir(nm, function (er, inst) {
+  if (!alreadyInstalledManually) fs.readdir(nm, function (er, inst) {
     if (er) return alreadyInstalledManually = []
 
     // don't even mess with non-package looking things
@@ -625,7 +625,8 @@ function targetResolver (where, context, deps) {
         // otherwise, make sure that it's a semver match with what we want.
         var bd = parent.bundleDependencies
         if (bd && bd.indexOf(d.name) !== -1 ||
-            semver.satisfies(d.version, deps[d.name] || "*", true)) {
+            semver.satisfies(d.version, deps[d.name] || "*", true) ||
+            deps[d.name] === d._resolved) {
           return cb(null, d.name)
         }
 
@@ -637,6 +638,7 @@ function targetResolver (where, context, deps) {
       alreadyInstalledManually = inst
     })
   })
+  if(npm.config.get("force")) alreadyInstalledManually = []
 
   var to = 0
   return function resolver (what, cb) {

--- a/test/tap/ignore-shrinkwrap.js
+++ b/test/tap/ignore-shrinkwrap.js
@@ -1,5 +1,4 @@
 var test = require("tap").test
-var npm = require("../../")
 var pkg = './ignore-shrinkwrap'
 
 var mr = require("npm-registry-mock")

--- a/test/tap/url-dependencies.js
+++ b/test/tap/url-dependencies.js
@@ -1,0 +1,78 @@
+var test = require("tap").test
+var rimraf = require("rimraf")
+
+var spawn = require("child_process").spawn
+var npm = require.resolve("../../bin/npm-cli.js")
+var node = process.execPath
+var pkg = "./url-dependencies"
+
+test("url-dependencies: download first time", function(t) {
+  rimraf.sync(__dirname + "/url-dependencies/node_modules")
+
+  performInstall(function(output){
+    if(!tarballWasFetched(output)){
+      t.fail("Tarball was not fetched")
+    }else{
+      t.pass("Tarball was fetched")
+    }
+    t.end()
+  })
+})
+
+test("url-dependencies: do not download subsequent times", function(t) {
+  rimraf.sync(__dirname + "/url-dependencies/node_modules")
+
+  performInstall(function(){
+    performInstall(function(output){
+      if(tarballWasFetched(output)){
+        t.fail("Tarball was fetched second time around")
+      }else{
+        t.pass("Tarball was not fetched")
+      }
+      t.end()
+    })
+  })
+})
+
+test("url-dependencies: still downloads multiple times when using --force", function(t) {
+  rimraf.sync(__dirname + "/url-dependencies/node_modules")
+
+  performInstall(function(){
+    performInstall(true, function(output){
+      if(tarballWasFetched(output)){
+        t.pass("Tarball was fetched when using --force")
+      }else{
+        t.fail("Tarball was not fetched when using --force")
+      }
+      t.end()
+    })
+  })
+})
+
+function tarballWasFetched(output){
+  return output.indexOf("http GET https://registry.npmjs.org/once/-/once-1.2.0.tgz") > -1
+}
+
+function performInstall (force, cb) {
+  if(typeof force === "function") cb = force, force = false
+  var output = ""
+    , child = spawn(node, [npm, "install", force ? "--force" : ""], {
+        cwd: pkg,
+        env: {
+          // npm_config_registry: "http://localhost:1337",
+          npm_config_cache_lock_stale: 1000,
+          npm_config_cache_lock_wait: 1000,
+          HOME: process.env.HOME,
+          Path: process.env.PATH,
+          PATH: process.env.PATH
+        }
+      })
+
+  child.stderr.on("data", function(data){
+    output += data.toString()
+  })
+  child.on("close", function () {
+    // process.exit()
+    cb(output)
+  })
+}

--- a/test/tap/url-dependencies/package.json
+++ b/test/tap/url-dependencies/package.json
@@ -1,0 +1,8 @@
+{
+  "author": "Steve Mason",
+  "name": "url-dependencies",
+  "version": "0.0.0",
+  "dependencies": {
+    "once": "https://registry.npmjs.org/once/-/once-1.2.0.tgz"
+  }
+}

--- a/test/tap/url-dependencies/package.json
+++ b/test/tap/url-dependencies/package.json
@@ -3,6 +3,6 @@
   "name": "url-dependencies",
   "version": "0.0.0",
   "dependencies": {
-    "once": "https://registry.npmjs.org/once/-/once-1.2.0.tgz"
+    "underscore": "http://localhost:1337/underscore/-/underscore-1.3.1.tgz"
   }
 }


### PR DESCRIPTION
Use the _resolved property from installed packages to avoid installing URL dependencies after they are already installed.  Also ensure that you can still use --force if the packages have really changed

This also fixes https://github.com/isaacs/npm/issues/3463 as shrinkwrapped dependencies are basically treated the same as tarball dependencies

Example package.json (any tarball URL will do, I just used one from the registry directly as it's small and I know everyone can get to it)

``` json
{
  "dependencies": {
    "once": "https://registry.npmjs.org/once/-/once-1.2.0.tgz"
  }
}
```

Existing behaviour:

```
$ time npm install
npm WARN package.json npm-cache-issue@0.0.0 No description
npm WARN package.json npm-cache-issue@0.0.0 No repository field.
npm WARN package.json npm-cache-issue@0.0.0 No README data
npm http GET https://registry.npmjs.org/once/-/once-1.2.0.tgz
npm http 200 https://registry.npmjs.org/once/-/once-1.2.0.tgz

real    0m2.398s
user    0m1.252s
sys 0m0.164s
```

With this patch:

```
$ npm install
npm WARN package.json npm-cache-issue@0.0.0 No description
npm WARN package.json npm-cache-issue@0.0.0 No repository field.
npm WARN package.json npm-cache-issue@0.0.0 No README data

real    0m1.306s
user    0m1.056s
sys 0m0.136s
```
