### PR TITLE
On 404, specify parent package if exists

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -714,7 +714,7 @@ function targetResolver (where, context, deps) {
       }
 
       if (data && !data._from) data._from = what
-
+      if (er && parent && parent.name) er.parent = parent.name
       return cb(er, data || [])
     })
   }

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -149,6 +149,9 @@ function errorHandler (er) {
     if (er.pkgid && er.pkgid !== "-") {
       var msg = ["'"+er.pkgid+"' is not in the npm registry."
                 ,"You should bug the author to publish it"]
+      if (er.parent) {
+        msg.push("It was specified as a dependency of '"+er.parent+"'")
+      }
       if (er.pkgid.match(/^node[\.\-]|[\.\-]js$/)) {
         var s = er.pkgid.replace(/^node[\.\-]|[\.\-]js$/g, "")
         if (s !== er.pkgid) {

--- a/test/tap/404-parent.js
+++ b/test/tap/404-parent.js
@@ -6,11 +6,11 @@ var path = require('path')
 var fs = require('fs')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
-var pkg = __dirname + '/404-parent'
+var pkg = path.resolve(__dirname, '404-parent')
 
 test('404-parent: if parent exists, specify parent in error message', function(t) {
   setup()
-  rimraf.sync(pkg+'/node_modules')
+  rimraf.sync(path.resolve(pkg, 'node_modules'))
   performInstall(function(err) {
     t.ok(err instanceof Error)
     t.pass('error was returned')
@@ -27,8 +27,8 @@ test('cleanup', function(t) {
 
 function setup() {
   mkdirp.sync(pkg)
-  mkdirp.sync(pkg + '/cache')
-  fs.writeFileSync(pkg + '/package.json', JSON.stringify({
+  mkdirp.sync(path.resolve(pkg, 'cache'))
+  fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify({
     author: 'Evan Lucas',
     name: '404-parent-test',
     version: '0.0.0',

--- a/test/tap/404-parent.js
+++ b/test/tap/404-parent.js
@@ -1,0 +1,49 @@
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../../')
+var osenv = require('osenv')
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var pkg = __dirname + '/404-parent'
+
+test('404-parent: if parent exists, specify parent in error message', function(t) {
+  setup()
+  rimraf.sync(pkg+'/node_modules')
+  performInstall(function(err) {
+    t.ok(err instanceof Error)
+    t.pass('error was returned')
+    t.ok(err.parent === '404-parent-test')
+    t.end()
+  })
+})
+
+test('cleanup', function(t) {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+  t.end()
+})
+
+function setup() {
+  mkdirp.sync(pkg)
+  mkdirp.sync(pkg + '/cache')
+  fs.writeFileSync(pkg + '/package.json', JSON.stringify({
+    author: 'Evan Lucas',
+    name: '404-parent-test',
+    version: '0.0.0',
+    description: 'Test for 404-parent',
+    dependencies: {
+      'test-npm-404-parent-test': '*'
+    }
+  }), 'utf8')
+  process.chdir(pkg)
+}
+
+function performInstall(cb) {
+  npm.load(function() {
+    npm.commands.install(pkg, [], function(err) {
+      cb(err)
+    })
+  })
+}


### PR DESCRIPTION
Fixes issue #4340.

If the npm client returns 404 and the package being installed is a dependency, then specify the parent package in the error message.
