### PR TITLE
npm install --save --exact semver

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -7,7 +7,7 @@ npm-install(1) -- Install a package
     npm install <tarball file>
     npm install <tarball url>
     npm install <folder>
-    npm install <name> [--save|--save-dev|--save-optional]
+    npm install <name> [--save|--save-dev|--save-optional] [--exact]
     npm install <name>@<tag>
     npm install <name>@<version>
     npm install <name>@<version range>
@@ -91,11 +91,18 @@ after packing it up into a tarball (b).
 
     * `--save-optional`: Package will appear in your `optionalDependencies`.
 
+    When using any of the above options to save dependencies to your
+    package.json, there is an additional, optional flag:
+
+    * `--exact`: Saved dependencies will be configured with an exact
+    version rather than using npm's default semver range operator.
+
     Examples:
 
           npm install sax --save
           npm install node-tap --save-dev
           npm install dtrace-provider --save-optional
+          npm install readable-stream --save --exact
 
 
     **Note**: If there is a file or folder named `<name>` in the current

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -637,6 +637,15 @@ hash.
 
 Only works if there is already a package.json file present.
 
+### exact
+
+* Default: false
+* Type: Boolean
+
+Dependencies saved to package.json using `--save`, `--save-dev` or
+`--save-optional` will be configured with an exact version rather than
+using npm's default semver range operator.
+
 ### searchopts
 
 * Default: ""

--- a/lib/install.js
+++ b/lib/install.js
@@ -351,7 +351,8 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
         return w
       }).reduce(function (set, k) {
         var rangeDescriptor = semver.valid(k[1], true) &&
-                              semver.gte(k[1], "0.1.0", true)
+                              semver.gte(k[1], "0.1.0", true) &&
+                              !npm.config.get("exact")
                             ? "^" : ""
         set[k[0]] = rangeDescriptor + k[1]
         return set

--- a/test/tap/install-save-exact.js
+++ b/test/tap/install-save-exact.js
@@ -1,0 +1,91 @@
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../../')
+var osenv = require('osenv')
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var pkg = path.join(__dirname, 'install-save-exact')
+var mr = require("npm-registry-mock")
+
+test("setup", function (t) {
+  mkdirp.sync(pkg)
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+  process.chdir(pkg)
+  t.end()
+})
+
+test('"npm install --save --exact should install local pkg', function(t) {
+  resetPackageJSON(pkg)
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save', true)
+        npm.config.set('exact', true)
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          t.deepEqual(pkgJson.dependencies, {
+            'underscore': '1.3.1'
+          }, 'Underscore dependency should specify exactly 1.3.1')
+          npm.config.set('save', undefined)
+          npm.config.set('exact', undefined)
+          s.close()
+          t.end()
+        })
+      })
+  })
+})
+
+test('"npm install --save-dev --exact should install local pkg', function(t) {
+  resetPackageJSON(pkg)
+
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save-dev', true)
+        npm.config.set('exact', true)
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          console.log(pkgJson)
+          t.deepEqual(pkgJson.devDependencies, {
+            'underscore': '1.3.1'
+          }, 'underscore devDependency should specify exactly 1.3.1')
+          s.close()
+          npm.config.set('save-dev', undefined)
+          npm.config.set('exact', undefined)
+          t.end()
+        })
+      })
+  })
+})
+
+test('cleanup', function(t) {
+  process.chdir(__dirname)
+  rimraf.sync(path.resolve(pkg, 'node_modules'))
+  rimraf.sync(path.resolve(pkg, 'cache'))
+  resetPackageJSON(pkg)
+  t.end()
+})
+
+function resetPackageJSON(pkg) {
+  var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+  delete pkgJson.dependencies
+  delete pkgJson.devDependencies
+  delete pkgJson.optionalDependencies
+  fs.writeFileSync(pkg + '/package.json', JSON.stringify(pkgJson))
+}
+
+

--- a/test/tap/install-save-exact/README.md
+++ b/test/tap/install-save-exact/README.md
@@ -1,0 +1,1 @@
+# just a test

--- a/test/tap/install-save-exact/index.js
+++ b/test/tap/install-save-exact/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/test/tap/install-save-exact/package.json
+++ b/test/tap/install-save-exact/package.json
@@ -1,0 +1,1 @@
+{"name":"bla","description":"fixture","version":"0.0.1","main":"index.js","repository":"git://github.com/robertkowalski/bogusfixture"}


### PR DESCRIPTION
Modified version of @isaacs [suggestion](https://github.com/npm/npm/issues/4713#issuecomment-35423346):

>  I would be ok with adding a single --save-exact | -E boolean option, which causes it to always save the exact version number installed. Patch welcome for that.

Implemented as a single `--exact` option to be combined with the `--save`, `--save-dev` and `--save-optional`, rather than `--save-exact`. Otherwise, for completeness it this would need introduce to be 3 new options: `--save-exact`, `--save-dev-exact` and `--save-optional-exact` which doesn't seem ideal.
