### PR TITLE
Always update timestamp of top-level node_modules

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -542,7 +542,13 @@ function installManyTop_ (what, where, context, cb) {
       packages.forEach(function (p) {
         context.family[p[0]] = p[1]
       })
-      return installMany(what, where, context, cb)
+      // ensure the node_modules directory's timestamp is updated even when its
+      // contents do not change.
+      var now = Date.now()
+      fs.utimes(nm, now, now, function(er) {
+        if (er) return cb(er)
+        return installMany(what, where, context, cb)
+      })
     })
   })
 }

--- a/test/tap/noargs-install-config-save.js
+++ b/test/tap/noargs-install-config-save.js
@@ -65,6 +65,28 @@ test("does not update the package.json with empty arguments", function (t) {
   })
 })
 
+test("updates node_modules directory timestamps when no modules changed", function(t) {
+  function modulesDirTimestamp() {
+    return fs.statSync(pkg + "/node_modules").mtime.getTime()
+  }
+  writePackageJson()
+  t.plan(1)
+
+  mr(common.port, function (s) {
+    var child = createChild([npm, "install"])
+    child.on("close", function () {
+      var origTimestamp = modulesDirTimestamp()
+      var child = createChild([npm, "install"])
+      child.on("close", function () {
+        s.close()
+        t.ok(modulesDirTimestamp() > origTimestamp)
+        t.end()
+      })
+    })
+  })
+
+});
+
 test("updates the package.json (adds dependencies) with an argument", function (t) {
   writePackageJson()
   t.plan(1)


### PR DESCRIPTION
Explicitly updating the timestamp in this way ensures that the
directory's "modified" attribute reflects the last time `npm install`
was invoked (regardless of whether any new modules were actually
installed). This will allow build tools like GNU Make to avoid
repeatedly requesting modules after the dependencies have been
satisfied.
