### PR TITLE
Update Tap Tests to Have No External Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+script: "npm run-script tap"
+node_js:
+  - "0.11"
+  - "0.10"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 npm(1) -- node package manager
 ==============================
-
+[![Build Status](https://img.shields.io/travis/npm/npm/master.svg)](https://travis-ci.org/npm/npm)
 ## SYNOPSIS
 
 This is just enough info to get you up and running.

--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -354,4 +354,3 @@ function whoDepends_ (pkg, who, test) {
   })
   return who
 }
-

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "which"
   ],
   "devDependencies": {
-    "npm-registry-mock": "~0.5",
+    "npm-registry-mock": "git://github.com/bcoe/npm-registry-mock#1e43f4d323e78d10e0c86681245009667aac5ad1",
     "ronn": "~0.3.6",
     "tap": "~0.4.0"
   },
@@ -148,7 +148,7 @@
   },
   "scripts": {
     "test": "node ./test/run.js && tap test/tap/*.js",
-    "tap": "tap test/tap/*.js",
+    "tap": "tap --timeout 120 test/tap/*.js",
     "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rm -rf test/*/*/node_modules && make -j32 doc",
     "dumpconf": "env | grep npm | sort | uniq",
     "echo": "node bin/npm-cli.js"

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "which"
   ],
   "devDependencies": {
-    "npm-registry-mock": "git://github.com/bcoe/npm-registry-mock#1e43f4d323e78d10e0c86681245009667aac5ad1",
+    "npm-registry-mock": "~0.6.2",
     "ronn": "~0.3.6",
     "tap": "~0.4.0"
   },

--- a/test/tap/404-parent.js
+++ b/test/tap/404-parent.js
@@ -7,6 +7,7 @@ var fs = require('fs')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
 var pkg = path.resolve(__dirname, '404-parent')
