### PR TITLE
Display spinner for install and update only

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -718,8 +718,8 @@ for this to work properly.
 * Default: true
 * Type: Boolean or `"always"`
 
-When set to `true`, npm will display an ascii spinner while it is doing
-things, if `process.stderr` is a TTY.
+When set to `true`, npm will display an ascii spinner while installing
+and/or updating things, if `process.stderr` is a TTY.
 
 Set to `false` to suppress the spinner, or set to `always` to output
 the spinner even for non-TTY outputs.

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -156,6 +156,11 @@ var commandCache = {}
                , "substack"
                , "visnup"
                ]
+  , spinCmds = [ "install"
+               , "i"
+               , "update"
+               , "up"
+               ]
   , fullList = npm.fullList = cmdList.concat(aliasNames).filter(function (c) {
       return plumbing.indexOf(c) === -1
     })
@@ -199,7 +204,7 @@ Object.keys(abbrevs).concat(plumbing).forEach(function addCommand (c) {
       }
       if (args.length === 1) args.unshift([])
 
-      npm.spinner.start()
+      if (spinCmds.indexOf(c) > -1) npm.spinner.start()
 
       npm.registry.version = npm.version
       if (!npm.registry.refer) {


### PR DESCRIPTION
Fixes #5363, limits spinner display to `install` and `update` commands (and their aliases) only.
