### PR TITLE
Enable overriding node-gyp binary

### DIFF
--- a/bin/node-gyp-bin/node-gyp
+++ b/bin/node-gyp-bin/node-gyp
@@ -1,2 +1,6 @@
 #!/usr/bin/env sh
-node "`dirname "$0"`/../../node_modules/node-gyp/bin/node-gyp.js" "$@"
+if [ "x$npm_config_node_gyp" = "x" ]; then
+  node "`dirname "$0"`/../../node_modules/node-gyp/bin/node-gyp.js" "$@"
+else
+  "$npm_config_node_gyp" "$@"
+fi

--- a/bin/node-gyp-bin/node-gyp.cmd
+++ b/bin/node-gyp-bin/node-gyp.cmd
@@ -1,1 +1,5 @@
-node "%~dp0\..\..\node_modules\node-gyp\bin\node-gyp.js" %*
+if not defined npm_config_node_gyp (
+  node "%~dp0\..\..\node_modules\node-gyp\bin\node-gyp.js" %*
+) else (
+  %npm_config_node_gyp% %*
+)


### PR DESCRIPTION
Enable overriding the node-gyp binary used by npm by specifying a config
option, similar to specifying the python interpreter.

Example usage:

```
npm install --node-gyp=<path-to-custom-node-gyp>
```
