### PR TITLE
npm outdated --parseable fix

### DIFF
--- a/doc/cli/npm-outdated.md
+++ b/doc/cli/npm-outdated.md
@@ -23,13 +23,6 @@ version of the package.
 
 Show information in JSON format.
 
-### long
-
-* Default: false
-* Type: Boolean
-
-Show extended information.
-
 ### parseable
 
 * Default: false

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -9,6 +9,9 @@ Does the following:
 If no packages are specified, then run for all installed
 packages.
 
+--parseable creates output like this:
+<fullpath>:<name@wanted>:<name@installed>:<name@latest>
+
 */
 
 module.exports = outdated
@@ -29,6 +32,7 @@ var path = require("path")
   , color = require("ansicolors")
   , styles = require("ansistyles")
   , table = require("text-table")
+  , os = require("os")
 
 function outdated (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
@@ -37,6 +41,8 @@ function outdated (args, silent, cb) {
     if (er || silent) return cb(er, list)
     if (npm.config.get("json")) {
       console.log(makeJSON(list))
+    } else if (npm.config.get("parseable")) {
+      console.log(makeParseable(list));
     } else {
       var outList = list.map(makePretty)
       var outTable = [[ styles.underline("Package")
@@ -54,27 +60,14 @@ function outdated (args, silent, cb) {
   })
 }
 
-// [[ dir, dep, has, want ]]
+// [[ dir, dep, has, want, latest ]]
 function makePretty (p) {
   var parseable = npm.config.get("parseable")
-    , long = npm.config.get("long")
     , dep = p[1]
     , dir = path.resolve(p[0], "node_modules", dep)
     , has = p[2]
     , want = p[3]
     , latest = p[4]
-
-  // XXX add --json support
-  // Should match (more or less) the output of ls --json
-
-  if (parseable) {
-    var str = dir
-    if (npm.config.get("long")) {
-      str += ":" + dep + "@" + want
-           + ":" + (has ? (dep + "@" + has) : "MISSING")
-    }
-    return str
-  }
 
   if (!npm.config.get("global")) {
     dir = path.relative(process.cwd(), dir)
@@ -96,6 +89,22 @@ function ansiTrim (str) {
 function dirToPrettyLocation (dir) {
   return dir.replace(/^node_modules[/\\]/, "")
             .replace(/[[/\\]node_modules[/\\]/g, " > ")
+}
+
+function makeParseable (list) {
+  return list.map(function (p) {
+    var dep = p[1]
+      , dir = path.resolve(p[0], "node_modules", dep)
+      , has = p[2]
+      , want = p[3]
+      , latest = p[4];
+
+    return [ dir
+           , dep + "@" + want
+           , (has ? (dep + "@" + has) : "MISSING")
+           , dep + "@" + latest
+           ].join(":")
+  }).join(os.EOL)
 }
 
 function makeJSON (list) {


### PR DESCRIPTION
Previous `--parseable` implementation was not displaying any relevant information about versions without combining `--long`. It might have been just copied from `npm ls`. Anyway, it seems `--long` has no use now so I removed it. Also added missing `latest` version info in parseable string. (... I guess no one was using `--parseable` before)

At a glance:
(previously) `npm outdated --parseable` -> `/.../node_modules/a`
(previously) `npm outdated --parseable --long` -> `/.../node_modules/a:a@(want):a@(has)`
(fixed) `npm outdated --parseable --long` -> `/.../node_modules/a:a@(want):a@(has):a@(latest)`

Plus: I removed the comment about `--json`(67 line) since it's already been implemented. 
