### PR TITLE
Fix npm repo error for unnormalized shorthand urls

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -15,6 +15,7 @@ var npm = require("./npm.js")
   , log = require("npmlog")
   , opener = require("opener")
   , github = require('github-url-from-git')
+  , githubUserRepo = require("github-url-from-username-repo")
 
 function repo (args, cb) {
   if (!args.length) return cb(repo.usage)
@@ -23,7 +24,14 @@ function repo (args, cb) {
     if (er) return cb(er)
     var r = d.repository;
     if (!r) return cb(new Error('no repository'));
-    var url = github(r.url);
+    // XXX remove this when npm@v1.3.10 from node 0.10 is deprecated
+    // from https://github.com/isaacs/npm-www/issues/418
+    if (githubUserRepo(r.url))
+      r.url = githubUserRepo(r.url)
+
+    var url = github(r.url)
+    if (!url)
+      return cb(new Error('no repository: could not get url'))
     opener(url, { command: npm.config.get("browser") }, cb)
   })
 }

--- a/node_modules/github-url-from-username-repo/.npmignore
+++ b/node_modules/github-url-from-username-repo/.npmignore
@@ -1,0 +1,13 @@
+*.swp
+.*.swp
+
+.DS_Store
+*~
+.project
+.settings
+npm-debug.log
+coverage.html
+.idea
+lib-cov
+
+node_modules

--- a/node_modules/github-url-from-username-repo/.travis.yml
+++ b/node_modules/github-url-from-username-repo/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.8"
+  - "0.10"

--- a/node_modules/github-url-from-username-repo/LICENSE
+++ b/node_modules/github-url-from-username-repo/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) Robert Kowalski ("Author")
+All rights reserved.
+
+The BSD License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/node_modules/github-url-from-username-repo/README.md
+++ b/node_modules/github-url-from-username-repo/README.md
@@ -1,0 +1,14 @@
+[![Build Status](https://travis-ci.org/robertkowalski/github-url-from-username-repo.png?branch=master)](https://travis-ci.org/robertkowalski/github-url-from-username-repo)
+[![Dependency Status](https://gemnasium.com/robertkowalski/github-url-from-username-repo.png)](https://gemnasium.com/robertkowalski/github-url-from-username-repo)
+
+
+# github-url-from-username-repo
+
+## Usage
+
+```javascript
+
+var getUrl = require("github-url-from-username-repo")
+getUrl("visionmedia/express") // git://github.com/visionmedia/express
+
+```

--- a/node_modules/github-url-from-username-repo/index.js
+++ b/node_modules/github-url-from-username-repo/index.js
@@ -1,0 +1,9 @@
+module.exports = getUrl
+
+function getUrl (r) {
+  if (!r) return
+  if (/^[\w-]+\/[\w-]+$/.test(r))
+    return "git://github.com/" + r
+  else
+    return null
+}

--- a/node_modules/github-url-from-username-repo/package.json
+++ b/node_modules/github-url-from-username-repo/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "github-url-from-username-repo",
+  "version": "0.0.2",
+  "description": "Create urls from username/repo",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha -R spec"
+  },
+  "devDependencies": {
+    "mocha": "~1.13.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:robertkowalski/github-url-from-username-repo.git"
+  },
+  "author": {
+    "name": "Robert Kowalski",
+    "email": "rok@kowalski.gd"
+  },
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/robertkowalski/github-url-from-username-repo/issues"
+  },
+  "keywords": [
+    "git",
+    "github",
+    "repo"
+  ],
+  "readme": "[![Build Status](https://travis-ci.org/robertkowalski/github-url-from-username-repo.png?branch=master)](https://travis-ci.org/robertkowalski/github-url-from-username-repo)\n[![Dependency Status](https://gemnasium.com/robertkowalski/github-url-from-username-repo.png)](https://gemnasium.com/robertkowalski/github-url-from-username-repo)\n\n\n# github-url-from-username-repo\n\n## Usage\n\n```javascript\n\nvar getUrl = require(\"github-url-from-username-repo\")\ngetUrl(\"visionmedia/express\") // git://github.com/visionmedia/express\n\n```",
+  "readmeFilename": "README.md",
+  "_id": "github-url-from-username-repo@0.0.2",
+  "_from": "github-url-from-username-repo@"
+}

--- a/node_modules/github-url-from-username-repo/test/index.js
+++ b/node_modules/github-url-from-username-repo/test/index.js
@@ -1,0 +1,21 @@
+var assert = require("assert")
+var getUrl = require("../")
+
+describe("github url from username/repo", function () {
+  it("returns a github url for the username/repo", function () {
+    var url = getUrl("visionmedia/express")
+    assert.equal("git://github.com/visionmedia/express", url)
+  })
+  it("works with -", function () {
+    var url = getUrl("vision-media/express-package")
+    assert.equal("git://github.com/vision-media/express-package", url)
+  })
+  it("returns null if it does not match", function () {
+    var url = getUrl("package")
+    assert.deepEqual(null, url)
+  })
+  it("returns undefined if no repo/user was given", function () {
+    var url = getUrl()
+    assert.deepEqual(undefined, url)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "editor": "0.0.4",
     "child-process-close": "~0.1.1",
     "npm-user-validate": "0.0.3",
-    "github-url-from-git": "1.1.1"
+    "github-url-from-git": "1.1.1",
+    "github-url-from-username-repo": "0.0.2"
   },
   "bundleDependencies": [
     "semver",
@@ -118,7 +119,8 @@
     "child-process-close",
     "editor",
     "npm-user-validate",
-    "github-url-from-git"
+    "github-url-from-git",
+    "github-url-from-username-repo"
   ],
   "devDependencies": {
     "ronn": "~0.3.6",


### PR DESCRIPTION
New npm versions are supporting the shorthand username/repo
in the repository field of the package.json - but sometimes
people with old npm versions are publishing them and they
do not get normalized.

Fixes #3952
