### PR TITLE
Fix lifecycle to pass `Infinity` for config env value

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -1,6 +1,7 @@
 
 exports = module.exports = lifecycle
 exports.cmd = cmd
+exports.makeEnv = makeEnv
 
 var log = require("npmlog")
   , spawn = require("child_process").spawn

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -313,6 +313,7 @@ function makeEnv (data, prefix, env) {
     var value = npm.config.get(i)
     if (value instanceof Stream || Array.isArray(value)) return
     if (!value) value = ""
+    else if (typeof value === "number") value = "" + value
     else if (typeof value !== "string") value = JSON.stringify(value)
 
     value = -1 !== value.indexOf("\n")

--- a/test/tap/lifecycle.js
+++ b/test/tap/lifecycle.js
@@ -1,0 +1,19 @@
+var test = require("tap").test
+var npm = require('../../')
+var path = require("path")
+var pkg = path.resolve(__dirname, "..", "..")
+var lifecycle = require('../../lib/utils/lifecycle')
+var Conf = require("npmconf").Conf
+
+test("lifecycle: make env correctly", function (t) {
+  npm.load(function() {
+    var env = lifecycle.makeEnv(pkg)
+
+    var conf = new Conf()
+    conf.addEnv(env)
+    conf.keys.forEach(function (key) {
+      t.equal(conf.get(key), npm.config.get(key))
+    })
+    t.end()
+  })
+})


### PR DESCRIPTION
The default value of depth config is Infinity and lifecycle.js was writing its value with `JSON.stringify`. Since `JSON.stringify(Infinity)` is `"null"`, `npm_config_depth` env was set to `"null"`. This led depth value to be read 0 within child process.
Also this causes tap(prune) test fail with https://github.com/npm/read-installed/pull/13 .
