### PR TITLE
Always update git urls with credentials

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -707,7 +707,7 @@ function targetResolver (where, context, deps) {
 
       // if the target is a git repository, we always want to fetch it
       var isGit = false
-        , maybeGit = what.split("@").pop()
+        , maybeGit = what.split("@").slice(1).join()
 
       if (maybeGit)
         isGit = isGitUrl(url.parse(maybeGit))

--- a/test/tap/outdated-git.js
+++ b/test/tap/outdated-git.js
@@ -18,6 +18,7 @@ test("dicovers new versions in outdated", function (t) {
       t.equal('git', d[0][3])
       t.equal('git', d[0][4])
       t.equal('git://github.com/robertkowalski/foo-private.git', d[0][5])
+      t.equal('git://user:pass@github.com/robertkowalski/foo-private.git', d[1][5])
     })
   })
 })

--- a/test/tap/outdated-git/package.json
+++ b/test/tap/outdated-git/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "main": "index.js",
   "dependencies": {
-    "foo-private": "git://github.com/robertkowalski/foo-private.git"
+    "foo-private": "git://github.com/robertkowalski/foo-private.git",
+    "foo-private-credentials": "git://user:pass@github.com/robertkowalski/foo-private.git"
   }
 }


### PR DESCRIPTION
Allow urls with "@": For example: git+https://user:pass@domain.com/repository.git

The current code return "domain.com/repository.git" instead of "git+https://user:pass@domain.com/repository.git"
