### PR TITLE
Don't strip dependencies that are also devDependencies when shrinkwrapping.

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -38,6 +38,11 @@ function shrinkwrap_ (pkginfo, silent, dev, cb) {
         return cb(er)
       if (data.devDependencies) {
         Object.keys(data.devDependencies).forEach(function (dep) {
+          if (data.dependencies && data.dependencies[dep]) {
+            // do not exclude the dev dependency if it's also listed as a dependency
+            return
+          }
+
           log.warn("shrinkwrap", "Excluding devDependency: %s", dep)
           delete pkginfo.dependencies[dep]
         })

--- a/test/tap/shrinkwrap-dev-dependency.js
+++ b/test/tap/shrinkwrap-dev-dependency.js
@@ -1,0 +1,66 @@
+var npm = npm = require("../../")
+var test = require("tap").test
+var path = require("path")
+var fs = require("fs")
+var osenv = require("osenv")
+var rimraf = require("rimraf")
+var mr = require("npm-registry-mock")
+var common = require("../common-tap.js")
+
+var pkg = path.resolve(__dirname, "shrinkwrap-dev-dependency")
+var desiredResultsPath = path.resolve(pkg, "desired-shrinkwrap-results.json")
+
+test("shrinkwrap doesn't strip out the dependency", function (t) {
+  t.plan(1)
+
+  mr(common.port, function (s) {
+    setup({ production: true }, function (err) {
+      if (err) return t.fail(err)
+
+      npm.install(".", function (err) {
+        if (err) return t.fail(err)
+
+        npm.commands.shrinkwrap([], true, function (err, results) {
+          if (err) return t.fail(err)
+
+          fs.readFile(desiredResultsPath, function (err, desired) {
+            if (err) return t.fail(err)
+
+            t.deepEqual(results, JSON.parse(desired))
+            s.close()
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  cleanup()
+  t.end()
+})
+
+
+function setup (opts, cb) {
+  cleanup()
+  process.chdir(pkg)
+
+  var allOpts = {
+    cache: path.resolve(pkg, "cache"),
+    registry: common.registry
+  }
+
+  for (var key in opts) {
+    allOpts[key] = opts[key]
+  }
+
+  npm.load(allOpts, cb)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(path.resolve(pkg, "node_modules"))
+  rimraf.sync(path.resolve(pkg, "cache"))
+  rimraf.sync(path.resolve(pkg, "npm-shrinkwrap.json"))
+}

--- a/test/tap/shrinkwrap-dev-dependency/desired-shrinkwrap-results.json
+++ b/test/tap/shrinkwrap-dev-dependency/desired-shrinkwrap-results.json
@@ -1,0 +1,12 @@
+{
+  "name": "npm-test-shrinkwrap-dev-dependency",
+  "version": "0.0.0",
+  "dependencies": {
+    "request": {
+      "version": "0.9.0"
+    },
+    "underscore": {
+      "version": "1.3.1"
+    }
+  }
+}

--- a/test/tap/shrinkwrap-dev-dependency/package.json
+++ b/test/tap/shrinkwrap-dev-dependency/package.json
@@ -1,0 +1,12 @@
+{
+  "author": "Domenic Denicola",
+  "name": "npm-test-shrinkwrap-dev-dependency",
+  "version": "0.0.0",
+  "dependencies": {
+    "request": "0.9.0",
+    "underscore": "1.3.1"
+  },
+  "devDependencies": {
+    "underscore": "1.5.1"
+  }
+}

--- a/test/tap/shrinkwrap-shared-dev-dependency.js
+++ b/test/tap/shrinkwrap-shared-dev-dependency.js
@@ -1,0 +1,58 @@
+var npm = npm = require("../../")
+var test = require("tap").test
+var path = require("path")
+var fs = require("fs")
+var osenv = require("osenv")
+var rimraf = require("rimraf")
+var mr = require("npm-registry-mock")
+var common = require("../common-tap.js")
+
+var pkg = path.resolve(__dirname, "shrinkwrap-shared-dev-dependency")
+var desiredResultsPath = path.resolve(pkg, "desired-shrinkwrap-results.json")
+
+test("shrinkwrap doesn't strip out the shared dependency", function (t) {
+  t.plan(1)
+
+  mr(common.port, function (s) {
+    setup(function (err) {
+      if (err) return t.fail(err)
+
+      npm.install(".", function (err) {
+        if (err) return t.fail(err)
+
+        npm.commands.shrinkwrap([], true, function (err, results) {
+          if (err) return t.fail(err)
+
+          fs.readFile(desiredResultsPath, function (err, desired) {
+            if (err) return t.fail(err)
+
+            t.deepEqual(results, JSON.parse(desired))
+            s.close()
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  cleanup()
+  t.end()
+})
+
+
+function setup (cb) {
+  cleanup()
+  process.chdir(pkg)
+
+  var opts = { cache: path.resolve(pkg, "cache"), registry: common.registry }
+  npm.load(opts, cb)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(path.resolve(pkg, "node_modules"))
+  rimraf.sync(path.resolve(pkg, "cache"))
+  rimraf.sync(path.resolve(pkg, "npm-shrinkwrap.json"))
+}

--- a/test/tap/shrinkwrap-shared-dev-dependency/desired-shrinkwrap-results.json
+++ b/test/tap/shrinkwrap-shared-dev-dependency/desired-shrinkwrap-results.json
@@ -1,0 +1,12 @@
+{
+  "name": "npm-test-shrinkwrap-shared-dev-dependency",
+  "version": "0.0.0",
+  "dependencies": {
+    "test-package-with-one-dep": {
+      "version": "0.0.0"
+    },
+    "test-package": {
+      "version": "0.0.0"
+    }
+  }
+}

--- a/test/tap/shrinkwrap-shared-dev-dependency/package.json
+++ b/test/tap/shrinkwrap-shared-dev-dependency/package.json
@@ -1,0 +1,11 @@
+{
+  "author": "Domenic Denicola",
+  "name": "npm-test-shrinkwrap-shared-dev-dependency",
+  "version": "0.0.0",
+  "dependencies": {
+    "test-package-with-one-dep": "0.0.0"
+  },
+  "devDependencies": {
+    "test-package": "0.0.0"
+  }
+}


### PR DESCRIPTION
This is a version of #3512 with the syntax error fixed and tests added.
