### PR TITLE
list runnable scripts

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -3,13 +3,14 @@ npm-run-script(1) -- Run arbitrary package scripts
 
 ## SYNOPSIS
 
-    npm run-script [<pkg>] <command>
+    npm run-script [<pkg>] [command]
 
 ## DESCRIPTION
 
 This runs an arbitrary command from a package's `"scripts"` object.
 If no package name is provided, it will search for a `package.json`
-in the current folder and use its `"scripts"` object.
+in the current folder and use its `"scripts"` object. If no `"command"`
+is provided, it will list the available top level scripts.
 
 It is used by the test, start, restart, and stop commands, but can be
 called directly, as well.

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -70,7 +70,7 @@ runScript.completion = function (opts, cb) {
 }
 
 function runScript (args, cb) {
-  if (!args.length) return cb(runScript.usage)
+  if (!args.length) return list(cb)
   var pkgdir = args.length === 1 ? process.cwd()
              : path.resolve(npm.dir, args[0])
     , cmd = args.pop()
@@ -78,6 +78,21 @@ function runScript (args, cb) {
   readJson(path.resolve(pkgdir, "package.json"), function (er, d) {
     if (er) return cb(er)
     run(d, pkgdir, cmd, cb)
+  })
+}
+
+function list(cb) {
+  var json = path.join(npm.prefix, 'package.json')
+  return readJson(json, function(er, d) {
+    if (er && er.code !== 'ENOENT' && er.code !== 'ENOTDIR') return cb(er)
+    if (er) d = {}
+    var scripts = Object.keys(d.scripts || {})
+    console.log()
+    scripts.forEach(function(script) {
+      console.log(' ', script)
+      console.log('   ', d.scripts[script])
+    })
+    return cb(null, scripts)
   })
 }
 


### PR DESCRIPTION
Running `npm run` will now list available scripts in the top level
package.json.  Fixes #4888
