### PR TITLE
Allow npm repo for current local directory, like npm install .

### DIFF
--- a/doc/cli/repo.md
+++ b/doc/cli/repo.md
@@ -4,12 +4,15 @@ npm-repo(1) -- Open package repository page in the browser
 ## SYNOPSIS
 
     npm repo <pkgname>
+    npm repo (with no args in a package dir)
 
 ## DESCRIPTION
 
 This command tries to guess at the likely location of a package's
 repository URL, and then tries to open it using the `--browser`
-config param.
+config param. If no packagename is provided, it will search for
+a `package.json` in the current folder and try to use the property
+of the name field.
 
 ## CONFIGURATION
 

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -16,22 +16,39 @@ var npm = require("./npm.js")
   , opener = require("opener")
   , github = require('github-url-from-git')
   , githubUserRepo = require("github-url-from-username-repo")
+  , path = require("path")
+  , readJson = require("read-package-json")
+  , fs = require("fs")
 
 function repo (args, cb) {
-  if (!args.length) return cb(repo.usage)
-  var n = args[0].split("@").shift()
+  var n = args.length && args[0].split("@").shift() || '.'
+  fs.stat(n, function (er, s) {
+    if (er && er.code === "ENOENT") return callRegistry(n, cb)
+    else if (er) return cb(er)
+    if (!s.isDirectory()) return callRegistry(n, cb)
+    readJson(path.resolve(n, "package.json"), function (er, d) {
+      if (er) return cb(er)
+      getUrlAndOpen(d, cb)
+    })
+  })
+}
+
+function getUrlAndOpen (d, cb) {
+  var r = d.repository;
+  if (!r) return cb(new Error('no repository'));
+  // XXX remove this when npm@v1.3.10 from node 0.10 is deprecated
+  // from https://github.com/isaacs/npm-www/issues/418
+  if (githubUserRepo(r.url))
+    r.url = githubUserRepo(r.url)
+  var url = github(r.url)
+  if (!url)
+    return cb(new Error('no repository: could not get url'))
+  opener(url, { command: npm.config.get("browser") }, cb)
+}
+
+function callRegistry (n, cb) {
   registry.get(n + "/latest", 3600, function (er, d) {
     if (er) return cb(er)
-    var r = d.repository;
-    if (!r) return cb(new Error('no repository'));
-    // XXX remove this when npm@v1.3.10 from node 0.10 is deprecated
-    // from https://github.com/isaacs/npm-www/issues/418
-    if (githubUserRepo(r.url))
-      r.url = githubUserRepo(r.url)
-
-    var url = github(r.url)
-    if (!url)
-      return cb(new Error('no repository: could not get url'))
-    opener(url, { command: npm.config.get("browser") }, cb)
+    getUrlAndOpen(d, cb)
   })
 }


### PR DESCRIPTION
If you are in your local module, you might want to visit
the repository without knowing the repo name or typing the name in.

This adds `npm repo .` and `npm repo` so that the npm-repo-command
behaves like npm install

I think I talked with @ro-ka at jsconfeu about this
