### PR TITLE
Alter text, so people will post the full output in issues

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -257,10 +257,9 @@ function errorHandler (er) {
 
   default:
     log.error("", er.stack || er.message || er)
-    log.error("", ["If you need help, you may report this log at:"
+    log.error("", ["If you need help, you may report this log in full version,"
+                  ,"also with the version of npm and node at:"
                   ,"    <http://github.com/isaacs/npm/issues>"
-                  ,"or email it to:"
-                  ,"    <npm-@googlegroups.com>"
                   ].join("\n"))
     printStack = false
     break


### PR DESCRIPTION
I noticed that we have alot of issues where we start to read the issue, and then have to ask the user for the whole output around the snippet they provide us, e.g.:
#4035
#4028
#3990
#3986
#3981

This is my attempt to save us and the users some time, looking for feedback on better wording :)
