### PR TITLE
Adding failing tap test for issue #4143

### DIFF
--- a/test/tap/not-cyclic.js
+++ b/test/tap/not-cyclic.js
@@ -1,0 +1,28 @@
+var test = require("tap").test
+    , fs = require("fs")
+    , path = require("path")
+    , npm = require("../../")
+    , rimraf = require("rimraf")
+
+test("install: does not erroneously throw ECYCLE", function (t) {
+    t.plan(1)
+
+    setup(function () {
+        npm.install(".", function (err) {
+            if (err) return t.fail(err)
+            t.ok(true, "npm install proceeded without error")
+        })
+    })
+})
+
+function setup (cb) {
+    var notCyclicPackageDir = path.join(__dirname, "not-cyclic");
+    process.chdir(notCyclicPackageDir)
+
+    npm.load(function () {
+        var notCyclicNodeModulesDir = path.join(notCyclicPackageDir, "node_modules");
+        rimraf.sync(notCyclicNodeModulesDir)
+        fs.mkdirSync(notCyclicNodeModulesDir)
+        cb()
+    })
+}

--- a/test/tap/not-cyclic/package.json
+++ b/test/tap/not-cyclic/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "npm-debug-root",
+  "version": "0.3.0",
+  "description": "fake project to debug an npm issue",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "npm-debug-level-1": "~0.2.0"
+  }
+}


### PR DESCRIPTION
Next I will follow up with a fix.

I just created a package.json that links to real published modules. What is the right way to do this? Would it be better to load them all as fixtures on the file system?
