### PR TITLE
Fix tests, also on windows

### DIFF
--- a/test/tap/outdated-new-versions.js
+++ b/test/tap/outdated-new-versions.js
@@ -1,25 +1,38 @@
 var test = require("tap").test
 var npm = require("../../")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+
 
 var mr = require("npm-registry-mock")
 
 // config
 var port = 1331
 var address = "http://localhost:" + port
-var pkg = __dirname + '/outdated-new-versions'
+var pkg = __dirname + "/outdated-new-versions"
+mkdirp.sync(pkg + "/cache")
 
 
 test("dicovers new versions in outdated", function (t) {
   process.chdir(pkg)
-
+  t.plan(2)
   mr(port, function (s) {
-    npm.load({registry: address}, function () {
+    npm.load({cache: pkg + "/cache", registry: address}, function () {
       npm.outdated(function (er, d) {
-        t.equal("1.5.1", d[0][4]) // dependencies
-        t.equal("2.27.0", d[1][4]) // devDependencies
+        for (var i = 0; i < d.length; i++) {
+          if (d[i][1] === "underscore")
+            t.equal("1.5.1", d[i][4])
+          if (d[i][1] === "request")
+            t.equal("2.27.0", d[i][4])
+        }
         s.close()
         t.end()
       })
     })
   })
+})
+
+test("cleanup", function (t) {
+  rimraf.sync(pkg + "/cache")
+  t.end()
 })

--- a/test/tap/prepublish.js
+++ b/test/tap/prepublish.js
@@ -8,6 +8,7 @@ var cache = pkg + '/cache'
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var path = require('path')
+var os = require('os')
 
 test('setup', function (t) {
   var n = 0
@@ -72,7 +73,7 @@ test('test', function (t) {
            , '> npm-test-prepublish@1.2.5 prepublish .\n'
            + '> echo ok\n'
            + '\n'
-           + 'ok\n'
+           + 'ok' + os.EOL
            + 'npm-test-prepublish-1.2.5.tgz')
     t.end()
   }

--- a/test/tap/publish-config.js
+++ b/test/tap/publish-config.js
@@ -1,5 +1,6 @@
 var test = require('tap').test
 var fs = require('fs')
+var osenv = require('osenv')
 var pkg = process.env.npm_config_tmp || '/tmp'
 pkg += '/npm-test-publish-config'
 
@@ -41,7 +42,8 @@ test(function (t) {
         npm_config_cache_lock_wait: 1000,
         HOME: process.env.HOME,
         Path: process.env.PATH,
-        PATH: process.env.PATH
+        PATH: process.env.PATH,
+        USERPROFILE: osenv.home()
       }
     })
   })


### PR DESCRIPTION
Should fix the timeouts in windows tests, too.

Runs with the current version specified in the `package.json`, run `npm install` to make sure npm-registry-mock is at 1.4.4
