### PR TITLE
specify dummy template dir when cloning

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -69,10 +69,14 @@ module.exports = function addRemoteGit (u, silent, cb_) {
 
     var p = path.join(npm.config.get("cache"), "_git-remotes", v)
 
-    checkGitDir(p, u, co, origUrl, silent, function(er, data) {
-      addModeRecursive(p, npm.modes.file, function(erAddMode) {
-        if (er) return cb(er, data)
-        return cb(erAddMode, data)
+    // we don't need global templates when cloning.  use this empty dir to specify as template dir  
+    mkdir(path.join(npm.config.get("cache"), "_git-remotes", "_templates"), function(er) {
+      if (er) return cb(er)
+      checkGitDir(p, u, co, origUrl, silent, function(er, data) {
+        addModeRecursive(p, npm.modes.file, function(erAddMode) {
+          if (er) return cb(er, data)
+          return cb(erAddMode, data)
+        })        
       })
     })
   })
@@ -110,7 +114,8 @@ function cloneGitRemote (p, u, co, origUrl, silent, cb) {
   mkdir(p, function (er) {
     if (er) return cb(er)
 
-    var args = [ "clone", "--mirror", u, p ]
+    var args = [ "clone", "--template=" + path.join(npm.config.get("cache"), 
+      "_git_remotes", "_templates"), "--mirror", u, p ]
     var env = gitEnv()
 
     // check for git


### PR DESCRIPTION
The solution I came up with for #5867 is to simply tell `git clone` to not use the global templates.  In fact, use _no_ templates.  We create an empty `_templates` dir within the cache that we can tell `git clone` to use via the `--template` option.

Please let me know if, for some reason, we need global Git templates for anything, or there's a better directory/name to use.
