### PR TITLE
Added configuration --proxy-excludes

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -570,6 +570,18 @@ this as true.
 
 A proxy to use for outgoing http requests.
 
+### proxy-excludes
+
+* Default: `null`
+* Type: String
+
+Indicates the hosts that should be accessed without going through the 
+proxy. Typically this defines internal hosts. 
+
+"*.foo.com, localhost" will indicate that every hosts in the foo.com 
+domain and the localhost should be accessed directly even if a proxy 
+server is specified.
+
 ### rebuild-bundle
 
 * Default: true

--- a/lib/utils/fetch.js
+++ b/lib/utils/fetch.js
@@ -77,6 +77,17 @@ function makeRequest (remote, fstr, headers) {
   var proxy
   if (remote.protocol !== "https:" || !(proxy = npm.config.get("https-proxy"))) {
     proxy = npm.config.get("proxy")
+    
+    // Check if we have an exclude list
+    var nonProxyHostsConfig = npm.config.get("proxy-excludes");
+    if (nonProxyHostsConfig) {
+      var nonProxyHosts = nonProxyHostsConfig.split(",");
+      nonProxyHosts.forEach(function(proxyHost) {
+        if (new RegExp(proxyHost.trim().replace("*", "(.*)")).test(remote.host)) {
+          proxy = null;
+        }
+      })
+    }
   }
 
   var sessionToken = npm.registry.sessionToken


### PR DESCRIPTION
npm config set --proxy-excludes="*.foo.com,localhost"
will indicate that every hosts in the foo.com domain and the localhost should be accessed directly even if a proxy server is specified.
