### PR TITLE
Make npm-debug.log path configurable.

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -12,8 +12,9 @@ var cbCalled = false
 
 
 process.on("exit", function (code) {
-  // console.error("exit", code)
   if (!npm.config.loaded) return
+  var logFile = path.resolve(process.cwd(), npm.config.get("log-file") || "npm-debug.log")
+
   if (code) itWorked = false
   if (itWorked) log.info("ok")
   else {
@@ -24,7 +25,7 @@ process.on("exit", function (code) {
     if (wroteLogFile) {
       log.error("", [""
                 ,"Additional logging details can be found in:"
-                ,"    " + path.resolve("npm-debug.log")
+                ,"    " + logFile
                 ].join("\n"))
       wroteLogFile = false
     }
@@ -44,6 +45,8 @@ process.on("exit", function (code) {
 })
 
 function exit (code, noLog) {
+  var logFile = path.resolve(process.cwd(), npm.config.get("log-file") || "npm-debug.log")
+
   exitCode = exitCode || process.exitCode || code
 
   var doExit = npm.config.get("_exit")
@@ -51,7 +54,7 @@ function exit (code, noLog) {
   if (log.level === "silent") noLog = true
 
   if (code && !noLog) writeLogFile(reallyExit)
-  else rm("npm-debug.log", function () { rm(npm.tmp, reallyExit) })
+  else rm(logFile, function () { rm(npm.tmp, reallyExit) })
 
   function reallyExit() {
     // truncate once it's been written.
@@ -317,12 +320,14 @@ function errorHandler (er) {
 
 var writingLogFile = false
 function writeLogFile (cb) {
+  var logFile = path.resolve(process.cwd(), npm.config.get("log-file") || "npm-debug.log")
+
   if (writingLogFile) return cb()
   writingLogFile = true
   wroteLogFile = true
 
   var fs = require("graceful-fs")
-    , fstr = fs.createWriteStream("npm-debug.log")
+    , fstr = fs.createWriteStream(logFile)
     , util = require("util")
     , os = require("os")
     , out = ""

--- a/test/tap/npm-debug-log.js
+++ b/test/tap/npm-debug-log.js
@@ -1,0 +1,95 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var npm = require("../../")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var fs = require('fs')
+var path = require('path')
+
+var PKG_DIR = path.resolve(__dirname, "npm-debug-log")
+var PKG = path.resolve(PKG_DIR, "package.json")
+var LOG = path.resolve(PKG_DIR, "npm-debug.log")
+
+var EXEC_OPTS = {
+  cwd: PKG_DIR,
+  stdio: 'ignore'
+}
+
+var DEFAULT_PKG = {
+  "name": "npm-debug-log-test",
+  "version": "1.2.3",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}
+
+test('setup', function (t) {
+  reset()
+
+  npm.load(function (err) {
+    t.ifError(err)
+    t.end()
+  })
+})
+
+test("does not create npm-debug.log for npm test", function (t) {
+  reset()
+
+  common.npm(['test'], EXEC_OPTS, function (err, code, stdout, stderr) {
+    t.ifError(err)
+    t.notEqual(code, 0, 'exit code should be non-zero')
+    t.ok(!fs.existsSync(LOG), 'log should not be created')
+    t.end()
+  })
+})
+
+test("creates npm-debug.log in current dir for npm run test", function (t) {
+  reset()
+
+  common.npm(['run', 'test'], EXEC_OPTS, function (err, code, stdout, stderr) {
+    t.ifError(err)
+    t.notEqual(code, 0, 'exit code should be non-zero')
+    t.ok(fs.existsSync(LOG), 'log should be created')
+    t.end()
+  })
+})
+
+test("configuring location of npm-debug.log", function (t) {
+  reset()
+  var differentLog = path.resolve(PKG_DIR, 'different.log')
+
+  common.npm(['run', 'test', '--log-file='+differentLog], EXEC_OPTS, function (err, code, stdout, stderr) {
+    t.ifError(err)
+    t.notEqual(code, 0, 'exit code should be non-zero')
+
+    t.ok(fs.existsSync(differentLog), 'log should be created in configured location')
+    t.ok(!fs.existsSync(LOG), 'default log should not exist')
+    t.end()
+  })
+})
+
+test("cleanup", function (t) {
+  reset()
+  t.end()
+})
+
+function reset(extendWith) {
+  fs.readdirSync(PKG_DIR).forEach(function(item) {
+    rimraf.sync(path.resolve(PKG_DIR, item))
+  })
+  var pkg = clone(DEFAULT_PKG)
+  extend(pkg, extendWith)
+  for (key in extend) { pkg[key] = extend[key]}
+  fs.writeFileSync(PKG, JSON.stringify(pkg, null, 2), 'ascii')
+  return pkg
+}
+
+function clone(a) {
+  return extend({}, a)
+}
+
+function extend(a, b) {
+  for (key in b) { a[key] = b[key]}
+  return a
+}
+

--- a/test/tap/npm-debug-log/package.json
+++ b/test/tap/npm-debug-log/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "npm-debug-log-test",
+  "version": "1.2.3",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}


### PR DESCRIPTION
If this is acceptable, I'll send the appropriate PRs for the `npm-log` config in npmconf and add docs.

Allows for location of `npm-debug.log` to be specified:

```
> npm install asdasdas --log-file=/var/log/npm/myapp.log
npm WARN package.json npm-debug-log-test@1.2.3 No description
npm WARN package.json npm-debug-log-test@1.2.3 No repository field.
npm WARN package.json npm-debug-log-test@1.2.3 No README data
npm ERR! 404 404 Not Found: asdasdas
npm ERR! 404
npm ERR! 404 'asdasdas' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it
npm ERR! 404 It was specified as a dependency of 'npm-debug-log-test'
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, or http url, or git url.

npm ERR! System Darwin 13.2.0
npm ERR! command "node" "/Users/timoxley/Projects/libs/npm/bin/npm-cli.js" "install" "asdasdas" "--log-file=/var/log/npm/myapp.log"
npm ERR! cwd /Users/timoxley/Projects/libs/npm/test/tap/npm-debug-log
npm ERR! node -v v0.10.24
npm ERR! npm -v 1.4.10
npm ERR! code E404
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /var/log/npm/myapp.log
npm ERR! not ok code 0
> ls /var/log/npm
myapp.log
```
## Possible Improvements
- a mkdirp on the log directory
- if specify an existing directory, default to writing `npm-debug.log` in that directory.
- alias/rename to `logfile` vs `log-file`
- fallback if it can't write to log just write to default `process.cwd()/npm-debug.log`

Related https://github.com/npm/npm/issues/1548
