### PR TITLE
Improves the readability of the 'outdated' output

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -52,7 +52,7 @@ function makePretty (p) {
 
   if (parseable) {
     var str = dir
-    if (npm.config.get("long")) {
+    if (long) {
       str += ":" + dep + "@" + want
            + ":" + (has ? (dep + "@" + has) : "MISSING")
     }
@@ -62,10 +62,11 @@ function makePretty (p) {
   if (!npm.config.get("global")) {
     dir = path.relative(process.cwd(), dir)
   }
-  return dep + " " + dir
+  return dep + " =>"
        + " current=" + (has || "MISSING")
        + " wanted=" + want
        + " latest=" + latest
+     + "\n" + Array(dep.length+5).join(" ") + "location=" + dir
 }
 
 function outdated_ (args, dir, parentHas, cb) {


### PR DESCRIPTION
This is purely a cosmetic change.  I found it hard to pick out the names of the modules that are being reported as outdated.

This PR makes it easier to see which module is out of date by reordering the information and adding a line break to put the location to its own line.

I also noticed that there was a second call to `npm.config.get("long")` on line 55, so I changed it to use the variable defined on line 43.

Before:

```
grunt-contrib-imagemin node_modules\grunt-contrib-imagemin current=0.1.4 wanted=0.1.4 latest=0.3.0
matchdep node_modules\matchdep current=0.1.2 wanted=0.1.2 latest=0.3.0
xml node_modules\feed\node_modules\xml current=0.0.8 wanted=0.0.10 latest=0.0.10
bson node_modules\mongodb\node_modules\bson current=0.2.2 wanted=0.2.2 latest=0.2.3
lodash node_modules\grunt-usemin\node_modules\lodash current=1.0.1 wanted=1.0.1 latest=2.3.0
```

After:

```
grunt-contrib-imagemin => current=0.1.4 wanted=0.1.4 latest=0.3.0
                          location=node_modules\grunt-contrib-imagemin
matchdep => current=0.1.2 wanted=0.1.2 latest=0.3.0
            location=node_modules\matchdep
bson => current=0.2.2 wanted=0.2.2 latest=0.2.3
        location=node_modules\mongodb\node_modules\bson
xml => current=0.0.8 wanted=0.0.10 latest=0.0.10
       location=node_modules\feed\node_modules\xml
lodash => current=1.0.1 wanted=1.0.1 latest=2.3.0
          location=node_modules\grunt-usemin\node_modules\lodash

```
