### PR TITLE
whoami: Don't crash if we don't have a username

### DIFF
--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -18,23 +18,22 @@ function whoami (args, silent, cb) {
   if (credentials) {
     if (credentials.username) {
       if (!silent) console.log(credentials.username)
-      process.nextTick(cb.bind(this, null, credentials.username))
+      return process.nextTick(cb.bind(this, null, credentials.username))
     }
     else if (credentials.token) {
-      npm.registry.whoami(registry, function (er, username) {
+      return npm.registry.whoami(registry, function (er, username) {
         if (er) return cb(er)
 
         if (!silent) console.log(username)
         cb(null, username)
       })
     }
-    else {
-      process.nextTick(cb.bind(this, new Error("credentials without username or token")))
-    }
   }
-  else {
-    var msg = "Not authed.  Run 'npm adduser'"
-    if (!silent) console.log(msg)
-      process.nextTick(cb.bind(this, null, msg))
-  }
+
+  // At this point, if they have a credentials object, it doesn't
+  // have a token or auth in it.  Probably just the default
+  // registry.
+  var msg = "Not authed.  Run 'npm adduser'"
+  if (!silent) console.log(msg)
+  process.nextTick(cb.bind(this, null, msg))
 }


### PR DESCRIPTION
The 'credentials' var will always be truthy, because there's
always _some_ registry URI.

See also npm/npmconf#40
