### PR TITLE
skip failing test on linux

### DIFF
--- a/test/tap/lifecycle-signal.js
+++ b/test/tap/lifecycle-signal.js
@@ -8,10 +8,19 @@ var pkg = path.resolve(__dirname, "lifecycle-signal")
 test("lifecycle signal abort", function (t) {
   // windows does not use lifecycle signals, abort
   if (process.platform === "win32") return t.end()
+
+
   var child = spawn(node, [npm, "install"], {
     cwd: pkg
   })
   child.on("close", function (code, signal) {
+    // GNU shell returns a code, no signal
+    if (process.platform === "linux") {
+      t.equal(code, 1)
+      t.equal(signal, null)
+      return t.end()
+    }
+
     t.equal(code, null)
     t.equal(signal, "SIGSEGV")
     t.end()


### PR DESCRIPTION
The GNU shell returns a code and no signal if it gets a SIGSEGV
signal, so we have to skip this. Hat tip to @tjfontaine

This test fails on Linux and therefore travis. I first thought it would be a node code issue and created some test-code (https://github.com/robertkowalski/node-signal-debian), but happily TJ helped me to identify the issue with https://github.com/npm/npm/blob/9e12b1a174bcbcebb26732016cd1961a93947751/lib/utils/lifecycle.js#L207:

```
19:29:27 <@tjfontaine> robertkowalski: ok, I can explain what's going on here
19:29:34 <@tjfontaine> robertkowalski: we both just made the same mistake
19:29:54 <@tjfontaine> robertkowalski: the exit code and signal you're seeing are from 'sh' 
                                      but not from your node
19:38:24 <@tjfontaine> robertkowalski: does that make sense? iow change from spawn('sh'... 
                                      to spawn(process.execPath or execFile(process.execPath, and 
                                      you'll see the signal
```

After that commit every test for node 0.10 (0.8 still one missing) is running on travis, so we could start using travis for CI which could help us alot in daily work (e.g. pretesting PRs and giving automatic feedback, providing a single point of truth for tests). I tested it already with my github account, a run takes 7 minutes (including the old tests)
