### PR TITLE
Updated readme "Fancy Install URL" to avoid redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ paths, etc.) then read on.
 ## Fancy Install (Unix)
 
 There's a pretty robust install script at
-<https://npmjs.org/install.sh>.  You can download that and run it.
+<https://www.npmjs.org/install.sh>.  You can download that and run it.
 
 ### Slightly Fancier
 


### PR DESCRIPTION
Avoid potential confusion when attempting to download directly with clients that won't follow redirects from the domain https://npmjs.org/ to https://www.npmjs.org/

Ex.
$ curl -i https://npmjs.org/install.sh
HTTP/1.1 301 Moved Permanently
Server: nginx/1.4.2
Date: Tue, 18 Mar 2014 00:06:32 GMT
Content-Type: text/html
Content-Length: 184
Connection: keep-alive
Location: https://www.npmjs.org/install.sh
