### PR TITLE
fix: npm run fails silently. closes #2959

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -1,4 +1,3 @@
-
 module.exports = runScript
 
 var lifecycle = require("./utils/lifecycle.js")
@@ -89,6 +88,13 @@ function run (pkg, wd, cmd, cb) {
            ,"restart"
            ,"prestart","start","poststart"]
   } else {
+    if (!pkg.scripts[cmd]) {
+      if (cmd === "test") {
+        pkg.scripts.test = "echo \"Error: no test specified\" && exit 1";
+      } else {
+        return cb(new Error("missing script: " + cmd));
+      }
+    }
     cmds = [cmd]
   }
   if (!cmd.match(/^(pre|post)/)) {

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -90,7 +90,7 @@ function run (pkg, wd, cmd, cb) {
   } else {
     if (!pkg.scripts[cmd]) {
       if (cmd === "test") {
-        pkg.scripts.test = "echo \"Error: no test specified\" && exit 1";
+        pkg.scripts.test = "echo \"Error: no test specified\"";
       } else {
         return cb(new Error("missing script: " + cmd));
       }


### PR DESCRIPTION
if the missing command is "test", logs a text error, otherwise creates an actual error.
