### PR TITLE
Fixing ReferenceError: num is not defined exception

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -1,4 +1,3 @@
-
 module.exports = help
 
 help.completion = function (opts, cb) {
@@ -24,7 +23,7 @@ function help (args, cb) {
 
   // npm help foo bar baz: search topics
   if (args.length > 1 && args[0]) {
-    return npm.commands["help-search"](args, num, cb)
+    return npm.commands["help-search"](args, argnum, cb)
   }
 
   var section = npm.deref(args[0]) || args[0]


### PR DESCRIPTION
Fixing the following exception:

4 error ReferenceError: num is not defined
4 error     at EventEmitter.help (/usr/local/lib/node_modules/npm/lib/help.js:27:46)
4 error     at Object.commandCache.(anonymous function) (/usr/local/lib/node_modules/npm/lib/npm.js:193:11)
4 error     at EventEmitter.<anonymous> (/usr/local/lib/node_modules/npm/bin/npm-cli.js:83:28)
4 error     at process._tickCallback (node.js:415:13)
