### PR TITLE
Update uninstall documentation to include flags

### DIFF
--- a/doc/cli/npm-uninstall.md
+++ b/doc/cli/npm-uninstall.md
@@ -11,6 +11,32 @@ npm-rm(1) -- Remove a package
 This uninstalls a package, completely removing everything npm installed
 on its behalf.
 
+* `npm uninstall <name> [--save|--save-dev|--save-optional]`:
+
+    Will uninstall locally installed package
+
+    Example:
+
+          npm uninstall sax
+
+    In global mode (ie, with `-g` or `--global` appended to the command),
+    it uninstalls the current package context as a global package.
+
+    `npm uninstall` takes 3 exclusive, optional flags which save or update
+    the package version in your main package.json:
+
+    * `--save`: Package will be removed from your `dependencies`.
+
+    * `--save-dev`: Package will be removed from your `devDependencies`.
+
+    * `--save-optional`: Package will be removed from your `optionalDependencies`.
+
+    Examples:
+
+          npm uninstall sax --save
+          npm uninstall node-tap --save-dev
+          npm uninstall dtrace-provider --save-optional
+
 ## SEE ALSO
 
 * npm-prune(1)


### PR DESCRIPTION
This update adds the notes to use --save, --save-dev, -g, and
--save-optional to the uninstall docs.
