### PR TITLE
Tiny fix for undefined results in help search

### DIFF
--- a/lib/help-search.js
+++ b/lib/help-search.js
@@ -157,6 +157,8 @@ function searchFiles (args, files, cb) {
 }
 
 function formatResults (args, results, cb) {
+  if (!results) return cb(null)
+
   var cols = Math.min(process.stdout.columns || Infinity, 80) + 1
 
   var out = results.map(function (res, i, results) {


### PR DESCRIPTION
When you search for something without any results npm dies in a gross looking error, this is a tiny fix that takes care of that. Making a PR in case someone knows this feature better than I do and thinks it's a good idea to put this somewhere else.
