### PR TITLE
Allow to build all the docs OOTB.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ npm-debug.log
 /test/packages/npm-test-depends-on-spark/which-spark.log
 /test/packages/test-package/random-data.txt
 /test/root
+node_modules/marked
 node_modules/ronn
 node_modules/tap
 node_modules/.bin

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ dev: install
 link: uninstall
 	node cli.js link -f
 
-clean: ronnclean doc-clean uninstall
+clean: markedclean ronnclean doc-clean uninstall
 	rm -rf npmrc
 	node cli.js cache clean
 
@@ -78,12 +78,16 @@ uninstall:
 
 doc: $(mandocs) $(htmldocs)
 
+markedclean:
+	rm -rf node_modules/marked node_modules/.bin/marked .building_marked
+
 ronnclean:
 	rm -rf node_modules/ronn node_modules/.bin/ronn .building_ronn
 
 docclean: doc-clean
 doc-clean:
 	rm -rf \
+    .building_marked \
     .building_ronn \
     html/doc \
     html/api \
@@ -149,6 +153,10 @@ html/doc/misc/%.html: doc/misc/%.md $(html_docdeps)
 	scripts/doc-build.sh $< $@
 
 
+marked: node_modules/.bin/marked
+
+node_modules/.bin/marked:
+	node cli.js install marked --no-global
 
 ronn: node_modules/.bin/ronn
 

--- a/scripts/doc-build.sh
+++ b/scripts/doc-build.sh
@@ -32,6 +32,32 @@ if ! [ -x node_modules/.bin/ronn ]; then
   fi
 fi
 
+if ! [ -x node_modules/.bin/marked ]; then
+  ps=0
+  if [ -f .building_marked ]; then
+    pid=$(cat .building_marked)
+    ps=$(ps -p $pid | grep $pid | wc -l) || true
+  fi
+
+  if [ -f .building_marked ] && [ $ps != 0 ]; then
+    while [ -f .building_marked ]; do
+      sleep 1
+    done
+  else
+    # a race to see which make process will be the one to install marked
+    echo $$ > .building_marked
+    sleep 1
+    if [ $(cat .building_marked) == $$ ]; then
+      make node_modules/.bin/marked
+      rm .building_marked
+    else
+      while [ -f .building_marked ]; do
+        sleep 1
+      done
+    fi
+  fi
+fi
+
 src=$1
 dest=$2
 name=$(basename ${src%.*})


### PR DESCRIPTION
Since 1.4.10, the html docs are generated via the marked module. When
doing the usual "make" dance, the build process stops when attempting to
generate the first html doc complaining about a missing
node_modules/.bin/marked.

This patch is a quick'n'dirty copy-pasta of the treatment applied to
load the ronn module but applied to marked. When applied against the
1.4.13 tarball it allows -- at least in a works-for-me manner -- to
generate all the docs.
