### PR TITLE
Passing args into run-scripts

### DIFF
--- a/doc/cli/npm-restart.md
+++ b/doc/cli/npm-restart.md
@@ -3,7 +3,7 @@ npm-restart(1) -- Start a package
 
 ## SYNOPSIS
 
-    npm restart <name>
+    npm restart [-- <args>]
 
 ## DESCRIPTION
 

--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -3,8 +3,8 @@ npm-run-script(1) -- Run arbitrary package scripts
 
 ## SYNOPSIS
 
-    npm run-script [<pkg>] [command]
-    npm run [<pkg>] [command]
+    npm run-script [command] [-- <args>]
+    npm run [command] [-- <args>]
 
 ## DESCRIPTION
 

--- a/doc/cli/npm-start.md
+++ b/doc/cli/npm-start.md
@@ -3,7 +3,7 @@ npm-start(1) -- Start a package
 
 ## SYNOPSIS
 
-    npm start <name>
+    npm start [-- <args>]
 
 ## DESCRIPTION
 

--- a/doc/cli/npm-stop.md
+++ b/doc/cli/npm-stop.md
@@ -3,7 +3,7 @@ npm-stop(1) -- Stop a package
 
 ## SYNOPSIS
 
-    npm stop <name>
+    npm stop [-- <args>]
 
 ## DESCRIPTION
 

--- a/doc/cli/npm-test.md
+++ b/doc/cli/npm-test.md
@@ -3,8 +3,8 @@ npm-test(1) -- Test a package
 
 ## SYNOPSIS
 
-      npm test <name>
-      npm tst <name>
+      npm test [-- <args>]
+      npm tst [-- <args>]
 
 ## DESCRIPTION
 

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -8,7 +8,7 @@ var lifecycle = require("./utils/lifecycle.js")
   , log = require("npmlog")
   , chain = require("slide").chain
 
-runScript.usage = "npm run-script [<pkg>] <command>"
+runScript.usage = "npm run-script <command> [-- <args>]"
 
 runScript.completion = function (opts, cb) {
 
@@ -69,13 +69,13 @@ runScript.completion = function (opts, cb) {
 
 function runScript (args, cb) {
   if (!args.length) return list(cb)
-  var pkgdir = args.length === 1 ? process.cwd()
-             : path.resolve(npm.dir, args[0])
-    , cmd = args.pop()
+
+  var pkgdir = process.cwd()
+    , cmd = args.shift()
 
   readJson(path.resolve(pkgdir, "package.json"), function (er, d) {
     if (er) return cb(er)
-    run(d, pkgdir, cmd, cb)
+    run(d, pkgdir, cmd, args, cb)
   })
 }
 
@@ -109,7 +109,7 @@ function list(cb) {
   })
 }
 
