### PR TITLE
Fix references to isaacs/npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ If this concerns you, inspect the source before using packages.
 When you find issues, please report them:
 
 * web:
-  <https://github.com/isaacs/npm/issues>
+  <https://github.com/npm/npm/issues>
 * email:
   <npm-@googlegroups.com>
 

--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -146,9 +146,9 @@ after packing it up into a tarball (b).
 
     Examples:
 
-          git+ssh://git@github.com:isaacs/npm.git#v1.0.27
-          git+https://isaacs@github.com/isaacs/npm.git
-          git://github.com/isaacs/npm.git#v1.0.27
+          git+ssh://git@github.com:npm/npm.git#v1.0.27
+          git+https://isaacs@github.com/npm/npm.git
+          git://github.com/npm/npm.git#v1.0.27
 
 You may combine multiple arguments, and even multiple types of arguments.
 For example:

--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -114,7 +114,7 @@ easily by doing `npm view npm contributors`.
 If you would like to contribute, but don't know what to work on, check
 the issues list or ask on the mailing list.
 
-* <http://github.com/isaacs/npm/issues>
+* <http://github.com/npm/npm/issues>
 * <npm-@googlegroups.com>
 
 ## BUGS
@@ -122,7 +122,7 @@ the issues list or ask on the mailing list.
 When you find issues, please report them:
 
 * web:
-  <http://github.com/isaacs/npm/issues>
+  <http://github.com/npm/npm/issues>
 * email:
   <npm-@googlegroups.com>
 

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -257,7 +257,7 @@ Do it like this:
 
     "repository" :
       { "type" : "git"
-      , "url" : "http://github.com/isaacs/npm.git"
+      , "url" : "http://github.com/npm/npm.git"
       }
 
     "repository" :

--- a/doc/misc/npm-coding-style.md
+++ b/doc/misc/npm-coding-style.md
@@ -133,7 +133,7 @@ string message to the callback.  Stack traces are handy.
 
 ## Logging
 
