### PR TITLE
Npm exec implementation for #3313

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,6 +1,8 @@
 module.exports = exec
 
 var path = require("path")
+  , pkgexec = require('./utils/pkgexec')
+  , log = require("npmlog")
   , readJson = require("read-package-json")
 
 exec.usage = "npm exec <command> [<options>]"
@@ -9,17 +11,9 @@ function exec(args, cb) {
   if (args.length < 1) return cb(exec.usage);
 
   var command = args[0]
-    , cmd = args.pop()
-    , pkgdir = process.cwd()
+    , cmd = args.slice(1)
 
-  readJson(path.resolve(pkgdir, "package.json"), function (er, package) {
-    if (er) return cb(er)
-    run(package, pkgdir, command, cmd, cb)
-  })
+  log.verbose("exec ", command)
+
+  pkgexec(command, cmd, cb);
 }
-
-function run(pkg, wd, command, cmd, cb) {
-  console.log('run', arguments);
-  cb();
-}
-

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -2,6 +2,7 @@ module.exports = exec
 
 var path = require("path")
   , pkgexec = require('./utils/pkgexec')
+  , chain = require("slide").chain
   , log = require("npmlog")
   , readJson = require("read-package-json")
 
@@ -12,8 +13,12 @@ function exec(args, cb) {
 
   var command = args[0]
     , cmd = args.slice(1)
+    , wd = process.cwd()
 
   log.verbose("exec ", command)
 
-  pkgexec(command, cmd, cb);
+  chain([
+    [readJson, path.resolve(wd, "package.json")]
+  , [pkgexec, command, cmd, chain.last, wd]
+  ], cb)
 }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,0 +1,25 @@
+module.exports = exec
+
+var path = require("path")
+  , readJson = require("read-package-json")
+
+exec.usage = "npm exec <command> [<options>]"
+
+function exec(args, cb) {
+  if (args.length < 1) return cb(exec.usage);
+
+  var command = args[0]
+    , cmd = args.pop()
+    , pkgdir = process.cwd()
+
+  readJson(path.resolve(pkgdir, "package.json"), function (er, package) {
+    if (er) return cb(er)
+    run(package, pkgdir, command, cmd, cb)
+  })
+}
+
+function run(pkg, wd, command, cmd, cb) {
+  console.log('run', arguments);
+  cb();
+}
+

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -161,6 +161,7 @@ var commandCache = {}
               , "restart"
               , "run-script"
               , "completion"
+              , "exec"
               ]
   , plumbing = [ "build"
                , "unbuild"

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -31,6 +31,8 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
       return cb()
     }
 
+    log.verbose("unsafe-perm in lifecycle", unsafe)
+
     lifecycle_(pkg, stage, wd, failOk, cb)
   })
 }

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -150,6 +150,8 @@ function runPackageLifecycle (pkg, env, wd, unsafe, cb) {
 
   console.log(note)
 
+  console.log(sh, [shFlag, cmd])
+
   var conf = { cwd: wd, env: env, customFds: [ 0, 1, 2] }
   var proc = spawn(sh, [shFlag, cmd], conf)
   proc.on("close", function (er, stdout, stderr) {

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -1,26 +1,12 @@
-
 exports = module.exports = lifecycle
 exports.cmd = cmd
 
 var log = require("npmlog")
-  , spawn = require("child_process").spawn
   , npm = require("../npm.js")
+  , pkgexec = require("./pkgexec.js")
   , path = require("path")
   , fs = require("graceful-fs")
   , chain = require("slide").chain
-  , constants = require("constants")
-  , Stream = require("stream").Stream
-  , PATH = "PATH"
-
-// windows calls it's path "Path" usually, but this is not guaranteed.
-if (process.platform === "win32") {
-  PATH = "Path"
-  Object.keys(process.env).forEach(function (e) {
-    if (e.match(/^PATH$/i)) {
-      PATH = e
-    }
-  })
-}
 
 function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
   if (typeof cb !== "function") cb = failOk, failOk = false
@@ -45,56 +31,23 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
       return cb()
     }
 
-    // set the env variables, then run scripts as a child process.
-    var env = makeEnv(pkg)
-    env.npm_lifecycle_event = stage
-    env.npm_node_execpath = env.NODE = env.NODE || process.execPath
-    env.npm_execpath = require.main.filename
-
-    // "nobody" typically doesn't have permission to write to /tmp
-    // even if it's never used, sh freaks out.
-    if (!npm.config.get("unsafe-perm")) env.TMPDIR = wd
-
-    lifecycle_(pkg, stage, wd, env, unsafe, failOk, cb)
+    lifecycle_(pkg, stage, wd, failOk, cb)
   })
 }
 
