### PR TITLE
Remove win from documented loglevels

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -465,7 +465,7 @@ to the npm registry.  Must be IPv4 in versions of Node prior to 0.12.
 
 * Default: "http"
 * Type: String
-* Values: "silent", "win", "error", "warn", "http", "info", "verbose", "silly"
+* Values: "silent", "error", "warn", "http", "info", "verbose", "silly"
 
 What level of logs to report.  On failure, *all* logs are written to
 `npm-debug.log` in the current working directory.


### PR DESCRIPTION
Removing the "win" loglevel from the documented valid values

It's no longer supported and displays the same output as "silly". See more at https://github.com/npm/npm/issues/5038#issuecomment-49494859
