### PR TITLE
Include alias run in run-script doc.

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -4,6 +4,7 @@ npm-run-script(1) -- Run arbitrary package scripts
 ## SYNOPSIS
 
     npm run-script [<pkg>] [command]
+    npm run [<pkg>] [command]
 
 ## DESCRIPTION
 


### PR DESCRIPTION
Scripts can be run as both `npm run-script` and `npm run`, but I couldn't find a succinct reference linking the two in the docs. This provides that (assuming it did not already exist).