+var mr = require("npm-registry-mock")
 
 test('404-parent: if parent exists, specify parent in error message', function(t) {
   setup()
@@ -41,9 +42,12 @@ function setup() {
 }
 
 function performInstall(cb) {
-  npm.load(function() {
-    npm.commands.install(pkg, [], function(err) {
-      cb(err)
+  mr(common.port, function (s) { // create mock registry.
+    npm.load({registry: common.registry}, function() {
+      npm.commands.install(pkg, [], function(err) {
+        cb(err)
+        s.close() // shutdown mock npm server.
+      })
     })
   })
 }

--- a/test/tap/dedupe.js
+++ b/test/tap/dedupe.js
@@ -4,17 +4,19 @@ var test = require("tap").test
   , existsSync = fs.existsSync || path.existsSync
   , npm = require("../../")
   , rimraf = require("rimraf")
+  , mr = require("npm-registry-mock")
+  , common = require('../common-tap.js')
 
 test("dedupe finds the common module and moves it up one level", function (t) {
-  t.plan(2)
-
-  setup(function () {
+  setup(function (s) {
     npm.install(".", function (err) {
       if (err) return t.fail(err)
       npm.dedupe(function(err) {
         if (err) return t.fail(err)
         t.ok(existsSync(path.join(__dirname, "dedupe", "node_modules", "minimist")))
-        t.ok(!existsSync(path.join(__dirname, "dedupe", "node_modules", "prime")))
+        t.ok(!existsSync(path.join(__dirname, "dedupe", "node_modules", "checker")))
+        s.close() // shutdown mock registry.
+        t.end()
       })
     })
   })
@@ -22,9 +24,11 @@ test("dedupe finds the common module and moves it up one level", function (t) {
 
 function setup (cb) {
   process.chdir(path.join(__dirname, "dedupe"))
-  npm.load(function () {
-    rimraf.sync(path.join(__dirname, "dedupe", "node_modules"))
-    fs.mkdirSync(path.join(__dirname, "dedupe", "node_modules"))
-    cb()
+  mr(common.port, function (s) { // create mock registry.
+    npm.load({registry: common.registry}, function() {
+      rimraf.sync(path.join(__dirname, "dedupe", "node_modules"))
+      fs.mkdirSync(path.join(__dirname, "dedupe", "node_modules"))
+      cb(s)
+    })
   })
 }

--- a/test/tap/dedupe/package.json
+++ b/test/tap/dedupe/package.json
@@ -4,8 +4,6 @@
   "version": "0.0.0",
   "dependencies": {
     "optimist": "0.6.0",
-    "clean": "2.1.6",
-    "informal": "0.0.1",
-    "pathogen": "0.1.5"
+    "clean": "2.1.6"
   }
 }

--- a/test/tap/git-cache-locking.js
+++ b/test/tap/git-cache-locking.js
@@ -21,6 +21,9 @@ test("setup", function (t) {
 
 test("git-cache-locking: install a git dependency", function (t) {
 
+  // disable git integration tests on Travis.
+  if (process.env.TRAVIS) return t.end()
+
   // package c depends on a.git#master and b.git#master
   // package b depends on a.git#master
   var child = spawn(node, [npm, "install", "git://github.com/nigelzor/npm-4503-c.git"], {

--- a/test/tap/lifecycle-signal.js
+++ b/test/tap/lifecycle-signal.js
@@ -7,7 +7,7 @@ var pkg = path.resolve(__dirname, "lifecycle-signal")
 
 test("lifecycle signal abort", function (t) {
   // windows does not use lifecycle signals, abort
-  if (process.platform === "win32") return t.end()
+  if (process.platform === "win32" || process.env.TRAVIS) return t.end()
   var child = spawn(node, [npm, "install"], {
     cwd: pkg
   })

--- a/test/tap/outdated-color.js
+++ b/test/tap/outdated-color.js
@@ -5,6 +5,7 @@ var mkdirp = require("mkdirp")
 var rimraf = require("rimraf")
 var mr = require("npm-registry-mock")
 var exec = require('child_process').exec
+var mr = require("npm-registry-mock")
 
 var pkg = __dirname + '/outdated'
 var NPM_BIN = __dirname + '/../../bin/npm-cli.js'
@@ -25,12 +26,15 @@ function ansiTrim (str) {
 // it's not running in a tty
 test("does not use ansi styling", function (t) {
   t.plan(3)
-  exec('node ' + NPM_BIN + ' outdated --color false', {
-    cwd: pkg
-  }, function(err, stdout) {
-    t.ifError(err)
-    t.ok(stdout, stdout.length)
-    t.ok(!hasControlCodes(stdout)) 
+  mr(common.port, function (s) { // create mock registry.
+    exec('node ' + NPM_BIN + ' outdated --registry ' + common.registry + ' --color false underscore', {
+      cwd: pkg
+    }, function(err, stdout) {
+      t.ifError(err)
+      t.ok(stdout, stdout.length)
+      t.ok(!hasControlCodes(stdout))
+      s.close()
+    })
   })
 })
 
@@ -38,4 +42,3 @@ test("cleanup", function (t) {
   rimraf.sync(pkg + "/cache")
   t.end()
 })
-

--- a/test/tap/peer-deps-invalid.js
+++ b/test/tap/peer-deps-invalid.js
@@ -4,18 +4,19 @@ var test = require("tap").test
 var rimraf = require("rimraf")
 var npm = require("../../")
 var http = require("http")
+var mr = require("npm-registry-mock")
 
 var okFile = new Buffer(
-'/**package\n' + 
-' * { "name": "npm-test-peer-deps-file"\n' + 
-' * , "main": "index.js"\n' + 
-' * , "version": "1.2.3"\n' + 
-' * , "description":"No package.json in sight!"\n' + 
-' * , "peerDependencies": { "dict": "1.1.0" }\n' + 
-' * , "dependencies": { "opener": "1.3.0" }\n' + 
-' * }\n' + 
-' **/\n' + 
-'\n' + 
+'/**package\n' +
+' * { "name": "npm-test-peer-deps-file"\n' +
+' * , "main": "index.js"\n' +
+' * , "version": "1.2.3"\n' +
+' * , "description":"No package.json in sight!"\n' +
+' * , "peerDependencies": { "underscore": "1.3.1" }\n' +
+' * , "dependencies": { "mkdirp": "0.3.5" }\n' +
+' * }\n' +
+' **/\n' +
+'\n' +
 'module.exports = "I\'m just a lonely index, naked as the day I was born."\n'
 )
 
@@ -25,7 +26,7 @@ var failFile = new Buffer(
 ' * , "main": "index.js"\n' +
 ' * , "version": "1.2.3"\n' +
 ' * , "description":"This one should conflict with the other one"\n' +
-' * , "peerDependencies": { "dict": "1.0.0" }\n' +
+' * , "peerDependencies": { "underscore": "1.3.3" }\n' +
 ' * }\n' +
 ' **/\n' +
 '\n' +
@@ -51,20 +52,25 @@ test("setup", function(t) {
 
 
 
-test("installing dependencies that having conflicting peerDependencies", function (t) {
+test("installing dependencies that have conflicting peerDependencies", function (t) {
   rimraf.sync(__dirname + "/peer-deps-invalid/node_modules")
   process.chdir(__dirname + "/peer-deps-invalid")
 
-  npm.load(function () {
-    console.error('back from load')
-    npm.commands.install([], function (err) {
-      console.error('back from install')
-      if (!err) {
-        t.fail("No error!")
-      } else {
-        t.equal(err.code, "EPEERINVALID")
-      }
-      t.end()
+  // we're already listening on common.port,
+  // use an alternative port for this test.
+  mr(1331, function (s) { // create mock registry.
+    npm.load({registry: "http://localhost:1331"}, function () {
+      console.error('back from load')
+      npm.commands.install([], function (err) {
+        console.error('back from install')
+        if (!err) {
+          t.fail("No error!")
+        } else {
+          t.equal(err.code, "EPEERINVALID")
+        }
+        t.end()
+        s.close() // shutdown mock registry.
+      })
     })
   })
 })

--- a/test/tap/peer-deps-without-package-json.js
+++ b/test/tap/peer-deps-without-package-json.js
@@ -3,7 +3,7 @@ var fs = require("fs")
 var test = require("tap").test
 var rimraf = require("rimraf")
 var npm = require("../../")
-
+var mr = require("npm-registry-mock")
 var http = require("http")
 
 
@@ -13,8 +13,8 @@ var js = new Buffer(
 ' * , "main": "index.js"\n' +
 ' * , "version": "1.2.3"\n' +
 ' * , "description":"No package.json in sight!"\n' +
-' * , "peerDependencies": { "dict": "1.1.0" }\n' +
-' * , "dependencies": { "opener": "1.3.0" }\n' +
+' * , "peerDependencies": { "underscore": "1.3.1" }\n' +
+' * , "dependencies": { "mkdirp": "0.3.5" }\n' +
 ' * }\n' +
 ' **/\n' +
 '\n' +
@@ -38,15 +38,20 @@ test("installing a peerDependencies-using package without a package.json present
   fs.mkdirSync(__dirname + "/peer-deps-without-package-json/node_modules")
   process.chdir(__dirname + "/peer-deps-without-package-json")
 
-  npm.load(function () {
-    npm.install(common.registry, function (err) {
-      if (err) {
-        t.fail(err)
-      } else {
-        t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/npm-test-peer-deps-file"))
-        t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/dict"))
-      }
-      t.end()
+  // we're already listening on common.port,
+  // use an alternative port for this test.
+  mr(1331, function (s) { // create mock registry.
+    npm.load({registry: 'http://localhost:1331'}, function () {
+      npm.install(common.registry, function (err) {
+        if (err) {
+          t.fail(err)
+        } else {
+          t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/npm-test-peer-deps-file"))
+          t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/underscore"))
+        }
+        t.end()
+        s.close() // shutdown mock registry.
+      })
     })
   })
 })

--- a/test/tap/sorted-package-json.js
+++ b/test/tap/sorted-package-json.js
@@ -24,7 +24,7 @@ test("sorting dependencies", function (t) {
 
   var before = JSON.parse(fs.readFileSync(packageJson).toString())
 
-  mr({port: common.port}, function (s) {
+  mr(common.port, function (s) {
     // underscore is already in the package.json,
     // but --save will trigger a rewrite with sort
     var child = spawn(node, [npm, "install", "--save", "underscore@1.3.3"], {


### PR DESCRIPTION
In an effort to add continuous integration to _npm/npm_, I've updated tap tests to rely on no external dependencies.

This pull request relies on https://github.com/npm/npm-registry-mock/pull/18, and will need to be updated with the appropriate package version when this is merged.

A few caveats:
- **git-cache-locking.js** hits an external git dependency, and has been disabled for travis.
  - In the future it would be great to start building out an approach for mocking git, which would let us move more tests over to travis.
  - I was looking at https://github.com/substack/pushover for this purpose.
- **lifecycle-signal.js** is disabled for travis, awaiting this pull request: https://github.com/npm/npm/pull/4663
- the timeout value has been increased for tap. Some tap tests have 50 or more assertions, which can hit the 30 second timeout, even though the test is running as expected.
