### PR TITLE
updated npm run-script usage

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -34,7 +34,7 @@ following scripts:
   stop and start scripts if no `restart` script is provided.
 
 Additionally, arbitrary scripts can be run by doing
-`npm run-script <stage> <pkg>`.
+`npm run-script <pkg> <stage>`.
 
 ## NOTE: INSTALL SCRIPTS ARE AN ANTIPATTERN
 


### PR DESCRIPTION
Seems that npm run-scripts params order is inverted, see https://github.com/npm/npm/blob/master/lib/run-script.js#L13
