### PR TITLE
Fix small typo in synopsis in npm-link.md.

### DIFF
--- a/doc/api/npm-link.md
+++ b/doc/api/npm-link.md
@@ -3,8 +3,8 @@ npm-link(3) -- Symlink a package folder
 
 ## SYNOPSIS
 
-    npm.command.link(callback)
-    npm.command.link(packages, callback)
+    npm.commands.link(callback)
+    npm.commands.link(packages, callback)
 
 ## DESCRIPTION
 


### PR DESCRIPTION
Fix small typo (add 's') in command's synopsis in npm-link.md.
