### PR TITLE
Add message about cleaning cache upon error

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -106,6 +106,7 @@ function errorHandler (er) {
   case "EPERM":
     log.error("", er)
     log.error("", ["\nPlease try running this command again as root/Administrator."
+              ,"If that fails, please try running `npm cache clean` first."
               ].join("\n"))
     printStack = true
     break


### PR DESCRIPTION
Full credits goes to http://blogs.msdn.com/b/matt-harrington/archive/2012/02/23/how-to-fix-node-js-npm-permission-problems.aspx

There is plenty issues floating around in repos of other packages. Unfortunately it seems that not many people are reading [Troubleshooting](https://github.com/npm/npm/wiki/Troubleshooting) which mentions it. I wasn't looking there too honestly. 
