### PR TITLE
Show error to user on npm update

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -199,7 +199,9 @@ function shouldUpdate (args, dir, dep, has, req, depth, cb) {
   // { version: , from: }
   var curr = has[dep]
 
-  function skip () {
+  function skip (er) {
+    // show user that no viable version can be found
+    if (er) return cb(er)
     outdated_( args
              , path.resolve(dir, "node_modules", dep)
              , has
@@ -226,7 +228,13 @@ function shouldUpdate (args, dir, dep, has, req, depth, cb) {
     cache.add(dep, req, function (er, d) {
       // if this fails, then it means we can't update this thing.
       // it's probably a thing that isn't published.
-      if (er) return skip()
+      if (er) {
+        if (er.code && er.code === 'ETARGET') {
+          // no viable version found
+          return skip(er)
+        }
+        return skip()
+      }
 
       // check that the url origin hasn't changed (#1727) and that
       // there is no newer version available

--- a/test/tap/outdated-notarget.js
+++ b/test/tap/outdated-notarget.js
@@ -1,0 +1,47 @@
+// Fixes Issue #1770
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../..')
+var osenv = require('osenv')
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var pkg = path.resolve(__dirname, 'outdated-notarget')
+var cache = path.resolve(pkg, 'cache')
+var mr = require('npm-registry-mock')
+
+test('outdated-target: if no viable version is found, show error', function(t) {
+  t.plan(1)
+  setup()
+  mr({port: common.port}, function(s) {
+    npm.load({ cache: cache, registry: common.registry}, function() {
+      npm.commands.update(function(er, d) {
+        t.equal(er.code, 'ETARGET')
+        s.close()
+        t.end()
+      })
+    })
+  })
+})
+
+test('cleanup', function(t) {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+  t.end()
+})
+
+function setup() {
+  mkdirp.sync(pkg)
+  mkdirp.sync(cache)
+  fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify({
+    author: 'Evan Lucas',
+    name: 'outdated-notarget',
+    version: '0.0.0',
+    description: 'Test for outdated-target',
+    dependencies: {
+      underscore: '~199.7.1'
+    }
+  }), 'utf8')
+  process.chdir(pkg)
+}


### PR DESCRIPTION
If a dependency is listed in the package.json, but the version does not
exist, show the user an error stating so.

Fixes #1770
