### PR TITLE
force reinstall flag for npm

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -7,7 +7,7 @@ npm-install(1) -- Install a package
     npm install <tarball file>
     npm install <tarball url>
     npm install <folder>
-    npm install <name> [--save|--save-dev|--save-optional] [--force-install]
+    npm install <name> [--save|--save-dev|--save-optional] [--force-reinstall]
     npm install <name>@<tag>
     npm install <name>@<version>
     npm install <name>@<version range>
@@ -67,7 +67,7 @@ after packing it up into a tarball (b).
 
           npm install https://github.com/indexzero/forever/tarball/v0.5.6
 
-* `npm install <name> [--save|--save-dev|--save-optional] [--force-install]`:
+* `npm install <name> [--save|--save-dev|--save-optional] [--force-reinstall]`:
 
     Do a `<name>@<tag>` install, where `<tag>` is the "tag" config. (See
     `npm-config(7)`.)
@@ -97,6 +97,10 @@ after packing it up into a tarball (b).
     `npm install` also takes an optional `--force-reinstall` flag which will
     cause npm to force installation of a dependency even if the requested package
     already exists in the node_modules directory.
+
+    Examples:
+
+          npm install emailjs --force-reinstall
 
     **Note**: If there is a file or folder named `<name>` in the current
     working directory, then it will try to install that, and only try to

--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -7,7 +7,7 @@ npm-install(1) -- Install a package
     npm install <tarball file>
     npm install <tarball url>
     npm install <folder>
-    npm install <name> [--save|--save-dev|--save-optional]
+    npm install <name> [--save|--save-dev|--save-optional] [--force-install]
     npm install <name>@<tag>
     npm install <name>@<version>
     npm install <name>@<version range>
@@ -67,7 +67,7 @@ after packing it up into a tarball (b).
 
           npm install https://github.com/indexzero/forever/tarball/v0.5.6
 
-* `npm install <name> [--save|--save-dev|--save-optional]`:
+* `npm install <name> [--save|--save-dev|--save-optional] [--force-install]`:
 
     Do a `<name>@<tag>` install, where `<tag>` is the "tag" config. (See
     `npm-config(7)`.)
@@ -79,7 +79,7 @@ after packing it up into a tarball (b).
 
           npm install sax
 
-    `npm install` takes 3 exclusive, optional flags which save or update
+    `npm install` takes 3 exclusive, optional save flags which save or update
     the package version in your main package.json:
 
     * `--save`: Package will appear in your `dependencies`.
@@ -94,6 +94,9 @@ after packing it up into a tarball (b).
           npm install node-tap --save-dev
           npm install dtrace-provider --save-optional
 
+    `npm install` also takes an optional `--force-reinstall` flag which will
+    cause npm to force installation of a dependency even if the requested package
+    already exists in the node_modules directory.
 
     **Note**: If there is a file or folder named `<name>` in the current
     working directory, then it will try to install that, and only try to

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -55,6 +55,7 @@ The following shorthands are parsed on the command-line:
 * `-reg`: `--registry`
 * `-v`: `--version`
 * `-f`: `--force`
+* `-fi`: `--force-reinstall`
 * `-desc`: `--description`
 * `-S`: `--save`
 * `-D`: `--save-dev`
@@ -263,6 +264,14 @@ Makes various commands more forceful.
 * publishing clobbers previously published versions.
 * skips cache when requesting from the registry.
 * prevents checks against clobbering non-npm files.
+
+### force-reinstall
+
+* Default: false
+* Type: Boolean
+
+If set to true, then npm will stubbornly download all node modules dependencies
+even if the dependency currently exists in the node_modules directory.
 
 ### fetch-retries
 

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -55,7 +55,7 @@ The following shorthands are parsed on the command-line:
 * `-reg`: `--registry`
 * `-v`: `--version`
 * `-f`: `--force`
-* `-fi`: `--force-reinstall`
+* `-fr`: `--force-reinstall`
 * `-desc`: `--description`
 * `-S`: `--save`
 * `-D`: `--save-dev`

