### PR TITLE
Read only registry

### DIFF
--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -199,7 +199,7 @@ function addNameRange (name, range, data, cb) {
 
   if (data) return next()
 
-  mapToRegistry(name, npm.config, function (er, uri) {
+  mapToRegistry(name, npm.config, 'GET', function (er, uri) {
     if (er) return cb(er)
 
     registry.get(uri, null, setData)

--- a/lib/utils/map-to-registry.js
+++ b/lib/utils/map-to-registry.js
@@ -49,7 +49,7 @@ function mapToRegistry(name, config, verb, cb) {
   // ...and finally use the default registry
   if (!uri) {
     if (verb === 'GET') {
-      uri = url.resolve(config.get("read_only_registry")||config.get("registry"), name)
+      uri = url.resolve(config.get("read-only-registry")||config.get("registry"), name)
     } else {
       uri = url.resolve(config.get("registry"), name)
     }

--- a/lib/utils/map-to-registry.js
+++ b/lib/utils/map-to-registry.js
@@ -5,7 +5,11 @@ var log = require("npmlog")
 
 module.exports = mapToRegistry
 
-function mapToRegistry(name, config, cb) {
+function mapToRegistry(name, config, verb, cb) {
+  if (cb == null) {
+    cb = verb
+    verb = void 0
+  }
   var uri
   var scopedRegistry
 
@@ -42,10 +46,13 @@ function mapToRegistry(name, config, cb) {
       log.verbose("mapToRegistry", "no registry URL found for scope", scope)
     }
   }
-
   // ...and finally use the default registry
   if (!uri) {
-    uri = url.resolve(config.get("registry"), name)
+    if (verb === 'GET') {
+      uri = url.resolve(config.get("read_only_registry")||config.get("registry"), name)
+    } else {
+      uri = url.resolve(config.get("registry"), name)
+    }
   }
 
   log.verbose("mapToRegistry", "name", name)


### PR DESCRIPTION
adds the ability to specify a registry that is only used for gets, useful for when using a local mirror for offline use but still what to be able to publish.
