### PR TITLE
Fix test for outdated-new-versions  in edge cases

### DIFF
--- a/test/tap/outdated-new-versions.js
+++ b/test/tap/outdated-new-versions.js
@@ -8,17 +8,23 @@ var port = 1331
 var address = "http://localhost:" + port
 var pkg = __dirname + '/outdated-new-versions'
 
-
 test("dicovers new versions in outdated", function (t) {
   process.chdir(pkg)
-
+  t.plan(2)
   mr(port, function (s) {
     npm.load({registry: address}, function () {
-      npm.outdated(function (er, d) {
-        t.equal("1.5.1", d[0][4]) // dependencies
-        t.equal("2.27.0", d[1][4]) // devDependencies
-        s.close()
-        t.end()
+      // purge old cached data from previous tests
+      npm.commands.cache.clean(["underscore"], function () {
+        npm.outdated(function (er, d) {
+          for (var i = 0; i < d.length; i++) {
+            if (d[i][1] === "underscore")
+              t.equal("1.5.1", d[i][4])
+            if (d[i][1] === "request")
+              t.equal("2.27.0", d[i][4])
+          }
+          s.close()
+          t.end()
+        })
       })
     })
   })


### PR DESCRIPTION
I noticed that the test for `outdated-new-versions.js` is not working in two cases:

Make the tests independent from the order of the data-Array which
differs when I run the test as standalone on my OSX machine.

Fix tests which clean cache:

As other tests are using underscore as test-package too and
are using other ports passed to spawn and exec via environment
variable the cached data the tests will fail as they try to
use a cached JSON with the previous registry url that uses
another port.
