### PR TITLE
Fix development dependency is preferred over dependency.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -252,7 +252,13 @@ function readDependencies (context, where, opts, cb) {
     if (opts && opts.dev) {
       if (!data.dependencies) data.dependencies = {}
       Object.keys(data.devDependencies || {}).forEach(function (k) {
-        data.dependencies[k] = data.devDependencies[k]
+        if (data.dependencies[k]) {
+          log.warn("package.json", "Dependency '%s' exists in both dependencies " +
+                   "and devDependencies, using '%s@%s' from dependencies",
+                    k, k, data.dependencies[k])
+        } else {
+          data.dependencies[k] = data.devDependencies[k]
+        }
       })
     }
 

--- a/test/tap/dev-dep-duplicate/desired-ls-results.json
+++ b/test/tap/dev-dep-duplicate/desired-ls-results.json
@@ -1,0 +1,9 @@
+{
+  "name": "dev-dep-duplicate",
+  "version": "0.0.0",
+  "dependencies": {
+    "underscore": {
+      "version": "1.5.1"
+    }
+  }
+}

--- a/test/tap/dev-dep-duplicate/package.json
+++ b/test/tap/dev-dep-duplicate/package.json
@@ -1,0 +1,11 @@
+{
+  "author": "Anders Janmyr",
+  "name": "dev-dep-duplicate",
+  "version": "0.0.0",
+  "dependencies": {
+    "underscore": "1.5.1"
+  },
+  "devDependencies": {
+    "underscore": "1.3.1"
+  }
+}

--- a/test/tap/install-with-dev-dep-duplicate.js
+++ b/test/tap/install-with-dev-dep-duplicate.js
@@ -1,0 +1,57 @@
+var npm = npm = require("../../")
+var test = require("tap").test
+var path = require("path")
+var fs = require("fs")
+var osenv = require("osenv")
+var rimraf = require("rimraf")
+var mr = require("npm-registry-mock")
+var common = require("../common-tap.js")
+
+var pkg = path.resolve(__dirname, "dev-dep-duplicate")
+var desiredResultsPath = path.resolve(pkg, "desired-ls-results.json")
+
+test("prefers version from dependencies over devDependencies", function (t) {
+  t.plan(1)
+
+  mr(common.port, function (s) {
+    setup(function (err) {
+      if (err) return t.fail(err)
+
+      npm.install(".", function (err) {
+        if (err) return t.fail(err)
+
+        npm.commands.ls([], true, function (err, _, results) {
+          if (err) return t.fail(err)
+
+          fs.readFile(desiredResultsPath, function (err, desired) {
+            if (err) return t.fail(err)
+
+            t.deepEqual(results, JSON.parse(desired))
+            s.close()
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  cleanup()
+  t.end()
+})
+
+
+function setup (cb) {
+  cleanup()
+  process.chdir(pkg)
+
+  var opts = { cache: path.resolve(pkg, "cache"), registry: common.registry};
+  npm.load(opts, cb)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(path.resolve(pkg, "node_modules"))
+  rimraf.sync(path.resolve(pkg, "cache"))
+}


### PR DESCRIPTION
If a dependency occurs in both the `dependencies` and the `devDependencies`
sections of package.json, npm should prefer the version from the `dependencies`
section since it is what is used when installed with `--production`

A warning is issued with information about what version is used.

A brief discussion can be found in this comment.
https://github.com/npm/npm/issues/5403#issuecomment-45278489
