### PR TITLE
Handle gzipped man pages too

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -1,4 +1,3 @@
-
 module.exports = help
 
 help.completion = function (opts, cb) {
@@ -63,7 +62,7 @@ function help (args, cb) {
     section = "package.json"
 
   // find either /section.n or /npm-section.n
-  var f = "+(npm-" + section + "|" + section + ").[0-9]"
+  var f = "+(npm-" + section + "|" + section + ").[0-9]?(\.gz)"
   return glob(manroot + "/*/" + f, function (er, mans) {
     if (er)
       return cb(er)


### PR DESCRIPTION
Some package builders (e.g. Archlinux `makepkg` or CRUX `pkgmk`) compress man pages by default.
