### PR TITLE
Fix undefined issues in completion

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -82,7 +82,7 @@ function completion (args, cb) {
     , partialWords = words.slice(0, w)
 
   // figure out where in that last word the point is.
-  var partialWord = args[w]
+  var partialWord = args[w] || "";
     , i = partialWord.length
   while (partialWord.substr(0, i) !== partialLine.substr(-1*i) && i > 0) {
     i --
@@ -107,7 +107,7 @@ function completion (args, cb) {
   console.error(opts)
 
   if (partialWords.slice(0, -1).indexOf("--") === -1) {
-    if (word.charAt(0) === "-") return configCompl(opts, cb)
+    if (word && word.charAt(0) === "-") return configCompl(opts, cb)
     if (words[w - 1]
         && words[w - 1].charAt(0) === "-"
         && !isFlag(words[w - 1])) {


### PR DESCRIPTION
When attempting completion without typing any argument / subcommand, the list of subcommands is not shown (zsh). This fixes it.
