### PR TITLE
fix cygwin encoding issue

### DIFF
--- a/bin/npm
+++ b/bin/npm
@@ -1,4 +1,5 @@
 #!/bin/sh
+(set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
 
 basedir=`dirname "$0"`
 


### PR DESCRIPTION
make sure that npm script runs on cygwin platform even when installed in DOS encoding
cf. http://sourceware.org/ml/cygwin-announce/2009-07/msg00002.html (option 4a)
