### PR TITLE
add `npm view .`

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -48,24 +48,54 @@ view.completion = function (opts, cb) {
 }
 
 var npm = require("./npm.js")
+  , readJson = require("read-package-json")
   , registry = npm.registry
   , log = require("npmlog")
   , util = require("util")
   , semver = require("semver")
   , mapToRegistry = require("./utils/map-to-registry.js")
   , npa = require("npm-package-arg")
+  , path = require('path')
 
 function view (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
-  if (!args.length) return cb("Usage: "+view.usage)
+
+  if (npm.config.get("global") === true) {
+    return cb(new Error("Cannot use view command in global mode."))
+  }
+
+  if (!args.length) args = ["."]
+
   var pkg = args.shift()
     , nv = npa(pkg)
     , name = nv.name
+    , local = (name === "." || !name)
+
+  if (local) {
+    var dir = npm.prefix
+    readJson(path.resolve(dir, "package.json"), function (er, d) {
+      d = d || {}
+      if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
+      if (!d.name) return cb(new Error("Invalid package.json"))
+
+      var p = d.name
+      nv = npa(p)
+      if (pkg && ~pkg.indexOf("@")) {
+        nv.rawSpec = pkg.split("@")[pkg.indexOf("@")]
+      }
+
+      fetchAndRead(nv, args, silent, cb)
+    })
+  } else {
+    fetchAndRead(nv, args, silent, cb)
+  }
+}
+
+function fetchAndRead (nv, args, silent, cb) {
+  // get the data about this package
+  var name = nv.name
     , version = nv.rawSpec || npm.config.get("tag")
 
-  if (name === ".") return cb(view.usage)
-
-  // get the data about this package
   mapToRegistry(name, npm.config, function (er, uri) {
     if (er) return cb(er)
 
@@ -268,4 +298,3 @@ function unparsePerson (d) {
        + (d.email ? " <"+d.email+">" : "")
        + (d.url ? " ("+d.url+")" : "")
 }
-

--- a/test/tap/view.js
+++ b/test/tap/view.js
@@ -1,0 +1,222 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var osenv = require("osenv")
+var path = require("path")
+var fs = require("fs")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var tmp = osenv.tmpdir()
+var t1dir = path.resolve(tmp, "view-local-no-pkg")
+var t2dir = path.resolve(tmp, "view-local-notmine")
+var t3dir = path.resolve(tmp, "view-local-mine")
+var mr = require("npm-registry-mock")
+
+test("setup", function(t) {
+  mkdirp.sync(t1dir)
+  mkdirp.sync(t2dir)
+  mkdirp.sync(t3dir)
+
+  fs.writeFileSync(t2dir + "/package.json", JSON.stringify({
+    author: "Evan Lucas"
+  , name: "test-repo-url-https"
+  , version: "0.0.1"
+  }), "utf8")
+
+  fs.writeFileSync(t3dir + "/package.json", JSON.stringify({
+    author: "Evan Lucas"
+  , name: "biscuits"
+  , version: "0.0.1"
+  }), "utf8")
+
+  t.pass("created fixtures")
+  t.end()
+})
+
+test("npm view . in global mode", function(t) {
+  process.chdir(t1dir)
+  common.npm([
+    "view"
+  , "."
+  , "--registry=" + common.registry
+  , "--global"
+  ], { cwd: t1dir }, function(err, code, stdout, stderr) {
+    t.ifError(err, "error should not exist")
+    t.equal(code, 1, "exit not ok")
+    t.similar(stderr, /Error: Cannot use view command in global mode./m)
+    t.end()
+  })
+})
+
+test("npm view . with no package.json", function(t) {
+  process.chdir(t1dir)
+  common.npm([
+    "view"
+  , "."
+  , "--registry=" + common.registry
+  ], { cwd: t1dir }, function(err, code, stdout, stderr) {
+    t.ifError(err, "error should not exist")
+    t.equal(code, 1, "exit not ok")
+    t.similar(stderr, /Error: Invalid package.json/m)
+    t.end()
+  })
+})
+
+test("npm view . with no published package", function(t) {
+  process.chdir(t3dir)
+  mr(common.port, function(s) {
+    common.npm([
+      "view"
+    , "."
+    , "--registry=" + common.registry
+    ], { cwd: t3dir }, function(err, code, stdout, stderr) {
+      t.ifError(err, "error should not exist")
+      t.equal(code, 1, "exit not ok")
+      t.similar(stderr, /Error: version not found/m)
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test("npm view .", function(t) {
+  process.chdir(t2dir)
+  mr(common.port, function(s) {
+    common.npm([
+      "view"
+    , "."
+    , "--registry=" + common.registry
+    ], { cwd: t2dir }, function(err, code, stdout, stderr) {
+      t.ifError(err, "error should not exist")
+      t.equal(code, 0, "exit ok")
+      var re = new RegExp("name: 'test-repo-url-https'")
+      t.similar(stdout, re)
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test("npm view . select fields", function(t) {
+  process.chdir(t2dir)
+  mr(common.port, function(s) {
+    common.npm([
+      "view"
+    , "."
+    , "main"
+    , "--registry=" + common.registry
+    ], { cwd: t2dir }, function(err, code, stdout, stderr) {
+      t.ifError(err, "error should not exist")
+      t.equal(code, 0, "exit ok")
+      t.equal(stdout.trim(), "index.js", "should print `index.js`")
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test("npm view .@<version>", function(t) {
+  process.chdir(t2dir)
+  mr(common.port, function(s) {
+    common.npm([
+      "view"
+    , ".@0.0.0"
+    , "version"
+    , "--registry=" + common.registry
+    ], { cwd: t2dir }, function(err, code, stdout, stderr) {
+      t.ifError(err, "error should not exist")
+      t.equal(code, 0, "exit ok")
+      t.equal(stdout.trim(), "0.0.0", "should print `0.0.0`")
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test("npm view .@<version> --json", function(t) {
+  process.chdir(t2dir)
+  mr(common.port, function(s) {
+    common.npm([
+      "view"
+    , ".@0.0.0"
+    , "version"
+    , "--json"
+    , "--registry=" + common.registry
+    ], { cwd: t2dir }, function(err, code, stdout, stderr) {
+      t.ifError(err, "error should not exist")
+      t.equal(code, 0, "exit ok")
+      t.equal(stdout.trim(), "\"0.0.0\"", "should print `\"0.0.0\"`")
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test("npm view <package name>", function(t) {
+  mr(common.port, function(s) {
+    common.npm([
+      "view"
+    , "underscore"
+    , "--registry=" + common.registry
+    ], { cwd: t2dir }, function(err, code, stdout, stderr) {
+      t.ifError(err, "error should not exist")
+      t.equal(code, 0, "exit ok")
+      var re = new RegExp("name: 'underscore'")
+      t.similar(stdout, re, "should have name `underscore`")
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test("npm view <package name> --json", function(t) {
+  t.plan(3)
+  mr(common.port, function(s) {
+    common.npm([
+      "view"
+    , "underscore"
+    , "--json"
+    , "--registry=" + common.registry
+    ], { cwd: t2dir }, function(err, code, stdout, stderr) {
+      s.close()
+      t.ifError(err, "error should not exist")
+      t.equal(code, 0, "exit ok")
+      try {
+        var out = JSON.parse(stdout.trim())
+        t.similar(out, {
+          maintainers: "jashkenas <jashkenas@gmail.com>"
+        }, "should have the same maintainer")
+      }
+      catch (er) {
+        t.fail("Unable to parse JSON")
+      }
+    })
+  })
+})
+
+test("npm view <package name> <field>", function(t) {
+  mr(common.port, function(s) {
+    common.npm([
+      "view"
+    , "underscore"
+    , "homepage"
+    , "--registry=" + common.registry
+    ], { cwd: t2dir }, function(err, code, stdout, stderr) {
+      t.ifError(err, "error should not exist")
+      t.equal(code, 0, "exit ok")
+      var re = new RegExp("name: 'underscore'")
+      t.equal(stdout.trim(), "http://underscorejs.org",
+        "homepage should equal `http://underscorejs.org`")
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test("cleanup", function(t) {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(t1dir)
+  rimraf.sync(t2dir)
+  rimraf.sync(t3dir)
+  t.pass("cleaned up")
+  t.end()
+})


### PR DESCRIPTION
Fixes #5520

This adds back the ability to run `npm view .`. If a package.json
exists in the cwd, it reads it to get the name and author. It fetches
the package from the registry. If the local package.json has an author
field, it validates that the author of the local package matches the
author of the fetched package.

Includes multiple tests for `npm view`
