### PR TITLE
adduser: allow change of the saved password

### DIFF
--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -66,13 +66,15 @@ function readUsername (c, u, cb) {
 function readPassword (c, u, cb) {
   var v = userValidate.pw
 
-  if (!c.changed) {
-    u.p = c.p
-    return cb()
-  }
   read({prompt: "Password: ", silent: true}, function (er, pw) {
     if (er) {
       return cb(er.message === "cancelled" ? er.message : er)
+    }
+
+    if (!c.changed && pw === '') {
+      // when the username was not changed,
+      // empty response means "use the old value"
+      pw = c.p
     }
 
     if (!pw) {
@@ -85,6 +87,7 @@ function readPassword (c, u, cb) {
       return readPassword(c, u, cb)
     }
 
+    c.changed = c.changed || c.p != pw
     u.p = pw
     cb(er)
   })


### PR DESCRIPTION
Modify `npm adduser` to allow the user to change the password used
for authentication. This is useful when the password was changed
via the website and the user wants to update local npm config
to use this new password.

Before this change, `npm adduser` would not ask for a password when
the username was not changed, thus it was not possible to easily
change the password while keeping the same username.
