### PR TITLE
Only chmodr git remotes in Windows

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -72,6 +72,7 @@ module.exports = function addRemoteGit (u, silent, cb_) {
     var p = path.join(npm.config.get("cache"), "_git-remotes", v)
 
     checkGitDir(p, u, co, origUrl, silent, function(er, data) {
+      if (process.platform !== "win32") return cb(er, data)
       chmodr(p, npm.modes.file, function(erChmod) {
         if (er) return cb(er, data)
         return cb(erChmod, data)


### PR DESCRIPTION
Recursively setting file permissions on git remotes breaks git
hooks for anyone who uses git templates and symlinks their hooks
across repositories by removing execute permissions on the shared
hooks.

Since the original commit that added this feature:
npm@48263bf
was a fix for a Windows only issue:
npm#3117

The proposed solution provided in this PR is to only apply the
file permissions in Windows.
