### PR TITLE
Tell users it's not our fault when no compatible versions are found

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -712,12 +712,14 @@ function installTargetsError (requested, data) {
   requested = data.name + (requested ? "@'" + requested + "'" : "")
 
   targets = targets.length
-          ? "Valid install targets:\n" + JSON.stringify(targets)
+          ? "Valid install targets:\n" + JSON.stringify(targets) + "\n"
           : "No valid targets found.\n"
           + "Perhaps not compatible with your version of node?"
 
-  return new Error( "No compatible version found: "
+  var er = new Error( "No compatible version found: "
                   + requested + "\n" + targets)
+  er.code = "ETARGET"
+  return er
 }
 
 function addNameVersion (name, v, data, cb) {

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -243,6 +243,14 @@ function errorHandler (er) {
               ].join("\n"))
     break
 
+  case "ETARGET":
+    log.error("notarget", [er.message
+              ,"This is most likely not a problem with npm itself."
+              ,"In most cases you or one of your dependencies are requesting"
+              ,"a package version that doesn't exist."
+              ].join("\n"))
+    break
+
   case "ENOTSUP":
     if (er.required) {
       log.error("notsup", [er.message


### PR DESCRIPTION
@domenic Fixes #3810

Example output: 

```
(18:08:03) [robert@tequila-osx] ~ $ npm i ./foo
npm http GET https://registry.npmjs.org/foo-private
npm http 304 https://registry.npmjs.org/foo-private
npm ERR! notarget No compatible version found: foo-private@'>=0.5.0-0 <0.6.0-0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["0.0.0","0.0.1","0.0.2","0.0.3","0.4.0","0.4.1","0.4.2"]
npm ERR! notarget
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you are requesting a package version that
npm ERR! notarget doesn't exist.

npm ERR! System Darwin 12.5.0
npm ERR! command "node" "/Users/robert/.nvm/v0.10.21/bin/npm" "i" "./foo"
npm ERR! cwd /Users/robert
npm ERR! node -v v0.10.21
npm ERR! npm -v 1.3.13
npm ERR! code ETARGET
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/robert/npm-debug.log
npm ERR! not ok code 0
```
