### PR TITLE
lifecycle: proxy the child process' "signal" to npm

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -204,8 +204,10 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
   }
 
   var proc = spawn(sh, [shFlag, cmd], conf)
-  proc.on("close", function (code) {
-    if (code) {
+  proc.on("close", function (code, signal) {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else if (code) {
       var er = new Error("Exit status " + code)
     }
     if (er && !npm.ROLLBACK) {


### PR DESCRIPTION
This way, if an `npm test` script (or any other lifecycle process) ends
up exiting because of a signal like a SIGSEGV, then npm will exit the same
way (since the `code` will be null when a signal is present), and not
obscure the signal the occurred.

For example, given this `package.json` file:

``` json
{
  "name": "sigsegv",
  "version": "0.0.0",
  "scripts": {
    "test": "node -e 'process.kill(process.pid, \"SIGSEGV\")'"
  }
}
```

Before this patch, npm would obscure the seg fault exit status:

```
$ npm test

> sigsegv@0.0.0 test /Users/nrajlich/t
> node -e 'process.kill(process.pid, "SIGSEGV")'

$ echo $?
0
```

After this patch, the proper signal is relayed to npm, and thus the shell:

```
$ node ../npm/bin/npm-cli.js test

> sigsegv@0.0.0 test /Users/nrajlich/t
> node -e 'process.kill(process.pid, "SIGSEGV")'

Segmentation fault: 11

$ echo $?
139
```
