### PR TITLE
Use the npm logger thats configurable

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -99,7 +99,7 @@ function install (args, cb_) {
       var tree = treeify(installed || [])
         , pretty = prettify(tree, installed).trim()
 
-      if (pretty) console.log(pretty)
+      if (pretty) log.warn(pretty)
       save(where, installed, tree, pretty, hasArguments, cb_)
     })
   }

--- a/lib/install.js
+++ b/lib/install.js
@@ -99,7 +99,9 @@ function install (args, cb_) {
       var tree = treeify(installed || [])
         , pretty = prettify(tree, installed).trim()
 
-      if (pretty) log.warn(pretty)
+      if (pretty && log.levels[log.level] <= log.levels.warn) {
+        console.log(pretty)
+      }
       save(where, installed, tree, pretty, hasArguments, cb_)
     })
   }

--- a/test/tap/install-cli-unicode.js
+++ b/test/tap/install-cli-unicode.js
@@ -15,12 +15,15 @@ function hasOnlyAscii (s) {
 test('does not use unicode with --unicode false', function (t) {
   t.plan(3)
   mr(common.port, function (s) {
+    process.env.npm_config_loglevel = ''
     exec('node ' + NPM_BIN + ' install --unicode false read', {
       cwd: pkg
     }, function(err, stdout) {
       t.ifError(err)
       t.ok(stdout, stdout.length)
       t.ok(hasOnlyAscii(stdout))
+
+      process.env.npm_config_loglevel = 'error'
       s.close()
     })
   })

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -34,7 +34,7 @@ test("it should not throw", function (t) {
   mr(common.port, function (s) {
     npm.load({
       cache: pkg + "/cache",
-      loglevel: 'silent',
+      loglevel: 'warn',
       parseable: true,
       registry: common.registry }
     , function () {


### PR DESCRIPTION
npm should respect the configuration loglevel. i.e. when running with loglevel silent or error it should not write to stdout.

This means it shouldnt print the result of `install` to stdout.
