### PR TITLE
append original filename to shasum error

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -287,6 +287,10 @@ function fetchAndShaCheck (u, tmp, shasum, cb) {
     if (!shasum) return cb(null, response)
     // validate that the url we just downloaded matches the expected shasum.
     sha.check(tmp, shasum, function (er) {
+      if (er != null && er.message) {
+        // add original filename for better debuggability
+        er.message = er.message + '\n' + 'From:     ' + u
+      }
       return cb(er, response, shasum)
     })
   })


### PR DESCRIPTION
I got tired of issues like #4329.

Right now shasum error is completely useless, because it doesn't show what package is it for. Since npm is asynchronous, I can't say for sure what tarball has the wrong shasum.

I can find out it easily myself, but if you try to explain it to someone in the issue tracker, it can take days to debug.

In this pull request I added an url of the tarball we're having trouble with to the error message, so the error message will look like this:

```
npm ERR! Error: shasum check failed for /home/alex/tmp/npm-8553-aUcxcRuO/1387271146938-0.7521299144718796/tmp.tgz
npm ERR! Expected: cd9560f019543c1cf3109b6cb5a0ccae727e91c4
npm ERR! Actual:   ce3af7760f1289d02bf6a7ad19f3214c4e5c7c2e
npm ERR! From:     http://registry.npmjs.org/sinopia/-/sinopia-0.5.5.tgz
npm ERR!     at /tmp/npm/node_modules/sha/index.js:38:8
npm ERR!     at ReadStream.<anonymous> (/tmp/npm/node_modules/sha/index.js:85:7)
npm ERR!     at ReadStream.EventEmitter.emit (events.js:117:20)
npm ERR!     at _stream_readable.js:920:16
npm ERR!     at process._tickCallback (node.js:415:13)
```

Now I can say something like "download that url with wget and compare with what you have in tmp.tgz", which is much easier. Feel free to rewrite this with a better error message if you want...
