### PR TITLE
add email and _auth for publish-config test

### DIFF
--- a/test/tap/publish-config.js
+++ b/test/tap/publish-config.js
@@ -35,7 +35,7 @@ test(function (t) {
     // itself functions normally.
     //
     // Make sure that we don't sit around waiting for lock files
-    child = spawn(node, [npm, 'publish'], {
+    child = spawn(node, [npm, 'publish', '--email=fancy', '--_auth=feast'], {
       cwd: pkg,
       env: {
         npm_config_cache_lock_stale: 1000,


### PR DESCRIPTION
This test wont run on a system without an .npmrc. For some reason I wasn't able to set these with `npm_config_` environment variables.
