### PR TITLE
Don't crash if shrinkwrap-dependencies were not passed in pkginfo

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -59,7 +59,7 @@ function shrinkwrap_ (pkginfo, silent, dev, cb) {
 function save (pkginfo, silent, cb) {
   // copy the keys over in a well defined order
   // because javascript objects serialize arbitrarily
-  pkginfo.dependencies = sortedObject(pkginfo.dependencies)
+  pkginfo.dependencies = sortedObject(pkginfo.dependencies || {})
   try {
     var swdata = JSON.stringify(pkginfo, null, 2) + "\n"
   } catch (er) {

--- a/test/tap/shrinkwrap-empty-deps.js
+++ b/test/tap/shrinkwrap-empty-deps.js
@@ -1,0 +1,47 @@
+var test = require("tap").test
+  , npm = require("../../")
+  , mr = require("npm-registry-mock")
+  , common = require("../common-tap.js")
+  , path = require("path")
+  , fs = require("fs")
+  , osenv = require("osenv")
+  , rimraf = require("rimraf")
+  , pkg = __dirname + "/shrinkwrap-empty-deps"
+
+test("returns a list of removed items", function (t) {
+  var desiredResultsPath = path.resolve(pkg, "npm-shrinkwrap.json")
+
+  cleanup()
+
+  mr(common.port, function (s) {
+    setup(function () {
+      npm.shrinkwrap([], function (err) {
+        if (err) return t.fail(err)
+        fs.readFile(desiredResultsPath, function (err, desired) {
+          if (err) return t.fail(err)
+          t.deepEqual({
+            "name": "npm-test-shrinkwrap-empty-deps",
+            "version": "0.0.0",
+            "dependencies": {}
+          }, JSON.parse(desired))
+          cleanup()
+          s.close()
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+function setup (cb) {
+  cleanup()
+  process.chdir(pkg)
+  npm.load({cache: pkg + "/cache", registry: common.registry}, function () {
+    cb()
+  })
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(path.resolve(pkg, "npm-shrinkwrap.json"))
+}

--- a/test/tap/shrinkwrap-empty-deps/package.json
+++ b/test/tap/shrinkwrap-empty-deps/package.json
@@ -1,0 +1,7 @@
+{
+  "author": "Rockbert",
+  "name": "npm-test-shrinkwrap-empty-deps",
+  "version": "0.0.0",
+  "dependencies": {},
+  "devDependencies": {}
+}


### PR DESCRIPTION
This prevents npm from crashing on shrinkwrap if a `package.json`
has no dependencies defined.

Added a test for @kislyuk

replaces: https://github.com/npm/npm/pull/4953