--- a/lib/install.js
+++ b/lib/install.js
@@ -623,7 +623,7 @@ function targetResolver (what, where, context, deps) {
         if (er) return cb(null, [])
 
         if (!forceReinstall) {
-          // for a --skip-installed install we test the available packages
+          // without a --force-reinstall, we test the available packages
           // against what's in node_modules, allowing for semver matching
           // which even allows for cmds like:
           //   npm install 'pkg@>=0.1.0' --skip-installed

--- a/lib/install.js
+++ b/lib/install.js
@@ -566,7 +566,7 @@ function installMany (what, where, context, cb) {
     // what is a list of things.
     // resolve each one.
     asyncMap( what
-            , targetResolver(where, context, d)
+            , targetResolver(what, where, context, d)
             , function (er, targets) {
 
       if (er) return cb(er)
@@ -601,13 +601,14 @@ function installMany (what, where, context, cb) {
   })
 }
 
-function targetResolver (where, context, deps) {
-  var alreadyInstalledManually = context.explicit ? [] : null
+function targetResolver (what, where, context, deps) {
+  var forceReinstall = npm.config.get('force-reinstall')
+    , alreadyInstalledManually = context.explicit && forceReinstall ? [] : null
     , nm = path.resolve(where, "node_modules")
     , parent = context.parent
     , wrap = context.wrap
 
-  if (!context.explicit) fs.readdir(nm, function (er, inst) {
+  if (!context.explicit || !forceReinstall) fs.readdir(nm, function (er, inst) {
     if (er) return alreadyInstalledManually = []
 
     // don't even mess with non-package looking things
@@ -621,12 +622,25 @@ function targetResolver (where, context, deps) {
         // error means it's not a package, most likely.
         if (er) return cb(null, [])
 
-        // if it's a bundled dep, then assume that anything there is valid.
-        // otherwise, make sure that it's a semver match with what we want.
-        var bd = parent.bundleDependencies
-        if (bd && bd.indexOf(d.name) !== -1 ||
-            semver.satisfies(d.version, deps[d.name] || "*", true)) {
-          return cb(null, d.name)
+        if (!forceReinstall) {
+          // for a --skip-installed install we test the available packages
+          // against what's in node_modules, allowing for semver matching
+          // which even allows for cmds like:
+          //   npm install 'pkg@>=0.1.0' --skip-installed
+          if (what.some(function (w) {
+               return new RegExp("^" + d.name + "(@|$)").test(w) &&
+                 semver.satisfies(d.version, w.split("@")[1] || "*", true)
+              })) {
+            return cb(null, d.name)
+          }
+        } else {
+          // if it's a bundled dep, then assume that anything there is valid.
+          // otherwise, make sure that it's a semver match with what we want.
+          var bd = parent.bundleDependencies
+          if (bd && bd.indexOf(d.name) !== -1 ||
+              semver.satisfies(d.version, deps[d.name] || "*", true)) {
+            return cb(null, d.name)
+          }
         }
 
         // something is there, but it's not satisfactory.  Clobber it.

--- a/node_modules/npmconf/config-defs.js
+++ b/node_modules/npmconf/config-defs.js
@@ -222,6 +222,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , editor : osenv.editor()
     , "engine-strict": false
     , force : false
+    , "force-reinstall" : false
 
     , "fetch-retries": 2
     , "fetch-retry-factor": 10
@@ -319,6 +320,7 @@ exports.types =
   , editor : String
   , "engine-strict": Boolean
   , force : Boolean
+  , "force-reinstall" : Boolean
   , "fetch-retries": Number
   , "fetch-retry-factor": Number
   , "fetch-retry-mintimeout": Number


### PR DESCRIPTION
@KevinSheedy made an [excellent suggestion](https://github.com/isaacs/npm/pull/2388#issuecomment-21664472) on improving upon @rvagg's <code>--skip-installed</code> flag for npm.

this is my attempt at making that happen.

the goal of this patch is to make npm be smart about making network requests upon <code>npm install XYZ</code> commands. currently, it fetches <code>XYZ</code> everytime, even when the library already exists.

for continuous integration and provisioned development environments, this feature will come in handy. particularly the many many times i'm on a bus and i need to re-run some setup scripts...

this PR is meant to override https://github.com/isaacs/npm/pull/2388 which is a bit stale by now and proposes an odd syntax that @isaacs [pointed out](https://github.com/isaacs/npm/pull/2388#issuecomment-21657832).
