### PR TITLE
Check SHA before using files from cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -857,6 +857,10 @@ function addNameVersion (name, v, data, cb) {
           if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR")
             return cb(er)
           if (er) return fetchit()
+          // check the SHA of the package we have, to ensure it wasn't installed
+          // from somewhere other than the registry (eg, a fork)
+          if (data._shasum && dist.shasum && data._shasum !== dist.shasum)
+            return fetchit()
           return cb(null, data)
         })
       } else return fetchit()


### PR DESCRIPTION
Fixes #3265.

Because 'npm install' _always_ writes every package to the cache (even
if it isn't installed from the registry) before installing it, it's easy
to end up in a situation where "npm install foo" installs something
other than the appropriate version from the registry.  eg:

  npm cache clean
  # Install a fork of version 0.0.1:
  npm install https://github.com/glasser/npm-cache-corruption/tarball/93c447e
  rm -rf node_modules
  # Before this commit, this would install the same fork as above
  npm install npm-cache-corruption

See https://gist.github.com/glasser/5391502 for more details on the reproduction.

Note that this only does the check against cache entries created with npm 1.4.7 or newer, since older versions don't save the SHA locally.
