### PR TITLE
Fix URL in install.sh script when installing with curl

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,7 @@ if [ "x$0" = "xsh" ]; then
   # on some systems, you can just do cat>npm-install.sh
   # which is a bit cuter.  But on others, &1 is already closed,
   # so catting to another script file won't do anything.
-  curl -s https://npmjs.org/install.sh > npm-install-$$.sh
+  curl -s https://www.npmjs.org/install.sh > npm-install-$$.sh
   sh npm-install-$$.sh
   ret=$?
   rm npm-install-$$.sh


### PR DESCRIPTION
- when currently running `curl https://npmjs.org/install.sh` it returns:
  
  ```
  <html>Moved: <a href="https://www.npmjs.org/install.sh">https://www.npmjs.org/install.sh</a>
  ```

This causes the install script to exit with `Syntax error: newline unexpected`.

I'm not sure if the redirect was made on purpose, anyway it breaks the
installation process.
