### PR TITLE
install: let preinstall can update package.json

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -119,71 +119,81 @@ function install (args, cb_) {
     })
   }
 
-  mkdir(where, function (er, made) {
+  preinstall(where, function(er) {
     if (er) return cb(er)
-    // install dependencies locally by default,
-    // or install current folder globally
-    if (!args.length) {
-      var opt = { dev: npm.config.get("dev") || !npm.config.get("production") }
+    mkdir(where, function (er, made) {
+      if (er) return cb(er)
+      // install dependencies locally by default,
+      // or install current folder globally
+      if (!args.length) {
+        var opt = { dev: npm.config.get("dev") || !npm.config.get("production") }
 
-      if (npm.config.get("global")) args = ["."]
-      else return readDependencies(null, where, opt, function (er, data) {
-        if (er) {
-          log.error("install", "Couldn't read dependencies")
-          return cb(er)
-        }
-        var deps = Object.keys(data.dependencies || {})
-        log.verbose("install", "where, deps", [where, deps])
+        if (npm.config.get("global")) args = ["."]
+        else return readDependencies(null, where, opt, function (er, data) {
+          if (er) {
+            log.error("install", "Couldn't read dependencies")
+            return cb(er)
+          }
+          var deps = Object.keys(data.dependencies || {})
+          log.verbose("install", "where, deps", [where, deps])
+          var context = { family: {}
+                        , ancestors: {}
+                        , explicit: false
+                        , parent: data
+                        , root: true
+                        , wrap: null }
+
+          if (data.name === path.basename(where) &&
+              path.basename(path.dirname(where)) === "node_modules") {
+            // Only include in ancestry if it can actually be required.
+            // Otherwise, it does not count.
+            context.family[data.name] =
+              context.ancestors[data.name] = data.version
+          }
+
+          installManyTop(deps.map(function (dep) {
+            var target = data.dependencies[dep]
+              , parsed = url.parse(target.replace(/^git\+/, "git"))
+            target = dep + "@" + target
+            return target
+          }), where, context, function(er, results) {
+            if (er) return cb(er, results)
+            lifecycle(data, "prepublish", where, function(er) {
+              return cb(er, results)
+            })
+          })
+        })
+      }
+
+      // initial "family" is the name:version of the root, if it's got
+      // a package.json file.
+      var jsonFile = path.resolve(where, "package.json")
+      readJson(jsonFile, log.warn, function (er, data) {
+        if (er
+            && er.code !== "ENOENT"
+            && er.code !== "ENOTDIR") return cb(er)
+        if (er) data = null
         var context = { family: {}
                       , ancestors: {}
-                      , explicit: false
+                      , explicit: true
                       , parent: data
                       , root: true
                       , wrap: null }
-
-        if (data.name === path.basename(where) &&
+        if (data && data.name === path.basename(where) &&
             path.basename(path.dirname(where)) === "node_modules") {
-          // Only include in ancestry if it can actually be required.
-          // Otherwise, it does not count.
-          context.family[data.name] =
-            context.ancestors[data.name] = data.version
+          context.family[data.name] = context.ancestors[data.name] = data.version
         }
-
-        installManyTop(deps.map(function (dep) {
-          var target = data.dependencies[dep]
-            , parsed = url.parse(target.replace(/^git\+/, "git"))
-          target = dep + "@" + target
-          return target
-        }), where, context, function(er, results) {
-          if (er) return cb(er, results)
-          lifecycle(data, "prepublish", where, function(er) {
-            return cb(er, results)
-          })
-        })
+        var fn = npm.config.get("global") ? installMany : installManyTop
+        fn(args, where, context, cb)
       })
-    }
-
-    // initial "family" is the name:version of the root, if it's got
-    // a package.json file.
-    var jsonFile = path.resolve(where, "package.json")
-    readJson(jsonFile, log.warn, function (er, data) {
-      if (er
-          && er.code !== "ENOENT"
-          && er.code !== "ENOTDIR") return cb(er)
-      if (er) data = null
-      var context = { family: {}
-                    , ancestors: {}
-                    , explicit: true
-                    , parent: data
-                    , root: true
-                    , wrap: null }
-      if (data && data.name === path.basename(where) &&
-          path.basename(path.dirname(where)) === "node_modules") {
-        context.family[data.name] = context.ancestors[data.name] = data.version
-      }
-      var fn = npm.config.get("global") ? installMany : installManyTop
-      fn(args, where, context, cb)
     })
+  })
+}
+
+function preinstall (where, cb) {
+  readJson(path.join(where, "package.json"), log.warn, function (er, data) {
+    if (er) return cb(er)
+    lifecycle(data, "preinstall", where, cb)
   })
 }
 
@@ -245,6 +255,7 @@ function readDependencies (context, where, opts, cb) {
 
   readJson( path.resolve(where, "package.json")
           , log.warn
+          , false, false  // avoid cache
           , function (er, data) {
     if (er && er.code === "ENOENT") er.code = "ENOPACKAGEJSON"
     if (er)  return cb(er)


### PR DESCRIPTION
hi, @npm, I created this module [npm-private-cli](https://github.com/yorkie/npm-private-cli) that would update the `dependencies` of my package.json, AND i post this script into my preinstall of scripts in package.json:

``` JSON
{
  "scripts": { "preinstall": "npm-private -u yorkie -p xxx" }
}
```

Then the result what I except is not in my shell, `preinstall` script had updated my package.json, but `npm install` always use the old version of the package.json, then I notice that you enable the cache in your `readJson` module/function, so I think the correct or what user expected is `npm install` should use the latest package.json(disabled cache).

Also, I would make a PR for your `read-package-json` module to enable a cache control argument.
:)
