### PR TITLE
Pass GIT_SSL_NO_VERIFY to git command execution

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -564,7 +564,7 @@ function gitEnv () {
   if (gitEnv_) return gitEnv_
   gitEnv_ = {}
   for (var k in process.env) {
-    if (!~['GIT_PROXY_COMMAND','GIT_SSH'].indexOf(k) && k.match(/^GIT/)) continue
+    if (!~['GIT_PROXY_COMMAND','GIT_SSH','GIT_SSL_NO_VERIFY'].indexOf(k) && k.match(/^GIT/)) continue
     gitEnv_[k] = process.env[k]
   }
   return gitEnv_


### PR DESCRIPTION
On some machines we get such an error:

```
npm ERR! git clone https://github.com/hegemonic/taffydb.git Cloning into bare repository '/home/buildfarm/buildAgent3/work/1e02d2bc22f0472a/.npm/_git-remotes/https-github-com-hegemonic-taffydb-git-386cf83c'...
npm ERR! git clone https://github.com/hegemonic/taffydb.git 
npm ERR! git clone https://github.com/hegemonic/taffydb.git fatal: unable to access 'https://github.com/hegemonic/taffydb.git/': server certificate verification failed. CAfile: /etc/ssl/certs/yandex-ca.pem CRLfile: none
```

To fix this we could usually run `git` with `GIT_SSL_NO_VERIFY` env var set to `1`.

``` sh
GIT_SSL_NO_VERIFY=1 git clone https://github.com/hegemonic/taffydb.git
```

So we need an ability to do it with `npm` too, like:

``` sh
GIT_SSL_NO_VERIFY=1 npm install
```

But for now npm do not pass all the `GIT_*` env vars, so this case is only solvable with

``` sh
git config --global http.sslVerify "false"
```

This could help as a workaround, but is not very good as a general solution. Because it sets global config option for git.
