### PR TITLE
fix scope pacakge link in windows

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -75,8 +75,7 @@ function linkStuff (pkg, folder, global, didRB, cb) {
   // if it's global, and folder is in {prefix}/node_modules,
   // then bins are in {prefix}/bin
   // otherwise, then bins are in folder/../.bin
-  var index = folder.length - pkg.name.length
-    , parent = folder.slice(index) === pkg.name ? folder.slice(0, index - 1) : path.dirname(folder)
+  var parent = pkg.name[0] === "@" ? path.dirname(path.dirname(folder)) : path.dirname(folder)
     , gnm = global && npm.globalDir
     , gtop = parent === gnm
 


### PR DESCRIPTION
scoped package name should be `@scope/name`, but the end of install path in windows is `@scope\name`
