### PR TITLE
Fix read-installed options

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -313,6 +313,7 @@ function makeEnv (data, prefix, env) {
     var value = npm.config.get(i)
     if (value instanceof Stream || Array.isArray(value)) return
     if (!value) value = ""
+    else if (typeof value === "number") value = "" + value
     else if (typeof value !== "string") value = JSON.stringify(value)
 
     value = -1 !== value.indexOf("\n")

--- a/node_modules/read-installed/read-installed.js
+++ b/node_modules/read-installed/read-installed.js
@@ -106,7 +106,10 @@ function readInstalled (folder, opts, cb) {
     cb = opts
     opts = {}
   }
-  var depth = Infinity || opts.depth, log = function () {} || opts.log, dev = false || opts.dev
+
+  var depth = opts.depth === 0 ? 0 : (opts.depth || Infinity)
+    , log = opts.log || function () {}
+    , dev = opts.dev || false
 
   readInstalled_(folder, null, null, null, 0, depth, dev, function (er, obj) {
     if (er) return cb(er)


### PR DESCRIPTION
Options were ignored, and `opts.depth` can be zero.

Comment about the second commit:
The default value of `depth` config is `Infinity` and lifecycle.js was writing its value with `JSON.stringify`. Since `JSON.stringify(Infinity)` is `"null"`, `npm_config_depth` env was set to `"null"`, read as 0 within child process. This led `depth` to be 0 in unit tests.
