### PR TITLE
Expect sanity from Linux in  `lifecycle-signal-test`

### DIFF
--- a/test/tap/lifecycle-signal.js
+++ b/test/tap/lifecycle-signal.js
@@ -13,13 +13,6 @@ test("lifecycle signal abort", function (t) {
     cwd: pkg
   })
   child.on("close", function (code, signal) {
-    // GNU shell returns a code, no signal
-    if (process.platform === "linux") {
-      t.equal(code, 1)
-      t.equal(signal, null)
-      return t.end()
-    }
-
     t.equal(code, null)
     t.equal(signal, "SIGSEGV")
     t.end()


### PR DESCRIPTION
Do not expect Linux to return 1 as error code and no signal indication
when child is killed by SIGSEGV.

I'm sure there was a reason behind this, so just throwing it out here for a review.
