### PR TITLE
Fixed: Don't fetch tarballs on every "npm install" (take 2)

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -627,7 +627,8 @@ function targetResolver (where, context, deps) {
         // otherwise, make sure that it's a semver match with what we want.
         var bd = parent.bundleDependencies
         if (bd && bd.indexOf(d.name) !== -1 ||
-            semver.satisfies(d.version, deps[d.name] || "*", true)) {
+            semver.satisfies(d.version, deps[d.name] || "*", true) ||
+            deps[d.name] === d._resolved) {
           return cb(null, d.name)
         }
 

--- a/test/tap/url-dependencies.js
+++ b/test/tap/url-dependencies.js
@@ -1,0 +1,72 @@
+var test = require("tap").test
+var rimraf = require("rimraf")
+
+var mr = require("npm-registry-mock")
+
+var spawn = require("child_process").spawn
+var npm = require.resolve("../../bin/npm-cli.js")
+var node = process.execPath
+var pkg = "./url-dependencies"
+
+var mockRoutes = {
+  "get": {
+    "/underscore/-/underscore-1.3.1.tgz": [200]
+  }
+}
+
+test("url-dependencies: download first time", function(t) {
+  rimraf.sync(__dirname + "/url-dependencies/node_modules")
+
+  performInstall(function(output){
+    if(!tarballWasFetched(output)){
+      t.fail("Tarball was not fetched")
+    }else{
+      t.pass("Tarball was fetched")
+    }
+    t.end()
+  })
+})
+
+test("url-dependencies: do not download subsequent times", function(t) {
+  rimraf.sync(__dirname + "/url-dependencies/node_modules")
+
+  performInstall(function(){
+    performInstall(function(output){
+      if(tarballWasFetched(output)){
+        t.fail("Tarball was fetched second time around")
+      }else{
+        t.pass("Tarball was not fetched")
+      }
+      t.end()
+    })
+  })
+})
+
+function tarballWasFetched(output){
+  return output.indexOf("http GET http://localhost:1337/underscore/-/underscore-1.3.1.tgz") > -1
+}
+
+function performInstall (cb) {
+  mr({port: 1337, mocks: mockRoutes}, function(s){
+    var output = ""
+      , child = spawn(node, [npm, "install"], {
+          cwd: pkg,
+          env: {
+            npm_config_registry: "http://localhost:1337",
+            npm_config_cache_lock_stale: 1000,
+            npm_config_cache_lock_wait: 1000,
+            HOME: process.env.HOME,
+            Path: process.env.PATH,
+            PATH: process.env.PATH
+          }
+        })
+
+    child.stderr.on("data", function(data){
+      output += data.toString()
+    })
+    child.on("close", function () {
+      s.close()
+      cb(output)
+    })
+  })
+}

--- a/test/tap/url-dependencies/package.json
+++ b/test/tap/url-dependencies/package.json
@@ -1,0 +1,8 @@
+{
+  "author": "Steve Mason",
+  "name": "url-dependencies",
+  "version": "0.0.0",
+  "dependencies": {
+    "underscore": "http://localhost:1337/underscore/-/underscore-1.3.1.tgz"
+  }
+}


### PR DESCRIPTION
Re-do of 644c2ff (reverted in d8c907e) which does not include the --force 'reinstall everything' option

See #3913 for more details
