### PR TITLE
Imp/npm install checks

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -73,6 +73,7 @@ var npm = require("./npm.js")
   , lifecycle = require("./utils/lifecycle.js")
   , archy = require("archy")
   , isGitUrl = require("./utils/is-git-url.js")
+  , npmInstallChecks = require("npm-install-checks")
 
 function install (args, cb_) {
   var hasArguments = !!args.length
@@ -842,12 +843,16 @@ function installOne_ (target, where, context, cb) {
   }
   installOnesInProgress[target.name].push(where)
   var indexOfIOIP = installOnesInProgress[target.name].length - 1
+    , force = npm.config.get("force")
+    , nodeVersion = npm.config.get("node-version")
+    , strict = npm.config.get("engine-strict")
+    , c = npmInstallChecks
 
   chain
-    ( [ [checkEngine, target]
-      , [checkPlatform, target]
-      , [checkCycle, target, context.ancestors]
-      , [checkGit, targetFolder]
+    ( [ [c.checkEngine, target, npm.version, nodeVersion, force, strict]
+      , [c.checkPlatform, target, force]
+      , [c.checkCycle, target, context.ancestors]
+      , [c.checkGit, targetFolder]
       , [write, target, targetFolder, context] ]
     , function (er, d) {
         installOnesInProgress[target.name].splice(indexOfIOIP, 1)
@@ -858,146 +863,6 @@ function installOne_ (target, where, context, cb) {
         cb(er, d)
       }
     )
-}
-
-function checkEngine (target, cb) {
-  var npmv = npm.version
-    , force = npm.config.get("force")
-    , nodev = force ? null : npm.config.get("node-version")
-    , strict = npm.config.get("engine-strict") || target.engineStrict
-    , eng = target.engines
-  if (!eng) return cb()
-  if (nodev && eng.node && !semver.satisfies(nodev, eng.node)
-      || eng.npm && !semver.satisfies(npmv, eng.npm)) {
-    if (strict) {
-      var er = new Error("Unsupported")
-      er.code = "ENOTSUP"
-      er.required = eng
-      er.pkgid = target._id
-      return cb(er)
-    } else {
-      log.warn( "engine", "%s: wanted: %j (current: %j)"
-              , target._id, eng, {node: nodev, npm: npm.version} )
-    }
-  }
-  return cb()
-}
-
-function checkPlatform (target, cb) {
-  var platform = process.platform
-    , arch = process.arch
-    , osOk = true
-    , cpuOk = true
-    , force = npm.config.get("force")
-
-  if (force) {
-    return cb()
-  }
-
-  if (target.os) {
-    osOk = checkList(platform, target.os)
-  }
-  if (target.cpu) {
-    cpuOk = checkList(arch, target.cpu)
-  }
-  if (!osOk || !cpuOk) {
-    var er = new Error("Unsupported")
-    er.code = "EBADPLATFORM"
-    er.os = target.os || ['any']
-    er.cpu = target.cpu || ['any']
-    er.pkgid = target._id
-    return cb(er)
-  }
-  return cb()
-}
-
-function checkList (value, list) {
-  var tmp
-    , match = false
-    , blc = 0
-  if (typeof list === "string") {
-    list = [list]
-  }
-  if (list.length === 1 && list[0] === "any") {
-    return true
-  }
-  for (var i = 0; i < list.length; ++i) {
-    tmp = list[i]
-    if (tmp[0] === '!') {
-      tmp = tmp.slice(1)
-      if (tmp === value) {
-        return false
-      }
-      ++blc
-    } else {
-      match = match || tmp === value
-    }
-  }
-  return match || blc === list.length
-}
-
-function checkCycle (target, ancestors, cb) {
-  // there are some very rare and pathological edge-cases where
-  // a cycle can cause npm to try to install a never-ending tree
-  // of stuff.
-  // Simplest:
-  //
-  // A -> B -> A' -> B' -> A -> B -> A' -> B' -> A -> ...
-  //
-  // Solution: Simply flat-out refuse to install any name@version
-  // that is already in the prototype tree of the ancestors object.
-  // A more correct, but more complex, solution would be to symlink
-  // the deeper thing into the new location.
-  // Will do that if anyone whines about this irl.
-  //
-  // Note: `npm install foo` inside of the `foo` package will abort
-  // earlier if `--force` is not set.  However, if it IS set, then
-  // we need to still fail here, but just skip the first level. Of
-  // course, it'll still fail eventually if it's a true cycle, and
-  // leave things in an undefined state, but that's what is to be
-  // expected when `--force` is used.  That is why getPrototypeOf
-  // is used *twice* here: to skip the first level of repetition.
-
-  var p = Object.getPrototypeOf(Object.getPrototypeOf(ancestors))
-    , name = target.name
-    , version = target.version
-  while (p && p !== Object.prototype && p[name] !== version) {
-    p = Object.getPrototypeOf(p)
-  }
-  if (p[name] !== version) return cb()
-
-  var er = new Error("Unresolvable cycle detected")
-  var tree = [target._id, JSON.parse(JSON.stringify(ancestors))]
-    , t = Object.getPrototypeOf(ancestors)
-  while (t && t !== Object.prototype) {
-    if (t === p) t.THIS_IS_P = true
-    tree.push(JSON.parse(JSON.stringify(t)))
-    t = Object.getPrototypeOf(t)
-  }
-  log.verbose("unresolvable dependency tree", tree)
-  er.pkgid = target._id
-  er.code = "ECYCLE"
-  return cb(er)
-}
-
-function checkGit (folder, cb) {
-  // if it's a git repo then don't touch it!
-  fs.lstat(folder, function (er, s) {
-    if (er || !s.isDirectory()) return cb()
-    else checkGit_(folder, cb)
-  })
-}
-
-function checkGit_ (folder, cb) {
-  fs.stat(path.resolve(folder, ".git"), function (er, s) {
-    if (!er && s.isDirectory()) {
-      var e = new Error("Appears to be a git repo or submodule.")
-      e.path = folder
-      e.code = "EISGIT"
-      return cb(e)
-    }
-    cb()
-  })
 }
 
 function write (target, targetFolder, context, cb_) {

--- a/node_modules/npm-install-checks/LICENSE
+++ b/node_modules/npm-install-checks/LICENSE
@@ -1,0 +1,234 @@
+Copyright (c) Robert Kowalski ("Author")
+All rights reserved.
+
+
+The BSD License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+This uses parts of npm, (c) Isaac Z. Schlueter, under the following license:
+
+
+The Artistic License 2.0
+
+Copyright (c) 2000-2006, The Perl Foundation.
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+Preamble
+
+This license establishes the terms under which a given free software
+Package may be copied, modified, distributed, and/or redistributed.
+The intent is that the Copyright Holder maintains some artistic
+control over the development of that Package while still keeping the
+Package available as open source and free software.
+
+You are always permitted to make arrangements wholly outside of this
+license directly with the Copyright Holder of a given Package.  If the
+terms of this license do not permit the full use that you propose to
+make of the Package, you should contact the Copyright Holder and seek
+a different licensing arrangement.
+
+Definitions
+
+    "Copyright Holder" means the individual(s) or organization(s)
+    named in the copyright notice for the entire Package.
+
+    "Contributor" means any party that has contributed code or other
+    material to the Package, in accordance with the Copyright Holder's
+    procedures.
+
+    "You" and "your" means any person who would like to copy,
+    distribute, or modify the Package.
+
+    "Package" means the collection of files distributed by the
+    Copyright Holder, and derivatives of that collection and/or of
+    those files. A given Package may consist of either the Standard
+    Version, or a Modified Version.
+
+    "Distribute" means providing a copy of the Package or making it
+    accessible to anyone else, or in the case of a company or
+    organization, to others outside of your company or organization.
+
+    "Distributor Fee" means any fee that you charge for Distributing
+    this Package or providing support for this Package to another
+    party.  It does not mean licensing fees.
+
+    "Standard Version" refers to the Package if it has not been
+    modified, or has been modified only in ways explicitly requested
+    by the Copyright Holder.
+
+    "Modified Version" means the Package, if it has been changed, and
+    such changes were not explicitly requested by the Copyright
+    Holder.
+
+    "Original License" means this Artistic License as Distributed with
+    the Standard Version of the Package, in its current version or as
+    it may be modified by The Perl Foundation in the future.
+
+    "Source" form means the source code, documentation source, and
+    configuration files for the Package.
+
+    "Compiled" form means the compiled bytecode, object code, binary,
+    or any other form resulting from mechanical transformation or
+    translation of the Source form.
+
+
+Permission for Use and Modification Without Distribution
+
+(1)  You are permitted to use the Standard Version and create and use
+Modified Versions for any purpose without restriction, provided that
+you do not Distribute the Modified Version.
+
+
+Permissions for Redistribution of the Standard Version
+
+(2)  You may Distribute verbatim copies of the Source form of the
+Standard Version of this Package in any medium without restriction,
+either gratis or for a Distributor Fee, provided that you duplicate
+all of the original copyright notices and associated disclaimers.  At
+your discretion, such verbatim copies may or may not include a
+Compiled form of the Package.
+
+(3)  You may apply any bug fixes, portability changes, and other
+modifications made available from the Copyright Holder.  The resulting
+Package will still be considered the Standard Version, and as such
+will be subject to the Original License.
+
+
+Distribution of Modified Versions of the Package as Source
+
+(4)  You may Distribute your Modified Version as Source (either gratis
+or for a Distributor Fee, and with or without a Compiled form of the
+Modified Version) provided that you clearly document how it differs
+from the Standard Version, including, but not limited to, documenting
+any non-standard features, executables, or modules, and provided that
+you do at least ONE of the following:
+
+    (a)  make the Modified Version available to the Copyright Holder
+    of the Standard Version, under the Original License, so that the
+    Copyright Holder may include your modifications in the Standard
+    Version.
+
+    (b)  ensure that installation of your Modified Version does not
+    prevent the user installing or running the Standard Version. In
+    addition, the Modified Version must bear a name that is different
+    from the name of the Standard Version.
+
+    (c)  allow anyone who receives a copy of the Modified Version to
+    make the Source form of the Modified Version available to others
+    under
+
+        (i)  the Original License or
+
+        (ii)  a license that permits the licensee to freely copy,
+        modify and redistribute the Modified Version using the same
+        licensing terms that apply to the copy that the licensee
+        received, and requires that the Source form of the Modified
+        Version, and of any works derived from it, be made freely
+        available in that license fees are prohibited but Distributor
+        Fees are allowed.
+
+
+Distribution of Compiled Forms of the Standard Version
+or Modified Versions without the Source
+
+(5)  You may Distribute Compiled forms of the Standard Version without
+the Source, provided that you include complete instructions on how to
+get the Source of the Standard Version.  Such instructions must be
+valid at the time of your distribution.  If these instructions, at any
+time while you are carrying out such distribution, become invalid, you
+must provide new instructions on demand or cease further distribution.
+If you provide valid instructions or cease distribution within thirty
+days after you become aware that the instructions are invalid, then
+you do not forfeit any of your rights under this license.
+
+(6)  You may Distribute a Modified Version in Compiled form without
+the Source, provided that you comply with Section 4 with respect to
+the Source of the Modified Version.
+
+
+Aggregating or Linking the Package
+
+(7)  You may aggregate the Package (either the Standard Version or
+Modified Version) with other packages and Distribute the resulting
+aggregation provided that you do not charge a licensing fee for the
+Package.  Distributor Fees are permitted, and licensing fees for other
+components in the aggregation are permitted. The terms of this license
+apply to the use and Distribution of the Standard or Modified Versions
+as included in the aggregation.
+
+(8) You are permitted to link Modified and Standard Versions with
+other works, to embed the Package in a larger work of your own, or to
+build stand-alone binary or bytecode versions of applications that
+include the Package, and Distribute the result without restriction,
+provided the result does not expose a direct interface to the Package.
+
+
+Items That are Not Considered Part of a Modified Version
+
+(9) Works (including, but not limited to, modules and scripts) that
+merely extend or make use of the Package, do not, by themselves, cause
+the Package to be a Modified Version.  In addition, such works are not
+considered parts of the Package itself, and are not subject to the
+terms of this license.
+
+
+General Provisions
+
+(10)  Any use, modification, and distribution of the Standard or
+Modified Versions is governed by this Artistic License. By using,
+modifying or distributing the Package, you accept this license. Do not
+use, modify, or distribute the Package, if you do not accept this
+license.
+
+(11)  If your Modified Version has been derived from a Modified
+Version made by someone other than you, you are nevertheless required
+to ensure that your Modified Version complies with the requirements of
+this license.
+
+(12)  This license does not grant you the right to use any trademark,
+service mark, tradename, or logo of the Copyright Holder.
+
+(13)  This license includes the non-exclusive, worldwide,
+free-of-charge patent license to make, have made, use, offer to sell,
+sell, import and otherwise transfer the Package with respect to any
+patent claims licensable by the Copyright Holder that are necessarily
+infringed by the Package. If you institute patent litigation
+(including a cross-claim or counterclaim) against any party alleging
+that the Package constitutes direct or contributory patent
+infringement, then this Artistic License to you shall terminate on the
+date that such litigation is filed.
+
+(14)  Disclaimer of Warranty:
+THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS
+IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+NON-INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL
+LAW. UNLESS REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THE PACKAGE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/node_modules/npm-install-checks/README.md
+++ b/node_modules/npm-install-checks/README.md
@@ -1,0 +1,25 @@
+# npm-install-checks
+
+A package that contains checks that npm runs during the installation.
+
+## API
+
+### .checkEngine(target, npmVer, nodeVer, force, strict, cb)
+Check if node/npm version is supported by the package.
+
+Error type: `ENOTSUP`
+
+### .checkPlatform(target, force, cb)
+Check if OS/Arch is supported by the package.
+
+Error type: `EBADPLATFORM`
+
+### .checkCycle(target, ancestors, cb)
+Check for cyclic dependencies.
+
+Error type: `ECYCLE`
+
+### .checkGit(folder, cb)
+Check if a folder is a .git folder.
+
+Error type: `EISGIT`

--- a/node_modules/npm-install-checks/index.js
+++ b/node_modules/npm-install-checks/index.js
@@ -1,0 +1,146 @@
+var fs = require("fs")
+var path = require("path")
+var log = require("npmlog")
+var semver = require("semver")
+
+exports.checkEngine = checkEngine
+function checkEngine (target, npmVer, nodeVer, force, strict, cb) {
+  var nodev = force ? null : nodeVer
+    , strict = strict || target.engineStrict
+    , eng = target.engines
+  if (!eng) return cb()
+  if (nodev && eng.node && !semver.satisfies(nodev, eng.node)
+      || eng.npm && !semver.satisfies(npmVer, eng.npm)) {
+
+    if (strict) {
+      var er = new Error("Unsupported")
+      er.code = "ENOTSUP"
+      er.required = eng
+      er.pkgid = target._id
+      return cb(er)
+    } else {
+      log.warn( "engine", "%s: wanted: %j (current: %j)"
+              , target._id, eng, {node: nodev, npm: npmVer} )
+    }
+  }
+  return cb()
+}
+
+exports.checkPlatform = checkPlatform
+function checkPlatform (target, force, cb) {
+  var platform = process.platform
+    , arch = process.arch
+    , osOk = true
+    , cpuOk = true
+
+  if (force) {
+    return cb()
+  }
+
+  if (target.os) {
+    osOk = checkList(platform, target.os)
+  }
+  if (target.cpu) {
+    cpuOk = checkList(arch, target.cpu)
+  }
+  if (!osOk || !cpuOk) {
+    var er = new Error("Unsupported")
+    er.code = "EBADPLATFORM"
+    er.os = target.os || ['any']
+    er.cpu = target.cpu || ['any']
+    er.pkgid = target._id
+    return cb(er)
+  }
+  return cb()
+}
+
+function checkList (value, list) {
+  var tmp
+    , match = false
+    , blc = 0
+  if (typeof list === "string") {
+    list = [list]
+  }
+  if (list.length === 1 && list[0] === "any") {
+    return true
+  }
+  for (var i = 0; i < list.length; ++i) {
+    tmp = list[i]
+    if (tmp[0] === '!') {
+      tmp = tmp.slice(1)
+      if (tmp === value) {
+        return false
+      }
+      ++blc
+    } else {
+      match = match || tmp === value
+    }
+  }
+  return match || blc === list.length
+}
+
+exports.checkCycle = checkCycle
+function checkCycle (target, ancestors, cb) {
+  // there are some very rare and pathological edge-cases where
+  // a cycle can cause npm to try to install a never-ending tree
+  // of stuff.
+  // Simplest:
+  //
+  // A -> B -> A' -> B' -> A -> B -> A' -> B' -> A -> ...
+  //
+  // Solution: Simply flat-out refuse to install any name@version
+  // that is already in the prototype tree of the ancestors object.
+  // A more correct, but more complex, solution would be to symlink
+  // the deeper thing into the new location.
+  // Will do that if anyone whines about this irl.
+  //
+  // Note: `npm install foo` inside of the `foo` package will abort
+  // earlier if `--force` is not set.  However, if it IS set, then
+  // we need to still fail here, but just skip the first level. Of
+  // course, it'll still fail eventually if it's a true cycle, and
+  // leave things in an undefined state, but that's what is to be
+  // expected when `--force` is used.  That is why getPrototypeOf
+  // is used *twice* here: to skip the first level of repetition.
+
+  var p = Object.getPrototypeOf(Object.getPrototypeOf(ancestors))
+    , name = target.name
+    , version = target.version
+  while (p && p !== Object.prototype && p[name] !== version) {
+    p = Object.getPrototypeOf(p)
+  }
+  if (p[name] !== version) return cb()
+
+  var er = new Error("Unresolvable cycle detected")
+  var tree = [target._id, JSON.parse(JSON.stringify(ancestors))]
+    , t = Object.getPrototypeOf(ancestors)
+  while (t && t !== Object.prototype) {
+    if (t === p) t.THIS_IS_P = true
+    tree.push(JSON.parse(JSON.stringify(t)))
+    t = Object.getPrototypeOf(t)
+  }
+  log.verbose("unresolvable dependency tree", tree)
+  er.pkgid = target._id
+  er.code = "ECYCLE"
+  return cb(er)
+}
+
+exports.checkGit = checkGit
+function checkGit (folder, cb) {
+  // if it's a git repo then don't touch it!
+  fs.lstat(folder, function (er, s) {
+    if (er || !s.isDirectory()) return cb()
+    else checkGit_(folder, cb)
+  })
+}
+
+function checkGit_ (folder, cb) {
+  fs.stat(path.resolve(folder, ".git"), function (er, s) {
+    if (!er && s.isDirectory()) {
+      var e = new Error("Appears to be a git repo or submodule.")
+      e.path = folder
+      e.code = "EISGIT"
+      return cb(e)
+    }
+    cb()
+  })
+}

--- a/node_modules/npm-install-checks/package.json
+++ b/node_modules/npm-install-checks/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "npm-install-checks",
+  "version": "1.0.0",
+  "description": "checks that npm runs during the installation of a module",
+  "main": "index.js",
+  "dependencies": {
+    "npmlog": "0.0.6",
+    "semver": "~2.2.1"
+  },
+  "devDependencies": {
+    "tap": "~0.4.8",
+    "rimraf": "~2.2.5",
+    "mkdirp": "~0.3.5"
+  },
+  "scripts": {
+    "test": "tap test/*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/robertkowalski/npm-install-checks.git"
+  },
+  "homepage": "https://github.com/robertkowalski/npm-install-checks",
+  "keywords": [
+    "npm,",
+    "install"
+  ],
+  "author": {
+    "name": "Robert Kowalski",
+    "email": "rok@kowalski.gd"
+  },
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/robertkowalski/npm-install-checks/issues"
+  },
+  "readme": "# npm-install-checks\n\nA package that contains checks that npm runs during the installation.\n\n## API\n\n### .checkEngine(target, npmVer, nodeVer, force, strict, cb)\nCheck if node/npm version is supported by the package.\n\nError type: `ENOTSUP`\n\n### .checkPlatform(target, force, cb)\nCheck if OS/Arch is supported by the package.\n\nError type: `EBADPLATFORM`\n\n### .checkCycle(target, ancestors, cb)\nCheck for cyclic dependencies.\n\nError type: `ECYCLE`\n\n### .checkGit(folder, cb)\nCheck if a folder is a .git folder.\n\nError type: `EISGIT`\n",
+  "readmeFilename": "README.md",
+  "_id": "npm-install-checks@1.0.0",
+  "dist": {
+    "shasum": "7e1469b5e0c693b2ae2a8830b5fc4e7bf76c88fd"
+  },
+  "_from": "npm-install-checks@1.0.0",
+  "_resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.0.tgz"
+}

--- a/node_modules/npm-install-checks/test/check-engine.js
+++ b/node_modules/npm-install-checks/test/check-engine.js
@@ -1,0 +1,35 @@
+var test = require("tap").test
+var c = require("../index.js").checkEngine
+
+test("no engine defined", function (t) {
+  c({ engines: {}}, "1.1.2", "0.2.1", false, true, function (err) {
+    t.notOk(err, "no error present")
+    t.end()
+  })
+})
+
+test("node version too old", function (t) {
+  var target = { engines: { node: "0.10.24" }}
+  c(target, "1.1.2", "0.10.18", false, true, function (err) {
+    t.ok(err, "returns an error")
+    t.equals(err.required.node, "0.10.24")
+    t.end()
+  })
+})
+
+test("npm version too old", function (t) {
+  var target = { engines: { npm: "1.3.6" }}
+    c(target, "1.4.2", "0.2.1", false, true, function (err) {
+      t.ok(err, "returns an error")
+      t.equals(err.required.npm, "1.3.6")
+      t.end()
+    })
+})
+
+test("strict=false does not return an error", function (t) {
+  var target = { engines: { npm: "1.3.6" }}
+  c(target, "1.4.2", "0.2.1", false, false, function (err) {
+    t.notOk(err, "returns no error")
+    t.end()
+  })
+})

--- a/node_modules/npm-install-checks/test/check-git.js
+++ b/node_modules/npm-install-checks/test/check-git.js
@@ -1,0 +1,31 @@
+var test = require("tap").test
+var c = require("../index.js").checkGit
+var fs = require("fs")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var path = require("path")
+var gitFixturePath = path.resolve(__dirname, "out")
+
+test("is .git repo", function (t) {
+  mkdirp(gitFixturePath + "/.git", function () {
+    c(gitFixturePath, function (err) {
+      t.ok(err, "error present")
+      t.equal(err.code, "EISGIT")
+      t.end()
+    })
+  })
+})
+
+test("is not a .git repo", function (t) {
+  c(__dirname, function (err) {
+    t.notOk(err, "error not present")
+    t.end()
+  })
+})
+
+test("cleanup", function (t) {
+  rimraf(gitFixturePath, function () {
+    t.pass("cleanup")
+    t.end()
+  })
+})

--- a/node_modules/npm-install-checks/test/check-platform.js
+++ b/node_modules/npm-install-checks/test/check-platform.js
@@ -1,0 +1,44 @@
+var test = require("tap").test
+var c = require("../index.js").checkPlatform
+
+test("target cpu wrong", function (t) {
+  var target = {}
+  target.cpu = "enten-cpu"
+  target.os = "any"
+  c(target, false, function (err) {
+    t.ok(err, "error present")
+    t.equal(err.code, "EBADPLATFORM")
+    t.end()
+  })
+})
+
+test("os wrong", function (t) {
+  var target = {}
+  target.cpu = "any"
+  target.os = "enten-os"
+  c(target, false, function (err) {
+    t.ok(err, "error present")
+    t.equal(err.code, "EBADPLATFORM")
+    t.end()
+  })
+})
+
+test("nothing wrong", function (t) {
+  var target = {}
+  target.cpu = "any"
+  target.os = "any"
+  c(target, false, function (err) {
+    t.notOk(err, "no error present")
+    t.end()
+  })
+})
+
+test("force", function (t) {
+  var target = {}
+  target.cpu = "enten-cpu"
+  target.os = "any"
+  c(target, true, function (err) {
+    t.notOk(err, "no error present")
+    t.end()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.3",
     "path-is-inside": "~1.0.0",
-    "columnify": "0.1.2"
+    "columnify": "0.1.2",
+    "npm-install-checks": "~1.0.0"
   },
   "bundleDependencies": [
     "semver",
@@ -131,7 +132,8 @@
     "ansicolors",
     "ansistyles",
     "path-is-inside",
-    "columnify"
+    "columnify",
+    "npm-install-checks"
   ],
   "devDependencies": {
     "ronn": "~0.3.6",


### PR DESCRIPTION
I will happily transfer the module to the org if we decide to take 
this PR. isaacs is already added as owner for the package.

People, including me want to add/change things in `install.js` -
@luk and @isaacs are right when they say that we should not add
more and more code to it. 

So the only option is to remove more and more code from install.js into 
own modules. This has a nice side effect, because it makes the small 
functions testable with real unit-tests (which is also a ticket tagged
with i-wanna-be-the-very best). The module `npm-install-checks` has tests 
for most of the extracted functions now. 

This removes the following checks from `install.js` into an own module, which are run
during installation:
- checkEngine
- checkPlatform
- checkCycle
- checkGit
