### PR TITLE
Add option for omitting `git tag` on `npm version`

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -65,8 +65,8 @@ function version (args, silent, cb_) {
         cb_(er)
       }
 
-      var tags = npm.config.get('git-tag-version')
-      tags = (tags === true || tags === undefined) ? true : false
+      var tags = npm.config.get('skip-git-tag')
+      tags = (tags !== true) ? true : false
       var doGit = !er && s.isDirectory() && tags
       if (!doGit) return write(data, cb)
       else checkGit(data, cb)

--- a/lib/version.js
+++ b/lib/version.js
@@ -65,7 +65,9 @@ function version (args, silent, cb_) {
         cb_(er)
       }
 
-      var doGit = !er && s.isDirectory()
+      var tags = npm.config.get('git-tag-version')
+      tags = (tags === true || tags === undefined) ? true : false
+      var doGit = !er && s.isDirectory() && tags
       if (!doGit) return write(data, cb)
       else checkGit(data, cb)
     })

--- a/test/tap/skip-git-tag.js
+++ b/test/tap/skip-git-tag.js
@@ -10,12 +10,8 @@ var mkdirp = require('mkdirp')
 var which = require('which')
 var util = require('util')
 var spawn = require('child_process').spawn
-var args = [ npmc
-           , 'version'
-           , 'patch'
-           , '--no-git-tag-version'
-           ]
-var pkg = __dirname + '/version-no-tags'
+
+var pkg = __dirname + '/skip-git-tag'
 
 test("npm version <semver> without git tag", function (t) {
   setup()
@@ -25,17 +21,17 @@ test("npm version <semver> without git tag", function (t) {
         var child = spawn(git, ['tag', '-l', tag])
         var out = ''
         child.stdout.on('data', function(d) {
-          out += data.toString()
+          out += d.toString()
         })
         child.on('exit', function() {
           return _cb(null, Boolean(~out.indexOf(tag)))
         })
       }
-      
+
       var child = spawn(git, ['init'])
       child.stdout.pipe(process.stdout)
       child.on('exit', function() {
-        npm.config.set('git-tag-version', false)
+        npm.config.set('skip-git-tag', true)
         npm.commands.version(['patch'], function(err) {
           if (err) return t.fail('Error perform version patch')
           var testPkg = require(pkg+'/package')
@@ -62,9 +58,9 @@ function setup() {
   mkdirp.sync(pkg + '/cache')
   fs.writeFileSync(pkg + '/package.json', JSON.stringify({
     author: "Evan Lucas",
-    name: "version-no-tags-test",
+    name: "skip-git-tag-test",
     version: "0.0.0",
-    description: "Test for git-tag-version flag"
+    description: "Test for skip-git-tag flag"
   }), 'utf8')
   process.chdir(pkg)
 }

--- a/test/tap/version-no-tags.js
+++ b/test/tap/version-no-tags.js
@@ -1,0 +1,70 @@
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../../')
+var npmc = require.resolve('../../')
+var osenv = require('osenv')
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var which = require('which')
+var util = require('util')
+var spawn = require('child_process').spawn
+var args = [ npmc
+           , 'version'
+           , 'patch'
+           , '--no-git-tag-version'
+           ]
+var pkg = __dirname + '/version-no-tags'
+
+test("npm version <semver> without git tag", function (t) {
+  setup()
+  npm.load({ cache: pkg + '/cache', registry: common.registry}, function () {
+    which('git', function(err, git) {
+      function tagExists(tag, _cb) {
+        var child = spawn(git, ['tag', '-l', tag])
+        var out = ''
+        child.stdout.on('data', function(d) {
+          out += data.toString()
+        })
+        child.on('exit', function() {
+          return _cb(null, Boolean(~out.indexOf(tag)))
+        })
+      }
+      
+      var child = spawn(git, ['init'])
+      child.stdout.pipe(process.stdout)
+      child.on('exit', function() {
+        npm.config.set('git-tag-version', false)
+        npm.commands.version(['patch'], function(err) {
+          if (err) return t.fail('Error perform version patch')
+          var testPkg = require(pkg+'/package')
+          if (testPkg.version !== '0.0.1') t.fail(testPkg.version+' !== \'0.0.1\'')
+          t.ok('0.0.1' === testPkg.version)
+          tagExists('v0.0.1', function(err, exists) {
+            t.equal(exists, false, 'git tag DOES exist')
+            t.pass('git tag does not exist')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+test('cleanup', function(t) {
+  rimraf.sync(pkg)
+  t.end()
+})
+
+function setup() {
+  mkdirp.sync(pkg)
+  mkdirp.sync(pkg + '/cache')
+  fs.writeFileSync(pkg + '/package.json', JSON.stringify({
+    author: "Evan Lucas",
+    name: "version-no-tags-test",
+    version: "0.0.0",
+    description: "Test for git-tag-version flag"
+  }), 'utf8')
+  process.chdir(pkg)
+}


### PR DESCRIPTION
Useful if you need to increase the version in any additional files
prior to actually adding a new tag on a git repository.
