### PR TITLE
Don't run prepublish on npm install --production.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -154,6 +154,7 @@ function install (args, cb_) {
           return target
         }), where, context, function(er, results) {
           if (er) return cb(er, results)
+          if (!opt.dev) return cb(null, results)
           lifecycle(data, "prepublish", where, function(er) {
             return cb(er, results)
           })

--- a/test/tap/install-prepublish.js
+++ b/test/tap/install-prepublish.js
@@ -1,0 +1,27 @@
+var test = require("tap").test
+var npm = require.resolve("../../bin/npm-cli.js")
+var node = process.execPath
+var exec = require("child_process").exec
+var path = require("path")
+var pkg = path.resolve(__dirname, "install-prepublish")
+
+test("prepublish runs on install", function (t) {
+  t.plan(2)
+  exec([node, npm, "install"].join(" "), {
+    cwd: pkg
+  }, function(err, stdout) {
+    t.ifError(err)
+    t.ok(stdout.match(/prepublish ran\./))
+  })
+})
+
+test("prepublish does not run on install --production", function (t) {
+  t.plan(2)
+  exec([node, npm, "install", "--production"].join(" "), {
+    cwd: pkg
+  }, function(err, stdout) {
+    t.ifError(err)
+    t.ok(!stdout.match(/prepublish ran\./))
+  })
+})
+

--- a/test/tap/install-prepublish/package.json
+++ b/test/tap/install-prepublish/package.json
@@ -1,0 +1,4 @@
+{ "name":"install-prepublish",
+  "version":"1.2.5",
+  "scripts": {"prepublish":"node -e 'console.log(\"prepublish ran.\")'"}}
+


### PR DESCRIPTION
- `npm install` usually installs devDependencies+regular deps
- `npm install --production` only installs non-devDependencies
- `npm install` always runs `prepublish` scripts
- prepublish scripts often rely on dev dependencies
- _Problem_: `npm install --production` will try invoke missing devDependencies

This pull request prevents prepublish scripts from running when the `--production` flag is present.

Seems to make sense to me. 

Although…
People tend to flip out when things change though so it may not be worth rocking the boat. 

I wonder if "breaking" behaviour changes such as this should obey semver conventions, you could consider npm's command line it's api i.e. when will npm hit 2.x?
