### PR TITLE
remove ambigious square brackets

### DIFF
--- a/doc/api/npm.md
+++ b/doc/api/npm.md
@@ -4,7 +4,7 @@ npm(3) -- node package manager
 ## SYNOPSIS
 
     var npm = require("npm")
-    npm.load([configObject], function (er, npm) {
+    npm.load(configObject, function (er, npm) {
       // use the npm object, now that it's loaded.
 
       npm.config.set(key, val)


### PR DESCRIPTION
I read the npm api and then tried running

``` js
npm.load([{ ... }], ...)
```

This didn't do what I expected.

I should have actually passed in a single object.

I interpreted the example as "pass in an array argument" instead of "pass in an optional object"
