### PR TITLE
#5101 Add cases for ENOSPC and EROFS to display user-friendly error

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -265,17 +265,18 @@ function errorHandler (er) {
                 +JSON.stringify({npm:npm.version
                                 ,node:npm.config.get("node-version")})
                 ].join("\n"))
+    }
       break
 
   case "ENOSPC":
-    log.error("network", [er.message
+    log.error("nospc", [er.message
               ,"This is most likely not a problem with npm itself"
               ,"and is related to insufficient space on your system."
               ].join("\n"))
     break
 
   case "EROFS":
-    log.error("network", [er.message
+    log.error("rofs", [er.message
               ,"This is most likely not a problem with npm itself"
               ,"and is related to read-only permissions."
               ,"\nVerify that you have write access to the directory"

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -266,6 +266,21 @@ function errorHandler (er) {
                                 ,node:npm.config.get("node-version")})
                 ].join("\n"))
       break
+
+  case "ENOSPC":
+    log.error("network", [er.message
+              ,"This is most likely not a problem with npm itself"
+              ,"and is related to insufficient space on your system."
+              ].join("\n"))
+    break
+
+  case "EROFS":
+    log.error("network", [er.message
+              ,"This is most likely not a problem with npm itself"
+              ,"and is related to read-only permissions."
+              ,"\nVerify that you have write access to the directory"
+              ].join("\n"))
+    break
     } // else passthrough
 
   default:

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -279,7 +279,7 @@ function errorHandler (er) {
     log.error("rofs", [er.message
               ,"This is most likely not a problem with npm itself"
               ,"and is related to read-only permissions."
-              ,"\nVerify that you have write access to the directory"
+              ,"\nVerify that the file system is not read-only."
               ].join("\n"))
     break
 

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -265,8 +265,8 @@ function errorHandler (er) {
                 +JSON.stringify({npm:npm.version
                                 ,node:npm.config.get("node-version")})
                 ].join("\n"))
-    }
       break
+    } // else passthrough
 
   case "ENOSPC":
     log.error("nospc", [er.message
@@ -282,7 +282,6 @@ function errorHandler (er) {
               ,"\nVerify that you have write access to the directory"
               ].join("\n"))
     break
-    } // else passthrough
 
   default:
     log.error("", er.stack || er.message || er)


### PR DESCRIPTION
Do these errors require an error code associated with them?
