### PR TITLE
Do not add the directory containing node executable to PATH #5876

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -71,11 +71,6 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
     , p = wd.split("node_modules")
     , acc = path.resolve(p.shift())
 
-  // first add the directory containing the `node` executable currently
-  // running, so that any lifecycle script that invoke "node" will execute
-  // this same one.
-  pathArr.unshift(path.dirname(process.execPath))
-
   p.forEach(function (pp) {
     pathArr.unshift(path.join(acc, "node_modules", ".bin"))
     acc = path.join(acc, "node_modules", pp)


### PR DESCRIPTION
Adding the directory containing current node executable may lead to run
different executable than original PATH.
