### PR TITLE
smaller/equals version than current will throw an error

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -56,7 +56,10 @@ function version (args, silent, cb_) {
 		var newVer = semver.valid(args[0])
 		if (!newVer) newVer = semver.inc(data.version, args[0])
 		if (!newVer) return cb_(version.usage)
-    if (data.version === newVer) return cb_(new Error("Version not changed"))
+    if (semver.lte(newVer, data.version) && !npm.config.get("force"))
+      return cb_(new Error("Version smaller or equals the old version. " +
+                           "Use --force to enforce this version."))
+
     data.version = newVer
 
     fs.stat(path.join(process.cwd(), ".git"), function (er, s) {


### PR DESCRIPTION
referencing #4087 if the version is smaller or equals
an error is thrown, can be overwritten be --force
