### PR TITLE
Sort dependencies when --save'ing.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -74,6 +74,7 @@ var npm = require("./npm.js")
   , archy = require("archy")
   , isGitUrl = require("./utils/is-git-url.js")
   , npmInstallChecks = require("npm-install-checks")
+  , sortedObject = require("sorted-object")
 
 function install (args, cb_) {
   var hasArguments = !!args.length
@@ -378,7 +379,7 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
       var bundle = data.bundleDependencies || data.bundledDependencies
       delete data.bundledDependencies
       if (!Array.isArray(bundle)) bundle = []
-      data.bundleDependencies = bundle
+      data.bundleDependencies = bundle.sort()
     }
 
     log.verbose('saving', things)
@@ -390,6 +391,8 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
         if (i === -1) bundle.push(t)
       }
     })
+
+    data[deps] = sortedObject(data[deps])
 
     data = JSON.stringify(data, null, 2) + "\n"
     fs.writeFile(saveTarget, data, function (er) {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -8,6 +8,7 @@ var npm = require("./npm.js")
   , fs = require("fs")
   , path = require("path")
   , readJson = require("read-package-json")
+  , sortedObject = require("sorted-object")
 
 shrinkwrap.usage = "npm shrinkwrap"
 
@@ -58,7 +59,7 @@ function shrinkwrap_ (pkginfo, silent, dev, cb) {
 function save (pkginfo, silent, cb) {
   // copy the keys over in a well defined order
   // because javascript objects serialize arbitrarily
-  pkginfo.dependencies = copyOrder(pkginfo.dependencies)
+  pkginfo.dependencies = sortedObject(pkginfo.dependencies)
   try {
     var swdata = JSON.stringify(pkginfo, null, 2) + "\n"
   } catch (er) {
@@ -74,13 +75,4 @@ function save (pkginfo, silent, cb) {
     console.log("wrote npm-shrinkwrap.json")
     cb(null, pkginfo)
   })
-}
-
-function copyOrder(obj) {
-  var result = {}
-  var keys = Object.keys(obj).sort()
-  keys.forEach(function (key) {
-    result[key] = obj[key]
-  })
-  return result
 }

--- a/node_modules/sorted-object/LICENSE.txt
+++ b/node_modules/sorted-object/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright © 2014 Domenic Denicola <domenic@domenicdenicola.com>
+
+This work is free. You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To Public License, Version 2,
+as published by Sam Hocevar. See below for more details.
+
+        DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
+
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.

--- a/node_modules/sorted-object/README.md
+++ b/node_modules/sorted-object/README.md
@@ -1,0 +1,20 @@
+# Get a Version of an Object with Sorted Keys
+
+Although objects in JavaScript are theoretically unsorted, in practice most engines use insertion order—at least, ignoring numeric keys. This manifests itself most prominently when dealing with an object's JSON serialization.
+
+So, for example, you might be trying to serialize some object to a JSON file. But every time you write it, it ends up being output in a different order, depending on how you created it in the first place! This makes for some ugly diffs.
+
+**sorted-object** gives you the answer. Just use this package to create a version of your object with its keys sorted before serializing, and you'll get a consistent order every time.
+
+```js
+var sortedObject = require("sorted-object");
+
+var objectToSerialize = generateStuffNondeterministically();
+
+// Before:
+fs.writeFileSync("dest.json", JSON.stringify(objectToSerialize));
+
+// After:
+var sortedVersion = sortedObject(objectToSerialize);
+fs.writeFileSync("dest.json", JSON.stringify(sortedVersion));
+```

--- a/node_modules/sorted-object/lib/sorted-object.js
+++ b/node_modules/sorted-object/lib/sorted-object.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = function (input) {
+    var output = Object.create(null);
+
+    Object.keys(input).sort().forEach(function (key) {
+        output[key] = input[key];
+    });
+
+    return output;
+};

--- a/node_modules/sorted-object/package.json
+++ b/node_modules/sorted-object/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "sorted-object",
+  "description": "Returns a copy of an object with its keys sorted",
+  "keywords": [
+    "sort",
+    "keys",
+    "object"
+  ],
+  "version": "1.0.0",
+  "author": {
+    "name": "Domenic Denicola",
+    "email": "domenic@domenicdenicola.com",
+    "url": "http://domenic.me/"
+  },
+  "license": "WTFPL",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/domenic/sorted-object.git"
+  },
+  "bugs": {
+    "url": "http://github.com/domenic/sorted-object/issues"
+  },
+  "main": "lib/sorted-object.js",
+  "scripts": {
+    "test": "tape test/tests.js",
+    "lint": "jshint lib && jshint test"
+  },
+  "devDependencies": {
+    "jshint": "~2.4.3",
+    "tape": "~2.4.2"
+  },
+  "readme": "# Get a Version of an Object with Sorted Keys\n\nAlthough objects in JavaScript are theoretically unsorted, in practice most engines use insertion order—at least, ignoring numeric keys. This manifests itself most prominently when dealing with an object's JSON serialization.\n\nSo, for example, you might be trying to serialize some object to a JSON file. But every time you write it, it ends up being output in a different order, depending on how you created it in the first place! This makes for some ugly diffs.\n\n**sorted-object** gives you the answer. Just use this package to create a version of your object with its keys sorted before serializing, and you'll get a consistent order every time.\n\n```js\nvar sortedObject = require(\"sorted-object\");\n\nvar objectToSerialize = generateStuffNondeterministically();\n\n// Before:\nfs.writeFileSync(\"dest.json\", JSON.stringify(objectToSerialize));\n\n// After:\nvar sortedVersion = sortedObject(objectToSerialize);\nfs.writeFileSync(\"dest.json\", JSON.stringify(sortedVersion));\n```\n",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/domenic/sorted-object",
+  "_id": "sorted-object@1.0.0",
+  "_from": "sorted-object@"
+}

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "ansistyles": "~0.1.3",
     "path-is-inside": "~1.0.0",
     "columnify": "0.1.2",
-    "npm-install-checks": "~1.0.0"
+    "npm-install-checks": "~1.0.0",
+    "sorted-object": "~1.0.0"
   },
   "bundleDependencies": [
     "semver",
@@ -133,7 +134,8 @@
     "ansistyles",
     "path-is-inside",
     "columnify",
-    "npm-install-checks"
+    "npm-install-checks",
+    "sorted-object"
   ],
   "devDependencies": {
     "ronn": "~0.3.6",

--- a/test/tap/sorted-package-json.js
+++ b/test/tap/sorted-package-json.js
@@ -1,0 +1,93 @@
+var test = require("tap").test
+  , path = require("path")
+  , rimraf = require("rimraf")
+  , mkdirp = require("mkdirp")
+  , spawn = require("child_process").spawn
+  , npm = require.resolve("../../bin/npm-cli.js")
+  , node = process.execPath
+  , pkg = path.resolve(__dirname, "sorted-package-json")
+  , tmp = path.join(pkg, "tmp")
+  , cache = path.join(pkg, "cache")
+  , fs = require("fs")
+  , common = require("../common-tap.js")
+  , mr = require("npm-registry-mock")
+  , osenv = require("osenv")
+
+
+test("sorting dependencies", function (t) {
+  var packageJson = path.resolve(pkg, "package.json")
+
+  cleanup()
+  mkdirp.sync(cache)
+  mkdirp.sync(tmp)
+  setup()
+
+  var before = JSON.parse(fs.readFileSync(packageJson).toString())
+
+  mr({port: common.port}, function (s) {
+    // underscore is already in the package.json,
+    // but --save will trigger a rewrite with sort
+    var child = spawn(node, [npm, "install", "--save", "underscore@1.3.3"], {
+      cwd: pkg,
+      env: {
+        npm_config_registry: common.registry,
+        npm_config_cache: cache,
+        npm_config_tmp: tmp,
+        npm_config_prefix: pkg,
+        npm_config_global: "false",
+        HOME: process.env.HOME,
+        Path: process.env.PATH,
+        PATH: process.env.PATH
+      }
+    })
+
+    child.on("close", function (code) {
+      var result = fs.readFileSync(packageJson).toString()
+        , resultAsJson = JSON.parse(result)
+
+      s.close()
+
+      t.same(Object.keys(resultAsJson.dependencies),
+        Object.keys(before.dependencies).sort())
+
+      t.notSame(Object.keys(resultAsJson.dependencies),
+        Object.keys(before.dependencies))
+
+      t.ok(resultAsJson.dependencies.underscore)
+      t.ok(resultAsJson.dependencies.request)
+      t.end()
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  cleanup()
+  t.pass("cleaned up")
+  t.end()
+})
+
+function setup() {
+  mkdirp.sync(pkg)
+
+  fs.writeFileSync(path.resolve(pkg, "package.json"), JSON.stringify({
+    "name": "sorted-package-json",
+    "version": "0.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "Rocko Artischocko",
+    "license": "ISC",
+    "dependencies": {
+      "underscore": "^1.3.3",
+      "request": "^0.9.0"
+    }
+  }, null, 2), 'utf8')
+}
+
+function cleanup() {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(cache)
+  rimraf.sync(pkg)
+}

--- a/test/tap/url-dependencies.js
+++ b/test/tap/url-dependencies.js
@@ -43,16 +43,16 @@ test("url-dependencies: do not download subsequent times", function(t) {
 })
 
 function tarballWasFetched(output){
-  return output.indexOf("http GET http://localhost:1337/underscore/-/underscore-1.3.1.tgz") > -1
+  return output.indexOf("http GET " + common.registry + "/underscore/-/underscore-1.3.1.tgz") > -1
 }
 
 function performInstall (cb) {
-  mr({port: 1337, mocks: mockRoutes}, function(s){
+  mr({port: common.port, mocks: mockRoutes}, function(s){
     var output = ""
       , child = spawn(node, [npm, "install"], {
           cwd: pkg,
           env: {
-            npm_config_registry: "http://localhost:1337",
+            npm_config_registry: common.registry,
             npm_config_cache_lock_stale: 1000,
             npm_config_cache_lock_wait: 1000,
             HOME: process.env.HOME,


### PR DESCRIPTION
Uses sorted-object package to abstract away code shared by shrinkwrap and
install.

Supercedes #4390.
