### PR TITLE
Fix failing tap test, caused by read-installed update

### DIFF
--- a/test/tap/peer-deps-extraneous.js
+++ b/test/tap/peer-deps-extraneous.js
@@ -1,0 +1,50 @@
+var npm = npm = require("../../"),
+  test = require("tap").test,
+  path = require("path"),
+  osenv = require("osenv"),
+  rimraf = require("rimraf"),
+  mr = require("npm-registry-mock"),
+  common = require("../common-tap.js")
+
+var pkg = path.resolve(__dirname, "peer-deps-extraneous")
+
+test("flags request peer-dependency as extraneous", function (t) {
+  t.plan(1)
+
+  mr(common.port, function (s) {
+    setup(function (err) {
+      if (err) return t.fail(err)
+
+      npm.install(".", function (err) {
+        if (err) return t.fail(err)
+
+        npm.commands.ls([], true, function (err, _, results) {
+          if (err) return t.fail(err)
+
+          t.true(results.dependencies.request.extraneous)
+          s.close()
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  cleanup()
+  t.end()
+})
+
+function setup (cb) {
+  cleanup()
+  process.chdir(pkg)
+
+  var opts = { cache: path.resolve(pkg, "cache"), registry: common.registry};
+  npm.load(opts, cb)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(path.resolve(pkg, "node_modules"))
+  rimraf.sync(path.resolve(pkg, "cache"))
+}

--- a/test/tap/peer-deps-extraneous/package.json
+++ b/test/tap/peer-deps-extraneous/package.json
@@ -1,0 +1,8 @@
+{
+  "author": "Domenic Denicola",
+  "name": "npm-test-peer-deps-installer",
+  "version": "0.0.0",
+  "dependencies": {
+    "npm-test-peer-deps": "*"
+  }
+}

--- a/test/tap/peer-deps/package.json
+++ b/test/tap/peer-deps/package.json
@@ -3,6 +3,7 @@
   "name": "npm-test-peer-deps-installer",
   "version": "0.0.0",
   "dependencies": {
-    "npm-test-peer-deps": "*"
+    "npm-test-peer-deps": "*",
+    "request": "0.9.x"
   }
 }


### PR DESCRIPTION
Updating read-installed to 2.0.1 broke _test/tap/peer-deps.js_.
