### PR TITLE
Support file:// protocol for local tarball installs

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -263,6 +263,9 @@ function add (args, cb) {
     case "https:":
       return addRemoteTarball(spec, null, name, cb)
 
+    case "file:":
+      return addLocal(spec.slice('file://'.length), cb);
+
     default:
       if (isGitUrl(p))
         return addRemoteGit(spec, p, name, false, cb)


### PR DESCRIPTION
I find the behaviour of npm to be inconsistent with installing local tarballs - using `npm install /path/to/package.tgz` on the command line works fine, but adding the same to dependencies in `package.json` causes npm to interpret the path as a version spec, and tries to pull from the registry.

This patch solves this by allowing the file:// protocol, which will always treat the spec as a local path, so the following will both work consistently:

```
npm install file:///path/to/package.tgz
```

```
  "dependencies": {
    "package": "file:///path/to/package.tgz"
  }
```
