### PR TITLE
Remove mention of npm prune --production from CLI documentation.

### DIFF
--- a/doc/cli/npm-prune.md
+++ b/doc/cli/npm-prune.md
@@ -4,7 +4,6 @@ npm-prune(1) -- Remove extraneous packages
 ## SYNOPSIS
 
     npm prune [<name> [<name ...]]
-    npm prune [<name> [<name ...]] [--production]
 
 ## DESCRIPTION
 
@@ -14,9 +13,6 @@ removed.
 
 Extraneous packages are packages that are not listed on the parent
 package's dependencies list.
-
-If the `--production` flag is specified, this command will remove the
-packages specified in your `devDependencies`.
 
 ## SEE ALSO
 


### PR DESCRIPTION
The feature provided by the --production command line switch was removed by commit 1101b6a (following issue #4509). Keeping it in the CLI documentation is confusing to me, and I think it is confusing for others too.
