### PR TITLE
adding save-range configuration option

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -648,6 +648,19 @@ devDependencies hash.
 
 Only works if there is already a package.json file present.
 
+### save-range
+
+* Default: '^'
+* Type: String
+
+Configure how versions of packages installed to a package.json file via 
+`--save` or `--save-dev` get prefixed.
+
+For example if a package has version `1.2.3`, by default it's version is
+set to `^1.2.3` which allows minor upgrades for that package, but after  
+`npm config set save-range='~'` it would be set to `~1.2.3` which only allows
+patch upgrades.
+
 ### searchopts
 
 * Default: ""

--- a/lib/install.js
+++ b/lib/install.js
@@ -337,6 +337,7 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
   }
 
   var saveBundle = npm.config.get('save-bundle')
+  var saveRange = npm.config.get('save-range') || "^";
 
   // each item in the tree is a top-level thing that should be saved
   // to the package.json file.
@@ -353,7 +354,7 @@ function save (where, installed, tree, pretty, hasArguments, cb) {
         var rangeDescriptor = semver.valid(k[1], true) &&
                               semver.gte(k[1], "0.1.0", true) &&
                               !npm.config.get("save-exact")
-                            ? "^" : ""
+                            ? saveRange : ""
         set[k[0]] = rangeDescriptor + k[1]
         return set
       }, {})

--- a/test/tap/install-save-range.js
+++ b/test/tap/install-save-range.js
@@ -1,0 +1,140 @@
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../../')
+var osenv = require('osenv')
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var pkg = path.join(__dirname, 'install-save-range')
+var mr = require("npm-registry-mock")
+
+test("setup", function (t) {
+  mkdirp.sync(pkg)
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+  process.chdir(pkg)
+  t.end()
+})
+
+test('"npm install --save with default save-range should install local pkg versioned to allow minor updates', function(t) {
+  resetPackageJSON(pkg)
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save', true)
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          t.deepEqual(pkgJson.dependencies, {
+            'underscore': '^1.3.1'
+          }, 'Underscore dependency should specify ^1.3.1')
+          npm.config.set('save', undefined)
+          s.close()
+          t.end()
+        })
+      })
+  })
+})
+
+test('"npm install --save-dev with default save-range should install local pkg to dev dependencies versioned to allow minor updates', function(t) {
+  resetPackageJSON(pkg)
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save-dev', true)
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          t.deepEqual(pkgJson.devDependencies, {
+            'underscore': '^1.3.1'
+          }, 'Underscore devDependency should specify ^1.3.1')
+          npm.config.set('save-dev', undefined)
+          s.close()
+          t.end()
+        })
+      })
+  })
+})
+
+test('"npm install --save with "~" save-range should install local pkg versioned to allow patch updates', function(t) {
+  resetPackageJSON(pkg)
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save', true)
+        npm.config.set('save-range', '~')
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          t.deepEqual(pkgJson.dependencies, {
+            'underscore': '~1.3.1'
+          }, 'Underscore dependency should specify ~1.3.1')
+          npm.config.set('save', undefined)
+          npm.config.set('save-range', undefined)
+          s.close()
+          t.end()
+        })
+      })
+  })
+})
+
+test('"npm install --save-dev with "~" save-range should install local pkg to dev dependencies versioned to allow patch updates', function(t) {
+  resetPackageJSON(pkg)
+  mr(common.port, function (s) {
+    npm.load({
+      cache: pkg + "/cache",
+      loglevel: 'silent',
+      registry: common.registry }, function(err) {
+        t.ifError(err)
+        npm.config.set('save-dev', true)
+        npm.config.set('save-range', '~')
+        npm.commands.install(['underscore@1.3.1'], function(err) {
+          t.ifError(err)
+          var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+          t.ok(JSON.parse(fs.readFileSync(p)))
+          var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+          t.deepEqual(pkgJson.devDependencies, {
+            'underscore': '~1.3.1'
+          }, 'Underscore devDependency should specify ~1.3.1')
+          npm.config.set('save-dev', undefined)
+          npm.config.set('save-range', undefined)
+          s.close()
+          t.end()
+        })
+      })
+  })
+})
+
+test('cleanup', function(t) {
+  process.chdir(__dirname)
+  rimraf.sync(path.resolve(pkg, 'node_modules'))
+  rimraf.sync(path.resolve(pkg, 'cache'))
+  resetPackageJSON(pkg)
+  t.end()
+})
+
+function resetPackageJSON(pkg) {
+  var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+  delete pkgJson.dependencies
+  delete pkgJson.devDependencies
+  delete pkgJson.optionalDependencies
+  var json = JSON.stringify(pkgJson, null, 2) + "\n"
+  fs.writeFileSync(pkg + '/package.json', json, "ascii")
+}
+
+

--- a/test/tap/install-save-range/README.md
+++ b/test/tap/install-save-range/README.md
@@ -1,0 +1,1 @@
+# just a test

--- a/test/tap/install-save-range/index.js
+++ b/test/tap/install-save-range/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/test/tap/install-save-range/package.json
+++ b/test/tap/install-save-range/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bla",
+  "description": "fixture",
+  "version": "0.0.1",
+  "main": "index.js",
+  "repository": "git://github.com/robertkowalski/bogusfixture"
+}


### PR DESCRIPTION
- npm install --save|--save-dev takes npm.config['save-range'] into
  account when prefixing the version in the package.json
- by default the version is prefixed with '^'
- added tests for this feature
- added documentation for this feature including one example
- tests are passing without npmconf changes, but this commit goes alongside [c10b608] in npmconf repo

I suppose you'd merge https://github.com/npm/npmconf/pull/25 first, publish a new version and check in the update with the `node_modules`.