-function checkForLink (pkg, cb) {
-  var f = path.join(npm.dir, pkg.name)
-  fs.lstat(f, function (er, s) {
-    cb(null, !(er || !s.isSymbolicLink()))
-  })
-}
-
-function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
-  var pathArr = []
-    , p = wd.split("node_modules")
-    , acc = path.resolve(p.shift())
-
-  // first add the directory containing the `node` executable currently
-  // running, so that any lifecycle script that invoke "node" will execute
-  // this same one.
-  pathArr.unshift(path.dirname(process.execPath))
-
-  p.forEach(function (pp) {
-    pathArr.unshift(path.join(acc, "node_modules", ".bin"))
-    acc = path.join(acc, "node_modules", pp)
-  })
-  pathArr.unshift(path.join(acc, "node_modules", ".bin"))
-
-  // we also unshift the bundled node-gyp-bin folder so that
-  // the bundled one will be used for installing things.
-  pathArr.unshift(path.join(__dirname, "..", "..", "bin", "node-gyp-bin"))
-
-  if (env[PATH]) pathArr.push(env[PATH])
-  env[PATH] = pathArr.join(process.platform === "win32" ? ";" : ":")
-
+function lifecycle_ (pkg, stage, wd, failOk, cb) {
   var packageLifecycle = pkg.scripts && pkg.scripts.hasOwnProperty(stage)
+    , env = {}
 
-  if (packageLifecycle) {
-    // define this here so it's available to all scripts.
-    env.npm_lifecycle_script = pkg.scripts[stage]
-  }
+  if (!packageLifecycle) return cb()
+
+  // define this here so it's available to all scripts.
+  env.npm_lifecycle_event = stage
+  env.npm_lifecycle_script = pkg.scripts[stage]
+
+  // "nobody" typically doesn't have permission to write to /tmp
+  // even if it's never used, sh freaks out.
+  if (!npm.config.get("unsafe-perm")) env.TMPDIR = wd
 
   if (failOk) {
     cb = (function (cb_) { return function (er) {
@@ -110,10 +63,24 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
     }})(cb)
   }
 
-  chain
-    ( [ packageLifecycle && [runPackageLifecycle, pkg, env, wd, unsafe]
-      , [runHookLifecycle, pkg, env, wd, unsafe] ]
-    , cb )
+  runPackageLifecycle(pkg, env, wd, cb)
+}
+
+function runPackageLifecycle (pkg, env, wd, cb) {
+  // run package lifecycle scripts in the package root, or the nearest parent.
+  var stage = env.npm_lifecycle_event
+    , cmd = env.npm_lifecycle_script.split(/\s+/)
+    , sh = cmd.shift()
+    , args = cmd
+
+  pkgexec(sh, args, pkg, wd, env, function(er) {
+    if (er && !npm.ROLLBACK) {
+      er.stage = stage
+      return cb(er)
+    }
+
+    cb()
+  });
 }
 
 function validWd (d, cb) {
@@ -127,167 +94,6 @@ function validWd (d, cb) {
     }
     return cb(null, d)
   })
