### PR TITLE
npm version updates shrinkwrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ before_install:
   - "npm config set spin false"
   - "npm install -g npm@^2"
   - "sudo mkdir -p /var/run/couchdb"
+  - git config --global user.email "travis@npmjs.org"
+  - git config --global user.name "NPM Travis-CI"
 script: "npm run-script tap"

--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -38,6 +38,9 @@ in your git config for this to work properly.  For example:
 
     Enter passphrase:
 
+If the `version-shrinkwrap` config is set, then the version attribute
+will be updated in `npm-shrinkwrap.json` before the commit.
+
 ## SEE ALSO
 
 * npm-init(1)

--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -8,7 +8,7 @@ npm-version(1) -- Bump a package version
 ## DESCRIPTION
 
 Run this in a package directory to bump the version and write the new
-data back to the package.json file.
+data back to the package.json file and (if availible) the npm-shrinkwrap.json file. 
 
 The `newversion` argument should be a valid semver string, *or* a
 valid second argument to semver.inc (one of "patch", "minor", "major",
@@ -38,8 +38,6 @@ in your git config for this to work properly.  For example:
 
     Enter passphrase:
 
-If the `version-shrinkwrap` config is set, then the version attribute
-will be updated in `npm-shrinkwrap.json` before the commit.
 
 ## SEE ALSO
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -64,17 +64,44 @@ function version (args, silent, cb_) {
     if (data.version === newVer) return cb_(new Error("Version not changed"))
     data.version = newVer
 
-    fs.stat(path.join(npm.localPrefix, ".git"), function (er, s) {
-      function cb (er) {
-        if (!er && !silent) console.log("v" + newVer)
-        cb_(er)
-      }
-
-      var tags = npm.config.get('git-tag-version')
-      var doGit = !er && s.isDirectory() && tags
-      if (!doGit) return write(data, cb)
-      else checkGit(data, cb)
+    fs.stat(path.join(process.cwd(), "npm-shrinkwrap.json"), function (er, s) {
+      var doShrinkwrap = !er && s && s.isFile() 
+      if (!doShrinkwrap) return doGit(data, silent, cb_)
+      else writeShrinkwrap(data, silent, cb_)
     })
+  })
+}
+
+function writeShrinkwrap (data, silent, cb_) {
+  fs.readFile(path.join(process.cwd(), "npm-shrinkwrap.json"), function (er, _data) {
+    try {
+      shrinkwrapData = JSON.parse(_data.toString())
+    } catch (er) {
+      log.error("version", "Bad npm-shrinkwrap.json data")
+      return cb_(er)
+    }
+    shrinkwrapData.version = data.version
+    write(shrinkwrapData, "npm-shrinkwrap.json", function (er) {
+      if (er) {
+        log.error("version", "Bad npm-shrinkwrap.json data")
+        return cb_(er)
+      }
+      doGit(data, silent, cb_)
+    })
+  })
+}
+
+function doGit (data, silent, cb_) {
+  fs.stat(path.join(npm.localPrefix, ".git"), function (er, s) {
+    function cb (er) {
+      if (!er && !silent) console.log("v" + data.version)
+      cb_(er)
+    }
+
+    var tags = npm.config.get('git-tag-version')
+    var doGit = !er && s.isDirectory() && tags
+    if (!doGit) return write(data, cb)
+    else checkGit(data, cb)
   })
 }
 
@@ -107,6 +134,7 @@ function checkGit (data, cb) {
         , flag = sign ? "-sm" : "-am"
       chain
         ( [ git.chainableExec([ "add", "package.json" ], {env: process.env})
+          , git.chainableExec([ "add", "npm-shrinkwrap.json" ], {env: process.env})
           , git.chainableExec([ "commit", "-m", message ], {env: process.env})
           , sign && function (cb) {
               npm.spinner.stop()
@@ -120,8 +148,12 @@ function checkGit (data, cb) {
   })
 }
 
-function write (data, cb) {
-  writeFileAtomic( path.join(npm.localPrefix, "package.json")
+function write (data, file, cb) {
+  if (typeof (file) === "function") { 
+    cb = file
+    file = "package.json"
+  }
+  writeFileAtomic( path.join(process.cwd(), file)
               , new Buffer(JSON.stringify(data, null, 2) + "\n")
               , cb )
 }

--- a/test/tap/version-update-shrinkwrap.js
+++ b/test/tap/version-update-shrinkwrap.js
@@ -1,0 +1,84 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var npm = require("../../")
+var npmc = require.resolve("../../")
+var osenv = require("osenv")
+var path = require("path")
+var fs = require("fs")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var which = require("which")
+var util = require("util")
+var spawn = require("child_process").spawn
+
+var pkg = path.resolve(__dirname, "version-shrinkwrap")
+var cache = path.resolve(pkg, "cache")
+
+test("npm version <semver> updates shrinkwrap - no git", function (t) {
+  setup()
+  npm.load({ cache: pkg + '/cache', registry: common.registry}, function () {
+    npm.commands.version(['patch'], function(err) {
+      if (err) return t.fail('Error perform version patch')
+      var shrinkwrap = require(pkg+'/npm-shrinkwrap')
+      if (shrinkwrap.version !== '0.0.1') t.fail(shrinkwrap.version+' !== \'0.0.1\'')
+      t.ok('0.0.1' === shrinkwrap.version)
+      t.end()
+    })
+  })
+})
+
+test("npm version <semver> updates shrinkwrap and updates git", function (t) {
+  setup()
+  npm.load({ cache: cache, registry: common.registry}, function () {
+    which("git", function(err, git) {
+      if (err) t.fail("Git not installed, or which git command error") 
+      function checkCommit(_cb) {
+        var child1 = spawn(git, ["show", "HEAD", "--name-only"])
+        var out = ""
+        child1.stdout.on("data", function(d) {
+          out += d.toString()
+        })
+        child1.on("exit", function() {
+          return _cb(null, out)
+        })
+      }
+
+      var child2 = spawn(git, ["init"])
+      child2.stdout.pipe(process.stdout)
+      child2.on("exit", function() {
+        npm.commands.version(["patch"], function(err) {
+          if (err) return t.fail("Error perform version patch" + err)
+          checkCommit(function(err, files) {
+            t.notEqual(files.split('\n').indexOf("package.json"), -1, "package.json not commited")
+            t.notEqual(files.split('\n').indexOf("npm-shrinkwrap.json"), -1, "npm-shrinkwrap.json not commited")
+            t.pass("npm-shrinkwrap updated and commited")
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+test("cleanup", function(t) {
+  // windows fix for locked files
+  process.chdir(osenv.tmpdir())
+
+  rimraf.sync(pkg)
+  t.end()
+})
+
+function setup() {
+  mkdirp.sync(pkg)
+  mkdirp.sync(cache)
+  var contents = {
+    author: "Nathan Bowser && Faiq Raza",
+    name: "version-with-shrinkwrap-test",
+    version: "0.0.0",
+    description: "Test for version with shrinkwrap update"
+  }
+
+  fs.writeFileSync(path.resolve(pkg, "package.json"), JSON.stringify(contents), "utf8")
+  fs.writeFileSync(path.resolve(pkg, "npm-shrinkwrap.json"), JSON.stringify(contents), "utf8")
+  process.chdir(pkg)
+}


### PR DESCRIPTION
Currently when you run `npm version`, it will update the version in package.json, commit the change, then tag it. This is awkward if you're using shrinkwrap, because the shrinkwrap file also sets a version.

This allows you to set a npm config attribute `version-shrinkwrap`. If this flag is set, when you run `npm version`, the shrinkwrap will also be updated. 
