### PR TITLE
fix the tests for peer-deps-invalid.js

### DIFF
--- a/test/tap/peer-deps-invalid.js
+++ b/test/tap/peer-deps-invalid.js
@@ -1,65 +1,31 @@
 var common = require('../common-tap.js')
 var fs = require("fs")
+var path = require("path")
 var test = require("tap").test
 var rimraf = require("rimraf")
 var npm = require("../../")
-var http = require("http")
 var mr = require("npm-registry-mock")
+var pkg = __dirname + "/peer-deps-invalid"
 
-var okFile = new Buffer(
-'/**package\n' +
-' * { "name": "npm-test-peer-deps-file"\n' +
-' * , "main": "index.js"\n' +
-' * , "version": "1.2.3"\n' +
-' * , "description":"No package.json in sight!"\n' +
-' * , "peerDependencies": { "underscore": "1.3.1" }\n' +
-' * , "dependencies": { "mkdirp": "0.3.5" }\n' +
-' * }\n' +
-' **/\n' +
-'\n' +
-'module.exports = "I\'m just a lonely index, naked as the day I was born."\n'
-)
-
-var failFile = new Buffer(
-'/**package\n' +
-' * { "name": "npm-test-peer-deps-file-invalid"\n' +
-' * , "main": "index.js"\n' +
-' * , "version": "1.2.3"\n' +
-' * , "description":"This one should conflict with the other one"\n' +
-' * , "peerDependencies": { "underscore": "1.3.3" }\n' +
-' * }\n' +
-' **/\n' +
-'\n' +
-'module.exports = "I\'m just a lonely index, naked as the day I was born."\n'
-)
-
-var server
-test("setup", function(t) {
-  server = http.createServer(function (req, res) {
-    res.setHeader('content-type', 'application/javascript')
-    switch (req.url) {
-      case "/ok.js":
-        return res.end(okFile)
-      default:
-        return res.end(failFile)
-    }
-  })
-  server.listen(common.port, function() {
-    t.pass("listening")
-    t.end()
-  })
-})
-
-
+var okFile = fs.readFileSync(path.join(pkg, "file-ok.js"), "utf8")
+var failFile = fs.readFileSync(path.join(pkg, "file-fail.js"), "utf8")
 
 test("installing dependencies that have conflicting peerDependencies", function (t) {
-  rimraf.sync(__dirname + "/peer-deps-invalid/node_modules")
-  process.chdir(__dirname + "/peer-deps-invalid")
+  rimraf.sync(pkg + "/node_modules")
+  rimraf.sync(pkg + "/cache")
+  process.chdir(pkg)
 
-  // we're already listening on common.port,
-  // use an alternative port for this test.
-  mr(1331, function (s) { // create mock registry.
-    npm.load({registry: "http://localhost:1331"}, function () {
+  var customMocks = {
+    "get": {
+      "/ok.js": [200, okFile],
+      "/invalid.js": [200, failFile]
+    }
+  }
+  mr({port: common.port, mocks: customMocks}, function (s) { // create mock registry.
+    npm.load({
+      cache: pkg + "/cache",
+      registry: common.registry
+    }, function () {
       console.error('back from load')
       npm.commands.install([], function (err) {
         console.error('back from install')
@@ -75,9 +41,8 @@ test("installing dependencies that have conflicting peerDependencies", function 
   })
 })
 
-test("shutdown", function(t) {
-  server.close(function() {
-    t.pass("closed")
-    t.end()
-  })
+test("cleanup", function (t) {
+  rimraf.sync(pkg + "/node_modules")
+  rimraf.sync(pkg + "/cache")
+  t.end()
 })

--- a/test/tap/peer-deps-invalid/file-fail.js
+++ b/test/tap/peer-deps-invalid/file-fail.js
@@ -1,0 +1,10 @@
+/**package
+* { "name": "npm-test-peer-deps-file-invalid"
+* , "main": "index.js"
+* , "version": "1.2.3"
+* , "description":"This one should conflict with the other one"
+* , "peerDependencies": { "underscore": "1.3.3" }
+* }
+**/
+
+module.exports = "I\'m just a lonely index, naked as the day I was born."

--- a/test/tap/peer-deps-invalid/file-ok.js
+++ b/test/tap/peer-deps-invalid/file-ok.js
@@ -1,0 +1,11 @@
+/**package
+* { "name": "npm-test-peer-deps-file"
+* , "main": "index.js"
+* , "version": "1.2.3"
+* , "description":"No package.json in sight!"
+* , "peerDependencies": { "underscore": "1.3.1" }
+* , "dependencies": { "mkdirp": "0.3.5" }
+* }
+**/
+
+module.exports = "I\'m just a lonely index, naked as the day I was born."

--- a/test/tap/peer-deps-without-package-json.js
+++ b/test/tap/peer-deps-without-package-json.js
@@ -1,53 +1,37 @@
 var common = require('../common-tap.js')
 var fs = require("fs")
+var path = require("path")
 var test = require("tap").test
 var rimraf = require("rimraf")
 var npm = require("../../")
 var mr = require("npm-registry-mock")
-var http = require("http")
+var pkg = __dirname + "/peer-deps-without-package-json"
 
-
-var js = new Buffer(
-'/**package\n' +
-' * { "name": "npm-test-peer-deps-file"\n' +
-' * , "main": "index.js"\n' +
-' * , "version": "1.2.3"\n' +
-' * , "description":"No package.json in sight!"\n' +
-' * , "peerDependencies": { "underscore": "1.3.1" }\n' +
-' * , "dependencies": { "mkdirp": "0.3.5" }\n' +
-' * }\n' +
-' **/\n' +
-'\n' +
-'module.exports = "I\'m just a lonely index, naked as the day I was born."\n')
-
-var server
-test("setup", function(t) {
-  server = http.createServer(function (q, s) {
-    s.setHeader('content-type', 'application/javascript')
-    s.end(js)
-  })
-  server.listen(common.port, function () {
-    t.pass('listening')
-    t.end()
-  })
-})
-
+var js = fs.readFileSync(path.join(pkg, "file-js.js"), "utf8")
 test("installing a peerDependencies-using package without a package.json present (GH-3049)", function (t) {
 
-  rimraf.sync(__dirname + "/peer-deps-without-package-json/node_modules")
-  fs.mkdirSync(__dirname + "/peer-deps-without-package-json/node_modules")
-  process.chdir(__dirname + "/peer-deps-without-package-json")
+  rimraf.sync(pkg + "/node_modules")
+  rimraf.sync(pkg + "/cache")
 
-  // we're already listening on common.port,
-  // use an alternative port for this test.
-  mr(1331, function (s) { // create mock registry.
-    npm.load({registry: 'http://localhost:1331'}, function () {
-      npm.install(common.registry, function (err) {
+  fs.mkdirSync(pkg + "/node_modules")
+  process.chdir(pkg)
+
+  var customMocks = {
+    "get": {
+      "/ok.js": [200, js],
+    }
+  }
+  mr({port: common.port, mocks: customMocks}, function (s) { // create mock registry.
+    npm.load({
+      registry: common.registry,
+      cache: pkg + "/cache"
+    }, function () {
+      npm.install(common.registry + "/ok.js", function (err) {
         if (err) {
           t.fail(err)
         } else {
-          t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/npm-test-peer-deps-file"))
-          t.ok(fs.existsSync(__dirname + "/peer-deps-without-package-json/node_modules/underscore"))
+          t.ok(fs.existsSync(pkg + "/node_modules/npm-test-peer-deps-file"))
+          t.ok(fs.existsSync(pkg + "/node_modules/underscore"))
         }
         t.end()
         s.close() // shutdown mock registry.
@@ -57,8 +41,7 @@ test("installing a peerDependencies-using package without a package.json present
 })
 
 test("cleanup", function (t) {
-  server.close(function() {
-    t.pass("closed")
-    t.end()
-  })
+  rimraf.sync(pkg + "/node_modules")
+  rimraf.sync(pkg + "/cache")
+  t.end()
 })

--- a/test/tap/peer-deps-without-package-json/file-js.js
+++ b/test/tap/peer-deps-without-package-json/file-js.js
@@ -1,0 +1,11 @@
+/**package
+* { "name": "npm-test-peer-deps-file"
+* , "main": "index.js"
+* , "version": "1.2.3"
+* , "description":"No package.json in sight!"
+* , "peerDependencies": { "underscore": "1.3.1" }
+* , "dependencies": { "mkdirp": "0.3.5" }
+* }
+**/
+
+module.exports = "I\'m just a lonely index, naked as the day I was born."


### PR DESCRIPTION
This fixes `npm run tap` and the travis tests

Seems that during the "make tests run offline"-refactor there was a small bug introduced.
