### PR TITLE
make `npm outdated` work with --depth

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -33,7 +33,7 @@ var path = require("path")
 function outdated (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
   var dir = path.resolve(npm.dir, "..")
-  outdated_(args, dir, {}, function (er, list) {
+  outdated_(args, dir, {}, 0, function (er, list) {
     if (er || silent) return cb(er, list)
     if (npm.config.get("json")) {
       console.log(makeJSON(list))
@@ -114,7 +114,7 @@ function makeJSON (list) {
   return JSON.stringify(out, null, 2)
 }
 
-function outdated_ (args, dir, parentHas, cb) {
+function outdated_ (args, dir, parentHas, depth, cb) {
   // get the deps from package.json, or {<dir/node_modules/*>:"*"}
   // asyncMap over deps:
   //   shouldHave = cache.add(dep, req).version
@@ -123,6 +123,9 @@ function outdated_ (args, dir, parentHas, cb) {
   //   else if dep in args or args is empty
   //     return [dir, dep, has, shouldHave]
 
+  if (depth > npm.config.get("depth")) {
+    return cb(null, [])
+  }
   var deps = null
   readJson(path.resolve(dir, "package.json"), function (er, d) {
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
@@ -183,12 +186,12 @@ function outdated_ (args, dir, parentHas, cb) {
     // if has[dep] !== shouldHave[dep], then cb with the data
     // otherwise dive into the folder
     asyncMap(Object.keys(deps), function (dep, cb) {
-      shouldUpdate(args, dir, dep, has, deps[dep], cb)
+      shouldUpdate(args, dir, dep, has, deps[dep], depth, cb)
     }, cb)
   }
 }
 
-function shouldUpdate (args, dir, dep, has, req, cb) {
+function shouldUpdate (args, dir, dep, has, req, depth, cb) {
   // look up the most recent version.
   // if that's what we already have, or if it's not on the args list,
   // then dive into it.  Otherwise, cb() with the data.
@@ -200,6 +203,7 @@ function shouldUpdate (args, dir, dep, has, req, cb) {
     outdated_( args
              , path.resolve(dir, "node_modules", dep)
              , has
+             , depth + 1
              , cb )
   }
 

--- a/test/tap/outdated-with-depth.js
+++ b/test/tap/outdated-with-depth.js
@@ -1,0 +1,53 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var npm = require("../../")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+
+var mr = require("npm-registry-mock")
+
+var pkg = __dirname + "/outdated-with-depth"
+mkdirp.sync(pkg + "/cache")
+
+var expected = [ pkg + '/node_modules/request'
+               , 'underscore'
+               , '1.1.0'
+               , '1.3.3'
+               , '1.5.1'
+               , '~1.3.1'
+               ]
+
+test("depth option should work for outdated", function (t) {
+  process.chdir(pkg)
+  t.plan(3)
+
+  mr(common.port, function (s) {
+
+    npm.load({
+      cache: pkg + "/cache",
+      registry: common.registry,
+      loglevel: 'silent',
+      depth: 0 }
+    , function () {
+      npm.outdated(function (er, d) {
+        t.equal(d.length, 0)
+        next()
+      })
+    })
+
+    function next () {
+      npm.config.set("depth", 1)
+      npm.outdated(function (er, d) {
+        t.equal(d.length, 1)
+        t.deepEqual(d[0], expected)
+        s.close()
+        t.end()
+      })
+    }
+  })
+})
+
+test("cleanup", function (t) {
+  rimraf.sync(pkg + "/cache")
+  t.end()
+})

--- a/test/tap/outdated-with-depth/node_modules/request/node_modules/underscore/package.json
+++ b/test/tap/outdated-with-depth/node_modules/request/node_modules/underscore/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "underscore",
+  "author": "Evan You",
+  "version": "1.1.0"
+}

--- a/test/tap/outdated-with-depth/node_modules/request/package.json
+++ b/test/tap/outdated-with-depth/node_modules/request/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "request",
+  "author": "Evan You",
+  "version": "2.27.0",
+  "dependencies": {
+    "underscore": "~1.3.1"
+  }
+}

--- a/test/tap/outdated-with-depth/package.json
+++ b/test/tap/outdated-with-depth/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "outdated-with-depth",
+  "author": "Evan You",
+  "version": "0.0.0",
+  "devDependencies": {
+    "request": "~2.27.0"
+  }
+}


### PR DESCRIPTION
For https://github.com/isaacs/npm/issues/4192
Making it use read-installed seems to be out of scope for this, so I simply patched the existing. Tap test included.
