### PR TITLE
Support multiple package names in npm docs | npm home

### DIFF
--- a/doc/cli/npm-docs.md
+++ b/doc/cli/npm-docs.md
@@ -3,17 +3,18 @@ npm-docs(1) -- Docs for a package in a web browser maybe
 
 ## SYNOPSIS
 
-    npm docs <pkgname>
+    npm docs [<pkgname> [<pkgname> ...]]
     npm docs (with no args in a package dir)
-    npm home <pkgname>
+    npm home [<pkgname> [<pkgname> ...]]
     npm home (with no args in a package dir)
 
 ## DESCRIPTION
 
 This command tries to guess at the likely location of a package's
 documentation URL, and then tries to open it using the `--browser`
-config param. If no package name is provided, it will search for
-a `package.json` in the current folder and use the `name` property.
+config param. You can pass multiple package names at once. If no
+package name is provided, it will search for a `package.json` in
+the current folder and use the `name` property.
 
 ## CONFIGURATION
 

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -5,7 +5,6 @@ docs.usage += "\n"
 docs.usage += "npm docs ."
 
 docs.completion = function (opts, cb) {
-  if (opts.conf.argv.remain.length > 2) return cb()
   registry.get("/-/short", 60000, function (er, list) {
     return cb(null, list || [])
   })
@@ -22,8 +21,20 @@ function url (json) {
 }
 
 function docs (args, cb) {
-  var project = args[0] || '.'
-    , package = path.resolve(process.cwd(), "package.json")
+  args = args || []
+  var pending = args.length
+  if (!pending) return getDoc('.', cb)
+  args.forEach(function(proj) {
+    getDoc(proj, function(err) {
+      if (err) return cb(err)
+      --pending || cb()
+    })
+  })
+}
+
+function getDoc (project, cb) {
+  project = project || '.'
+  var package = path.resolve(process.cwd(), "package.json")
 
   if (project === '.' || project === './') {
     try {


### PR DESCRIPTION
Currently, you can only get docs for a single package at a time:

``` sh
$ npm home express connect # only gets docs for express, ignores second argument
```

This change allows you to specify multiple packages to `npm home`:

``` sh
$ npm home express connect # get docs for express & connect
$ npm home express connect mux-demux dnode browserify # get docs for all of these
```
