### PR TITLE
Add failing regression test for npm ls --depth=0

### DIFF
--- a/test/common-tap.js
+++ b/test/common-tap.js
@@ -1,2 +1,34 @@
+var spawn = require('child_process').spawn
+
 var port = exports.port = 1337
 exports.registry = "http://localhost:" + port
+
+exports.run = run
+function run (cmd, t, opts, cb) {
+  if (!opts)
+    opts = {}
+  if (!Array.isArray(cmd))
+    throw new Error("cmd must be an Array")
+  if (!t || !t.end)
+    throw new Error("node-tap instance is missing")
+
+  var c = ""
+    , e = ""
+    , node = process.execPath
+    , child = spawn(node, cmd, opts)
+
+  child.stderr.on("data", function (chunk) {
+    e += chunk
+  })
+
+  child.stdout.on("data", function (chunk) {
+    c += chunk
+  })
+
+  child.stdout.on("end", function () {
+    if (cb)
+      cb(t, c, e, { cmd: cmd, opts: opts })
+    else
+      t.end()
+  })
+}

--- a/test/tap/ls-depth-cli.js
+++ b/test/tap/ls-depth-cli.js
@@ -1,0 +1,83 @@
+var common = require('../common-tap')
+  , test = require('tap').test
+  , path = require('path')
+  , spawn = require('child_process').spawn
+  , rimraf = require('rimraf')
+  , mkdirp = require('mkdirp')
+  , pkg = __dirname + '/ls-depth'
+  , cache = pkg + '/cache'
+  , tmp = pkg + '/tmp'
+  , node = process.execPath
+  , npm = path.resolve(__dirname, '../../cli.js')
+  , mr = require('npm-registry-mock')
+
+function run (command, t, cb) {
+  var c = ''
+    , child = spawn(node, command, {
+      cwd: pkg
+    })
+
+    child.stdout.on('data', function (chunk) {
+      c += chunk
+    })
+
+    child.stdout.on('end', function () {
+      if (test)
+        cb(t, c)
+      else
+        t.end()
+    })
+}
+
+function cleanup () {
+  rimraf.sync(pkg + '/cache')
+  rimraf.sync(pkg + '/tmp')
+  rimraf.sync(pkg + '/node_modules')
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg + '/cache')
+  mkdirp.sync(pkg + '/tmp')
+  mr(common.port, function (s) {
+    run([npm, 'install', '--registry=' + common.registry], t, function (t, c) {
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test('npm ls --depth=0', function (t) {
+  run([npm, 'ls', '--depth=0'], t, function (t, c) {
+    t.has(c, /test-package-with-one-dep@0\.0\.0/
+      , "output contains test-package-with-one-dep@0.0.0")
+    t.doesNotHave(c, /test-package@0\.0\.0/
+      , "output not contains test-package@0.0.0")
+    t.end()
+  })
+})
+
+test('npm ls --depth=1', function (t) {
+  run([npm, 'ls', '--depth=1'], t, function (t, c) {
+    t.has(c, /test-package-with-one-dep@0\.0\.0/
+      , "output contains test-package-with-one-dep@0.0.0")
+    t.has(c, /test-package@0\.0\.0/
+      , "output contains test-package@0.0.0")
+    t.end()
+  })
+})
+
+test('npm ls (no depth defined)', function (t) {
+  run([npm, 'ls'], t, function (t, c) {
+    t.has(c, /test-package-with-one-dep@0\.0\.0/
+      , "output contains test-package-with-one-dep@0.0.0")
+    t.has(c, /test-package@0\.0\.0/
+      , "output contains test-package@0.0.0")
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})

--- a/test/tap/ls-depth-cli.js
+++ b/test/tap/ls-depth-cli.js
@@ -1,7 +1,6 @@
 var common = require('../common-tap')
   , test = require('tap').test
   , path = require('path')
-  , spawn = require('child_process').spawn
   , rimraf = require('rimraf')
   , mkdirp = require('mkdirp')
   , pkg = __dirname + '/ls-depth'
@@ -10,24 +9,8 @@ var common = require('../common-tap')
   , node = process.execPath
   , npm = path.resolve(__dirname, '../../cli.js')
   , mr = require('npm-registry-mock')
+  , opts = {cwd: pkg}
 
-function run (command, t, cb) {
-  var c = ''
-    , child = spawn(node, command, {
-      cwd: pkg
-    })
-
-    child.stdout.on('data', function (chunk) {
-      c += chunk
-    })
-
-    child.stdout.on('end', function () {
-      if (test)
-        cb(t, c)
-      else
-        t.end()
-    })
-}
 
 function cleanup () {
   rimraf.sync(pkg + '/cache')
@@ -40,7 +23,12 @@ test('setup', function (t) {
   mkdirp.sync(pkg + '/cache')
   mkdirp.sync(pkg + '/tmp')
   mr(common.port, function (s) {
-    run([npm, 'install', '--registry=' + common.registry], t, function (t, c) {
+    common.run([
+      npm
+    , 'install'
+    , '--registry=' + common.registry
+    ], t, opts
+    , function (t, c) {
       s.close()
       t.end()
     })
@@ -48,7 +36,7 @@ test('setup', function (t) {
 })
 
 test('npm ls --depth=0', function (t) {
-  run([npm, 'ls', '--depth=0'], t, function (t, c) {
+  common.run([npm, 'ls', '--depth=0'], t, opts, function (t, c) {
     t.has(c, /test-package-with-one-dep@0\.0\.0/
       , "output contains test-package-with-one-dep@0.0.0")
     t.doesNotHave(c, /test-package@0\.0\.0/
@@ -58,7 +46,7 @@ test('npm ls --depth=0', function (t) {
 })
 
 test('npm ls --depth=1', function (t) {
-  run([npm, 'ls', '--depth=1'], t, function (t, c) {
+  common.run([npm, 'ls', '--depth=1'], t, opts, function (t, c) {
     t.has(c, /test-package-with-one-dep@0\.0\.0/
       , "output contains test-package-with-one-dep@0.0.0")
     t.has(c, /test-package@0\.0\.0/
@@ -68,7 +56,7 @@ test('npm ls --depth=1', function (t) {
 })
 
 test('npm ls (no depth defined)', function (t) {
-  run([npm, 'ls'], t, function (t, c) {
+  common.run([npm, 'ls'], t, opts, function (t, c) {
     t.has(c, /test-package-with-one-dep@0\.0\.0/
       , "output contains test-package-with-one-dep@0.0.0")
     t.has(c, /test-package@0\.0\.0/

--- a/test/tap/ls-depth/package.json
+++ b/test/tap/ls-depth/package.json
@@ -1,0 +1,8 @@
+{
+  "author": "Rocko Artischocko",
+  "name": "ls-depth",
+  "version": "0.0.0",
+  "dependencies": {
+    "test-package-with-one-dep": "0.0.0"
+  }
+}

--- a/test/tap/startstop.js
+++ b/test/tap/startstop.js
@@ -9,41 +9,16 @@ var common = require('../common-tap')
   , tmp = pkg + '/tmp'
   , node = process.execPath
   , npm = path.resolve(__dirname, '../../cli.js')
+  , opts = { cwd: pkg }
 
-function run (command, t, parse) {
-  var c = ''
-    , e = ''
-    , node = process.execPath
-    , child = spawn(node, [npm, command], {
-      cwd: pkg
-    })
+function testOutput (t, c, e, o) {
+  if (e)
+    throw new Error('npm ' + command + ' stderr: ' + e.toString())
 
-    child.stderr.on('data', function (chunk) {
-      e += chunk
-    })
-
-    child.stdout.on('data', function (chunk) {
-      c += chunk
-    })
-
-    child.stdout.on('end', function () {
-      if (e) {
-        throw new Error('npm ' + command + ' stderr: ' + e.toString())
-      }
-      if (parse) {
-        // custom parsing function
-        c = parse(c)
-        t.equal(c.actual, c.expected)
-        t.end()
-        return
-      }
-
-      c = c.trim().split('\n')
-      c = c[c.length - 1]
-      t.equal(c, command)
-      t.end()
-    })
-
+  c = c.trim().split('\n')
+  c = c[c.length - 1]
+  t.equal(c, o.cmd[1])
+  t.end()
 }
 
 function cleanup () {
@@ -56,23 +31,27 @@ test('setup', function (t) {
   mkdirp.sync(pkg + '/cache')
   mkdirp.sync(pkg + '/tmp')
   t.end()
-
 })
 
 test('npm start', function (t) {
-  run('start', t)
+  common.run([npm, 'start'], t, opts, testOutput)
 })
 
 test('npm stop', function (t) {
-  run('stop', t)
+  common.run([npm, 'stop'], t, opts, testOutput)
 })
 
 test('npm restart', function (t) {
-  run ('restart', t, function (output) {
-    output = output.split('\n').filter(function (val) {
+  common.run([npm, 'restart'], t, opts, function (t, c, e) {
+    if (e)
+      throw new Error('npm ' + command + ' stderr: ' + e.toString())
+
+    var output = c.split('\n').filter(function (val) {
       return val.match(/^s/)
     })
-    return {actual: output, expected: output}
+
+    t.same(output.sort(), ['start', 'stop'].sort())
+    t.end()
   })
 })
 


### PR DESCRIPTION
This test should turn green if read-installed is fixed and should
avoid regressions in the future.

This tests the cli, as it turned out that the programatical version
of npm has a bug where depth=0 is not working

https://github.com/npm/npm/issues/4733
