### PR TITLE
Finally all npm tests pass locally on OSX with Node 0.10.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "devDependencies": {
     "ronn": "~0.3.6",
     "tap": "~0.4.0",
-    "npm-registry-mock": "~0.4.1"
+    "npm-registry-mock": "~0.5.2"
   },
   "engines": {
     "node": ">=0.6",

--- a/test/tap/ignore-shrinkwrap.js
+++ b/test/tap/ignore-shrinkwrap.js
@@ -8,11 +8,13 @@ var child
 var spawn = require("child_process").spawn
 var npm = require.resolve("../../bin/npm-cli.js")
 var node = process.execPath
+var path = require('path')
+var mock = path.join(__dirname, 'ignore-shrinkwrap/index.js')
 
 var customMocks = {
   "get": {
-    "/package.js": [200, {"ente" : true}],
-    "/shrinkwrap.js": [200, {"ente" : true}]
+    "/package.js": [200, mock],
+    "/shrinkwrap.js": [200, mock]
   }
 }
 

--- a/test/tap/ignore-shrinkwrap/index.js
+++ b/test/tap/ignore-shrinkwrap/index.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+    return true;
+}

--- a/test/tap/prepublish.js
+++ b/test/tap/prepublish.js
@@ -43,6 +43,7 @@ test('test', function (t) {
   var node = process.execPath
   var npm = path.resolve(__dirname, '../../cli.js')
   var env = {
+    npm_config_loglevel: 'silent',
     npm_config_cache: cache,
     npm_config_tmp: tmp,
     npm_config_prefix: pkg,


### PR DESCRIPTION
Some minor tweaks to make all tests pass locally on my Mac. Windows testing welcome!
- Set `loglevel` to silent in `prepublish` test
- Upgraded `npm-registry-mock` to latest for `outdated` test
- Used a different mock format for latest `npm-registry-mock` for `ignore-shrinkwrap` test
