### PR TITLE
Use `npm.config.get('prefix')` instead of `globalPrefix` getter

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -355,8 +355,7 @@ function load (npm, cli, cb) {
                   , file: 0666 & (~umask)
                   , umask: umask }
 
-      var gp = Object.getOwnPropertyDescriptor(config, "globalPrefix")
-      Object.defineProperty(npm, "globalPrefix", gp)
+      npm.globalPrefix = npm.config.get('prefix')
 
       var lp = Object.getOwnPropertyDescriptor(config, "localPrefix")
       Object.defineProperty(npm, "localPrefix", lp)


### PR DESCRIPTION
`defaults` getter in  `npmconf`'s `config-defs.js` covers all the cases
we need for global prefix resolution, while the getter didn't even load
the config file before determining the global prefix.

`globalPrefix` getter remains unused and should be removed from
`npmconf`.

Fixes #5343.
