### PR TITLE
Don't *always* fetch remote repositories of git-dependencies

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -550,24 +550,30 @@ function cloneGitRemote (p, u, co, origUrl, silent, cb) {
 
 function archiveGitRemote (p, u, co, origUrl, cb) {
   var git = npm.config.get("git")
-  var archive = [ "fetch", "-a", "origin" ]
-  var resolve = [ "rev-list", "-n1", co ]
+  var argsFetch = [ "fetch", "-a", "origin" ]
+  var argsResolve = [ "rev-list", "-n1", co ]
+  var argsArchive = [ "archive", co, "--format=tar", "--prefix=package/" ]
   var env = gitEnv()
 
   var errState = null
   var n = 0
   var resolved = null
-  var tmp
-
-  exec(git, archive, {cwd: p, env: env}, function (er, stdout, stderr) {
-    stdout = (stdout + "\n" + stderr).trim()
-    if (er) {
-      log.error("git fetch -a origin ("+u+")", stdout)
-      return cb(er)
-    }
-    log.verbose("git fetch -a origin ("+u+")", stdout)
-    tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
-    verifyOwnership()
+  // we look in the locally cached repo for `co`, if we dont find a
+  // commit with a hash that fits `co` we need to fetch the remote repo
+  // otherwise just create a tarball from the cached repo.
+  exec(git, argsResolve, {cwd: p, env: env}, function(er, stdout, stderr){
+    // when `git rev-list` fails, we assume its because the hash is not in the cache
+    if (!er && co.length > 4 && stdout.slice(0, co.length) === co)
+      return verifyOwnership()
+    exec(git, argsFetch, {cwd: p, env: env}, function (er, stdout, stderr) {
+      stdout = (stdout + "\n" + stderr).trim()
+      if (er) {
+        log.error("git fetch -a origin (" + u + ")", stdout)
+        return cb(er)
+      }
+      log.verbose("git fetch -a origin (" + u + ")", stdout)
+      verifyOwnership()
+    })
   })
 
   function verifyOwnership() {
@@ -592,7 +598,7 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
   }
 
   function resolveHead () {
-    exec(git, resolve, {cwd: p, env: env}, function (er, stdout, stderr) {
+    exec(git, argsResolve, {cwd: p, env: env}, function (er, stdout, stderr) {
       stdout = (stdout + "\n" + stderr).trim()
       if (er) {
         log.error("Failed resolving git HEAD (" + u + ")", stderr)
@@ -618,15 +624,15 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
   }
 
   function next () {
+    var tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
     mkdir(path.dirname(tmp), function (er) {
       if (er) return cb(er)
       var gzip = zlib.createGzip({ level: 9 })
       var git = npm.config.get("git")
-      var args = ["archive", co, "--format=tar", "--prefix=package/"]
       var out = fs.createWriteStream(tmp)
       var env = gitEnv()
       cb = once(cb)
-      var cp = spawn(git, args, { env: env, cwd: p })
+      var cp = spawn(git, argsArchive, { env: env, cwd: p })
       cp.on("error", cb)
       cp.stderr.on("data", function(chunk) {
         log.silly(chunk.toString(), "git archive")

--- a/test/tap/git-dependencies.js
+++ b/test/tap/git-dependencies.js
@@ -1,0 +1,156 @@
+// 1) setup (create two packages A and B, serve A via http)
+//    *) A is a git-repository with two commits
+//    *) serve A via http on http://localhost:<port> (`git update-server-info`)
+// 2) run `npm i` inside package B
+//    *) B depends on A#master
+//    *) it should fetch and update the cache
+// 3) run `npm i` inside package B again
+//    *) B depends on A#<first-commit>
+//    *) it should not fetch (since the commit is already in the local cache)
+// 4) let B depend on the second commit of A and run `npm i` again
+//    *) B depends on A#<second-commit>
+//    *) it should not fetch (since the commit is already in the local cache)
+// 5) create a third commit in A and let B depend on it and run `npm i` again
+//    *) it should fetch and update the cache
+
+if (process.platform === "win32") {
+  console.error("skipping test, because windows and bash")
+  return
+}
+
+var test = require("tap").test
+var fs = require("fs")
+var path = require("path")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var http = require("http")
+var url = require("url")
+var exec = require("child_process").exec
+var spawn = require("child_process").spawn
+
+var port = 10000+Math.random()*10000|0
+var urlA = "git+http://localhost:"+port+"/"
+
+var pathNpm = path.resolve(__dirname, "..", "..", "bin", "npm-cli.js")
+var pathTest = path.resolve(__dirname, "git-dependencies")
+var pathTmp = path.resolve(pathTest, "tmp")
+var pathCache = path.resolve(pathTest, "cache")
+var pathA = path.resolve(pathTest, "A")
+var pathB = path.resolve(pathTest, "B")
+var pathAgit = path.resolve(pathA, ".git")
+var pathApkg = path.resolve(pathA, "package.json")
+var pathBpkg = path.resolve(pathB, "package.json")
+var pathAindex = path.resolve(pathA, "index.js")
+var pathBindex = path.resolve(pathB, "index.js")
+
+var pkgA = { name: "A", version: "0.0.0" }
+var pkgB = { name: "B", version: "0.0.0", dependencies: { A: urlA } }
+var npmEnv = { npm_config_cache: pathCache
+             , npm_config_tmp: pathTmp
+             , npm_config_prefix: pathTest
+             , npm_config_global: "false"
+             , HOME: process.env.HOME
+             , Path: process.env.PATH
+             , PATH: process.env.PATH }
+
+var gitServer, gitServerRequests = 0
+
+test("setup", function(t) {
+  rimraf.sync(pathTest)
+  mkdirp.sync(pathTmp)
+  mkdirp.sync(pathCache)
+  mkdirp.sync(pathA)
+  mkdirp.sync(pathB)
+  fs.writeFileSync(pathApkg, JSON.stringify(pkgA))
+  fs.writeFileSync(pathBpkg, JSON.stringify(pkgB))
+  fs.writeFileSync(pathAindex, "module.exports = 1")
+  fs.writeFileSync(pathBindex, "module.exports = require('A')")
+  var cmd = "git init . && git add . && git commit -am'commit 1'"
+          + " && echo 'module.exports = 2' > index.js"
+          + " && git commit -am'commit 2'"
+          + " && git update-server-info"
+  exec(cmd, {cwd:pathA}, function(err, d) {
+    t.notOk(err, 'setup packages')
+    serveGit(pathAgit, port, function(err) {
+      t.notOk(err, "serve git-repo")
+      t.end()
+    })
+  })
+})
+
+test("install A#<first-commit>", function(t) {
+  getCommits(pathA, function(err, d){
+    fs.writeFileSync(pathBpkg, JSON.stringify(pkgB))
+    exec(pathNpm+' i', {cwd:pathB, env:npmEnv}, function(err, d) {
+      t.notOk(err, d)
+      t.end()
+    })
+  })
+})
+
+test("install A#<first-commit> again", function(t) {
+  var currRequests = gitServerRequests
+  getCommits(pathA, function(err, d){
+    pkgB.dependencies.A = urlA+"#"+d[d.length-1]
+    fs.writeFileSync(pathBpkg, JSON.stringify(pkgB))
+    exec(pathNpm+' i', {cwd:pathB, env:npmEnv}, function(err, d) {
+      t.notOk(err, d)
+      t.equal(currRequests, gitServerRequests, "it should not fetch")
+      t.end()
+    })
+  })
+})
+
+test("install A#<second-commit>", function(t) {
+  var currRequests = gitServerRequests
+  getCommits(pathA, function(err, d) {
+    pkgB.dependencies.A = urlA+"#"+d[d.length-2]
+    fs.writeFileSync(pathBpkg, JSON.stringify(pkgB))
+    exec(pathNpm+' i', {cwd:pathB, env:npmEnv}, function(err, d) {
+      t.notOk(err, d)
+      t.equal(currRequests, gitServerRequests, "it should not fetch")
+      t.end()
+    })
+  })
+})
+
+test("make a third commit and install A#<third-commit>", function(t) {
+  var currRequests = gitServerRequests
+  var cmd = "echo 'module.exports = 3' > index.js"
+          + " && git commit -am'commit 3'"
+          + " && git update-server-info"
+  exec(cmd, {cwd:pathA}, function(err, d) {
+    getCommits(pathA, function(err, d) {
+      pkgB.dependencies.A = urlA+"#"+d[d.length-3]
+      fs.writeFileSync(pathBpkg, JSON.stringify(pkgB))
+      exec(pathNpm+' i', {cwd:pathB, env:npmEnv}, function(err, d) {
+        t.notOk(err, d)
+        t.ok(currRequests < gitServerRequests, "it should fetch")
+        t.end()
+      })
+    })
+  })
+})
+
+test("cleanup", function(t){
+  rimraf.sync(pathTest)
+  gitServer.close()
+  t.end()
+})
+
+function getCommits(path, cb) {
+  exec("git log --pretty='%H'", {cwd:path}, function(err, d){
+    if (err) return cb(err)
+    cb(null, d.trim().split('\n'))
+  })
+}
+
+function serveGit(path, port, cb) {
+  gitServer = http.createServer(handler).listen(port, cb)
+  function handler(req, res) {
+    gitServerRequests++
+    var p = path+url.parse(req.url).pathname
+    fs.createReadStream(p).pipe(res)
+  }
+}
+


### PR DESCRIPTION
this PR trys to fix #4191

currently when you do `npm i` and you have a git-dependency 
it will create a local cache of the repo if not already present.
then it will do `git archive` on that local cached repo to create 
a tarball for the git-ref you defined in the package.json
(which is `master` by default). now when you run `npm i` again it 
will fetch the remote repo to update the cache, no matter what!
even if you did not change the git-ref.

so can we just skip the fetching-part once we have a local cached
repo and we didnt even change the git-ref? the problem is:
how do we know if the git-ref you put in your dependency-url is
a commit-hash or branch/tag-name?

consider following package.json:

```
{ "name" : "foo"
, "version" : "0.0.0"
, "dependencies" : { "bla" : "ghUser/ghRepo#blub" }
}
```

how can we know if `blub` is a commit-hash, a branch or a tag? we cant.

an idea would be to introduce another seperator for the git-url:
`ghUser/ghRepo@branchOrTag` which indicates that we mean a branch and
not a commit-hash?

this PR currently implements: just look in the locally cached repo for a commit
with the hash `blub` and if we find any we just assume that it must
be a commit-hash. then we just skip fetching the remote repo and
just pull out a tarball of the cached repo. 

also i am currently only skipping the fetch if the specified git-ref is longer
than 4 chars (because what if someone defines `ghUser/ghRepo#a`).

further improvement would be to even skip creating the tarball if
the hash in the current installed package's package.json points already
to `blub`. but i did not look into the relevant codepath yet, so no idea.
