### PR TITLE
Added shell script install example to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ paths, etc.) then read on.
 
 There's a pretty robust install script at
 <https://npmjs.org/install.sh>.  You can download that and run it.
+Here's an example using curl:
+
+    curl -L https://npmjs.org/install.sh | sh
 
 ### Slightly Fancier
 


### PR DESCRIPTION
Added a simple example of installing npm by itself via curl. This helps solve [an issue](https://github.com/Homebrew/homebrew/pull/27479) with the node homebrew formula where users will want a simple way to install npm after installing node. Homebrew maintainers would rather see this curl example in the npm README rather than directly in the node formula. This way the formula can just link to it.

It also just helps in general to have an example when users find the npm README and want to use the shell script.

This is tangentially related to #3794.
