### PR TITLE
Use https instead of ssh to fulfill clone command for all users

### DIFF
--- a/node_modules/github-url-from-username-repo/index.js
+++ b/node_modules/github-url-from-username-repo/index.js
@@ -3,7 +3,7 @@ module.exports = getUrl
 function getUrl (r) {
   if (!r) return
   if (/^[\w-]+\/[\w-]+$/.test(r))
-    return "git://github.com/" + r
+    return "https://github.com/" + r
   else
     return null
 }

--- a/node_modules/github-url-from-username-repo/test/index.js
+++ b/node_modules/github-url-from-username-repo/test/index.js
@@ -4,11 +4,11 @@ var getUrl = require("../")
 describe("github url from username/repo", function () {
   it("returns a github url for the username/repo", function () {
     var url = getUrl("visionmedia/express")
-    assert.equal("git://github.com/visionmedia/express", url)
+    assert.equal("https://github.com/visionmedia/express", url)
   })
   it("works with -", function () {
     var url = getUrl("vision-media/express-package")
-    assert.equal("git://github.com/vision-media/express-package", url)
+    assert.equal("https://github.com/vision-media/express-package", url)
   })
   it("returns null if it does not match", function () {
     var url = getUrl("package")


### PR DESCRIPTION
I was trying to install nodebb by using vagrant and puppet and recognized that npm install wasn't working because it was trying to fetch a package from a github repo which was defined in package.json with username/github_repo over ssh. Since the vagrant user has no working keypair at github the server blocked the clone command. It would be better from my point of view to use https instead, since it should not make a difference for all other use cases. 
What do you think?
