### PR TITLE
Fix 'weird error'.

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -85,6 +85,9 @@ function errorHandler (er) {
   if (typeof er === "string") {
     log.error("", er)
     return exit(1, true)
+  } else if (typeof er === "number") {
+    log_error("exit code", er)
+    return exit(1, true)
   } else if (!(er instanceof Error)) {
     log.error("weird error", er)
     return exit(1, true)


### PR DESCRIPTION
Whenever npm gets an error code that is numeric, it outputs
'weird error' - including practically every instance of running
'npm test'.

This change outputs 'exit code' for numeric errors and 'weird error'
for the remaining cases.

Related: #3918
