### PR TITLE
cleanup debt that grew over time in tests

### DIFF
--- a/test/common-tap.js
+++ b/test/common-tap.js
@@ -1,0 +1,2 @@
+var port = exports.port = 1337
+exports.registry = "http://localhost:" + port

--- a/test/tap/ignore-shrinkwrap.js
+++ b/test/tap/ignore-shrinkwrap.js
@@ -1,3 +1,4 @@
+var common = require("../common-tap.js")
 var test = require("tap").test
 var npm = require("../../")
 var pkg = './ignore-shrinkwrap'
@@ -16,8 +17,8 @@ var customMocks = {
   }
 }
 
-test("ignore-shrinkwrap: using the option", function(t) {
-  mr({port: 1337, mocks: customMocks}, function (s) {
+test("ignore-shrinkwrap: using the option", function (t) {
+  mr({port: common.port, mocks: customMocks}, function (s) {
     s._server.on("request", function (req, res) {
       switch (req.url) {
         case "/shrinkwrap.js":
@@ -35,8 +36,8 @@ test("ignore-shrinkwrap: using the option", function(t) {
   })
 })
 
-test("ignore-shrinkwrap: NOT using the option", function(t) {
-  mr({port: 1337, mocks: customMocks}, function (s) {
+test("ignore-shrinkwrap: NOT using the option", function (t) {
+  mr({port: common.port, mocks: customMocks}, function (s) {
     s._server.on("request", function (req, res) {
       switch (req.url) {
         case "/shrinkwrap.js":
@@ -65,7 +66,7 @@ function createChild (ignoreShrinkwrap) {
   return spawn(node, args, {
     cwd: pkg,
     env: {
-      npm_config_registry: "http://localhost:1337",
+      npm_config_registry: common.registry,
       npm_config_cache_lock_stale: 1000,
       npm_config_cache_lock_wait: 1000,
       HOME: process.env.HOME,

--- a/test/tap/noargs-install-config-save.js
+++ b/test/tap/noargs-install-config-save.js
@@ -19,6 +19,7 @@ pkg += path.sep + "noargs-install-config-save"
 function writePackageJson() {
   rimraf.sync(pkg)
   mkdirp.sync(pkg)
+  mkdirp.sync(pkg + "/cache")
 
   fs.writeFileSync(pkg + "/package.json", JSON.stringify({
     "author": "Rocko Artischocko",
@@ -34,6 +35,7 @@ function createChild (args) {
   var env = {
     npm_config_save: true,
     npm_config_registry: common.registry,
+    npm_config_cache: pkg + "/cache",
     HOME: process.env.HOME,
     Path: process.env.PATH,
     PATH: process.env.PATH
@@ -77,4 +79,9 @@ test("updates the package.json (adds dependencies) with an argument", function (
       t.end()
     })
   })
+})
+
+test("cleanup", function (t) {
+  rimraf.sync(pkg + "/cache")
+  t.end()
 })

--- a/test/tap/noargs-install-config-save.js
+++ b/test/tap/noargs-install-config-save.js
@@ -46,7 +46,6 @@ function createChild (args) {
 
   return spawn(node, args, {
     cwd: pkg,
-    stdio: "inherit",
     env: env
   })
 }

--- a/test/tap/noargs-install-config-save.js
+++ b/test/tap/noargs-install-config-save.js
@@ -1,3 +1,4 @@
+var common = require("../common-tap.js")
 var test = require("tap").test
 var npm = require.resolve("../../bin/npm-cli.js")
 var osenv = require("osenv")
@@ -32,7 +33,7 @@ function writePackageJson() {
 function createChild (args) {
   var env = {
     npm_config_save: true,
-    npm_config_registry: "http://localhost:1337",
+    npm_config_registry: common.registry,
     HOME: process.env.HOME,
     Path: process.env.PATH,
     PATH: process.env.PATH
@@ -52,7 +53,7 @@ test("does not update the package.json with empty arguments", function (t) {
   writePackageJson()
   t.plan(1)
 
-  mr(1337, function (s) {
+  mr(common.port, function (s) {
     var child = createChild([npm, "install"])
     child.on("close", function (m) {
       var text = JSON.stringify(fs.readFileSync(pkg + "/package.json", "utf8"))
@@ -67,7 +68,7 @@ test("updates the package.json (adds dependencies) with an argument", function (
   writePackageJson()
   t.plan(1)
 
-  mr(1337, function (s) {
+  mr(common.port, function (s) {
     var child = createChild([npm, "install", "underscore"])
     child.on("close", function (m) {
       var text = JSON.stringify(fs.readFileSync(pkg + "/package.json", "utf8"))

--- a/test/tap/outdated-include-devdependencies.js
+++ b/test/tap/outdated-include-devdependencies.js
@@ -1,18 +1,17 @@
+var common = require("../common-tap.js")
 var test = require("tap").test
 var npm = require("../../")
 
 var mr = require("npm-registry-mock")
 
 // config
-var port = 1331
-var address = "http://localhost:" + port
 var pkg = __dirname + '/outdated-include-devdependencies'
 
 
 test("includes devDependencies in outdated", function (t) {
   process.chdir(pkg)
-  mr(port, function (s) {
-    npm.load({registry: address}, function () {
+  mr(common.port, function (s) {
+    npm.load({registry: common.registry}, function () {
       npm.outdated(function (er, d) {
         t.equal("1.5.1", d[0][3])
         s.close()

--- a/test/tap/outdated-include-devdependencies.js
+++ b/test/tap/outdated-include-devdependencies.js
@@ -1,17 +1,18 @@
 var common = require("../common-tap.js")
 var test = require("tap").test
 var npm = require("../../")
-
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
 var mr = require("npm-registry-mock")
 
 // config
 var pkg = __dirname + '/outdated-include-devdependencies'
-
+mkdirp.sync(pkg + "/cache")
 
 test("includes devDependencies in outdated", function (t) {
   process.chdir(pkg)
   mr(common.port, function (s) {
-    npm.load({registry: common.registry}, function () {
+    npm.load({cache: pkg + "/cache", registry: common.registry}, function () {
       npm.outdated(function (er, d) {
         t.equal("1.5.1", d[0][3])
         s.close()
@@ -19,4 +20,9 @@ test("includes devDependencies in outdated", function (t) {
       })
     })
   })
+})
+
+test("cleanup", function (t) {
+  rimraf.sync(pkg + "/cache")
+  t.end()
 })

--- a/test/tap/outdated-new-versions.js
+++ b/test/tap/outdated-new-versions.js
@@ -1,14 +1,11 @@
+var common = require("../common-tap.js")
 var test = require("tap").test
 var npm = require("../../")
 var mkdirp = require("mkdirp")
 var rimraf = require("rimraf")
 
-
 var mr = require("npm-registry-mock")
 
-// config
-var port = 1331
-var address = "http://localhost:" + port
 var pkg = __dirname + "/outdated-new-versions"
 mkdirp.sync(pkg + "/cache")
 
@@ -16,8 +13,9 @@ mkdirp.sync(pkg + "/cache")
 test("dicovers new versions in outdated", function (t) {
   process.chdir(pkg)
   t.plan(2)
-  mr(port, function (s) {
-    npm.load({cache: pkg + "/cache", registry: address}, function () {
+
+  mr(common.port, function (s) {
+    npm.load({cache: pkg + "/cache", registry: common.registry}, function () {
       npm.outdated(function (er, d) {
         for (var i = 0; i < d.length; i++) {
           if (d[i][1] === "underscore")

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -1,3 +1,4 @@
+var common = require("../common-tap.js")
 var fs = require("fs")
 var test = require("tap").test
 var rimraf = require("rimraf")
@@ -5,16 +6,16 @@ var npm = require("../../")
 
 var mr = require("npm-registry-mock")
 // config
-var port = 1331
-var address = "http://localhost:" + port
 var pkg = __dirname + '/outdated'
 
 test("it should not throw", function (t) {
   rimraf.sync(pkg + "/node_modules")
   process.chdir(pkg)
 
-  mr(port, function (s) {
-    npm.load({registry: address}, function () {
+  mr(common.port, function (s) {
+    npm.load({
+      registry: common.registry }
+    , function () {
       npm.install(".", function (err) {
         npm.outdated(function (er, d) {
           console.log(d)
@@ -27,6 +28,6 @@ test("it should not throw", function (t) {
 })
 
 test("cleanup", function (t) {
-  rimraf.sync(pkg + "/node_modules")
+  cleanup()
   t.end()
 })

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -9,11 +9,12 @@ var mr = require("npm-registry-mock")
 var pkg = __dirname + '/outdated'
 
 test("it should not throw", function (t) {
-  rimraf.sync(pkg + "/node_modules")
+  cleanup()
   process.chdir(pkg)
 
   mr(common.port, function (s) {
     npm.load({
+      cache: pkg + "/cache",
       registry: common.registry }
     , function () {
       npm.install(".", function (err) {
@@ -31,3 +32,8 @@ test("cleanup", function (t) {
   cleanup()
   t.end()
 })
+
+function cleanup () {
+  rimraf.sync(pkg + "/node_modules")
+  rimraf.sync(pkg + "/cache")
+}

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -15,6 +15,7 @@ test("it should not throw", function (t) {
   mr(common.port, function (s) {
     npm.load({
       cache: pkg + "/cache",
+      loglevel: 'silent',
       registry: common.registry }
     , function () {
       npm.install(".", function (err) {

--- a/test/tap/outdated/README.md
+++ b/test/tap/outdated/README.md
@@ -1,0 +1,1 @@
+# just a test

--- a/test/tap/outdated/package.json
+++ b/test/tap/outdated/package.json
@@ -1,8 +1,10 @@
 {
   "name": "bla",
+  "description": "fixture",
   "version": "0.0.1",
   "main": "index.js",
   "dependencies": {
     "underscore": "1.3.1"
-  }
+  },
+  "repository": "git://github.com/robertkowalski/bogusfixture"
 }

--- a/test/tap/peer-deps-invalid.js
+++ b/test/tap/peer-deps-invalid.js
@@ -1,3 +1,4 @@
+var common = require('../common-tap.js')
 var fs = require("fs")
 var test = require("tap").test
 var rimraf = require("rimraf")
@@ -42,7 +43,7 @@ test("setup", function(t) {
         return res.end(failFile)
     }
   })
-  server.listen(1337, function() {
+  server.listen(common.port, function() {
     t.pass("listening")
     t.end()
   })

--- a/test/tap/peer-deps-without-package-json.js
+++ b/test/tap/peer-deps-without-package-json.js
@@ -1,3 +1,4 @@
+var common = require('../common-tap.js')
 var fs = require("fs")
 var test = require("tap").test
 var rimraf = require("rimraf")
@@ -25,7 +26,7 @@ test("setup", function(t) {
     s.setHeader('content-type', 'application/javascript')
     s.end(js)
   })
-  server.listen(1337, function() {
+  server.listen(common.port, function () {
     t.pass('listening')
     t.end()
   })
@@ -38,7 +39,7 @@ test("installing a peerDependencies-using package without a package.json present
   process.chdir(__dirname + "/peer-deps-without-package-json")
 
   npm.load(function () {
-    npm.install('http://localhost:1337/', function (err) {
+    npm.install(common.registry, function (err) {
       if (err) {
         t.fail(err)
       } else {

--- a/test/tap/publish-config.js
+++ b/test/tap/publish-config.js
@@ -1,3 +1,4 @@
+var common = require('../common-tap.js')
 var test = require('tap').test
 var fs = require('fs')
 var osenv = require('osenv')
@@ -9,7 +10,7 @@ require('mkdirp').sync(pkg)
 fs.writeFileSync(pkg + '/package.json', JSON.stringify({
   name: 'npm-test-publish-config',
   version: '1.2.3',
-  publishConfig: { registry: 'http://localhost:13370' }
+  publishConfig: { registry: common.registry }
 }), 'utf8')
 
 var spawn = require('child_process').spawn
@@ -25,7 +26,7 @@ test(function (t) {
     res.statusCode = 500
     res.end('{"error":"sshhh. naptime nao. \\^O^/ <(YAWWWWN!)"}')
     child.kill()
-  }).listen(13370, function () {
+  }).listen(common.port, function () {
     t.pass('server is listening')
 
     // don't much care about listening to the child's results

--- a/test/tap/uninstall-package.js
+++ b/test/tap/uninstall-package.js
@@ -1,24 +1,41 @@
 var test = require("tap").test
   , npm = require("../../")
+  , rimraf = require("rimraf")
+  , mr = require("npm-registry-mock")
+  , common = require("../common-tap.js")
+  , pkg = __dirname + "/uninstall-package"
 
 test("returns a list of removed items", function (t) {
   t.plan(1)
-
-  setup(function () {
-    npm.install(".", function (err) {
-      if (err) return t.fail(err)
-      npm.uninstall("once", "ini", "lala", function (err, d) {
+  mr(common.port, function (s) {
+    setup(function () {
+      npm.install(".", function (err) {
         if (err) return t.fail(err)
-        t.same(d.sort(), ["once", "ini"].sort())
-        t.end()
+        npm.uninstall("underscore", "request", "lala", function (err, d) {
+          if (err) return t.fail(err)
+          t.same(d.sort(), ["underscore", "request"].sort())
+          s.close()
+          t.end()
+        })
       })
     })
   })
 })
 
+test("cleanup", function (t) {
+  cleanup()
+  t.end()
+})
+
 function setup (cb) {
-  process.chdir(__dirname + "/uninstall-package")
-  npm.load(function () {
+  cleanup()
+  process.chdir(pkg)
+  npm.load({cache: pkg + "/cache", registry: common.registry}, function () {
     cb()
   })
+}
+
+function cleanup () {
+  rimraf.sync(pkg + "/node_modules")
+  rimraf.sync(pkg + "/cache")
 }

--- a/test/tap/uninstall-package/package.json
+++ b/test/tap/uninstall-package/package.json
@@ -1,9 +1,11 @@
 {
   "name": "beep",
   "version": "0.0.0",
+  "author": "Rockbert",
+  "description": "i am a fixture",
   "main": "index.js",
   "dependencies": {
-    "once": "*",
-    "ini": "*"
+    "underscore": "~1.3.1",
+    "request": "~0.9.0"
   }
 }


### PR DESCRIPTION
There were always some things that bothered me regarding some tap tests that I wrote:
- Some tests are using the global cache with mocked modules which can get messy, as the cache.json points to the address from the mock-registry.
- no centralized config for port/registry address makes it hard to switch the port/address, this grew over time with the number of tests
- Some tests wrote warnings to taps output when running npm run tap
- Bonus: convert an old test to use no network any more

I splitted every topic in a single commit for better readability, I can rebase if everything is ok.
