### PR TITLE
Add --no-verify

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -97,7 +97,7 @@ function checkGit (data, cb) {
         , flag = sign ? "-sm" : "-am"
       chain
         ( [ git.chainableExec([ "add", "package.json" ], {env: process.env})
-          , git.chainableExec([ "commit", "-m", message ], {env: process.env})
+          , git.chainableExec([ "commit", "-m", message, "-n" ], {env: process.env})
           , sign && function (cb) {
               npm.spinner.stop()
               cb()


### PR DESCRIPTION
`npm version` should not fail if someone has a "funny" pre commit hook.
