### PR TITLE
Add command npm-exec

### DIFF
--- a/doc/api/npm-exec.md
+++ b/doc/api/npm-exec.md
@@ -1,0 +1,10 @@
+npm-exec(3) -- Run an executable from npm bin folder
+====================================================
+
+## SYNOPSIS
+
+    npm.commands.exec(args, cb)
+
+## DESCRIPTION
+
+Print the folder where npm will install executables.

--- a/doc/cli/npm-exec.md
+++ b/doc/cli/npm-exec.md
@@ -1,0 +1,15 @@
+npm-exec(1) -- Run an executable from npm bin folder
+====================================================
+
+## SYNOPSIS
+
+    npm exec <cmd> [args]
+
+## DESCRIPTION
+
+Run an executable from npm bin folder.
+
+## SEE ALSO
+
+* npm-bin(1)
+* npmrc(5)

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,0 +1,38 @@
+module.exports = exec
+
+var fs = require("fs")
+var npm = require("./npm.js")
+var exec = require("child_process").exec
+var path = require("path")
+
+exec.usage = "npm exec <cmd> [args]\nnpm exec -g <cmd> [args]"
+
+function exec (args, silent, cb) {
+  if (typeof cb !== "function") cb = silent, silent = false
+
+  var b = npm.bin
+    , PATH = (process.env.PATH || "").split(":")
+    , cmd = args[0] || ""
+    , executable = path.join(b, cmd)
+
+  if (!cmd) {
+    return cb("Usage: " + exec.usage)
+  } else if (!fs.existsSync(executable)) {
+    return cb("Invalid command: " + cmd)
+  } else {
+    exec(args.join(' '), function (err, stdout, stderr) {
+      if (err) {
+        err = err.message.replace("Command failed: ", "")
+      }
+      if (!silent) {
+        process.stdout.write(stdout)
+        // process.stderr.write(stderr)
+      }
+      process.nextTick(cb.bind(this, err, stdout))
+    })
+  }
+
+  if (npm.config.get("global") && PATH.indexOf(b) === -1) {
+    npm.config.get("logstream").write("(not in PATH env variable)\n")
+  }
+}

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -154,6 +154,7 @@ var commandCache = {}
               , "prefix"
               , "bin"
               , "whoami"
+              , "exec"
 
               , "test"
               , "stop"


### PR DESCRIPTION
Sub-command to run executables installed in npm bin folder.
Picks up modules from `./node_modules/bin` or global `bin` directory. It uses `npm.bin` for getting the executable path.
