### PR TITLE
Publish tag process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,9 @@ man: $(cli_docs) $(api_docs)
 test: doc
 	node cli.js test
 
+tag:
+	npm tag npm@$(PUBLISHTAG) latest
+
 publish: link doc
 	@git push origin :v$(shell npm -v) 2>&1 || true
 	git clean -fd &&\

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,6 @@ test: doc
 
 publish: link doc
 	@git push origin :v$(shell npm -v) 2>&1 || true
-	@npm unpublish npm@$(shell npm -v) 2>&1 || true
 	git clean -fd &&\
 	git push origin &&\
 	git push origin --tags &&\

--- a/Makefile
+++ b/Makefile
@@ -175,38 +175,7 @@ publish: link doc
 	git clean -fd &&\
 	git push origin &&\
 	git push origin --tags &&\
-	npm publish &&\
-	make doc-publish
-
-docpublish: doc-publish
-doc-publish: doc
-	# legacy urls
-	for f in $$(find html/doc/{cli,files,misc}/ -name '*.html'); do \
-    j=$$(basename $$f | sed 's|^npm-||g'); \
-    if ! [ -f html/doc/$$j ] && [ $$j != README.html ] && [ $$j != index.html ]; then \
-      perl -pi -e 's/ href="\.\.\// href="/g' <$$f >html/doc/$$j; \
-    fi; \
-  done
-	mkdir -p html/api
-	for f in $$(find html/doc/api/ -name '*.html'); do \
-    j=$$(basename $$f | sed 's|^npm-||g'); \
-    perl -pi -e 's/ href="\.\.\// href="/g' <$$f >html/api/$$j; \
-  done
-	rsync -vazu --stats --no-implied-dirs --delete \
-    html/doc/* \
-    ../npm-www/doc
-	rsync -vazu --stats --no-implied-dirs --delete \
-    html/static/style.css \
-    ../npm-www/static/
-	#cleanup
-	rm -rf html/api
-	for f in html/doc/*.html; do \
-    case $$f in \
-      html/doc/README.html) continue ;; \
-      html/doc/index.html) continue ;; \
-      *) rm $$f ;; \
-    esac; \
-  done
+	npm publish
 
 release:
 	@bash scripts/release.sh
@@ -214,4 +183,4 @@ release:
 sandwich:
 	@[ $$(whoami) = "root" ] && (echo "ok"; echo "ham" > sandwich) || (echo "make it yourself" && exit 13)
 
-.PHONY: all latest install dev link doc clean uninstall test man doc-publish doc-clean docclean docpublish release
+.PHONY: all latest install dev link doc clean uninstall test man doc-clean docclean release

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # vim: set softtabstop=2 shiftwidth=2:
 SHELL = bash
 
+PUBLISHTAG = $(shell node scripts/publish-tag.js)
+
 markdowns = $(shell find doc -name '*.md' | grep -v 'index') README.md
 
 html_docdeps = html/dochead.html \
@@ -175,7 +177,7 @@ publish: link doc
 	git clean -fd &&\
 	git push origin &&\
 	git push origin --tags &&\
-	npm publish
+	npm publish --tag=$(PUBLISHTAG)
 
 release:
 	@bash scripts/release.sh

--- a/scripts/publish-tag.js
+++ b/scripts/publish-tag.js
@@ -1,0 +1,3 @@
+var semver = require("semver")
+var version = semver.parse(require("../package.json").version)
+console.log('v%s.%s.next', version.major, version.minor)


### PR DESCRIPTION
The new process is this:
1. `npm version minor` (or `prerelease` or whatever): Bumps the version number, creates git tag, etc.
2. `make publish`: This will publish that version as `--tag=v2.0.next` or `--tag=v1.4.next` as appropriate.
3. At some point later, `make tag`.  This will tag the current `v1.4.next` as "latest"

Review plz @othiym23 
