### PR TITLE
add failing test for repo shorthands

### DIFF
--- a/test/tap/outdated-git.js
+++ b/test/tap/outdated-git.js
@@ -12,13 +12,14 @@ mkdirp.sync(pkg + "/cache")
 
 test("dicovers new versions in outdated", function (t) {
   process.chdir(pkg)
-  t.plan(4)
+  t.plan(5)
   npm.load({cache: pkg + "/cache", registry: common.registry}, function () {
     npm.outdated(function (er, d) {
       t.equal('git', d[0][3])
       t.equal('git', d[0][4])
       t.equal('git://github.com/robertkowalski/foo-private.git', d[0][5])
       t.equal('git://user:pass@github.com/robertkowalski/foo-private.git', d[1][5])
+      t.equal('git://github.com/robertkowalski/foo', d[2][5])
     })
   })
 })

--- a/test/tap/outdated-git/package.json
+++ b/test/tap/outdated-git/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "dependencies": {
     "foo-private": "git://github.com/robertkowalski/foo-private.git",
-    "foo-private-credentials": "git://user:pass@github.com/robertkowalski/foo-private.git"
+    "foo-private-credentials": "git://user:pass@github.com/robertkowalski/foo-private.git",
+    "foo-github": "robertkowalski/foo"
   }
 }


### PR DESCRIPTION
can get merged if normalize-package-data in read-package-json
is updated, should turn green then

https://github.com/npm/npm/pull/4635
