### PR TITLE
Document the arguments for `npm-outdated'.

### DIFF
--- a/doc/cli/npm-outdated.md
+++ b/doc/cli/npm-outdated.md
@@ -14,6 +14,43 @@ The resulting field 'wanted' shows the latest version according to the
 version specified in the package.json, the field 'latest' the very latest
 version of the package.
 
+## CONFIGURATION
+
+### json
+
+* Default: false
+* Type: Boolean
+
+Show information in JSON format.
+
+### long
+
+* Default: false
+* Type: Boolean
+
+Show extended information.
+
+### parseable
+
+* Default: false
+* Type: Boolean
+
+Show parseable output instead of tree view.
+
+### global
+
+* Default: false
+* Type: Boolean
+
+Check packages in the global install prefix instead of in the current
+project.
+
+### depth
+
+* Type: Int
+
+Max depth for checking dependency tree.
+
 ## SEE ALSO
 
 * npm-update(1)


### PR DESCRIPTION
Mostly referred to [`npm-ls`](https://github.com/npm/npm/blob/master/doc/cli/npm-ls.md) document.