-}
-
-function runPackageLifecycle (pkg, env, wd, unsafe, cb) {
-  // run package lifecycle scripts in the package root, or the nearest parent.
-  var stage = env.npm_lifecycle_event
-    , user = unsafe ? null : npm.config.get("user")
-    , group = unsafe ? null : npm.config.get("group")
-    , cmd = env.npm_lifecycle_script
-    , sh = "sh"
-    , shFlag = "-c"
-
-  if (process.platform === "win32") {
-    sh = "cmd"
-    shFlag = "/c"
-  }
-
-  log.verbose("unsafe-perm in lifecycle", unsafe)
-
-  var note = "\n> " + pkg._id + " " + stage + " " + wd
-           + "\n> " + cmd + "\n"
-
-  console.log(note)
-
-  var conf = { cwd: wd, env: env, customFds: [ 0, 1, 2] }
-  var proc = spawn(sh, [shFlag, cmd], conf)
-  proc.on("close", function (er, stdout, stderr) {
-    if (er && !npm.ROLLBACK) {
-      log.info(pkg._id, "Failed to exec "+stage+" script")
-      er.message = pkg._id + " "
-                 + stage + ": `" + env.npm_lifecycle_script+"`\n"
-                 + er.message
-      if (er.code !== "EPERM") {
-        er.code = "ELIFECYCLE"
-      }
-      er.pkgid = pkg._id
-      er.stage = stage
-      er.script = env.npm_lifecycle_script
-      er.pkgname = pkg.name
-      return cb(er)
-    } else if (er) {
-      log.error(pkg._id+"."+stage, er)
-      log.error(pkg._id+"."+stage, "continuing anyway")
-      return cb()
-    }
-    cb(er)
-  })
-}
-
-function runHookLifecycle (pkg, env, wd, unsafe, cb) {
-  // check for a hook script, run if present.
-  var stage = env.npm_lifecycle_event
-    , hook = path.join(npm.dir, ".hooks", stage)
-    , user = unsafe ? null : npm.config.get("user")
-    , group = unsafe ? null : npm.config.get("group")
-    , cmd = hook
-
-  fs.stat(hook, function (er) {
-    if (er) return cb()
-
-    var conf = { cwd: wd, env: env, customFds: [ 0, 1, 2] }
-    var proc = spawn("sh", ["-c", cmd], conf)
-    proc.on("close", function (er) {
-      if (er) {
-        er.message += "\nFailed to exec "+stage+" hook script"
-        log.info(pkg._id, er)
-      }
-      if (npm.ROLLBACK) return cb()
-      cb(er)
-    })
-  })
-}
-
-function makeEnv (data, prefix, env) {
-  prefix = prefix || "npm_package_"
-  if (!env) {
-    env = {}
-    for (var i in process.env) if (!i.match(/^npm_/)) {
-      env[i] = process.env[i]
-    }
-
-    // npat asks for tap output
-    if (npm.config.get("npat")) env.TAP = 1
-
-    // express and others respect the NODE_ENV value.
-    if (npm.config.get("production")) env.NODE_ENV = "production"
-
-  } else if (!data.hasOwnProperty("_lifecycleEnv")) {
-    Object.defineProperty(data, "_lifecycleEnv",
-      { value : env
-      , enumerable : false
-      })
-  }
-
-  for (var i in data) if (i.charAt(0) !== "_") {
-    var envKey = (prefix+i).replace(/[^a-zA-Z0-9_]/g, '_')
-    if (i === "readme") {
-      continue
-    }
-    if (data[i] && typeof(data[i]) === "object") {
-      try {
-        // quick and dirty detection for cyclical structures
-        JSON.stringify(data[i])
-        makeEnv(data[i], envKey+"_", env)
-      } catch (ex) {
-        // usually these are package objects.
-        // just get the path and basic details.
-        var d = data[i]
-        makeEnv( { name: d.name, version: d.version, path:d.path }
-               , envKey+"_", env)
-      }
-    } else {
-      env[envKey] = String(data[i])
-      env[envKey] = -1 !== env[envKey].indexOf("\n")
-                  ? JSON.stringify(env[envKey])
-                  : env[envKey]
-    }
-
-  }
-
-  if (prefix !== "npm_package_") return env
-
-  prefix = "npm_config_"
-  var pkgConfig = {}
-    , keys = npm.config.keys
-    , pkgVerConfig = {}
-    , namePref = data.name + ":"
-    , verPref = data.name + "@" + data.version + ":"
-
-  keys.forEach(function (i) {
-    if (i.charAt(0) === "_" && i.indexOf("_"+namePref) !== 0) {
-      return
-    }
-    var value = npm.config.get(i)
-    if (value instanceof Stream || Array.isArray(value)) return
-    if (!value) value = ""
-    else if (typeof value !== "string") value = JSON.stringify(value)
-
-    value = -1 !== value.indexOf("\n")
-          ? JSON.stringify(value)
-          : value
-    i = i.replace(/^_+/, "")
-    if (i.indexOf(namePref) === 0) {
-      var k = i.substr(namePref.length).replace(/[^a-zA-Z0-9_]/g, "_")
-      pkgConfig[ k ] = value
-    } else if (i.indexOf(verPref) === 0) {
-      var k = i.substr(verPref.length).replace(/[^a-zA-Z0-9_]/g, "_")
-      pkgVerConfig[ k ] = value
-    }
-    var envKey = (prefix+i).replace(/[^a-zA-Z0-9_]/g, "_")
-    env[envKey] = value
-  })
-
-  prefix = "npm_package_config_"
-  ;[pkgConfig, pkgVerConfig].forEach(function (conf) {
-    for (var i in conf) {
-      var envKey = (prefix+i)
-      env[envKey] = conf[i]
-    }
-  })
-
-  return env
 }
 
 function cmd (stage) {

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -150,8 +150,6 @@ function runPackageLifecycle (pkg, env, wd, unsafe, cb) {
 
   console.log(note)
 
-  console.log(sh, [shFlag, cmd])
-
   var conf = { cwd: wd, env: env, customFds: [ 0, 1, 2] }
   var proc = spawn(sh, [shFlag, cmd], conf)
   proc.on("close", function (er, stdout, stderr) {

--- a/lib/utils/pkgexec.js
+++ b/lib/utils/pkgexec.js
@@ -1,0 +1,154 @@
+module.exports = pkgexec;
+
+var readJson = require("read-package-json")
+  , npm = require("../npm.js")
+  , log = require("npmlog")
+  , path = require('path')
+  , chain = require("slide").chain
+  , spawn = require("child_process").spawn
+  , Stream = require("stream").Stream
+
+function pkgexec(sh, args, cb) {
+  var pkgdir = process.cwd()
+
+  chain([
+    [readJson, path.resolve(pkgdir, "package.json")]
+  , [runCommand, pkgdir, sh, args, chain.last]
+  ], cb)
+}
+
+function runCommand(wd, command, args, pkg, cb) {
+  var sh = "sh"
+    , shFlag = "-c"
+    , cmd
+    , cmdArgs
+
+  if (process.platform === "win32") {
+    sh = "cmd"
+    shFlag = "/c"
+  }
+
+  var note = "\n> " + pkg._id + " " + command + " " + wd
+           + "\n> " + command + ' ' + args.join(' ') + "\n"
+
+  console.log(note)
+
+  cmd = [command].concat(args).join(' ')
+
+  cmdArgs = [shFlag, cmd]
+
+  var env = makeEnv(pkg)
+  var conf = { cwd: wd, env: process.env, customFds: [ 0, 1, 2] }
+  var proc = spawn(sh, cmdArgs, conf)
+  proc.on("close", function (er, stdout, stderr) {
+    if (er && !npm.ROLLBACK) {
+      log.info(pkg._id, "Failed to exec "+command+" script")
+      er.message = pkg._id + " "
+                  + command + ": `" + env.npm_lifecycle_script+"`\n"
+                  + er.message
+      if (er.code !== "EPERM") {
+        er.code = "ELIFECYCLE"
+      }
+      er.pkgid = pkg._id
+      er.script = env.command
+      er.pkgname = pkg.name
+      return cb(er)
+    } else if (er) {
+      log.error(pkg._id+"."+command, er)
+      log.error(pkg._id+"."+command, "continuing anyway")
+      return cb()
+    }
+    cb(er)
+  })
+}
+
+function makeEnv (data, prefix, env) {
+  prefix = prefix || "npm_package_"
+  if (!env) {
+    env = {}
+    for (var i in process.env) if (!i.match(/^npm_/)) {
+      env[i] = process.env[i]
+    }
+
+    // npat asks for tap output
+    if (npm.config.get("npat")) env.TAP = 1
+
+    // express and others respect the NODE_ENV value.
+    if (npm.config.get("production")) env.NODE_ENV = "production"
+
+  } else if (!data.hasOwnProperty("_lifecycleEnv")) {
+    Object.defineProperty(data, "_lifecycleEnv",
+      { value : env
+      , enumerable : false
+      })
+  }
+
+  for (var i in data) if (i.charAt(0) !== "_") {
+    var envKey = (prefix+i).replace(/[^a-zA-Z0-9_]/g, '_')
+    if (i === "readme") {
+      continue
+    }
+    if (data[i] && typeof(data[i]) === "object") {
+      try {
+        // quick and dirty detection for cyclical structures
+        JSON.stringify(data[i])
+        makeEnv(data[i], envKey+"_", env)
+      } catch (ex) {
+        // usually these are package objects.
+        // just get the path and basic details.
+        var d = data[i]
+        makeEnv( { name: d.name, version: d.version, path:d.path }
+               , envKey+"_", env)
+      }
+    } else {
+      env[envKey] = String(data[i])
+      env[envKey] = -1 !== env[envKey].indexOf("\n")
+                  ? JSON.stringify(env[envKey])
+                  : env[envKey]
+    }
+
+  }
+
+  if (prefix !== "npm_package_") return env
+
+  prefix = "npm_config_"
+  var pkgConfig = {}
+    , keys = npm.config.keys
+    , pkgVerConfig = {}
+    , namePref = data.name + ":"
+    , verPref = data.name + "@" + data.version + ":"
+
+  keys.forEach(function (i) {
+    if (i.charAt(0) === "_" && i.indexOf("_"+namePref) !== 0) {
+      return
+    }
+    var value = npm.config.get(i)
+    if (value instanceof Stream || Array.isArray(value)) return
+    if (!value) value = ""
+    else if (typeof value !== "string") value = JSON.stringify(value)
+
+    value = -1 !== value.indexOf("\n")
+          ? JSON.stringify(value)
+          : value
+    i = i.replace(/^_+/, "")
+    if (i.indexOf(namePref) === 0) {
+      var k = i.substr(namePref.length).replace(/[^a-zA-Z0-9_]/g, "_")
+      pkgConfig[ k ] = value
+    } else if (i.indexOf(verPref) === 0) {
+      var k = i.substr(verPref.length).replace(/[^a-zA-Z0-9_]/g, "_")
+      pkgVerConfig[ k ] = value
+    }
+    var envKey = (prefix+i).replace(/[^a-zA-Z0-9_]/g, "_")
+    env[envKey] = value
+  })
+
+  prefix = "npm_package_config_"
+  ;[pkgConfig, pkgVerConfig].forEach(function (conf) {
+    for (var i in conf) {
+      var envKey = (prefix+i)
+      env[envKey] = conf[i]
+    }
+  })
+
+  return env
+}

--- a/lib/utils/pkgexec.js
+++ b/lib/utils/pkgexec.js
@@ -3,21 +3,70 @@ module.exports = pkgexec;
 var readJson = require("read-package-json")
   , npm = require("../npm.js")
   , log = require("npmlog")
+  , fs = require('fs')
   , path = require('path')
   , chain = require("slide").chain
   , spawn = require("child_process").spawn
   , Stream = require("stream").Stream
+  , PATH = "PATH"
 
-function pkgexec(sh, args, cb) {
-  var pkgdir = process.cwd()
-
-  chain([
-    [readJson, path.resolve(pkgdir, "package.json")]
-  , [runCommand, pkgdir, sh, args, chain.last]
-  ], cb)
+// windows calls it's path "Path" usually, but this is not guaranteed.
+if (process.platform === "win32") {
+  PATH = "Path"
+  Object.keys(process.env).forEach(function (e) {
+    if (e.match(/^PATH$/i)) {
+      PATH = e
+    }
+  })
 }
 
-function runCommand(wd, command, args, pkg, cb) {
+function pkgexec(sh, args, cb) {
+  var wd = process.cwd()
+
+  validWd(wd, function(er, wd) {
+    if (er) return cb(er)
+
+    chain([
+      [readJson, path.resolve(wd, "package.json")]
+    , [pkgexec_, wd, sh, args, chain.last]
+    ], cb)
+  })
+}
+
+function pkgexec_(wd, shell_command, args, pkg, cb) {
+  var pathArr = []
+    , p = wd.split("node_modules")
+    , acc = path.resolve(p.shift())
+
+  // set the env variables, then run scripts as a child process.
+  var env = makeEnv(pkg)
+
+  // first add the directory containing the `node` executable currently
+  // running, so that any lifecycle script that invoke "node" will execute
+  // this same one.
+  pathArr.unshift(path.dirname(process.execPath))
+
+  p.forEach(function (pp) {
+    pathArr.unshift(path.join(acc, "node_modules", ".bin"))
+    acc = path.join(acc, "node_modules", pp)
+  })
+  pathArr.unshift(path.join(acc, "node_modules", ".bin"))
+
+  // we also unshift the bundled node-gyp-bin folder so that
+  // the bundled one will be used for installing things.
+  pathArr.unshift(path.join(__dirname, "..", "..", "bin", "node-gyp-bin"))
+
+  if (env[PATH]) pathArr.push(env[PATH])
+  env[PATH] = pathArr.join(process.platform === "win32" ? ";" : ":")
+
+  console.log(pathArr)
+
+  chain
+    ( [ [runCommand, wd, shell_command, args, env, pkg] ]
+    , cb )
+}
+
+function runCommand(wd, command, args, env, pkg, cb) {
   var sh = "sh"
     , shFlag = "-c"
     , cmd
@@ -37,7 +86,6 @@ function runCommand(wd, command, args, pkg, cb) {
 
   cmdArgs = [shFlag, cmd]
 
-  var env = makeEnv(pkg)
   var conf = { cwd: wd, env: process.env, customFds: [ 0, 1, 2] }
   var proc = spawn(sh, cmdArgs, conf)
   proc.on("close", function (er, stdout, stderr) {
@@ -151,4 +199,17 @@ function makeEnv (data, prefix, env) {
   })
 
   return env
+}
+
+function validWd (d, cb) {
+  fs.stat(d, function (er, st) {
+    if (er || !st.isDirectory()) {
+      var p = path.dirname(d)
+      if (p === d) {
+        return cb(new Error("Could not find suitable wd"))
+      }
+      return validWd(p, cb)
+    }
+    return cb(null, d)
+  })
 }

--- a/lib/utils/pkgexec.js
+++ b/lib/utils/pkgexec.js
@@ -1,7 +1,6 @@
 module.exports = pkgexec;
 
-var readJson = require("read-package-json")
-  , npm = require("../npm.js")
+var npm = require("../npm.js")
   , log = require("npmlog")
   , fs = require('fs')
   , path = require('path')
@@ -20,26 +19,31 @@ if (process.platform === "win32") {
   })
 }
 
-function pkgexec(sh, args, cb) {
-  var wd = process.cwd()
+function pkgexec(sh, args, pkg, wd, env_vars, cb) {
+  if (typeof cb !== "function") cb = env_vars, env_vars = {}
 
-  validWd(wd, function(er, wd) {
-    if (er) return cb(er)
-
-    chain([
-      [readJson, path.resolve(wd, "package.json")]
-    , [pkgexec_, wd, sh, args, chain.last]
-    ], cb)
-  })
+  pkgexec_(wd, sh, args, pkg, env_vars, cb)
 }
 
-function pkgexec_(wd, shell_command, args, pkg, cb) {
+function pkgexec_(wd, shell_command, args, pkg, env_vars, cb) {
   var pathArr = []
     , p = wd.split("node_modules")
     , acc = path.resolve(p.shift())
 
   // set the env variables, then run scripts as a child process.
   var env = makeEnv(pkg)
+
+  // allow to pass env variables from outer code
+  for (var i in env_vars) {
+    env[i] = env_vars[i]
+  }
+
+  env.npm_node_execpath = env.NODE = env.NODE || process.execPath
+  env.npm_execpath = require.main.filename
+
+  // "nobody" typically doesn't have permission to write to /tmp
+  // even if it's never used, sh freaks out.
+  if (!npm.config.get("unsafe-perm")) env.TMPDIR = wd
 
   // first add the directory containing the `node` executable currently
   // running, so that any lifecycle script that invoke "node" will execute
@@ -59,10 +63,12 @@ function pkgexec_(wd, shell_command, args, pkg, cb) {
   if (env[PATH]) pathArr.push(env[PATH])
   env[PATH] = pathArr.join(process.platform === "win32" ? ";" : ":")
 
-  console.log(pathArr)
-
   chain
-    ( [ [runCommand, wd, shell_command, args, env, pkg] ]
+    ( [
+        [runCommand, wd, shell_command, args, env, pkg]
+      , env.npm_lifecycle_event &&
+        [runHookLifecycle, env.npm_lifecycle_event, pkg, env, wd]
+      ]
     , cb )
 }
 
@@ -92,7 +98,7 @@ function runCommand(wd, command, args, env, pkg, cb) {
     if (er && !npm.ROLLBACK) {
       log.info(pkg._id, "Failed to exec "+command+" script")
       er.message = pkg._id + " "
-                  + command + ": `" + env.npm_lifecycle_script+"`\n"
+                  + command + ": `" + cmd
                   + er.message
       if (er.code !== "EPERM") {
         er.code = "ELIFECYCLE"
@@ -201,15 +207,23 @@ function makeEnv (data, prefix, env) {
   return env
 }
 
-function validWd (d, cb) {
-  fs.stat(d, function (er, st) {
-    if (er || !st.isDirectory()) {
-      var p = path.dirname(d)
-      if (p === d) {
-        return cb(new Error("Could not find suitable wd"))
+function runHookLifecycle (stage, pkg, env, wd, cb) {
+  // check for a hook script, run if present.
+  var hook = path.join(npm.dir, ".hooks", stage)
+    , cmd = hook
+
+  fs.stat(hook, function (er) {
+    if (er) return cb()
+
+    var conf = { cwd: wd, env: env, customFds: [ 0, 1, 2] }
+    var proc = spawn("sh", ["-c", cmd], conf)
+    proc.on("close", function (er) {
+      if (er) {
+        er.message += "\nFailed to exec "+stage+" hook script"
+        log.info(pkg._id, er)
       }
-      return validWd(p, cb)
-    }
-    return cb(null, d)
+      if (npm.ROLLBACK) return cb()
+      cb(er)
+    })
   })
 }


### PR DESCRIPTION
Hi

I've extracted the exec code from the lifecycle.js and added an npm exec command to run scripts in the package context. In part it fixes #3313. In reality I couldn't eliminate lifecycle at all, because it contains some specific logic like hooks.

I know that @grncdr works on the same task, but it happened that I've made this work too and I'll be happy if it will be useful.

I'm ready to fix things if needed.
