### PR TITLE
Added support for install --development

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -249,6 +249,12 @@ function readDependencies (context, where, opts, cb) {
     if (er && er.code === "ENOENT") er.code = "ENOPACKAGEJSON"
     if (er)  return cb(er)
 
+    if (npm.config.get("development")) {
+      data.dependencies = {}
+      //Reset after the first pass so devDependencies have dependencies
+      npm.config.set("development", false)
+    }
+
     if (opts && opts.dev) {
       if (!data.dependencies) data.dependencies = {}
       Object.keys(data.devDependencies || {}).forEach(function (k) {

--- a/test/tap/install-development.js
+++ b/test/tap/install-development.js
@@ -1,0 +1,39 @@
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../../')
+var osenv = require('osenv')
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var pkg = path.join(__dirname, 'install-development')
+//shared with ./install-production.js
+
+test("setup", function (t) {
+  rimraf.sync(path.resolve(pkg, 'node_modules'))
+  process.chdir(pkg)
+  t.end()
+})
+
+test('"npm install . --development" should install only devDependencies', function(t) {
+  npm.load(function() {
+    npm.config.set("development", true)
+    npm.config.set("production", false)
+    npm.commands.install(['.'], function(err) {
+      var p = path.resolve(pkg, 'node_modules/format-package-json/package.json')
+      t.ok(JSON.parse(fs.readFileSync(p, 'utf8')), "format-package-json was installed")
+      p = path.resolve(pkg, 'node_modules/format-package-json/node_modules/detect-indent/package.json')
+      t.ok(JSON.parse(fs.readFileSync(p, 'utf8')), "format-package-json/node_modules/detect-indent was installed")
+      p = path.resolve(pkg, 'node_modules/foo/package.json')
+      t.notOk(fs.existsSync(p), "foo was not installed")
+      t.end()
+    })
+  })
+})
+
+test('cleanup', function(t) {
+  process.chdir(__dirname)
+  rimraf.sync(path.resolve(pkg, 'node_modules'))
+  t.end()
+})
+

--- a/test/tap/install-development/package.json
+++ b/test/tap/install-development/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "install-development",
+  "version": "0.0.0",
+  "description": "only install dev deps",
+  "dependencies": {
+    "foo": "*"
+  },
+  "devDependencies": {
+    "format-package-json": "*"
+  }
+}

--- a/test/tap/install-production.js
+++ b/test/tap/install-production.js
@@ -1,0 +1,38 @@
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../../')
+var osenv = require('osenv')
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var pkg = path.join(__dirname, 'install-development')
+//shared with ./install-development.js
+
+test("setup", function (t) {
+  rimraf.sync(path.resolve(pkg, 'node_modules'))
+  process.chdir(pkg)
+  t.end()
+})
+
+test('"npm install . --production" should install dependencies', function(t) {
+  npm.load(function() {
+    npm.config.set("development", false)
+    npm.config.set("production", true)
+    npm.commands.install(['.'], function(err) {
+      var p = path.resolve(pkg, 'node_modules/foo/package.json')
+      t.ok(JSON.parse(fs.readFileSync(p, 'utf8')), "foo was installed")
+      p = path.resolve(pkg, 'node_modules/format-package-json/package.json')
+      t.notOk(fs.existsSync(p), "format-package-json was not installed")
+      t.end()
+    })
+  })
+})
+
+test('cleanup', function(t) {
+  process.chdir(__dirname)
+  rimraf.sync(path.resolve(pkg, 'node_modules'))
+  t.end()
+})
+
+


### PR DESCRIPTION
This basically installs the packages that `npm prune --production` would remove.

Use case:

In a CI environment, I need to:
- install production dependencies
- analyze them and their size
- display any warnings or helpful information
- install the devDependencies
- run their tests
- prune --production
- package for deployment

Now, I could do a `--production` install, then install without but I actually want to "switch" registries in between these. I only want "production" dependencies installed from a private local registry, but devDependencies can come from anywhere as they will be deleted with a prune. If a production dependency isn't in my local registry, it should 404 but doing a two pass install without scoping it would let it install anyway and then `prune` wouldn't work as I would expect.

I couldn't get all the tests to run on any of my dev machines from master or this branch, but I did add 7 passing tests for this functionality:

```
 ./node_modules/.bin/tap ./test/tap/install-development.js ./test/tap/install-production.js 
ok ./test/tap/install-development.js .................... 4/4
ok ./test/tap/install-production.js ..................... 3/3
total ................................................... 7/7
ok
```
