### PR TITLE
Don't squash execute perms in _git-remotes/ dir

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -10,7 +10,6 @@ var mkdir = require("mkdirp")
   , zlib = require("zlib")
   , which = require("which")
   , crypto = require("crypto")
-  , chmodr = require("chmodr")
   , npm = require("../npm.js")
   , rm = require("../utils/gently-rm.js")
   , inflight = require("inflight")
@@ -72,9 +71,9 @@ module.exports = function addRemoteGit (u, silent, cb_) {
     var p = path.join(npm.config.get("cache"), "_git-remotes", v)
 
     checkGitDir(p, u, co, origUrl, silent, function(er, data) {
-      chmodr(p, npm.modes.file, function(erChmod) {
+      addModeRecursive(p, npm.modes.file, function(erAddMode) {
         if (er) return cb(er, data)
-        return cb(erChmod, data)
+        return cb(erAddMode, data)
       })
     })
   })
@@ -234,3 +233,44 @@ function gitEnv () {
   }
   return gitEnv_
 }
+
+// similar to chmodr except it add permissions rather than overwriting them
+// adapted from https://github.com/isaacs/chmodr/blob/master/chmodr.js
+function addModeRecursive(p, mode, cb) {
+  fs.readdir(p, function (er, children) {
+    // any error other than ENOTDIR means it's not readable, or
+    // doesn't exist. give up.
+    if (er && er.code != "ENOTDIR") return cb(er)
+    var isDir = !er
+    var m = isDir ? dirMode(mode) : mode
+    if (er || !children.length) return addMode(p, mode, cb)
+    var len = children.length
+    var errState = null
+    children.forEach(function (child) {
+      addModeRecursive(path.resolve(p, child), mode, then)
+    })
+    function then (er) {
+      if (errState) return
+      if (er) return cb(errState = er)
+      if (-- len === 0) return addMode(p, dirMode(mode), cb)
+    }
+  })
+}
+
+function addMode(p, mode, cb) {
+    // TODO: read the mode from p and OR it with mode
+    fs.stat(p, function (er, stats) {
+      if (er) return cb(er)
+      mode = stats.mode | mode
+      fs.chmod(p, mode, cb)
+    })
+}
+
+// taken from https://github.com/isaacs/chmodr/blob/master/chmodr.js
+function dirMode(mode) {
+  if (mode & 0400) mode |= 0100
+  if (mode & 040) mode |= 010
+  if (mode & 04) mode |= 01
+  return mode
+}
+

--- a/test/tap/git-cache-permissions.js
+++ b/test/tap/git-cache-permissions.js
@@ -1,0 +1,80 @@
+var test = require("tap").test
+  , fs = require("fs")
+  , path = require("path")
+  , rimraf = require("rimraf")
+  , mkdirp = require("mkdirp")
+  , spawn = require("child_process").spawn
+  , npm = require("../../lib/npm")
+  , npmCli = require.resolve("../../bin/npm-cli.js")
+  , node = process.execPath
+  , pkg = path.resolve(__dirname, "git-cache-permissions")
+  , tmp = path.join(pkg, "tmp")
+  , cache = path.join(pkg, "cache")
+
+
+test("setup", function (t) {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  mkdirp.sync(cache)
+  mkdirp.sync(tmp)
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+  t.end()
+})
+
+test("git-cache-permissions: install a git dependency", function (t) {
+
+  // disable git integration tests on Travis.
+  if (process.env.TRAVIS) return t.end()
+
+  var command = [ npmCli
+                , "install"
+                , "git://github.com/nigelzor/npm-4503-a.git"
+                ]
+  var child = spawn(node, command, {
+    cwd: pkg,
+    env: {
+      npm_config_cache: cache,
+      npm_config_tmp: tmp,
+      npm_config_prefix: pkg,
+      npm_config_global: "false",
+      npm_config_umask: "00",
+      HOME: process.env.HOME,
+      Path: process.env.PATH,
+      PATH: process.env.PATH
+    },
+    stdio: "inherit"
+  })
+
+  child.on("close", function (code) {
+    t.equal(code, 0, "npm install should succeed")
+
+    // verify permissions on git hooks
+    var repoDir = "git-github-com-nigelzor-npm-4503-a-git-40c5cb24"
+    var hooksPath = path.join(cache, "_git-remotes", repoDir, "hooks")
+    fs.readdir(hooksPath, function (err, files) {
+      if (err) {
+        t.ok(false, "error reading hooks: " + err)
+        t.end()
+      }
+
+      files.forEach(function (file) {
+        var stats = fs.statSync(path.join(hooksPath, file))
+        var message = "hook [" + file + "] should have correct permissions"
+
+        // Possible error conditions and the resulting file modes on hooks
+        // npm.modes.file is used directly -> "100666"
+        // permissions are left untouched  -> "100755"
+        // we do not want permissions left untouched because of
+        // https://github.com/npm/npm/issues/3117
+        t.equal(stats.mode.toString(8), "100777", message)
+      })
+
+      t.end()
+    })
+  })
+})
+
+test('cleanup', function(t) {
+  rimraf.sync(pkg)
+  t.end()
+})


### PR DESCRIPTION
A previous fix for https://github.com/npm/npm/issues/3117
explicitly set the permissions for all files to a hard-coded
value, regardless of what the permissions were previously.

This changes that behavior to _add_ the permissions that were
previously being _set_ so that existing execute permissions are
maintained.

This is a redo of the much more blunt solution attempted in
https://github.com/npm/npm/pull/5728
thanks to some very helpful feedback from @othiym23
