### PR TITLE
sort deps with --save

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -390,6 +390,9 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
       }
     })
 
+    // Sort deps
+    data[deps] = sortObject(data[deps])
+
     data = JSON.stringify(data, null, 2) + "\n"
     fs.writeFile(saveTarget, data, function (er) {
       cb(er, installed, tree, pretty)
@@ -397,6 +400,19 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
   })
 }
 
+function sortObject(obj) {
+  var out = Object.create(null)
+  var keys = Object.keys(obj).sort(function (a, b) {
+    return (a[0] === b[0]) && (a.length < b.length ? -1 : 1)
+           || (a[0].toLowerCase() < b[0].toLowerCase() ? -1 : 1)
+  })
+
+  keys.forEach(function (key) {
+    out[key] = obj[key]
+  })
+
+  return out
+}
 
 // Outputting *all* the installed modules is a bit confusing,
 // because the length of the path does not make it clear

--- a/lib/install.js
+++ b/lib/install.js
@@ -402,12 +402,10 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
 
 function sortObject(obj) {
   var out = Object.create(null)
-  var keys = Object.keys(obj).sort(function (a, b) {
-    return (a[0] === b[0]) && (a.length < b.length ? -1 : 1)
-           || (a[0].toLowerCase() < b[0].toLowerCase() ? -1 : 1)
-  })
 
-  keys.forEach(function (key) {
+  Object.keys(obj).sort(function (a, b) {
+    return a.toLowerCase().localeCompare(b.toLowerCase())
+  }).forEach(function (key) {
     out[key] = obj[key]
   })
 


### PR DESCRIPTION
This will keep deps ordered in a nice way, from this:

```
"dependencies": {
    "koa": "~0.1.2",
    "koa-router": "~1.6.1",
    "co": "~3.0.1",
    "request": "~2.30.0",
    "colors": "~0.6.2",
    "async": "~0.2.9",
    "JSONStream": "~0.7.1",
    "qs": "~0.6.6",
    "event-stream": "~3.0.20",
    "json-array-stream": "~0.1.2",
    "koa-jsonp": "~0.0.3",
    "koa-mount": "~1.2.2",
    "koa-compress": "~1.0.0",
    "koa-favicon": "~1.0.1",
    "koa-response-time": "~1.0.1",
    "debug": "~0.7.4",
    "co-body": "0.0.1",
    "nano": "~4.2.1"
  },
```

to

```
"dependencies": {
  "async": "~0.2.9",
  "co": "~3.0.1",
  "colors": "~0.6.2",
  "co-body": "0.0.1",
  "debug": "~0.7.4",
  "json-array-stream": "~0.1.2",
  "JSONStream": "~0.7.1",
  "koa": "~0.1.2",
  "koa-jsonp": "~0.0.3",
  "koa-mount": "~1.2.2",
  "koa-router": "~1.6.1",
  "koa-favicon": "~1.0.1",
  "koa-compress": "~1.0.0",
  "koa-response-time": "~1.0.1",
  "nano": "~4.2.1",
  "request": "~2.30.0"
}
```

I think that a `--save --sort` or a `--save-sort` is necessary, but before go any further I wanted to check if this is something that could be potentially merged.

P.S. test are passing even though we need the test for this feature.
