### PR TITLE
npm update --save mixes devDependencies into dependencies in package.json

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -165,6 +165,10 @@ function outdated_ (args, dir, parentHas, depth, cb) {
     }
 
     if (npm.config.get("save")) {
+      // remove optional dependencies from dependencies during --save.
+      Object.keys(d.optionalDependencies || {}).forEach(function (k) {
+        delete deps[k]
+      })
       return next()
     }
 

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -155,12 +155,29 @@ function outdated_ (args, dir, parentHas, depth, cb) {
   }
   var deps = null
   readJson(path.resolve(dir, "package.json"), function (er, d) {
+    d = d || {}
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     deps = (er) ? true : (d.dependencies || {})
+
+    if (npm.config.get("save-dev")) {
+      deps = d.devDependencies || {}
+      return next()
+    }
+
+    if (npm.config.get("save")) {
+      return next()
+    }
+
+    if (npm.config.get("save-optional")) {
+      deps = d.optionalDependencies || {}
+      return next()
+    }
+
     var doUpdate = npm.config.get("dev") ||
                     (!npm.config.get("production") &&
                     !Object.keys(parentHas).length &&
                     !npm.config.get("global"))
+
     if (!er && d && doUpdate) {
       Object.keys(d.devDependencies || {}).forEach(function (k) {
         if (!(k in parentHas)) {

--- a/test/tap/update-save.js
+++ b/test/tap/update-save.js
@@ -107,10 +107,7 @@ test("optionalDependencies are merged into dependencies during --save", function
     t.equal(code, 0)
 
     var pkgdata = JSON.parse(fs.readFileSync(PKG, 'utf8'))
-    t.deepEqual(pkgdata.dependencies, {
-      mkdirp: '^0.3.5',
-      underscore: '^1.3.3'
-    }, 'dependencies should be updated with optional dependencies')
+    t.deepEqual(pkgdata.dependencies, {mkdirp: '^0.3.5'}, 'dependencies should not include optional dependencies')
     t.deepEqual(pkgdata.devDependencies, pkg.devDependencies, 'dev dependencies should be untouched')
     t.deepEqual(pkgdata.optionalDependencies, pkg.optionalDependencies, 'optional dependencies should be untouched')
     t.end()

--- a/test/tap/update-save.js
+++ b/test/tap/update-save.js
@@ -14,7 +14,11 @@ var MODULES_DIR = path.resolve(PKG_DIR, "node_modules")
 
 var EXEC_OPTS = {
   cwd: PKG_DIR,
-  stdio: 'ignore'
+  stdio: 'ignore',
+  env: {
+    npm_config_registry: common.registry,
+    npm_config_loglevel: 'verbose'
+  }
 }
 
 var DEFAULT_PKG = {
@@ -28,7 +32,7 @@ var DEFAULT_PKG = {
   }
 }
 
-var s = undefined
+var s = undefined // mock server reference
 
 test('setup', function (t) {
   resetPackage()
@@ -48,10 +52,11 @@ test("update regular dependencies only", function (t) {
   common.npm(['update', '--save'], EXEC_OPTS, function (err, code) {
     t.ifError(err)
     t.equal(code, 0)
+
     var pkgdata = JSON.parse(fs.readFileSync(PKG, 'utf8'))
     t.deepEqual(pkgdata.dependencies, {mkdirp: '^0.3.5'}, 'only dependencies updated')
-    t.deepEqual(pkgdata.devDependencies, {underscore: '~1.3.1'}, 'dev dependencies should be untouched')
-    s.close()
+    t.deepEqual(pkgdata.devDependencies, DEFAULT_PKG.devDependencies, 'dev dependencies should be untouched')
+    t.deepEqual(pkgdata.optionalDependencies, DEFAULT_PKG.optionalDependencies, 'optional dependencies should be untouched')
     t.end()
   })
 })
@@ -59,29 +64,100 @@ test("update regular dependencies only", function (t) {
 test("update devDependencies only", function (t) {
   resetPackage()
 
-  common.npm(['update', '--save-dev'], EXEC_OPTS, function (err, code) {
+  common.npm(['update', '--save-dev'], EXEC_OPTS, function (err, code, stdout, stderr) {
     t.ifError(err)
     t.equal(code, 0)
+
     var pkgdata = JSON.parse(fs.readFileSync(PKG, 'utf8'))
+    t.deepEqual(pkgdata.dependencies, DEFAULT_PKG.dependencies, 'dependencies should be untouched')
     t.deepEqual(pkgdata.devDependencies, {underscore: '^1.3.3'}, 'dev dependencies should be updated')
-    t.deepEqual(pkgdata.dependencies, {mkdirp: '~0.3.0'}, 'dependencies should be untouched')
+    t.deepEqual(pkgdata.optionalDependencies, DEFAULT_PKG.optionalDependencies, 'optional dependencies should be untouched')
     t.end()
   })
 })
 
+test("update optionalDependencies only", function (t) {
+  resetPackage({
+    "optionalDependencies": {
+      "underscore": "~1.3.1"
+    }
+  })
 
-function resetPackage() {
+  common.npm(['update', '--save-optional'], EXEC_OPTS, function (err, code) {
+    t.ifError(err)
+    t.equal(code, 0)
+
+    var pkgdata = JSON.parse(fs.readFileSync(PKG, 'utf8'))
+    t.deepEqual(pkgdata.dependencies, DEFAULT_PKG.dependencies, 'dependencies should be untouched')
+    t.deepEqual(pkgdata.devDependencies, DEFAULT_PKG.devDependencies, 'dev dependencies should be untouched')
+    t.deepEqual(pkgdata.optionalDependencies, {underscore: '^1.3.3'}, 'optional dependencies should be updated')
+    t.end()
+  })
+})
+
+test("optionalDependencies are merged into dependencies during --save", function (t) {
+  var pkg = resetPackage({
+    "optionalDependencies": {
+      "underscore": "~1.3.1"
+    }
+  })
+
+  common.npm(['update', '--save'], EXEC_OPTS, function (err, code) {
+    t.ifError(err)
+    t.equal(code, 0)
+
+    var pkgdata = JSON.parse(fs.readFileSync(PKG, 'utf8'))
+    t.deepEqual(pkgdata.dependencies, {
+      mkdirp: '^0.3.5',
+      underscore: '^1.3.3'
+    }, 'dependencies should be updated with optional dependencies')
+    t.deepEqual(pkgdata.devDependencies, pkg.devDependencies, 'dev dependencies should be untouched')
+    t.deepEqual(pkgdata.optionalDependencies, pkg.optionalDependencies, 'optional dependencies should be untouched')
+    t.end()
+  })
+})
+
+test("semver prefix is replaced with configured save-prefix", function (t) {
+  resetPackage()
+
+  common.npm(['update', '--save', '--save-prefix', '~'], EXEC_OPTS, function (err, code) {
+    t.ifError(err)
+    t.equal(code, 0)
+
+    var pkgdata = JSON.parse(fs.readFileSync(PKG, 'utf8'))
+    t.deepEqual(pkgdata.dependencies, {
+      mkdirp: '~0.3.5'
+    }, 'dependencies should be updated')
+    t.deepEqual(pkgdata.devDependencies, DEFAULT_PKG.devDependencies, 'dev dependencies should be untouched')
+    t.deepEqual(pkgdata.optionalDependencies, DEFAULT_PKG.optionalDependencies, 'optional dependencies should be updated')
+    t.end()
+  })
+})
+
+function resetPackage(extendWith) {
   rimraf.sync(CACHE_DIR)
   rimraf.sync(MODULES_DIR)
   mkdirp.sync(CACHE_DIR)
-
-  fs.writeFileSync(PKG, JSON.stringify(DEFAULT_PKG, null, 2), 'ascii')
+  var pkg = clone(DEFAULT_PKG)
+  extend(pkg, extendWith)
+  for (key in extend) { pkg[key] = extend[key]}
+  fs.writeFileSync(PKG, JSON.stringify(pkg, null, 2), 'ascii')
+  return pkg
 }
 
 test("cleanup", function (t) {
+  s.close()
   resetPackage() // restore package.json
   rimraf.sync(CACHE_DIR)
   rimraf.sync(MODULES_DIR)
   t.end()
 })
 
+function clone(a) {
+  return extend({}, a)
+}
+
+function extend(a, b) {
+  for (key in b) { a[key] = b[key]}
+  return a
+}

--- a/test/tap/update-save.js
+++ b/test/tap/update-save.js
@@ -1,0 +1,87 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var npm = require("../../")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var fs = require('fs')
+var path = require('path')
+var mr = require("npm-registry-mock")
+
+var PKG_DIR = path.resolve(__dirname, "update-save")
+var PKG = path.resolve(PKG_DIR, "package.json")
+var CACHE_DIR = path.resolve(PKG_DIR, "cache")
+var MODULES_DIR = path.resolve(PKG_DIR, "node_modules")
+
+var EXEC_OPTS = {
+  cwd: PKG_DIR,
+  stdio: 'ignore'
+}
+
+var DEFAULT_PKG = {
+  "name": "update-save-example",
+  "version": "1.2.3",
+  "dependencies": {
+    "mkdirp": "~0.3.0"
+  },
+  "devDependencies": {
+    "underscore": "~1.3.1"
+  }
+}
+
+var s = undefined
+
+test('setup', function (t) {
+  resetPackage()
+
+  mr(common.port, function (server) {
+    npm.load({cache: CACHE_DIR, registry: common.registry}, function (err) {
+      t.ifError(err)
+      s = server
+      t.end()
+    })
+  })
+})
+
+test("update regular dependencies only", function (t) {
+  resetPackage()
+
+  common.npm(['update', '--save'], EXEC_OPTS, function (err, code) {
+    t.ifError(err)
+    t.equal(code, 0)
+    var pkgdata = JSON.parse(fs.readFileSync(PKG, 'utf8'))
+    t.deepEqual(pkgdata.dependencies, {mkdirp: '^0.3.5'}, 'only dependencies updated')
+    t.deepEqual(pkgdata.devDependencies, {underscore: '~1.3.1'}, 'dev dependencies should be untouched')
+    s.close()
+    t.end()
+  })
+})
+
+test("update devDependencies only", function (t) {
+  resetPackage()
+
+  common.npm(['update', '--save-dev'], EXEC_OPTS, function (err, code) {
+    t.ifError(err)
+    t.equal(code, 0)
+    var pkgdata = JSON.parse(fs.readFileSync(PKG, 'utf8'))
+    t.deepEqual(pkgdata.devDependencies, {underscore: '^1.3.3'}, 'dev dependencies should be updated')
+    t.deepEqual(pkgdata.dependencies, {mkdirp: '~0.3.0'}, 'dependencies should be untouched')
+    t.end()
+  })
+})
+
+
+function resetPackage() {
+  rimraf.sync(CACHE_DIR)
+  rimraf.sync(MODULES_DIR)
+  mkdirp.sync(CACHE_DIR)
+
+  fs.writeFileSync(PKG, JSON.stringify(DEFAULT_PKG, null, 2), 'ascii')
+}
+
+test("cleanup", function (t) {
+  resetPackage() // restore package.json
+  rimraf.sync(CACHE_DIR)
+  rimraf.sync(MODULES_DIR)
+  t.end()
+})
+

--- a/test/tap/update-save/README.md
+++ b/test/tap/update-save/README.md
@@ -1,0 +1,1 @@
+# just a test

--- a/test/tap/update-save/index.js
+++ b/test/tap/update-save/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/test/tap/update-save/package.json
+++ b/test/tap/update-save/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "update-save-example",
+  "version": "1.2.3",
+  "dependencies": {
+    "mkdirp": "~0.3.0"
+  },
+  "devDependencies": {
+    "underscore": "~1.3.1"
+  }
+}


### PR DESCRIPTION
When you run `npm-update --save|--save-dev|--save-optional`, all packages that needed updating will magically appear in the section specified by `--save|--save-dev|--save-optional`,  regardless of whether they were originally regular, development or optional dependencies. :-1: .

Example of running `npm update --save` on a simple `package.json` with only a development dependency:
#### Before

``` json
{
  "name": "update-save-test",
  "version": "0.5.0",
  "devDependencies": {
    "rimraf": "~2.0.0"
  }
}

```
#### After

``` json
{
  "name": "update-save-test",
  "version": "0.5.0",
  "devDependencies": {
    "rimraf": "~2.0.0"
  },
  "dependencies": {
    "rimraf": "~2.0.3"
  }
}

```
