### PR TITLE
test: do not hit real registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   "devDependencies": {
     "ronn": "~0.3.6",
     "tap": "~0.4.0",
-    "npm-registry-mock": "~0.5.3"
+    "npm-registry-mock": "~0.5.4"
   },
   "engines": {
     "node": ">=0.6",

--- a/test/tap/false_name.js
+++ b/test/tap/false_name.js
@@ -1,3 +1,12 @@
+// this is a test for fix #2538
+
+// the false_name-test-package has the name property "test-package" set
+// in the package.json and a dependency named "test-package" is also a
+// defined dependency of "test-package-with-one-dep".
+//
+// this leads to a conflict during installation and the fix is covered
+// by this test
+
 var test = require("tap").test
   , fs = require("fs")
   , path = require("path")
@@ -5,24 +14,38 @@ var test = require("tap").test
   , spawn = require("child_process").spawn
   , npm = require("../../")
   , rimraf = require("rimraf")
+  , common = require("../common-tap.js")
+  , mr = require("npm-registry-mock")
+  , pkg = __dirname + "/false_name"
 
 test("not every pkg.name can be required", function (t) {
-  t.plan(1)
+  rimraf.sync(pkg + "/cache")
 
-  setup(function () {
-    npm.install(".", function (err) {
-      if (err) return t.fail(err)
-      t.ok(existsSync(__dirname +
-        "/false_name/node_modules/tap/node_modules/buffer-equal"))
+  t.plan(1)
+  mr(common.port, function (s) {
+    setup(function () {
+      npm.install(".", function (err) {
+        if (err) return t.fail(err)
+        s.close()
+        t.ok(existsSync(pkg + "/node_modules/test-package-with-one-dep/" +
+          "node_modules/test-package"))
+      })
     })
   })
 })
 
+test("cleanup", function (t) {
+  rimraf.sync(pkg + "/cache")
+  rimraf.sync(pkg + "/node_modules")
+  t.end()
+})
+
 function setup (cb) {
-  process.chdir(__dirname + "/false_name")
-  npm.load(function () {
-    rimraf.sync(__dirname + "/false_name/node_modules")
-    fs.mkdirSync(__dirname + "/false_name/node_modules")
-    cb()
-  })
+  process.chdir(pkg)
+  npm.load({cache: pkg + "/cache", registry: common.registry},
+    function () {
+      rimraf.sync(pkg + "/node_modules")
+      fs.mkdirSync(pkg + "/node_modules")
+      cb()
+    })
 }

--- a/test/tap/false_name/package.json
+++ b/test/tap/false_name/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "buffer-equal",
+  "name": "test-package",
   "version": "0.0.0",
   "main": "index.js",
   "dependencies": {
-    "tap": "0.2.5"
+    "test-package-with-one-dep": "0.0.0"
   }
 }


### PR DESCRIPTION
Let the test use the npm-registry-mock.

For this test this reduces the time to the assertion to 0.276s
without SSD) from 2.548s (with empty cache)
