### PR TITLE
Less package json changes

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -53,9 +53,9 @@ function version (args, silent, cb_) {
       return cb_(er)
     }
 
-		var newVer = semver.valid(args[0])
-		if (!newVer) newVer = semver.inc(data.version, args[0])
-		if (!newVer) return cb_(version.usage)
+    var newVer = semver.valid(args[0])
+    if (!newVer) newVer = semver.inc(data.version, args[0])
+    if (!newVer) return cb_(version.usage)
     if (data.version === newVer) return cb_(new Error("Version not changed"))
     data.version = newVer
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -10,6 +10,7 @@ var exec = require("child_process").execFile
   , log = require("npmlog")
   , which = require("which")
   , npm = require("./npm.js")
+  , jsonFile = require("json-file-plus")
 
 version.usage = "npm version [<newversion> | major | minor | patch]\n"
               + "\n(run in package dir)\n"
@@ -22,35 +23,24 @@ version.usage = "npm version [<newversion> | major | minor | patch]\n"
 function version (args, silent, cb_) {
   if (typeof cb_ !== "function") cb_ = silent, silent = false
   if (args.length > 1) return cb_(version.usage)
-  fs.readFile(path.join(process.cwd(), "package.json"), function (er, data) {
+  jsonFile(path.join(process.cwd(), "package.json"), function (er, file) {
+    if (er) {
+      log.error("version", e.message)
+      return cb_(er)
+    }
+
+    var data = file.data
     if (!args.length) {
       var v = {}
       Object.keys(process.versions).forEach(function (k) {
         v[k] = process.versions[k]
       })
       v.npm = npm.version
-      try {
-        data = JSON.parse(data.toString())
-      } catch (er) {
-        data = null
-      }
       if (data && data.name && data.version) {
         v[data.name] = data.version
       }
       console.log(v)
       return cb_()
-    }
-
-    if (er) {
-      log.error("version", "No package.json found")
-      return cb_(er)
-    }
-
-    try {
-      data = JSON.parse(data)
-    } catch (er) {
-      log.error("version", "Bad package.json data")
-      return cb_(er)
     }
 
     var newVer = semver.valid(args[0])
@@ -67,13 +57,13 @@ function version (args, silent, cb_) {
 
       var tags = npm.config.get('git-tag-version')
       var doGit = !er && s.isDirectory() && tags
-      if (!doGit) return write(data, cb)
-      else checkGit(data, cb)
+      if (!doGit) return file.save(cb)
+      else checkGit(file, cb)
     })
   })
 }
 
-function checkGit (data, cb) {
+function checkGit (file, cb) {
   var git = npm.config.get("git")
   var args = [ "status", "--porcelain" ]
   var env = process.env
@@ -97,15 +87,16 @@ function checkGit (data, cb) {
       })
       if (lines.length) return cb(new Error(
         "Git working directory not clean.\n"+lines.join("\n")))
-      write(data, function (er) {
+      file.save(function (er) {
         if (er) return cb(er)
-        var message = npm.config.get("message").replace(/%s/g, data.version)
+        var version = file.data.version
+          , message = npm.config.get("message").replace(/%s/g, version)
           , sign = npm.config.get("sign-git-tag")
           , flag = sign ? "-sm" : "-am"
         chain
           ( [ [ exec, git, [ "add", "package.json" ], {env: process.env} ]
             , [ exec, git, [ "commit", "-m", message ], {env: process.env} ]
-            , [ exec, git, [ "tag", "v" + data.version, flag, message ]
+            , [ exec, git, [ "tag", "v" + version, flag, message ]
               , {env: process.env} ] ]
           , cb )
       })
@@ -113,8 +104,3 @@ function checkGit (data, cb) {
   }
 }
 
-function write (data, cb) {
-  fs.writeFile( path.join(process.cwd(), "package.json")
-              , new Buffer(JSON.stringify(data, null, 2) + "\n")
-              , cb )
-}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "graceful-fs": "^2.0.2",
     "ini": "~1.1.0",
     "init-package-json": "0.0.14",
+    "json-file-plus": "~0.2.3",
     "lockfile": "~0.4.0",
     "lru-cache": "~2.5.0",
     "minimatch": "~0.2.14",


### PR DESCRIPTION
Per #3299 and #3180 - this branch uses a module of mine, `json-file-plus`, to handle reading and writing to/from `package.json` files. The benefit of preserving formatting is that there will be fewer `package.json` diffs when using the `--save` option for developers who don't choose to use 2-space indentation. In addition, said developers may have decided they simply can't use `--save` due to this issue - this change will enable them to use it without fear of their style choices being rampantly overrun :-)

In addition, this results in less code in `lib/version`

The downsides are that it's another dependency.

If this is slated to be accepted, I'll happily do more PRs that use the `json-file-plus` module and cover every place package.json is read from and written to throughout `npm`.
