### PR TITLE
Remove spurious `er.code =` assignments.

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -112,7 +112,6 @@ function errorHandler (er) {
     break
 
   case "ELIFECYCLE":
-    er.code = "ELIFECYCLE"
     log.error("", er.message)
     log.error("", ["","Failed at the "+er.pkgid+" "+er.stage+" script."
               ,"This is most likely a problem with the "+er.pkgname+" package,"
@@ -126,7 +125,6 @@ function errorHandler (er) {
     break
 
   case "ENOGIT":
-    er.code = "ENOGIT"
     log.error("", er.message)
     log.error("", ["","Failed using git."
               ,"This is most likely not a problem with npm itself."
@@ -135,7 +133,6 @@ function errorHandler (er) {
     break
 
   case "EJSONPARSE":
-    er.code = "EJSONPARSE"
     log.error("", er.message)
     log.error("", "File: "+er.file)
     log.error("", ["Failed to parse package.json data."
@@ -146,7 +143,6 @@ function errorHandler (er) {
     break
 
   case "E404":
-    er.code = "E404"
     var msg = [er.message]
     if (er.pkgid && er.pkgid !== "-") {
       msg.push("", "'"+er.pkgid+"' is not in the npm registry."
@@ -168,7 +164,6 @@ function errorHandler (er) {
     break
 
   case "EPUBLISHCONFLICT":
-    er.code = "EPUBLISHCONFLICT"
     log.error("publish fail", ["Cannot publish over existing version."
               ,"Update the 'version' field in package.json and try again."
               ,""
@@ -181,7 +176,6 @@ function errorHandler (er) {
     break
 
   case "EISGIT":
-    er.code = "EISGIT"
     log.error("git", [er.message
               ,"    "+er.path
               ,"Refusing to remove it. Update manually,"
@@ -190,7 +184,6 @@ function errorHandler (er) {
     break
 
   case "ECYCLE":
-    er.code = "ECYCLE"
     log.error("cycle", [er.message
               ,"While installing: "+er.pkgid
               ,"Found a pathological dependency case that npm cannot solve."
@@ -199,7 +192,6 @@ function errorHandler (er) {
     break
 
   case "EBADPLATFORM":
-    er.code = "EBADPLATFORM"
     log.error("notsup", [er.message
               ,"Not compatible with your operating system or architecture: "+er.pkgid
               ,"Valid OS:    "+er.os.join(",")


### PR DESCRIPTION
Someone sanity-check me on this? Seems straightforward, but the original code is so silly I must be missing something....
