### PR TITLE
make `npm run` respect `--silent`

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -1,4 +1,3 @@
-
 exports = module.exports = lifecycle
 exports.cmd = cmd
 
@@ -161,7 +160,9 @@ function runCmd (note, cmd, pkg, env, stage, wd, unsafe, cb) {
   var user = unsafe ? null : npm.config.get("user")
     , group = unsafe ? null : npm.config.get("group")
 
-  console.log(note)
+  if (log.level !== 'silent') {
+    console.log(note)
+  }
   log.verbose("unsafe-perm in lifecycle", unsafe)
 
   if (process.platform === "win32") {


### PR DESCRIPTION
Currently npm will write to the `console` when you call `npm run foo`.

With this change npm run will detect whether log level is set to silent and then NOT log to console.

**Usecase:**

we run `npm test` in a pre-commit hook. A succesful pre-commit hook should write nothing to stdout for text editor / IDE integration to work correctly. Currently npm prints `> cmd` to stdout which breaks our text editor / IDE integration.
