### PR TITLE
prune: Added back --production support - fixes #4509

### DIFF
--- a/lib/prune.js
+++ b/lib/prune.js
@@ -21,7 +21,7 @@ function prune (args, cb) {
   })
 
   function next() {
-    var opt = { depth: npm.config.get("depth") }
+    var opt = { depth: npm.config.get("depth"), dev: npm.config.get("production") }
     readInstalled(npm.prefix, opt, function (er, data) {
       if (er) return cb(er)
       prune_(args, data, cb)


### PR DESCRIPTION
This adds back in `npm prune --production`.

Do you want me to add a test? I covered the code in `read-installed`[1] with tests.

[1] https://github.com/npm/read-installed/blob/master/test/dev.js#L19
