### PR TITLE
Fix for the curl call in the faq to reflect 301 redirect from npmjs.org to www.npmjs.org

### DIFF
--- a/doc/misc/npm-faq.md
+++ b/doc/misc/npm-faq.md
@@ -145,7 +145,7 @@ command.)
 
 In those cases, you can do this:
 
-    curl https://npmjs.org/install.sh | sh
+    curl https://www.npmjs.org/install.sh | sh
 
 ## What is a `package`?
 


### PR DESCRIPTION
As seen and requested on npm/npm-www#639
