### PR TITLE
Fixed some broken gist links in tests, all tests pass now

### DIFF
--- a/test/packages/npm-test-peer-deps/npm-ls.json
+++ b/test/packages/npm-test-peer-deps/npm-ls.json
@@ -1,8 +1,8 @@
 {
   "npm-test-peer-deps-file": {
     "version": "1.2.3",
-    "from": "https://raw.github.com/gist/3971128/3f6aa37b4fa1186c2f47da9b77dcc4ec496e3483/index.js",
-    "resolved": "https://raw.github.com/gist/3971128/3f6aa37b4fa1186c2f47da9b77dcc4ec496e3483/index.js",
+    "from": "https://gist.github.com/domenic/3971128/raw/7472b26a013ceb174c2d726314e9fa97465729bb/index.js",
+    "resolved": "https://gist.github.com/domenic/3971128/raw/7472b26a013ceb174c2d726314e9fa97465729bb/index.js",
     "dependencies": {
       "opener": {
         "version": "1.3.0",

--- a/test/packages/npm-test-peer-deps/package.json
+++ b/test/packages/npm-test-peer-deps/package.json
@@ -3,7 +3,7 @@
   "name": "npm-test-peer-deps",
   "version": "0.0.0",
   "dependencies": {
-    "npm-test-peer-deps-file": "https://raw.github.com/gist/3971128/3f6aa37b4fa1186c2f47da9b77dcc4ec496e3483/index.js"
+    "npm-test-peer-deps-file": "https://gist.github.com/domenic/3971128/raw/7472b26a013ceb174c2d726314e9fa97465729bb/index.js"
   },
   "scripts": {
     "test": "node test.js"

--- a/test/packages/npm-test-shrinkwrap/npm-shrinkwrap.json
+++ b/test/packages/npm-test-shrinkwrap/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "npm-test-single-file": {
       "version": "1.2.3",
-      "resolved": "https://raw.github.com/gist/1837112/index.js"
+      "resolved": "https://gist.github.com/isaacs/1837112/raw/9ef57a59fc22aeb1d1ca346b68826dcb638b8416/index.js"
     },
     "glob": {
       "version": "3.1.5",

--- a/test/packages/npm-test-shrinkwrap/package.json
+++ b/test/packages/npm-test-shrinkwrap/package.json
@@ -3,7 +3,7 @@
   "name": "npm-test-shrinkwrap",
   "version": "0.0.0",
   "dependencies": {
-    "npm-test-single-file": "https://raw.github.com/gist/1837112/index.js",
+    "npm-test-single-file": "https://gist.github.com/isaacs/1837112/raw/9ef57a59fc22aeb1d1ca346b68826dcb638b8416/index.js",
     "glob": "git://github.com/isaacs/node-glob.git#npm-test",
     "minimatch": "~0.1.0"
   },


### PR DESCRIPTION
There are broken tests that were referencing out dated gist url's.

I've updated these and now the tests pass again.
