### PR TITLE
doc: npm-explore can't handle a version

### DIFF
--- a/doc/cli/npm-explore.md
+++ b/doc/cli/npm-explore.md
@@ -3,7 +3,7 @@ npm-explore(1) -- Browse an installed package
 
 ## SYNOPSIS
 
-    npm explore <name>[@<version>] [ -- <cmd>]
+    npm explore <name> [ -- <cmd>]
 
 ## DESCRIPTION
 


### PR DESCRIPTION
Closes #5323

The current implementation of explore can not handle different versions:

``` javascript
function explore (args, cb) {
  if (args.length < 1 || !args[0]) return cb(explore.usage)
  var p = args.shift()
  args = args.join(" ").trim()
  if (args) args = ["-c", args]
  else args = []

  var cwd = path.resolve(npm.dir, p)
  var sh = npm.config.get("shell")
  fs.stat(cwd, function (er, s) {
    if (er || !s.isDirectory()) return cb(new Error(
      "It doesn't look like "+p+" is installed."))
    if (!args.length) console.log(
      "\nExploring "+cwd+"\n"+
      "Type 'exit' or ^D when finished\n")

    npm.spinner.stop()
    var shell = spawn(sh, args, { cwd: cwd, customFds: [0, 1, 2] })
    shell.on("close", function (er) {
      // only fail if non-interactive.
      if (!args.length) return cb()
      cb(er)
    })
  })
}
```
