### PR TITLE
Including github repository dependencies in outdated list

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -29,6 +29,7 @@ var path = require("path")
   , color = require("ansicolors")
   , styles = require("ansistyles")
   , table = require("text-table")
+  , githubUserRepo = require("github-url-from-username-repo")
 
 function outdated (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
@@ -217,7 +218,7 @@ function shouldUpdate (args, dir, dep, has, req, depth, cb) {
     return skip()
   }
 
-  if (isGitUrl(url.parse(req)))
+  if (isGitUrl(url.parse(req)) || githubUserRepo(req))
     return doIt("git", "git")
 
   var registry = npm.registry

--- a/test/tap/outdated-git.js
+++ b/test/tap/outdated-git.js
@@ -15,10 +15,17 @@ test("dicovers new versions in outdated", function (t) {
   t.plan(4)
   npm.load({cache: pkg + "/cache", registry: common.registry}, function () {
     npm.outdated(function (er, d) {
+      var fs = require('fs')
+      fs.writeFileSync('/home/cmisare/Desktop/output.json', JSON.stringify(d))
       t.equal('git', d[0][3])
       t.equal('git', d[0][4])
       t.equal('git://github.com/robertkowalski/foo-private.git', d[0][5])
+      t.equal('git', d[1][3])
+      t.equal('git', d[1][4])
       t.equal('git://user:pass@github.com/robertkowalski/foo-private.git', d[1][5])
+      t.equal('git', d[2][3])
+      t.equal('git', d[2][4])
+      t.equal('robertkowalski/foo', d[2][5])
     })
   })
 })

--- a/test/tap/outdated-git/package.json
+++ b/test/tap/outdated-git/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "dependencies": {
     "foo-private": "git://github.com/robertkowalski/foo-private.git",
-    "foo-private-credentials": "git://user:pass@github.com/robertkowalski/foo-private.git"
+    "foo-private-credentials": "git://user:pass@github.com/robertkowalski/foo-private.git",
+    "foo-github": "robertkowalski/foo"
   }
 }


### PR DESCRIPTION
Trying to make the behavior of a github url ("npm/npm") mirror that of an explicit git url ("git@github.com:npm/npm.git") when comparing the output from `npm outdated`
