### PR TITLE
doc: npm-folders(5) listed twice in npm-install.md

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -254,7 +254,6 @@ affects a real use-case, it will be investigated.
 * npm-config(7)
 * npmrc(5)
 * npm-registry(7)
-* npm-folders(5)
 * npm-tag(1)
 * npm-rm(1)
 * npm-shrinkwrap(1)


### PR DESCRIPTION
I am not sure if I'm missing some kind of documentation convention here, but I don't think `npm-folders(5)` should be listed twice in `SEE ALSO` here.
