### PR TITLE
Fixes: #5376, errbacks called before accessing nonexistent objects

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -273,13 +273,13 @@ npm.load = function (cli, cb_) {
   var onload = true
 
   function cb (er) {
-    if (loadErr) return
+    if (loadErr = er) return loadCb(loadErr);
     if (npm.config.get("force")) {
       log.warn("using --force", "I sure hope you know what you are doing.")
     }
     npm.config.loaded = true
     loaded = true
-    loadCb(loadErr = er)
+    loadCb(loadErr)
     if (onload = onload && npm.config.get("onload-script")) {
       require(onload)
       onload = false
@@ -305,6 +305,7 @@ function load (npm, cli, cb) {
     var builtin = path.resolve(__dirname, "..", "npmrc")
     npmconf.load(cli, builtin, function (er, config) {
       if (er === config) er = null
+      if (er) return cb(er)
 
       // Include npm-version and node-version in user-agent
       var ua = config.get("user-agent") || ""
@@ -325,9 +326,7 @@ function load (npm, cli, cb) {
         case "always": log.enableColor(); break
         case false: log.disableColor(); break
       }
-      log.resume()
-
-      if (er) return cb(er)
+      log.resume()        
 
       // see if we need to color normal output
       switch (color) {


### PR DESCRIPTION
This is just a simple patch to prevent the crash and make the actual error more visible.
