### PR TITLE
Verify ownership of git cloned/fetched files

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -512,19 +512,24 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
   })
 
   function verifyOwnership() {
-    getCacheStat(function(er, cs) {
-      if (er) {
-        log.error("Could not get cache stat")
-        return cb(er)
-      }
-      chownr(p, cs.uid, cs.gid, function(er) {
+    if (process.platform === "win32") {
+      log.silly("verifyOwnership", "skipping for windows")
+      resolveHead()
+    } else {
+      getCacheStat(function(er, cs) {
         if (er) {
-          log.error("Failed to change folder ownership under npm cache for %s", p)
+          log.error("Could not get cache stat")
           return cb(er)
         }
-        resolveHead()
+        chownr(p, cs.uid, cs.gid, function(er) {
+          if (er) {
+            log.error("Failed to change folder ownership under npm cache for %s", p)
+            return cb(er)
+          }
+          resolveHead()
+        })
       })
-    })
+    }
   }
 
   function resolveHead () {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -508,8 +508,24 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
     }
     log.verbose("git fetch -a origin ("+u+")", stdout)
     tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
-    resolveHead()
+    verifyOwnership()
   })
+
+  function verifyOwnership() {
+    getCacheStat(function(er, cs) {
+      if (er) {
+        log.error("Could not get cache stat")
+        return cb(er)
+      }
+      chownr(p, cs.uid, cs.gid, function(er) {
+        if (er) {
+          log.error("Failed to change folder ownership under npm cache for %s", p)
+          return cb(er)
+        }
+        resolveHead()
+      })
+    })
+  }
 
   function resolveHead () {
     exec(git, resolve, {cwd: p, env: env}, function (er, stdout, stderr) {


### PR DESCRIPTION
In the case when people use `sudo npm install -g` some of the cloned git dependencies go to the npm cache. In this case when npm executes git clone or fetch, git sets ownership to root. This cases troubles when you try to do later `npm install` for dependencies which already under npm_cache/_git-remotes/ and has root ownership.

This change can cause performance degradation when you have a lot of git dependencies, because each time when you ask for git dependency - it will verify ownership first for all files under git folder. Better option will be to change ownership only for new fetched/cloned files.
