### PR TITLE
Undefined "err" variable in "npm bugs"

### DIFF
--- a/lib/bugs.js
+++ b/lib/bugs.js
@@ -25,7 +25,7 @@ function bugs (args, cb) {
     else if (er) return cb (er)
     if (!s.isDirectory()) return callRegistry(n, cb)
     readJson(path.resolve(n, "package.json"), function(er, d) {
-      if (er) return cb(err)
+      if (er) return cb(er)
       getUrlAndOpen(d, cb)
     })
   })


### PR DESCRIPTION
One-liner to fix the error handling. If you run `npm bugs` in a directory that doesn't have a `package.json` then the command fails with `ReferenceError: err is not defined`
