### PR TITLE
dedupe: respect dependency versions

### DIFF
--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -249,10 +249,10 @@ function findVersions (npm, summary, cb) {
       var regVersions = er ? [] : Object.keys(data.versions)
       var locMatch = bestMatch(versions, ranges)
       var regMatch;
-      var tag = npm.config.get("tag");
-      var distTags = data["dist-tags"];
-      if (distTags && distTags[tag] && data.versions[distTags[tag]]) {
-        regMatch = distTags[tag]
+      var tag = npm.config.get("tag")
+      var distTag = data["dist-tags"] && data["dist-tags"][tag]
+      if (distTag && data.versions[distTag] && matches(distTag, ranges)) {
+        regMatch = distTag
       } else {
         regMatch = bestMatch(regVersions, ranges)
       }
@@ -262,11 +262,15 @@ function findVersions (npm, summary, cb) {
   }, cb)
 }
 
+function matches (version, ranges) {
+  return !ranges.some(function (r) {
+    return !semver.satisfies(version, r, true)
+  })
+}
+
 function bestMatch (versions, ranges) {
   return versions.filter(function (v) {
-    return !ranges.some(function (r) {
-      return !semver.satisfies(v, r, true)
-    })
+    return matches(v, ranges)
   }).sort(semver.compareLoose).pop()
 }
 

--- a/test/tap/dedupe.js
+++ b/test/tap/dedupe.js
@@ -6,7 +6,7 @@ var test = require("tap").test
   , rimraf = require("rimraf")
 
 test("dedupe finds the common module and moves it up one level", function (t) {
-  t.plan(1)
+  t.plan(2)
 
   setup(function () {
     npm.install(".", function (err) {
@@ -14,6 +14,7 @@ test("dedupe finds the common module and moves it up one level", function (t) {
       npm.dedupe(function(err) {
         if (err) return t.fail(err)
         t.ok(existsSync(path.join(__dirname, "dedupe", "node_modules", "minimist")))
+        t.ok(!existsSync(path.join(__dirname, "dedupe", "node_modules", "prime")))
       })
     })
   })

--- a/test/tap/dedupe/package.json
+++ b/test/tap/dedupe/package.json
@@ -4,6 +4,8 @@
   "version": "0.0.0",
   "dependencies": {
     "optimist": "0.6.0",
-    "clean": "2.1.6"
+    "clean": "2.1.6",
+    "informal": "0.0.1",
+    "pathogen": "0.1.5"
   }
 }


### PR DESCRIPTION
When a package depends on other packages that have a common dependency, `npm dedupe` always updates the dependency to the latest published version.

This PR makes `npm dedupe` check if the version satisfies the dependency requirements before updating it. 

---

More info on #4675
