### PR TITLE
Fix #5200

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -31,6 +31,10 @@ function init (args, cb) {
     log.resume()
     log.silly('package data', data)
     log.info('init', 'written successfully')
+    if (er && er.message === 'canceled') {
+      log.warn('init', 'canceled')
+      return cb(null, data)
+    }
     cb(er, data)
   })
 }


### PR DESCRIPTION
Only show warning when canceling `npm init`