-Logging is done using the [npmlog](https://github.com/isaacs/npmlog)
+Logging is done using the [npmlog](https://github.com/npm/npmlog)
 utility.
 
 Please clean up logs when they are no longer helpful.  In particular,

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -466,7 +466,7 @@ The default is "http", which shows http, warn, and error output.
 * Type: Stream
 
 This is the stream that is passed to the
-[npmlog](https://github.com/isaacs/npmlog) module at run time.
+[npmlog](https://github.com/npm/npmlog) module at run time.
 
 It cannot be set from the command line, but if you are using npm
 programmatically, you may wish to send logs to somewhere other than

--- a/doc/misc/npm-faq.md
+++ b/doc/misc/npm-faq.md
@@ -315,12 +315,12 @@ in a web browser.  This will also tell you if you are just unable to
 access the internet for some reason.
 
 If the registry IS down, let me know by emailing <i@izs.me> or posting
-an issue at <https://github.com/isaacs/npm/issues>.  We'll have
+an issue at <https://github.com/npm/npm/issues>.  We'll have
 someone kick it or something.
 
 ## Why no namespaces?
 
-Please see this discussion: <https://github.com/isaacs/npm/issues/798>
+Please see this discussion: <https://github.com/npm/npm/issues/798>
 
 tl;dr - It doesn't actually make things better, and can make them worse.
 
@@ -338,7 +338,7 @@ There is not sufficient need to impose namespace rules on everyone.
 
 Post an issue on the github project:
 
-* <https://github.com/isaacs/npm/issues>
+* <https://github.com/npm/npm/issues>
 
 ## Why does npm hate me?
 

--- a/doc/misc/npm-registry.md
+++ b/doc/misc/npm-registry.md
@@ -14,7 +14,7 @@ account information.
 The official public npm registry is at <http://registry.npmjs.org/>.  It
 is powered by a CouchDB database at
 <http://isaacs.iriscouch.com/registry>.  The code for the couchapp is
-available at <http://github.com/isaacs/npmjs.org>.  npm user accounts
+available at <http://github.com/npm/npmjs.org>.  npm user accounts
 are CouchDB users, stored in the <http://isaacs.iriscouch.com/_users>
 database.
 

--- a/html/index.html
+++ b/html/index.html
@@ -69,7 +69,7 @@ code { background:#fff ; outline: 1px solid #ccc; padding:0 2px; }
 <h2>Fancy Install</h2>
 
 <ol>
-  <li><a href="https://github.com/isaacs/npm">Get the code.</a>
+  <li><a href="https://github.com/npm/npm">Get the code.</a>
   <li>Do what <a href="https://npmjs.org/doc/README.html">the README</a>
       says to do.
 </ol>
@@ -88,7 +88,7 @@ program that you run on your computer!</p>
   <li><a href="doc/faq.html">FAQ</a>
   <li><a href="https://search.npmjs.org/">Search for Packages</a>
   <li><a href="https://groups.google.com/group/npm-">Mailing List</a>
-  <li><a href="https://github.com/isaacs/npm/issues">Bugs</a>
+  <li><a href="https://github.com/npm/npm/issues">Bugs</a>
 </ul>
 
 </body>

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -21,8 +21,8 @@ cache folders:
 1. urls: http!/server.com/path/to/thing
 2. c:\path\to\thing: file!/c!/path/to/thing
 3. /path/to/thing: file!/path/to/thing
-4. git@ private: git_github.com!isaacs/npm
-5. git://public: git!/github.com/isaacs/npm
+4. git@ private: git_github.com!npm/npm
+5. git://public: git!/github.com/npm/npm
 6. git+blah:// git-blah!/server.com/foo/bar
 
 adding a folder:
@@ -523,7 +523,7 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
       parsed.hash = stdout
       resolved = url.format(parsed)
 
-      // https://github.com/isaacs/npm/issues/3224
+      // https://github.com/npm/npm/issues/3224
       // node incorrectly sticks a / at the start of the path
       // We know that the host won't change, so split and detect this
       var spo = origUrl.split(parsed.host)

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -37,7 +37,7 @@ function getUrlAndOpen (d, cb) {
   var r = d.repository;
   if (!r) return cb(new Error('no repository'));
   // XXX remove this when npm@v1.3.10 from node 0.10 is deprecated
-  // from https://github.com/isaacs/npm-www/issues/418
+  // from https://github.com/npm/npm-www/issues/418
   if (githubUserRepo(r.url))
     r.url = githubUserRepo(r.url)
   var url = github(r.url)

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -270,7 +270,7 @@ function errorHandler (er) {
     log.error("", er.stack || er.message || er)
     log.error("", ["If you need help, you may report this *entire* log,"
                   ,"including the npm and node versions, at:"
-                  ,"    <http://github.com/isaacs/npm/issues>"
+                  ,"    <http://github.com/npm/npm/issues>"
                   ].join("\n"))
     printStack = false
     break

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/isaacs/npm"
+    "url": "https://github.com/npm/npm"
   },
   "bugs": {
     "email": "npm-@googlegroups.com",
-    "url": "http://github.com/isaacs/npm/issues"
+    "url": "http://github.com/npm/npm/issues"
   },
   "directories": {
     "doc": "./doc",

--- a/test/packages/npm-test-blerg3/package.json
+++ b/test/packages/npm-test-blerg3/package.json
@@ -1,5 +1,5 @@
 { "name":"npm-test-blerg3"
-, "homepage": "https://github.com/isaacs/npm/issues/2658"
+, "homepage": "https://github.com/npm/npm/issues/2658"
 , "version" : "0.0.0"
 , "scripts" : { "test" : "node test.js" }
 }


### PR DESCRIPTION
Github will forward from [github.com/isaacs/npm](https://github.com/isaacs/npm) to [github.com/npm/npm](https://github.com/npm/npm), but some tools don't know to follow that forward and error out.

I've replaced references to `isaacs/npm` with `npm/npm` in both places where it matters (`package.json`) and places it doesn't really matter but for aesthetic reasons (readme and docs).
