### PR TITLE
serialize shrinkwrap payload in order

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -53,7 +53,7 @@ function shrinkwrap_ (pkginfo, silent, dev, cb) {
 function save (pkginfo, silent, cb) {
   // copy the keys over in a well defined order
   // because javascript objects serialize arbitrarily
-  pkginfo = copyOrder(pkginfo)
+  pkginfo.dependencies = copyOrder(pkginfo.dependencies)
   try {
     var swdata = JSON.stringify(pkginfo, null, 2) + "\n"
   } catch (er) {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -51,6 +51,9 @@ function shrinkwrap_ (pkginfo, silent, dev, cb) {
 
 
 function save (pkginfo, silent, cb) {
+  // copy the keys over in a well defined order
+  // because javascript objects serialize arbitrarily
+  pkginfo = copyOrder(pkginfo)
   try {
     var swdata = JSON.stringify(pkginfo, null, 2) + "\n"
   } catch (er) {
@@ -66,4 +69,13 @@ function save (pkginfo, silent, cb) {
     console.log("wrote npm-shrinkwrap.json")
     cb(null, pkginfo)
   })
+}
+
+function copyOrder(obj) {
+  var result = {}
+  var keys = Object.keys(obj).sort()
+  keys.forEach(function (key) {
+    result[key] = obj[key]
+  })
+  return result
 }


### PR DESCRIPTION
**Use case:** when running `npm shrinkwrap` sometimes the keys move their location in the serialized json file. If we check the shrinkwrap file into git, then we have unneeded git diff noise of key/value pairs in the serialized json file moving from one location to another

JavaScript objects will serialize in an arbitrary key order because key enumeration is not well defined.

To avoid this we sort the keys and create a fresh object in a specific order. v8 will serialize this object in a consistent fashion.

The problem is _probably_ caused because `commands.ls` will write keys to the `pkginfo` in arbitrary order based on disk IO latency and such
