### PR TITLE
Always update git urls

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -72,6 +72,7 @@ var npm = require("./npm.js")
   , mkdir = require("mkdirp")
   , lifecycle = require("./utils/lifecycle.js")
   , archy = require("archy")
+  , isGitUrl = require("./utils/is-git-url.js")
 
 function install (args, cb_) {
   var hasArguments = !!args.length
@@ -690,11 +691,19 @@ function targetResolver (where, context, deps) {
         return cb(null, [])
       }
 
+      // if the target is a git repository, we always want to fetch it
+      var isGit = false
+        , maybeGit = what.split("@").pop()
+
+      if (maybeGit)
+        isGit = isGitUrl(url.parse(maybeGit))
+
       if (!er &&
           data &&
           !context.explicit &&
           context.family[data.name] === data.version &&
-          !npm.config.get("force")) {
+          !npm.config.get("force") &&
+          !isGit) {
         log.info("already installed", data.name + "@" + data.version)
         return cb(null, [])
       }

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -25,6 +25,7 @@ var path = require("path")
   , asyncMap = require("slide").asyncMap
   , npm = require("./npm.js")
   , url = require("url")
+  , isGitUrl = require("./utils/is-git-url.js")
 
 function outdated (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
@@ -164,6 +165,9 @@ function shouldUpdate (args, dir, dep, has, req, cb) {
   if (args.length && args.indexOf(dep) === -1) {
     return skip()
   }
+
+  if (isGitUrl(url.parse(req)))
+    return doIt("git", "git")
 
   var registry = npm.registry
   // search for the latest package

--- a/lib/update.js
+++ b/lib/update.js
@@ -32,7 +32,7 @@ function update (args, cb) {
         , dep = ww[1]
         , want = ww[3]
         , what = dep + "@" + want
-        , req = ww[4]
+        , req = ww[5]
         , url = require('url')
 
       // use the initial installation method (repo, tar, git) for updating

--- a/test/tap/outdated-git.js
+++ b/test/tap/outdated-git.js
@@ -1,0 +1,28 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var npm = require("../../")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var mr = require("npm-registry-mock")
+
+// config
+var pkg = __dirname + "/outdated-git"
+mkdirp.sync(pkg + "/cache")
+
+
+test("dicovers new versions in outdated", function (t) {
+  process.chdir(pkg)
+  t.plan(3)
+  npm.load({cache: pkg + "/cache", registry: common.registry}, function () {
+    npm.outdated(function (er, d) {
+      t.equal('git', d[0][3])
+      t.equal('git', d[0][4])
+      t.equal('git://github.com/robertkowalski/foo-private.git', d[0][5])
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  rimraf.sync(pkg + "/cache")
+  t.end()
+})

--- a/test/tap/outdated-git/README.md
+++ b/test/tap/outdated-git/README.md
@@ -1,0 +1,1 @@
+just a test

--- a/test/tap/outdated-git/package.json
+++ b/test/tap/outdated-git/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "outdated-git",
+  "author": "Rocko Artischocko",
+  "description": "fixture",
+  "version": "0.0.1",
+  "main": "index.js",
+  "dependencies": {
+    "foo-private": "git://github.com/robertkowalski/foo-private.git"
+  }
+}


### PR DESCRIPTION
Do directly an update if a git url is specified in the package.json
For outdated, print wanted=git and latest=git

Additionally, fixing a small, still unknown  bug in update,
regarding the positions of where, latest and req, introduced
by 2f7fd625a0f2

Fixes #1727
