### PR TITLE
#4569 - package.json update - request ~2.39.0 for fixing a proxy issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "read": "~1.0.4",
     "read-installed": "~3.0.0",
     "read-package-json": "~1.2.6",
-    "request": "~2.30.0",
+    "request": "~2.39.0",
     "retry": "~0.6.0",
     "rimraf": "~2.2.8",
     "semver": "~3.0.0",


### PR DESCRIPTION
Needs request ~2.39.0 in order to fix a proxy issue with npm, this is due to tunnel-agent and a bad interface problem (0.30.0 and 0.31.0 no revision increased but interface changed).

So, request does not work when a proxy is required with version 2.30.0, npm requires 2.39.0

eg. npm --proxy http://my.proxy.com:8080 update --production
