### PR TITLE
Fix testsuite, closes #4174

### DIFF
--- a/test/tap/lifecycle-signal.js
+++ b/test/tap/lifecycle-signal.js
@@ -6,6 +6,7 @@ var path = require("path")
 var pkg = path.resolve(__dirname, "lifecycle-signal")
 
 test("lifecycle signal abort", function (t) {
+  if (process.platform === "win32") return t.end()
   var child = spawn(node, [npm, "install"], {
     cwd: pkg
   })

--- a/test/tap/prepublish.js
+++ b/test/tap/prepublish.js
@@ -69,12 +69,14 @@ test('test', function (t) {
   }
   function onend () {
     c = c.trim()
-    t.equal( c
-           , '> npm-test-prepublish@1.2.5 prepublish .' + os.EOL
-           + '> echo ok' + os.EOL
-           + os.EOL
-           + 'ok' + os.EOL
-           + 'npm-test-prepublish-1.2.5.tgz')
+    var regex = new RegExp("" +
+      "> npm-test-prepublish@1.2.5 prepublish .\\r?\\n" +
+      "> echo ok\\r?\\n" +
+      "\\r?\\n" +
+      "ok\\r?\\n" +
+      "npm-test-prepublish-1.2.5.tgz", "ig")
+
+    t.ok(c.match(regex))
     t.end()
   }
 })


### PR DESCRIPTION
In case of `lifecycle-signal.js` which tests for the POSIX event `SIGSEGV` just return early if we are on windows, but maybe someone knows a better solution.

`prepublish.js` uses a Regex and is a little bit more flexible about the output regarding line-endings.
