### PR TITLE
"npm install ./pkg@1.2.3" should install local module

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -252,11 +252,16 @@ function add (args, cb) {
   // it could be that we got name@http://blah
   // in that case, we will not have a protocol now, but if we
   // split and check, we will.
-  if (!name && !p.protocol && spec.indexOf("@") !== -1) {
-    spec = spec.split("@")
-    name = spec.shift()
-    spec = spec.join("@")
-    return add([name, spec], cb)
+  if (!name && spec.indexOf("@") !== -1) {
+    var tmp = spec.split("@")
+
+    // split name@2.3.4 only if name is a valid package name,
+    // not split in case of "./test@example.com/" (local path)
+    if (!tmp[0].match(/[\/@\s\+%:]/)) {
+      name = tmp.shift()
+      spec = tmp.join("@")
+      return add([name, spec], cb)
+    }
   }
 
   switch (p.protocol) {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -256,7 +256,7 @@ function add (args, cb) {
     var tmp = spec.split("@")
 
     // split name@2.3.4 only if name is a valid package name,
-    // not split in case of "./test@example.com/" (local path)
+    // don't split in case of "./test@example.com/" (local path)
     if (!tmp[0].match(/[\/@\s\+%:]/)) {
       name = tmp.shift()
       spec = tmp.join("@")

--- a/test/tap/install-at-locally.js
+++ b/test/tap/install-at-locally.js
@@ -1,0 +1,30 @@
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../../')
+var osenv = require('osenv')
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var pkg = path.join(__dirname, 'install@something')
+
+test('"npm install ./package@1.2.3" should install local pkg', function(t) {
+  t.plan(1)
+  npm.load(function() {
+    var _stat = fs.stat
+    fs.stat = function(file) {
+      if (file === './package@1.2.3') {
+        t.ok(true, 'npm is running fs.stat("./package@1.2.3")')
+        fs.stat = _stat
+        t.end()
+      } else {
+        _stat.apply(fs, arguments)
+      }
+    }
+
+    npm.commands.cache.add('./package@1.2.3', function(err) {
+      t.fail('something weird is happening')
+    })
+  })
+})
+

--- a/test/tap/install-at-locally.js
+++ b/test/tap/install-at-locally.js
@@ -23,18 +23,12 @@ test('"npm install ./package@1.2.3" should install local pkg', function(t) {
 function setup() {
   mkdirp.sync(pkg)
   mkdirp.sync(path.resolve(pkg, 'node_modules'))
-  mkdirp.sync(path.resolve(pkg, 'package@1.2.3'))
-  fs.writeFileSync(path.resolve(pkg, 'package@1.2.3/package.json'), JSON.stringify({
-    name: 'install-at-locally',
-    version: '0.0.0',
-    description: 'Test for 404-parent',
-  }), 'utf8')
   process.chdir(pkg)
 }
 
 test('cleanup', function(t) {
   process.chdir(__dirname)
-  rimraf.sync(pkg)
+  rimraf.sync(path.resolve(pkg, 'node_modules'))
   t.end()
 })
 

--- a/test/tap/install-at-locally.js
+++ b/test/tap/install-at-locally.js
@@ -6,25 +6,34 @@ var path = require('path')
 var fs = require('fs')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
-var pkg = path.join(__dirname, 'install@something')
+var pkg = path.join(__dirname, 'install-at-locally')
 
 test('"npm install ./package@1.2.3" should install local pkg', function(t) {
+  setup()
   t.plan(1)
   npm.load(function() {
-    var _stat = fs.stat
-    fs.stat = function(file) {
-      if (file === './package@1.2.3') {
-        t.ok(true, 'npm is running fs.stat("./package@1.2.3")')
-        fs.stat = _stat
-        t.end()
-      } else {
-        _stat.apply(fs, arguments)
-      }
-    }
-
-    npm.commands.cache.add('./package@1.2.3', function(err) {
-      t.fail('something weird is happening')
+    npm.commands.install(['./package@1.2.3'], function(err) {
+      var p = path.resolve(pkg, 'node_modules/install-at-locally/package.json')
+      t.ok(JSON.parse(fs.readFileSync(p, 'utf8')))
+      t.end()
     })
   })
+})
+
+function setup() {
+  mkdirp.sync(pkg)
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+  mkdirp.sync(path.resolve(pkg, 'package@1.2.3'))
+  fs.writeFileSync(path.resolve(pkg, 'package@1.2.3/package.json'), JSON.stringify({
+    name: 'install-at-locally',
+    version: '0.0.0',
+    description: 'Test for 404-parent',
+  }), 'utf8')
+  process.chdir(pkg)
+}
+
+test('cleanup', function(t) {
+  rimraf.sync(pkg)
+  t.end()
 })
 

--- a/test/tap/install-at-locally.js
+++ b/test/tap/install-at-locally.js
@@ -33,6 +33,7 @@ function setup() {
 }
 
 test('cleanup', function(t) {
+  process.chdir(__dirname)
   rimraf.sync(pkg)
   t.end()
 })

--- a/test/tap/install-at-locally/package@1.2.3/package.json
+++ b/test/tap/install-at-locally/package@1.2.3/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "install-at-locally",
+  "version": "0.0.0",
+  "description": "Test for 404-parent"
+}


### PR DESCRIPTION
fix for #4662

Currently npm splits "./pkg@1.2.3" into "./pkg"@"1.2.3". But it doesn't make sense to do that since "./pkg" is not a valid package name. So I added that validation.

Test relies on a fact that npm is doing fs.stat for local installs. I didn't want to create a big file structure for this small task, since suite is taking too long to execute already.
