### PR TITLE
Document pre/post script behavior definition.

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -36,6 +36,9 @@ following scripts:
 Additionally, arbitrary scripts can be run by doing
 `npm run-script <pkg> <stage>`.
 
+Arbitrary scripts can also have BEFORE and AFTER behavior,  defined by
+including `pre<stage>` and `post<stage>` scripts in the package.json.
+
 ## NOTE: INSTALL SCRIPTS ARE AN ANTIPATTERN
 
 **tl;dr** Don't use `install`.  Use a `.gyp` file for compilation, and


### PR DESCRIPTION
Any script can have pre/post scripts, as _lib/run-script.js_ will parse the package.json and run them in the correct order (_line 125_).

This is undocumented, although it is used in at least one prominent repo ([angularjs tutorial](https://github.com/angular/angular-phonecat/blob/master/package.json)).

This documents this feature so that it's behavior can be referenced.
