### PR TITLE
replace escape codes with ansicolors

### DIFF
--- a/lib/help-search.js
+++ b/lib/help-search.js
@@ -6,6 +6,7 @@ var fs = require("graceful-fs")
   , asyncMap = require("slide").asyncMap
   , npm = require("./npm.js")
   , glob = require("glob")
+  , color = require("ansicolors")
 
 helpSearch.usage = "npm help-search <text>"
 
@@ -167,7 +168,7 @@ function formatResults (args, results, cb) {
         }).join(" ")
 
     out += ((new Array(Math.max(1, cols - out.length - r.length)))
-             .join (" ")) + r
+             .join(" ")) + r
 
     if (!npm.config.get("long")) return out
 
@@ -177,26 +178,21 @@ function formatResults (args, results, cb) {
       if (line === null || i > 3) return ""
       for (var out = line, a = 0, l = args.length; a < l; a ++) {
         var finder = out.toLowerCase().split(args[a].toLowerCase())
-          , newOut = []
+          , newOut = ""
           , p = 0
+
         finder.forEach(function (f) {
-          newOut.push( out.substr(p, f.length)
-                     , "\1"
-                     , out.substr(p + f.length, args[a].length)
-                     , "\2" )
+          newOut += out.substr(p, f.length)
+
+          var hilit = out.substr(p + f.length, args[a].length)
+          if (npm.color) hilit = color.bgBlack(color.red(hilit))
+          newOut += hilit
+
           p += f.length + args[a].length
         })
-        out = newOut.join("")
       }
-      var color = ""
-        , reset = ""
-      if (npm.color) {
-        color = "\033[31;40m"
-        reset = "\033[0m"
-      }
-      out = out.split("\1").join(color)
-               .split("\2").join(reset)
-      return out
+
+      return newOut
     }).join("\n").trim()
     return out
   }).join("\n")

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -15,6 +15,7 @@ var npm = require("./npm.js")
   , semver = require("semver")
   , url = require("url")
   , isGitUrl = require("./utils/is-git-url.js")
+  , color = require("ansicolors")
 
 ls.usage = "npm ls"
 
@@ -68,7 +69,7 @@ function ls (args, silent, cb) {
 
     // if any errors were found, then complain and exit status 1
     if (lite.problems && lite.problems.length) {
-      er = lite.problems.join('\n')
+      er = lite.problems.join("\n")
     }
     cb(er, data, lite)
   })
@@ -123,6 +124,7 @@ function getLite (data, noname) {
       var dep = data.dependencies[d]
       if (typeof dep === "string") {
         lite.problems = lite.problems || []
+        var p
         if (data.depth > maxDepth) {
           p = "max depth reached: "
         } else {
@@ -215,13 +217,12 @@ function makeArchy (data, long, dir) {
 }
 
 function makeArchy_ (data, long, dir, depth, parent, d) {
-  var color = npm.color
   if (typeof data === "string") {
     if (depth -1 <= npm.config.get("depth")) {
       // just missing
       var unmet = "UNMET DEPENDENCY"
-      if (color) {
-        unmet = "\033[31;40m" + unmet + "\033[0m"
+      if (npm.color) {
+        unmet = color.bgBlack(color.red(unmet))
       }
       data = unmet + " " + d + "@" + data
     } else {
@@ -234,29 +235,32 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
   // the top level is a bit special.
   out.label = data._id || ""
   if (data._found === true && data._id) {
-    var pre = color ? "\033[33;40m" : ""
-      , post = color ? "\033[m" : ""
-    out.label = pre + out.label.trim() + post + " "
+    if (npm.color) {
+      out.label = color.bgBlack(color.yellow(out.label.trim())) + " "
+    }
+    else {
+      out.label = out.label.trim() + " "
+    }
   }
   if (data.link) out.label += " -> " + data.link
 
   if (data.invalid) {
     if (data.realName !== data.name) out.label += " ("+data.realName+")"
-    out.label += " " + (color ? "\033[31;40m" : "")
-              + "invalid"
-              + (color ? "\033[0m" : "")
+    var invalid = "invalid"
+    if (npm.color) invalid = color.bgBlack(color.red(invalid))
+    out.label += " " + invalid
   }
 
   if (data.peerInvalid) {
-    out.label += " " + (color ? "\033[31;40m" : "")
-              + "peer invalid"
-              + (color ? "\033[0m" : "")
+    var peerInvalid = "peer invalid"
+    if (npm.color) peerInvalid = color.bgBlack(color.red(peerInvalid))
+    out.label += " " + peerInvalid
   }
 
   if (data.extraneous && data.path !== dir) {
-    out.label += " " + (color ? "\033[32;40m" : "")
-              + "extraneous"
-              + (color ? "\033[0m" : "")
+    var extraneous = "extraneous"
+    if (npm.color) extraneous = color.bgBlack(color.green(extraneous))
+    out.label += " " + extraneous
   }
 
   // add giturl to name@version


### PR DESCRIPTION
npm already has a dependency on `ansicolors` for `outdated`'s output, so use it in other places.
