### PR TITLE
adding the uninstallAll command.

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -161,6 +161,7 @@ var commandCache = {}
               , "restart"
               , "run-script"
               , "completion"
+              , "uninstall-all"
               ]
   , plumbing = [ "build"
                , "unbuild"

--- a/lib/uninstall-all.js
+++ b/lib/uninstall-all.js
@@ -1,0 +1,29 @@
+
+module.exports = uninstallAll
+
+uninstallAll.usage = "npm uninstallAll"
+
+var npm = require("./npm.js")
+	, log = require("npmlog")
+
+uninstallAll.completion = npm.commands.config.completion
+
+function uninstallAll (args, cb) {
+	//This is intended to help uninstall all node_modules in case the file path
+	//gets too long for the Windows OS. If it gets too long traditional delete
+	//commands fail. Continuous Integration solutions like Jenkins also fail
+	//due to the inability to delete the node_modules folder.
+	npm.ls(function(error, data, lite){
+		for(var dependency in lite.dependencies){
+			if (!lite.dependencies[dependency].missing) {
+				npm.uninstall(dependency);
+				log.info("uninstalling: " + dependency);
+			}else {
+				log.info("no uninstalling: " + dependency);
+			}
+		}
+	});
+
+	console.log("uninstallAll done");
+	cb();
+}


### PR DESCRIPTION
Continuous Integration solutions and even standard windows cmd delete commands can't delete the node_modules folder when it's dependencies get too deep (the file path gets too long). I've seen this error showing-up/reported on specific node modules' project and usually the contributor can't or won't fix it because it's not an issue with their module. I'm not sure why, but if the file path is too long somehow node is still able to delete the module. Grunt-html is an example of a module that produces this issue. I figure this solution is simple enough addition that it can be added as a feature.

I don't know what else you might need from me to get this accepted. Please tell me what you need and I'll work on adding it.
