### PR TITLE
fix `npm ls` labeling issue

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -128,8 +128,7 @@ function getLite (data, noname) {
       var dep = data.dependencies[d]
       if (typeof dep === "string") {
         lite.problems = lite.problems || []
-        var p
-        if (data.depth >= maxDepth) {
+        if (data.depth > maxDepth) {
           p = "max depth reached: "
         } else {
           p = "missing: "
@@ -223,14 +222,14 @@ function makeArchy (data, long, dir) {
 function makeArchy_ (data, long, dir, depth, parent, d) {
   var color = npm.color
   if (typeof data === "string") {
-    if (depth < npm.config.get("depth")) {
+    if (depth -1 <= npm.config.get("depth")) {
       // just missing
       var p = parent.link || parent.path
       var unmet = "UNMET DEPENDENCY"
       if (color) {
         unmet = "\033[31;40m" + unmet + "\033[0m"
       }
-      data = unmet + " " + d + " " + data
+      data = unmet + " " + d + "@" + data
     } else {
       data = d+"@"+ data
     }

--- a/test/tap/ls-depth-unmet.js
+++ b/test/tap/ls-depth-unmet.js
@@ -1,0 +1,97 @@
+var common = require('../common-tap')
+  , test = require('tap').test
+  , path = require('path')
+  , rimraf = require('rimraf')
+  , osenv = require('osenv')
+  , mkdirp = require('mkdirp')
+  , pkg = __dirname + '/ls-depth-unmet'
+  , cache = pkg + '/cache'
+  , tmp = pkg + '/tmp'
+  , node = process.execPath
+  , npm = path.resolve(__dirname, '../../cli.js')
+  , mr = require('npm-registry-mock')
+  , opts = {cwd: pkg}
+
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg + '/cache')
+  rimraf.sync(pkg + '/tmp')
+  rimraf.sync(pkg + '/node_modules')
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg + '/cache')
+  mkdirp.sync(pkg + '/tmp')
+  mr(common.port, function (s) {
+    var cmd = ['install', 'underscore@1.3.1', 'mkdirp', 'test-package-with-one-dep', '--registry=' + common.registry]
+    common.npm(cmd, opts, function (er, c) {
+      if (er) throw er
+      t.equal(c, 0)
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test('npm ls --depth=0', function (t) {
+  common.npm(['ls', '--depth=0'], opts, function (er, c, out) {
+    if (er) throw er
+    t.equal(c, 1)
+    t.has(out, /UNMET DEPENDENCY optimist@0\.6\.0/
+      , "output contains optimist@0.6.0 and labeled as unmet dependency")
+    t.has(out, /mkdirp@0\.3\.5 extraneous/
+      , "output contains mkdirp@0.3.5 and labeled as extraneous")
+    t.has(out, /underscore@1\.3\.1 invalid/
+      , "output contains underscore@1.3.1 and labeled as invalid")
+    t.has(out, /test-package-with-one-dep@0\.0\.0\n/
+      , "output contains test-package-with-one-dep@0.0.0 and has no labels")
+    t.doesNotHave(out, /test-package@0\.0\.0/
+      , "output does not contain test-package@0.0.0 which is at depth=1")
+    t.end()
+  })
+})
+
+test('npm ls --depth=1', function (t) {
+  common.npm(['ls', '--depth=1'], opts, function (er, c, out) {
+    if (er) throw er
+    t.equal(c, 1)
+    t.has(out, /UNMET DEPENDENCY optimist@0\.6\.0/
+      , "output contains optimist@0.6.0 and labeled as unmet dependency")
+    t.has(out, /mkdirp@0\.3\.5 extraneous/
+      , "output contains mkdirp@0.3.5 and labeled as extraneous")
+    t.has(out, /underscore@1\.3\.1 invalid/
+      , "output contains underscore@1.3.1 and labeled as invalid")
+    t.has(out, /test-package-with-one-dep@0\.0\.0\n/
+      , "output contains test-package-with-one-dep@0.0.0 and has no labels")
+    t.has(out, /test-package@0\.0\.0/
+      , "output contains test-package@0.0.0 which is at depth=1")
+    t.end()
+  })
+})
+
+test('npm ls --depth=Infinity', function (t) {
+  // travis has a preconfigured depth=0, in general we can not depend
+  // on the default value in all environments, so explictly set it here
+  common.npm(['ls', '--depth=Infinity'], opts, function (er, c, out) {
+    if (er) throw er
+    t.equal(c, 1)
+    t.has(out, /UNMET DEPENDENCY optimist@0\.6\.0/
+      , "output contains optimist@0.6.0 and labeled as unmet dependency")
+    t.has(out, /mkdirp@0\.3\.5 extraneous/
+      , "output contains mkdirp@0.3.5 and labeled as extraneous")
+    t.has(out, /underscore@1\.3\.1 invalid/
+      , "output contains underscore@1.3.1 and labeled as invalid")
+    t.has(out, /test-package-with-one-dep@0\.0\.0\n/
+      , "output contains test-package-with-one-dep@0.0.0 and has no labels")
+    t.has(out, /test-package@0\.0\.0/
+      , "output contains test-package@0.0.0 which is at depth=1")
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})

--- a/test/tap/ls-depth-unmet/package.json
+++ b/test/tap/ls-depth-unmet/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "ls-depth-umnet",
+    "author": "Evan You",
+    "version": "0.0.0",
+    "dependencies": {
+        "test-package-with-one-dep": "0.0.0",
+        "underscore": "1.5.1",
+        "optimist": "0.6.0"
+    }
+}


### PR DESCRIPTION
**NOTE**: This patch requires the `read-installed` package to be updated as well to pass the tests. See https://github.com/npm/read-installed/pull/24

Old problem from #4179: when a dependency's depth equals the specified max depth, it does not get properly labeled as "Unmet dependency", "invalid" or "extraneous".

This problem stems from the `read-installed` package which is not handling this edge case properly. It simply returns a string with no problem information when depth==maxDepth.
