### PR TITLE
Added client certificate parameters to tar download during an npm install

### DIFF
--- a/lib/utils/fetch.js
+++ b/lib/utils/fetch.js
@@ -83,6 +83,8 @@ function makeRequest (remote, fstr, headers) {
              , strictSSL: npm.config.get("strict-ssl")
              , rejectUnauthorized: npm.config.get("strict-ssl")
              , ca: remote.host === regHost ? npm.config.get("ca") : undefined
+             , cert: npm.config.get('cert')
+             , key: npm.config.get('key')
              , headers: { "user-agent": npm.config.get("user-agent") }}
   var req = request(opts)
   req.on("error", function (er) {


### PR DESCRIPTION
Added parameters to pass client certificate information down to the https request when a npm attachment is fetched. 

Without this change, the HTTP get for the npm module attachment fails when the NPM repository mirror you are pulling from requires client certificates that are passed via npm config settings.
