### PR TITLE
fix for npm not cleaning up lockfiles on ctrl+c

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -9,7 +9,7 @@ var cbCalled = false
   , path = require("path")
   , wroteLogFile = false
   , exitCode = 0
-
+  , nodeHasExitCode = typeof(process.exitCode) !== 'undefined'
 
 process.on("exit", function (code) {
   // console.error("exit", code)
@@ -37,7 +37,7 @@ process.on("exit", function (code) {
     if (exitCode === 0 && !itWorked) {
       exitCode = 1
     }
-    if (typeof(process.exitCode) === 'undefined') {
+    if (!nodeHasExitCode) {
       // script was executed by old node.js version (< 0.11.7),
       // which does not have process.exitCode, so we're
       // exitting right away

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -37,7 +37,16 @@ process.on("exit", function (code) {
     if (exitCode === 0 && !itWorked) {
       exitCode = 1
     }
-    if (exitCode !== 0) process.exit(exitCode)
+    if (typeof(process.exitCode) === 'undefined') {
+      // script was executed by old node.js version (< 0.11.7),
+      // which does not have process.exitCode, so we're
+      // exitting right away
+      //
+      // this will not call any other process.exit handlers
+      if (exitCode !== 0) process.exit(exitCode)
+    } else {
+      if (exitCode !== 0) process.exitCode = exitCode
+    }
   } else {
     itWorked = false // ready for next exit
   }

--- a/test/tap/cleanup-on-exit.js
+++ b/test/tap/cleanup-on-exit.js
@@ -1,0 +1,44 @@
+if (process.argv[2] === undefined) {
+  // parent
+
+  var test = require('tap').test
+    , path = require('path')
+    , fs = require('fs')
+    , spawn = require('child_process').spawn
+    , node = process.execPath
+
+  test('clean lock files on exit', function (t) {
+    if (process.versions.node < '0.11') return t.end()
+
+    var lockFile = path.join(__dirname, Math.random() + '.lock')
+    var child = spawn(node, [ __filename, lockFile ], { stdio: 'pipe' })
+    var stdout = ''
+    child.stdout.on('data', function(d) {
+      stdout += d
+    })
+    child.on('exit', function(code) {
+      t.ok(!fs.existsSync(lockFile))
+      t.equal(code, 1)
+      t.equal(stdout, 'loaded\n')
+      t.end()
+    })
+  })
+
+} else {
+  // child
+
+  var npm = require('../../')
+    , path = require('path')
+    , errorHandler = require('../../lib/utils/error-handler')
+
+  npm.load({}, function () {
+    var f = process.argv[2]
+    require('lockfile').lock(f, function(err) {
+      if (err) console.log(err)
+      console.log('loaded')
+      errorHandler(new Error('foo'))
+      process.exit()
+    })
+  })
+}
+


### PR DESCRIPTION
lockfile is capable of cleaning up after itself

However, npm error handler is calling process.exit() inside process.on('exit') which screws things up.

node < 0.10 doesn't have that feature, so npm on it will still be buggy... well it's a good reason for update, is it?
