### PR TITLE
Document a shrinkwrap corner case

### DIFF
--- a/doc/cli/npm-shrinkwrap.md
+++ b/doc/cli/npm-shrinkwrap.md
@@ -161,6 +161,17 @@ because A's shrinkwrap is constructed from a valid installation of B
 and recursively specifies all dependencies, the contents of B's
 shrinkwrap will implicitly be included in A's shrinkwrap.
 
+In case `npm shrinkwrap` was run after a `npm install` without the
+`--production` flag, there is a possibility that it generates a broken
+shrinkwrap file. This happens due to npm's strategy to optimize
+package installations, when one of the `devDependencies` fulfills the
+dependency of one of the modules in the dependency tree of your
+package's `dependencies`. If your package falls into that category,
+always run `npm install --production` prior to `npm shrinkwrap`.
+You can check the correctness of the shrinkwrap file by clearing the
+project's `node_modules` folder and run `npm ls` after
+`npm install --production`, then check for unmet dependencies.
+
 ### Caveats
 
 Shrinkwrap files only lock down package versions, not actual package


### PR DESCRIPTION
Hopefully the documentation on its own is explanation enough.

To trigger that case, use those dependencies in a package.json

```
{
  "name": "bar",
  "version": "0.0.0",
  "dependencies": {
    "fstream": "~0.1.25"
  },
  "devDependencies": {
    "mkdirp": "~0.3.5"
  }
}
```

and then run inside the package:

```
npm install; npm shrinkwrap; rm -r node_modules; npm install --production; npm ls
```

It leaves one with 

```
bar@0.0.0 /home/jzellner/bar
└─┬ fstream@0.1.25
  ├── graceful-fs@2.0.1
  ├── inherits@2.0.1
  ├── UNMET DEPENDENCY mkdirp 0.3
  └── rimraf@2.2.5
```

I don't think this is a bug, but I find it worth mentioning, after spending quite some time tracking it down in a  project with lots of dependencies.
