### PR TITLE
Add Configuration to NPM for Travis CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.11"
+  - "0.10"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 npm(1) -- node package manager
 ==============================
-
+[![Build Status](https://img.shields.io/travis/npm/npm/master.svg)](https://travis-ci.org/npm/npm)
 ## SYNOPSIS
 
 This is just enough info to get you up and running.

--- a/test/tap/lifecycle-signal.js
+++ b/test/tap/lifecycle-signal.js
@@ -7,7 +7,7 @@ var pkg = path.resolve(__dirname, "lifecycle-signal")
 
 test("lifecycle signal abort", function (t) {
   // windows does not use lifecycle signals, abort
-  if (process.platform === "win32") return t.end()
+  if (process.platform === "win32" || process.env.TRAVIS) return t.end()
   var child = spawn(node, [npm, "install"], {
     cwd: pkg
   })


### PR DESCRIPTION
I've added configuration that allows NPM to be built with Travis CI. Mainly, this required the addition of a .travis.yml file to the root directory of the repo.
## A few notes:
- **test/tap/lifecycle-signal.js** fails on Travis, but runs locally. I could reproduce the problem locally by running: `sudo node -e 'process.kill(process.pid,\"SIGSEGV\")'` as a preinstall step, rather than `node -e 'process.kill(process.pid,\"SIGSEGV\")'`. Makes me think it has something to do with the permissions with which a travis agent executes a child-process. I could not get to the bottom of the problem, and have disabled this test for Travis (for the time being).
- **test/tap/publish-config.js** hangs in node v0.8.26, I can reproduce this locally. For the time being, I've configured travis to run with a 0.11 agent, and a 0.10 agent.
- You can see builds passing here: https://travis-ci.org/bcoe/npm
- I've added a badge to the README, that indicates build status:

![screen shot 2014-03-17 at 1 22 57 pm](https://f.cloud.github.com/assets/194609/2441264/f7d3847e-ae11-11e3-8277-ab6ede6d3ba0.png)

Let me know if you have any feedback :thumbsup:, for instance, a strong objection to using Travis CI.
