### PR TITLE
npm tags vs github urls

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -610,8 +610,8 @@ function addNamed (name, x, data, cb_) {
   })
 }
 
-function addNameTag (name, tag, data, cb_) {
-  if (typeof cb_ !== "function") cb_ = data, data = null
+function addNameTag (name, tag, data, cb) {
+  if (typeof cb !== "function") cb = data, data = null
   log.info("addNameTag", [name, tag])
   var explicit = true
   if (!tag) {
@@ -619,13 +619,16 @@ function addNameTag (name, tag, data, cb_) {
     tag = npm.config.get("tag")
   }
 
-  function cb(er, data) {
+  if (~tag.indexOf('/')) {
     // might be username/project
     // in that case, try it as a github url.
-    if (er && tag.split("/").length === 2) {
-      return maybeGithub(tag, name, er, cb_)
+    if (tag.split("/").length === 2) {
+      return maybeGithub(tag, name, null, cb)
     }
-    return cb_(er, data)
+
+    // tag containing a slash is invalid anyway,
+    // since you can't manage it with "npm tag"
+    cb(new Error( "Invalid tag: " + tag ))
   }
 
   registry.get(name, function (er, data, json, response) {
@@ -858,7 +861,7 @@ function maybeGithub (p, name, er, cb) {
       log.info("maybeGithub", "Attempting %s from %s", p, upriv)
 
       return addRemoteGit(upriv, uppriv, false, name, function (er3, data) {
-        if (er3) return cb(er)
+        if (er3) return cb(er || er2)
         success(upriv, data)
       })
     }


### PR DESCRIPTION
Following discussion from https://github.com/visionmedia/npm/pull/15 .

If you write this to your package.json:

``` js
  "dependencies": {
    "github-package":"visionmedia/commander.js"
  },
```

npm will always request "github-package" from registry assuming that "visionmedia/commander.js" is a tag.

If this tag doesn't exist, npm will try to fetch it from github as a fallback.

My point is: since "user/repo" is an invalid tag (you can't do "npm tag package@1.2.3 user/repo"), I suggest it to make github request without hitting registry at all.
