### PR TITLE
fix no such property error

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -58,7 +58,7 @@ function view (args, silent, cb) {
   // get the data about this package
   registry.get(name, function (er, data) {
     if (er) return cb(er)
-    if (data["dist-tags"].hasOwnProperty(version)) {
+    if (data["dist-tags"] && data["dist-tags"].hasOwnProperty(version)) {
       version = data["dist-tags"][version]
     }
     var results = []


### PR DESCRIPTION
To reproduce: Publish a package with one version, unpublish it, `npm show` et voila, `data["dist-tags"]` isn't there.
