### PR TITLE
Check git config to see if https:// should be used instead of git://

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -58,6 +58,19 @@ module.exports = function addRemoteGit (u, silent, cb_) {
     u = u.replace(/^ssh:\/\//, "")
   }
 
+  // See if git is configured to use https:// instead of git://
+  var git = npm.config.get("git")
+  var args = [ "config", "--get", "url.https://.insteadof" ]
+  var env = gitEnv()
+  exec(git, args, {env: env}, function (er, stdout, stderr) {
+    stdoutTrimmed = (stdout + "\n" + stderr).trim()
+    log.verbose("git config url.https://.insteadof", stdoutTrimmed)
+    if ("git://" == stdout.trim()) {
+      log.verbose( "Using https:// instead of git:// for URLs")
+      u = u.replace(/^git:/, "https:")
+    }
+  })
+
   lock(u, function (er) {
     if (er) return cb(er)
 

--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -59,10 +59,9 @@ module.exports = function addRemoteGit (u, silent, cb_) {
   }
 
   // See if git is configured to use https:// instead of git://
-  var git = npm.config.get("git")
   var args = [ "config", "--get", "url.https://.insteadof" ]
   var env = gitEnv()
-  exec(git, args, {env: env}, function (er, stdout, stderr) {
+  git.whichAndExec(args, {env: env}, function (er, stdout, stderr) {
     stdoutTrimmed = (stdout + "\n" + stderr).trim()
     log.verbose("git config url.https://.insteadof", stdoutTrimmed)
     if ("git://" == stdout.trim()) {


### PR DESCRIPTION
Should fix #5257 and related issues for users behind firewalls blocking git://
as they should have the url.https://.ineadof option configured in their git config already

I've tested this change as part of building atom.io and confirmed it works for me.
