### PR TITLE
Remove npm from engines.

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,8 +159,7 @@
     "tap": "~0.4.12"
   },
   "engines": {
-    "node": ">=0.8",
-    "npm": "1"
+    "node": ">=0.8"
   },
   "scripts": {
     "test-legacy": "node ./test/run.js",


### PR DESCRIPTION
Does it even make any sense to have npm depend on any npm?

Potentially closes #5898