-function run (pkg, wd, cmd, cb) {
+function run (pkg, wd, cmd, args, cb) {
   var cmds = []
   if (!pkg.scripts) pkg.scripts = {}
   if (cmd === "restart") {
@@ -124,6 +124,11 @@ function run (pkg, wd, cmd, cb) {
   }
   log.verbose("run-script", cmds)
   chain(cmds.map(function (c) {
+    // pass cli arguments after -- to script.
+    if (args.length && pkg.scripts[c]) {
+      pkg.scripts[c] = pkg.scripts[c] + " " + args.join(" ")
+    }
+
     // when running scripts explicitly, assume that they're trusted.
     return [lifecycle, pkg, c, wd, true]
   }), cb)

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -349,13 +349,9 @@ function makeEnv (data, prefix, env) {
 
 function cmd (stage) {
   function CMD (args, cb) {
-    if (args.length) {
-      chain(args.map(function (p) {
-        return [npm.commands, "run-script", [p, stage]]
-      }), cb)
-    } else npm.commands["run-script"]([stage], cb)
+    npm.commands["run-script"]([stage].concat(args), cb)
   }
-  CMD.usage = "npm "+stage+" <name>"
+  CMD.usage = "npm "+stage+" [-- <args>]"
   var installedShallow = require("./completion/installed-shallow.js")
   CMD.completion = function (opts, cb) {
     installedShallow(opts, function (d) {

--- a/test/run.js
+++ b/test/run.js
@@ -7,7 +7,7 @@ var path = require("path")
   , testdir = __dirname
   , fs = require("graceful-fs")
   , npmpkg = path.dirname(testdir)
-  , npmcli = path.join(__dirname, "bin", "npm-cli.js")
+  , npmcli = path.resolve(npmpkg, "bin", "npm-cli.js")
 
 var temp = process.env.TMPDIR
          || process.env.TMP
@@ -63,7 +63,7 @@ function prefix (content, pref) {
 }
 
 var execCount = 0
-function exec (cmd, shouldFail, cb) {
+function exec (cmd, cwd, shouldFail, cb) {
   if (typeof shouldFail === "function") {
     cb = shouldFail, shouldFail = false
   }
@@ -81,7 +81,7 @@ function exec (cmd, shouldFail, cb) {
   cmd = cmd.replace(/^npm /, npmReplace + " ")
   cmd = cmd.replace(/^node /, nodeReplace + " ")
 
-  child_process.exec(cmd, {env: env}, function (er, stdout, stderr) {
+  child_process.exec(cmd, {cwd: cwd, env: env}, function (er, stdout, stderr) {
     if (stdout) {
       console.error(prefix(stdout, " 1> "))
     }
@@ -102,10 +102,8 @@ function exec (cmd, shouldFail, cb) {
 }
 
 function execChain (cmds, cb) {
-  chain(cmds.reduce(function (l, r) {
-    return l.concat(r)
-  }, []).map(function (cmd) {
-    return [exec, cmd]
+  chain(cmds.map(function (args) {
+    return [exec].concat(args)
   }), cb)
 }
 
@@ -118,9 +116,8 @@ function flatten (arr) {
 function setup (cb) {
   cleanup(function (er) {
     if (er) return cb(er)
-    execChain([ "node \""+path.resolve(npmpkg, "bin", "npm-cli.js")
-              + "\" install \""+npmpkg+"\""
-              , "npm config set package-config:foo boo"
+    execChain([ [ "node \""+npmcli+"\" install \""+npmpkg+"\"", root ],
+                [ "npm config set package-config:foo boo",  root ]
               ], cb)
   })
 }
@@ -134,6 +131,7 @@ function main (cb) {
   failures = 0
 
   process.chdir(testdir)
+  var base = path.resolve(root, path.join("lib", "node_modules"))
 
   // get the list of packages
   var packages = fs.readdirSync(path.resolve(testdir, "packages"))
@@ -150,17 +148,17 @@ function main (cb) {
       packagesToRm.push("npm")
     }
 
-    chain
-      ( [ setup
-        , [ exec, "npm install "+npmpkg ]
+    chain(
+        [ setup
+        , [ exec, "npm install "+npmpkg, testdir ]
         , [ execChain, packages.map(function (p) {
-              return "npm install packages/"+p
+              return [ "npm install packages/"+p, testdir ]
             }) ]
         , [ execChain, packages.map(function (p) {
-              return "npm test "+p
+              return [ "npm test", path.resolve(base, p) ]
             }) ]
         , [ execChain, packagesToRm.map(function (p) {
-              return "npm rm " + p
+              return [ "npm rm "+p, root ]
             }) ]
         , installAndTestEach
         ]
@@ -171,15 +169,15 @@ function main (cb) {
   function installAndTestEach (cb) {
     var thingsToChain = [
         setup
-        , [ execChain, packages.map(function (p) {
-              return [ "npm install packages/"+p
-                     , "npm test "+p
-                     , "npm rm "+p ]
-            }) ]
+        , [ execChain, flatten(packages.map(function (p) {
+              return [ [ "npm install packages/"+p, testdir ]
+                     , [ "npm test", path.resolve(base, p) ]
+                     , [ "npm rm "+p, root ] ]
+            })) ]
       ]
     if (process.platform !== "win32") {
       // Windows can't handle npm rm npm due to file-in-use issues.
-      thingsToChain.push([exec, "npm rm npm"])
+      thingsToChain.push([exec, "npm rm npm", testdir])
     }
 
     chain(thingsToChain, cb)

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -1,0 +1,50 @@
+var common = require('../common-tap')
+  , test = require('tap').test
+  , path = require('path')
+  , spawn = require('child_process').spawn
+  , rimraf = require('rimraf')
+  , mkdirp = require('mkdirp')
+  , pkg = __dirname + '/run-script'
+  , cache = pkg + '/cache'
+  , tmp = pkg + '/tmp'
+  , node = process.execPath
+  , npm = path.resolve(__dirname, '../../cli.js')
+  , opts = { cwd: pkg }
+
+function testOutput (t, command, er, code, stdout, stderr) {
+  if (er)
+    throw er
+
+  if (stderr)
+    throw new Error('npm ' + command + ' stderr: ' + stderr.toString())
+
+  stdout = stdout.trim().split('\n')
+  stdout = stdout[stdout.length - 1]
+  t.equal(stdout, command)
+  t.end()
+}
+
+function cleanup () {
+  rimraf.sync(pkg + '/cache')
+  rimraf.sync(pkg + '/tmp')
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg + '/cache')
+  mkdirp.sync(pkg + '/tmp')
+  t.end()
+})
+
+test('npm run-script', function (t) {
+  common.npm(['run-script', 'start'], opts, testOutput.bind(null, t, "start"))
+})
+
+test('npm run-script with args', function (t) {
+  common.npm(["run-script", "start", "--", "-e 'console.log(\"stop\")'"], opts, testOutput.bind(null, t, "stop"))
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})

--- a/test/tap/run-script/package.json
+++ b/test/tap/run-script/package.json
@@ -1,0 +1,6 @@
+{"name":"runscript"
+,"version":"1.2.3"
+,"scripts":{
+  "start":"node -e 'console.log(\"start\")'"
+  }
+}


### PR DESCRIPTION
this is the start of an approach for passing arguments into run-scripts that @isaacs and I have been talking about. It allows you to run:

`npm run-script start -- --foo=3`

The problem is that it breaks the ability to run a script in the context of a package, e.g., `npm start <package> <package> <package>`, `npm run-script start <package>`.

We will still have the ability to run commands in the context of another package, with with the syntax:

`npm explore <pkg> -- run test`, which seems like a reasonable compromise

thoughts

See #3494 
