### PR TITLE
Correct complexity numbering in npm-faq

### DIFF
--- a/doc/misc/npm-faq.md
+++ b/doc/misc/npm-faq.md
@@ -258,7 +258,7 @@ change it again?  npm doesn't currently track any state about past
 configuration settings, so this would be rather difficult to do
 properly.  It would have to track every previous value for this
 config, and always accept any of them, or else yesterday's install may
-be broken tomorrow.  Complexity hurdle #5.
+be broken tomorrow.  Complexity hurdle #4.
 
 Never going to happen.  The folder is named `node_modules`.  It is
 written indelibly in the Node Way, handed down from the ancient times


### PR DESCRIPTION
Number the complexity hurdles in the "renaming node_modules" section using natural numbers (1, 2, 3, 4) instead of Fibonacci Sequence numbers (1, 2, 3, 5).
