### PR TITLE
Adding handling of compressed man pages

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -63,13 +63,22 @@ function help (args, cb) {
     section = "package.json"
 
   // find either /section.n or /npm-section.n
-  var f = "+(npm-" + section + "|" + section + ").[0-9]"
+  var compext = "\.+(gz|bz2|lzma|[FYzZ]|xz)"
+  var f = "+(npm-" + section + "|" + section + ").[0-9]?(" + compext + ")"
   return glob(manroot + "/*/" + f, function (er, mans) {
     if (er)
       return cb(er)
 
     if (!mans.length)
       return npm.commands["help-search"](args, cb)
+
+    mans = mans.map(function (man) {
+      var ext = path.extname(man)
+      if (ext.match(compext))
+        man = path.basename(man, ext)
+
+      return man
+    })
 
     viewMan(pickMan(mans, pref), cb)
   })


### PR DESCRIPTION
Some Linux package managers compress man pages by default on package build. This change makes `npm help` to correctly handle compressed man pages.
