### PR TITLE
Make `npm install` respect `config.unicode`

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -448,7 +448,7 @@ function prettify (tree, installed) {
                      if (g) g = " (" + g + ")"
                      return c.what + g
                    })
-                 })
+                 }, "", { unicode: npm.config.get("unicode") })
   }).join("\n")
 }
 

--- a/test/tap/install-cli-unicode.js
+++ b/test/tap/install-cli-unicode.js
@@ -1,0 +1,38 @@
+var common = require('../common-tap.js')
+var test = require('tap').test
+var npm = require('../../')
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var exec = require('child_process').exec
+
+var pkg = __dirname + '/install-cli'
+var NPM_BIN = __dirname + '/../../bin/npm-cli.js'
+
+function hasOnlyAscii (s) {
+  return /^[\000-\177]*$/.test(s) ;
+}
+
+test('does not use unicode with --unicode false', function (t) {
+  t.plan(3)
+  mr(common.port, function (s) {
+    exec('node ' + NPM_BIN + ' install --unicode false read', {
+      cwd: pkg
+    }, function(err, stdout) {
+      t.ifError(err)
+      t.ok(stdout, stdout.length)
+      t.ok(hasOnlyAscii(stdout))
+      s.close()
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  mr(common.port, function (s) {
+    exec('node ' + NPM_BIN + ' uninstall read', {
+      cwd: pkg
+    }, function(err, stdout) {
+      s.close()
+    })
+  })
+  t.end()
+})

--- a/test/tap/install-cli/README.md
+++ b/test/tap/install-cli/README.md
@@ -1,0 +1,1 @@
+# Tests for `npm install` CLI output.

--- a/test/tap/install-cli/index.js
+++ b/test/tap/install-cli/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/test/tap/install-cli/package.json
+++ b/test/tap/install-cli/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "install-cli",
+  "description": "fixture",
+  "version": "0.0.1",
+  "main": "index.js",
+  "dependencies": {
+    "read": "1.0.5"
+  },
+  "repository": "git://github.com/robertkowalski/bogusfixture"
+}


### PR DESCRIPTION
Before:

```
~/Code/npm/test/tap/install-cli$ npm install --unicode false
npm http GET https://registry.npmjs.org/read/1.0.5
npm http 304 https://registry.npmjs.org/read/1.0.5
npm http GET https://registry.npmjs.org/mute-stream
npm http 304 https://registry.npmjs.org/mute-stream
read@1.0.5 node_modules/read
└── mute-stream@0.0.4
```

After:

```
~/Code/npm/test/tap/install-cli$ node ../../../bin/npm-cli.js install --unicode false
npm http GET https://registry.npmjs.org/read
npm http 304 https://registry.npmjs.org/read
npm http GET https://registry.npmjs.org/mute-stream
npm http 304 https://registry.npmjs.org/mute-stream
read@1.0.5 node_modules/read
`-- mute-stream@0.0.4
```

Fixes #4358.
