### PR TITLE
Patch for a hole in loglevel='silent' when using npm programmatically

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -95,7 +95,9 @@ function install (args, cb_) {
       var tree = treeify(installed || [])
         , pretty = prettify(tree, installed).trim()
 
-      if (pretty) console.log(pretty)
+      if ( npm.config.get('loglevel') !== 'silent' && pretty) {
+        console.log(pretty);
+      }
       save(where, installed, tree, pretty, hasArguments, cb_)
     })
   }


### PR DESCRIPTION
#### Issue

When using `npm.commands.install` programmatically, a "pretty" `console.log` describing the installed modules is run, even when `config.loglevel=silent`. 

Here's a simple test script which demonstrates the issue (modified from the example [here](https://github.com/isaacs/npm#using-npm-programmatically))

``` javascript
var npm = require('npm');
npm.load({
    registry: 'https://registry.npmjs.org',
    loglevel: 'silent'
}, function(err) {
    if (err) throw new Error(err);

    npm.commands.install(['lodash'], function(err, data) {
        // ...
    });
});
```
#### Proposed Solution

Checks if `npm.config.loglevel === 'silent'`, and skips writing a log if it does.

@isaacs If there's another way you'd rather go about approaching this, I'm happy to-- just figured this was the intended behavior ( it's what I was expecting when I configured `silent`, at least )  Thanks!
