### PR TITLE
Package verification using gpg

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -83,6 +83,7 @@ var mkdir = require("mkdirp")
   , chmodr = require("chmodr")
   , which = require("which")
   , isGitUrl = require("./utils/is-git-url.js")
+  , gpg = require("./utils/gpg.js")
 
 cache.usage = "npm cache add <tarball file>"
             + "\nnpm cache add <folder>"
@@ -261,7 +262,7 @@ function add (args, cb) {
   switch (p.protocol) {
     case "http:":
     case "https:":
-      return addRemoteTarball(spec, null, name, cb)
+      return addRemoteTarball(spec, null, null, name, cb)
 
     default:
       if (isGitUrl(p))
@@ -277,16 +278,34 @@ function add (args, cb) {
   }
 }
 
-function fetchAndShaCheck (u, tmp, shasum, cb) {
+function fetchAndCheck (u, uSign, tmp, shasum, cb) {
+  function shaCheck (next) {
+    if (!shasum) return next()
+    
+    // validate that the url we just downloaded matches the expected shasum.
+    sha.check(tmp, shasum, next)
+  }
+  
+  function gpgCheck (next) {
+    if (!uSign) return next()
+    
+    gpg.fetchAndVerifySign(uSign, tmp, next)
+  }
+
   fetch(u, tmp, function (er, response) {
     if (er) {
       log.error("fetch failed", u)
       return cb(er, response)
     }
-    if (!shasum) return cb(null, response)
-    // validate that the url we just downloaded matches the expected shasum.
-    sha.check(tmp, shasum, function (er) {
-      return cb(er, response, shasum)
+
+    shaCheck(function(er) {
+      if (er) return cb(er)
+
+      gpgCheck(function (er) {
+        if (er) return cb(er)
+
+        cb(er, response, shasum)
+      })
     })
   })
 }
@@ -294,7 +313,7 @@ function fetchAndShaCheck (u, tmp, shasum, cb) {
 // Only have a single download action at once for a given url
 // additional calls stack the callbacks.
 var inFlightURLs = {}
-function addRemoteTarball (u, shasum, name, cb_) {
+function addRemoteTarball (u, uSign, shasum, name, cb_) {
   if (typeof cb_ !== "function") cb_ = name, name = ""
   if (typeof cb_ !== "function") cb_ = shasum, shasum = null
 
@@ -320,10 +339,10 @@ function addRemoteTarball (u, shasum, name, cb_) {
   lock(u, function (er) {
     if (er) return cb(er)
 
-    log.verbose("addRemoteTarball", [u, shasum])
+    log.verbose("addRemoteTarball", [u, uSign, shasum])
     mkdir(path.dirname(tmp), function (er) {
       if (er) return cb(er)
-      addRemoteTarball_(u, tmp, shasum, done)
+      addRemoteTarball_(u, uSign, tmp, shasum, done)
     })
   })
 
@@ -333,7 +352,7 @@ function addRemoteTarball (u, shasum, name, cb_) {
   }
 }
 
-function addRemoteTarball_(u, tmp, shasum, cb) {
+function addRemoteTarball_(u, uSign, tmp, shasum, cb) {
   // Tuned to spread 3 attempts over about a minute.
   // See formula at <https://github.com/tim-kos/node-retry>.
   var operation = retry.operation
@@ -345,7 +364,7 @@ function addRemoteTarball_(u, tmp, shasum, cb) {
   operation.attempt(function (currentAttempt) {
     log.info("retry", "fetch attempt " + currentAttempt
       + " at " + (new Date()).toLocaleTimeString())
-    fetchAndShaCheck(u, tmp, shasum, function (er, response, shasum) {
+    fetchAndCheck(u, uSign, tmp, shasum, function (er, response, shasum) {
       // Only retry on 408, 5xx or no `response`.
       var sc = response && response.statusCode
       var statusRetry = !sc || (sc === 408 || sc >= 500)
@@ -777,12 +796,21 @@ function addNameVersion (name, v, data, cb) {
       tb.protocol = url.parse(npm.config.get("registry")).protocol
       delete tb.href
       tb = url.format(tb)
+
+      if (typeof(dist.signature) === 'string') {
+        var sign = url.parse(dist.signature)
+        sign.protocol = url.parse(npm.config.get("registry")).protocol
+        delete sign.href
+        sign = url.format(sign)
+      }
+
       // only add non-shasum'ed packages if --forced.
       // only ancient things would lack this for good reasons nowadays.
       if (!dist.shasum && !npm.config.get("force")) {
         return cb(new Error("package lacks shasum: " + data._id))
       }
       return addRemoteTarball( tb
+                             , sign
                              , dist.shasum
                              , name+"-"+ver
                              , cb )

--- a/lib/utils/gpg.js
+++ b/lib/utils/gpg.js
@@ -1,0 +1,142 @@
+
+var child_process = require("child_process")
+  , which = require("which")
+  , log = require("npmlog")
+  , fetch = require("./fetch.js")
+  , npm = require("../npm.js")
+
+var gpgExists = null;
+
+function fetchAndVerifySign (url, tmp, cb) {
+  var gpg = (npm.config.get && npm.config.get("gpg")) || 'gpg'
+    , tmpSign = tmp + '.sign'
+
+  // check if gpg is present in the system,
+  // warn if it doesn't (only in the first time)
+  if (gpgExists === null) {
+    which(gpg, function (err) {
+      if (err) {
+        log.warn('cannot find gpg',
+                 'npm won\'t be able to verify signed packages')
+        //       from a very tiny amount of non-lazy maintainers
+        //       who actually bothered to sign them
+      }
+
+      gpgExists = !err;
+      gpgFound(gpgExists)
+    })
+  } else {
+    gpgFound(gpgExists)
+  }
+
+  // if gpg is present, fetch .sign file, otherwise just return
+  function gpgFound (exists) {
+    if (!exists) return cb()
+
+    fetch(url, tmpSign, function (er) {
+      if (er) {
+        log.error("fetch failed", url)
+        return cb(er)
+      }
+
+      gpgVerifyFile(tmp, tmpSign, cb)
+    })
+  }
+}
+
+// call gpg and parse its output to check if signature is valid
+function gpgVerifyFile (tmp, tmpSign, cb) {
+  var args = ['--status-fd', 1, '--verify', tmpSign, tmp]
+    , opts = {env: process.env}
+    , gpg = (npm.config.get && npm.config.get("gpg")) || 'gpg'
+
+  child_process.execFile(gpg, args, opts, function (er, stdout, stderr) {
+    var lines = stdout.split('\n')
+      , keywords = {}
+      , cb_called = false
+
+    log.silly('gpg args', args)
+    log.silly('gpg stdout', stdout)
+    log.silly('gpg stderr', stderr)
+    log.silly('gpg status', (er && er.code) || 0)
+
+    function checkOutput (key, msg, keyid) {
+      if (cb_called) return
+
+      if (keywords[key]) {
+        if (msg.indexOf('#') >= 0) {
+          // replace '#' with the first argument (a long keyid)
+          if (!keyid) keyid = keywords[key].replace(/ .*/, '')
+          msg = msg.replace(/#/g, keyid)
+        }
+
+        cb_called = true
+
+        // error.code is mainly for tests, but can be useful elsewhere
+        var error = new Error('bad signature:\n' + msg)
+        error.code = 'GPG_' + key
+        cb(error)
+      }
+    }
+
+    // sometimes gpg returns an error without any output to status fd
+    if (!stdout && er) {
+      return cb(new Error('gpg error ' + er.code + ':\n' + stderr))
+    }
+
+    for (var i = 0; i < lines.length; i++) {
+      var match = lines[i].match(/^\[GNUPG:\] ([A-Z_]+) (.*)/)
+      if (match) keywords[match[1]] = match[2];
+    }
+
+    // We're starting from least expected errors to most expected ones
+    //
+    // It is usually a bad idea, but in this case we want to return
+    // a most specific error to a user, and don't take any chance of
+    // suspicious gpg output to slip through.
+
+    // specific errors first
+    checkOutput('NO_PUBKEY',
+      "Public key with keyid # is not available.")
+
+    checkOutput('REVKEYSIG',
+      "The signature with the keyid # was revoked.")
+
+    checkOutput('EXPSIG',
+      "Public key with the keyid # is expired.")
+
+    checkOutput('EXPKEYSIG',
+      "The signature with the keyid # was made by an expired key.")
+
+    // KEYEXPIRED msg doesn't provide keyid, so extract it from BADSIG
+    checkOutput('KEYEXPIRED',
+      "Public key with the keyid # is expired.",
+      (keywords.BADSIG || '').replace(/ .*/, ''))
+
+    // generic errors now
+    checkOutput('BADSIG',
+      "The signature with the keyid # has not been verified okay.")
+
+    // crc error or something
+    checkOutput('NODATA',
+      "The signature file is invalid.")
+
+    checkOutput('ERRSIG',
+      "The signature with the keyid # cannot be checked.")
+
+    // return if cb() called by checkOutput with an error
+    if (cb_called) return;
+
+    if (keywords.GOODSIG && keywords.VALIDSIG && er == null) {
+      // requiring presence of both keywords to say that it's valid
+      return cb()
+    }
+
+    // this should never happen (except for in tests)
+    return cb(new Error("gpg - cannot parse output:\n" + stdout))
+  })
+}
+
+module.exports.fetchAndVerifySign = fetchAndVerifySign
+module.exports.gpgVerifyFile = gpgVerifyFile
+

--- a/test/tap/gpg.js
+++ b/test/tap/gpg.js
@@ -1,0 +1,176 @@
+var test = require("tap").test
+var verify = require("../../lib/utils/gpg").gpgVerifyFile
+var child_process = require("child_process")
+var _orig_exec = child_process.execFile
+
+// A bunch of tests that override exec('gpg, ...) and check
+// that GPG output is parsed correctly
+
+function addTest (name, gpgOutput, gpgExitCode, cb) {
+  if (!cb) {
+    // gpgExitCode is optional, defaults to 0
+    cb = gpgExitCode
+    gpgExitCode = 0
+  }
+
+  test(name, function(t) {
+    child_process.execFile = function(file, args, opts, cb) {
+      if (gpgExitCode) {
+        cb({code: gpgExitCode}, gpgOutput, 'gpg_stderr_input')
+      } else {
+        cb(null, gpgOutput, 'gpg_stderr_output')
+      }
+    }
+    verify("xxxxx", "yyyyy", function(err) {
+      child_process.execFile = _orig_exec
+      cb(t, err)
+    })
+  })
+}
+
+test("setup", function(t) {
+  t.end()
+})
+
+test("calling", function(t) {
+  child_process.execFile = function(file, args, opts, cb) {
+    // both files should be arguments, so sign will be processed
+    // as a detached one
+    t.ok(args.indexOf("xxxxx") >= 0)
+    t.ok(args.indexOf("yyyyy") >= 0)
+
+    // these arguments should be present, it's weird if they don't
+    t.ok(args.indexOf("--status-fd") >= 0)
+    t.ok(args.indexOf("--verify") >= 0)
+
+    child_process.execFile = _orig_exec
+    t.end()
+  }
+  verify("xxxxx", "yyyyy", function() {});
+})
+
+var goodsig =
+  [ '[GNUPG:] SIG_ID 7yxv7UktU03mdVZGkBeftUfwNAE 2013-10-12 1381555456'
+  , '[GNUPG:] GOODSIG 98F4DE4B2D201C0A John Doe <test@example.com>'
+  , '[GNUPG:] VALIDSIG 37FCF987495045D2759C8FA898F4DE4B2D201C0A 2013-10-12 1381555456 0 4 0 1 2 00 37FCF987495045D2759C8FA898F4DE4B2D201C0A'
+  , '[GNUPG:] TRUST_ULTIMATE'
+  , ''
+  ].join("\n")
+
+var badsig = '[GNUPG:] BADSIG 98F4DE4B2D201C0A John Doe <test@example.com>\n'
+
+var expiredsig = 
+  [ '[GNUPG:] KEYEXPIRED 1169711867'
+  , '[GNUPG:] SIGEXPIRED deprecated-use-keyexpired-instead'
+  , '[GNUPG:] SIG_ID PqEHxvlYlEeX4yfEeOKZ65t96Tg 2010-03-05 1267754932'
+  , '[GNUPG:] KEYEXPIRED 1169711867'
+  , '[GNUPG:] SIGEXPIRED deprecated-use-keyexpired-instead'
+  , '[GNUPG:] EXPKEYSIG 98F4DE4B2D201C0A John Doe <test@example.com>'
+  , '[GNUPG:] KEYEXPIRED 1343379765'
+  , '[GNUPG:] SIGEXPIRED deprecated-use-keyexpired-instead'
+  , '[GNUPG:] VALIDSIG 8C369BDFA2B66CF61DB6E69DC15901320D9B5665 2010-03-05 1267754932 0 4 0 1 2 01 8C369BDFA2B66CF61DB6E69DC15901320D9B5665'
+  , ''
+  ].join("\n")
+
+var unknownsig =
+  [ '[GNUPG:] ERRSIG 98F4DE4B2D201C0A 1 2 00 1381093580 9'
+  , '[GNUPG:] NO_PUBKEY 98F4DE4B2D201C0A'
+  , ''
+  ].join("\n")
+
+var badfile =
+  [ '[GNUPG:] NODATA 1'
+  , '[GNUPG:] NODATA 2'
+  , ''
+  ].join("\n")
+
+addTest('good signature', goodsig, function(t, err) {
+  t.ok(!err)
+  t.end()
+})
+
+// shouldn't return success on non-zero status code, ever
+addTest('bad exit code', '', 1, function(t, err) {
+  t.ok(err.message.match(/gpg_stderr_input/))
+  t.end()
+})
+
+addTest('bad exit code 2', goodsig, 1, function(t, err) {
+  t.ok(err.message.match(/cannot parse output/))
+  t.end()
+})
+
+// routine checks
+addTest('bad sig', badsig, function(t, err) {
+  t.equal(err.code, 'GPG_BADSIG')
+  t.ok(err.message.match(/98F4DE4B2D201C0A/))
+  t.end()
+})
+
+addTest('expired sig', expiredsig, function(t, err) {
+  t.equal(err.code, 'GPG_EXPKEYSIG')
+  t.ok(err.message.match(/98F4DE4B2D201C0A/))
+  t.end()
+})
+
+addTest('corrupted sig', badfile, function(t, err) {
+  t.equal(err.code, 'GPG_NODATA')
+  t.end()
+})
+
+addTest('unknown sig', unknownsig, function(t, err) {
+  t.equal(err.code, 'GPG_NO_PUBKEY')
+  t.ok(err.message.match(/98F4DE4B2D201C0A/))
+  t.end()
+})
+
+// if there any suspicious output, fail
+addTest('joined sigs', goodsig+badsig, function(t, err) {
+  t.equal(err.code, 'GPG_BADSIG')
+  t.ok(err.message.match(/98F4DE4B2D201C0A/))
+  t.end()
+})
+
+addTest('joined sigs 2', badsig+goodsig, function(t, err) {
+  t.equal(err.code, 'GPG_BADSIG')
+  t.ok(err.message.match(/98F4DE4B2D201C0A/))
+  t.end()
+})
+
+addTest('joined sigs 3', goodsig+expiredsig, function(t, err) {
+  t.equal(err.code, 'GPG_EXPKEYSIG')
+  t.ok(err.message.match(/98F4DE4B2D201C0A/))
+  t.end()
+})
+
+// we're waiting for both validsig and goodsig
+addTest('no goodsig', goodsig.replace(/GOOD/, 'G00D'), function(t, err) {
+  t.ok(err.message.match(/cannot parse output/))
+  t.end()
+})
+
+addTest('no validsig', goodsig.replace(/VALID/, 'VAL1D'), function(t, err) {
+  t.ok(err.message.match(/cannot parse output/))
+  t.end()
+})
+
+// various garbage output
+addTest('garbage 1', goodsig.replace(/GNUPG/g, 'GPUNG'), function(t, err) {
+  t.ok(err.message.match(/cannot parse output/))
+  t.end()
+})
+
+addTest('garbage 2', goodsig.replace(/ /g, '  '), function(t, err) {
+  t.ok(err.message.match(/cannot parse output/))
+  t.end()
+})
+
+addTest('garbage 3', goodsig.replace(/\n/g, '\n '), function(t, err) {
+  t.ok(err.message.match(/cannot parse output/))
+  t.end()
+})
+
+test("shutdown", function(t) {
+  child_process.execFile = _orig_exec
+  t.end()
+})


### PR DESCRIPTION
It's a step towards package signing that was in roadmap for a quite long time. Since nobody seems to be doing that, I started to implement it myself, so...

For all current packages behaviour of npm is not changed.

However, if there's a `dist.signature` field near a `dist.tarball` field we're downloading (i.e. with `npm install`), npm will assume that `dist.signature` is a url pointing to a detached pgp signature, will download it and verify a tarball with it using external `gpg` program.

Web of trust is not used, all keys in the default public keyring are treated equally.

I also uploaded a [test package](http://registry.npmjs.org/test-package-signing/valid) you can use to check if npm behaves correctly in different cases. That's how you can test it:

``` perl
# Add a public key to your keyring, it can be a bad idea to add pgp
# keys this way, but it looks good enough for testing purposes
gpg --keyserver pgp.mit.edu --recv-key 0x7FC5D0F9888C20BC

# This is a only one correctly signed package, should be installed without issues
npm install test-package-signing@valid

# This package has an incorrect signature belonging to another file
npm install test-package-signing@badsig

# This is a package signed with a different key you don't have
npm install test-package-signing@diffkey

# This package has an garbage instead of signature
npm install test-package-signing@invalid

# This package has a wrong signature url (no sig uploaded)
npm install test-package-signing@nosig
```

It's a verification only. npm is still unable to sign anything, and it would require another few weeks to implement properly and a couple of pull requests to different npm dependencies. So I'd rather see your feedback to this one before continuing.
