### PR TITLE
Fix incorrect is-inside-a-directory checking.

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -872,10 +872,10 @@ function addLocalTarball (p, name, shasum, cb_) {
   if (typeof cb_ !== "function") cb_ = name, name = ""
   // if it's a tar, and not in place,
   // then unzip to .tmp, add the tmp folder, and clean up tmp
-  if (p.indexOf(npm.tmp) === 0)
+  if (pathIsInside(p, npm.tmp))
     return addTmpTarball(p, name, shasum, cb_)
 
-  if (p.indexOf(npm.cache) === 0) {
+  if (pathIsInside(p, npm.cache)) {
     if (path.basename(p) !== "package.tgz") return cb_(new Error(
       "Not a valid cache tarball name: "+p))
     return addPlacedTarball(p, name, shasum, cb_)
@@ -1117,7 +1117,7 @@ function addLocalDirectory (p, name, shasum, cb) {
   if (typeof cb !== "function") cb = name, name = ""
   // if it's a folder, then read the package.json,
   // tar it to the proper place, and add the cache tar
-  if (p.indexOf(npm.cache) === 0) return cb(new Error(
+  if (pathIsInside(p, npm.cache)) return cb(new Error(
     "Adding a cache directory to the cache will make the world implode."))
   readJson(path.join(p, "package.json"), false, function (er, data) {
     er = needName(er, data)
@@ -1135,8 +1135,8 @@ function addLocalDirectory (p, name, shasum, cb) {
       mkdir(path.dirname(tgz), function (er, made) {
         if (er) return cb(er)
 
-        var fancy = p.indexOf(npm.tmp) !== 0
-                    && p.indexOf(npm.cache) !== 0
+        var fancy = !pathIsInside(p, npm.tmp)
+                    && !pathIsInside(p, npm.cache)
         tar.pack(tgz, p, data, fancy, function (er) {
           if (er) {
             log.error( "addLocalDirectory", "Could not pack %j to %j"
@@ -1252,4 +1252,8 @@ function needVersion(er, data) {
   return er ? er
        : (data && !data.version) ? new Error("No version provided")
        : null
+}
+
+function pathIsInside (potentialChild, parent) {
+  return path.relative(parent, potentialChild).indexOf('..') === -1
 }


### PR DESCRIPTION
This caused me serious problems when my npm config had the cache location set to `C:\Users\Domenic\AppData\Roaming\npm-cache`, but my `process.cwd()` value was `c:\Users\...`, i.e. the drive letter casing was mismatched.

In general, the problem was that is-inside-this-directory checking was done with `potentialChild.indexOf(parent) === 0`, which fails for case-insensitive filesystems. Anyone who had manually configured their cache or tmp location, without matching the system's casing exactly, would have run into this problem.

In particular, the failure to use the correct detection method caused npm to try to run prepublish scripts for _everything_.

Why did this manifest now? It may be a Node 0.11 issue, or perhaps a Windows 8.1 one. My other computer, running Node 0.10 and Windows 8, does not exhibit the lowercase `process.cwd()` value.
