### PR TITLE
Don't immediately show spinner on login

### DIFF
--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -15,6 +15,7 @@ try {
 adduser.usage = "npm adduser\nThen enter stuff at the prompts"
 
 function adduser (args, cb) {
+  npm.spinner.stop()
   if (!crypto) return cb(new Error(
     "You must compile node with ssl support to use the adduser feature"))
 
@@ -131,9 +132,10 @@ function save (c, u, cb) {
     registry.username = u.u
     registry.password = u.p
   }
-
+  npm.spinner.start()
   // save existing configs, but yank off for this PUT
   registry.adduser(u.u, u.p, u.e, function (er) {
+    npm.spinner.stop()
     if (er) return cb(er)
     registry.username = u.u
     registry.password = u.p


### PR DESCRIPTION
Currently, the spinner is shown as soon as the username prompt is shown
for `npm login`/`npm adduser`.  This only stops the spinner until the
actual registry request is made.
