### PR TITLE
fix pipe not emit finish on tarball in 0.10.30

### DIFF
--- a/lib/cache/add-remote-tarball.js
+++ b/lib/cache/add-remote-tarball.js
@@ -87,41 +87,33 @@ function fetchAndShaCheck (u, tmp, shasum, cb) {
       return cb(er, response)
     }
 
-    // mkdir takes a little while, so don't drop chunks!
-    response.pause()
-
-    mkdir(path.dirname(tmp), function (er) {
-      if (er) return cb(er)
-
-      var tarball = createWriteStream(tmp, { mode : npm.modes.file })
-      tarball.on("error", function (er) {
-        cb(er)
-        tarball.destroy()
-      })
-
-      tarball.on("finish", function () {
-        if (!shasum) {
-          // Well, we weren't given a shasum, so at least sha what we have
-          // in case we want to compare it to something else later
-          return sha.get(tmp, function (er, shasum) {
-            log.silly("fetchAndShaCheck", "shasum", shasum)
-            cb(er, response, shasum)
-          })
-        }
-
-        // validate that the url we just downloaded matches the expected shasum.
-        log.silly("fetchAndShaCheck", "shasum", shasum)
-        sha.check(tmp, shasum, function (er) {
-          if (er && er.message) {
-            // add original filename for better debuggability
-            er.message = er.message + "\n" + "From:     " + u
-          }
-          return cb(er, response, shasum)
-        })
-      })
-
-      response.pipe(tarball)
-      response.resume()
+    var tarball = createWriteStream(tmp, { mode : npm.modes.file })
+    tarball.on("error", function (er) {
+      cb(er)
+      tarball.destroy()
     })
+
+    tarball.on("finish", function () {
+      if (!shasum) {
+        // Well, we weren't given a shasum, so at least sha what we have
+        // in case we want to compare it to something else later
+        return sha.get(tmp, function (er, shasum) {
+          log.silly("fetchAndShaCheck", "shasum", shasum)
+          cb(er, response, shasum)
+        })
+      }
+
+      // validate that the url we just downloaded matches the expected shasum.
+      log.silly("fetchAndShaCheck", "shasum", shasum)
+      sha.check(tmp, shasum, function (er) {
+        if (er && er.message) {
+          // add original filename for better debuggability
+          er.message = er.message + "\n" + "From:     " + u
+        }
+        return cb(er, response, shasum)
+      })
+    })
+
+    response.pipe(tarball)
   })
 }


### PR DESCRIPTION
in node v0.10.29 or v0.10.30, when the http response is not keepalive, this won't emit `finish` in downstream:

``` js
var http = require('http');
var fs = require('fs');
var path = require('path');
var tmp = path.join(__dirname, 't.tgz');

var opts = {
  hostname: 'registry.npmjs.com',
  method: 'GET',
  port: 80,
  path: '/cutter/-/cutter-0.0.3.tgz',
  headers: {
    Connection: 'close'
  }
}

http.request(opts, function (res) {
  console.log('connection: %s', res.headers.connection);
  res.resume();
  res.pause();
  setTimeout(function () {
    var tarball = fs.createWriteStream(tmp, { mode: 420 })
    tarball.on('finish', function () {
      console.log('tarball finish');
    })
    res.on('data', function (data) {
      console.log('res on data: %s', data.length);
    })
    res.on('end', function (d) {
      console.log('res end');
    })
    res.pipe(tarball);
    res.resume();
  }, 1000);

}).end();

// output:
// connection: close
// res on data: 3144
// res end
```

this is the logic in `lib/cache/add-remote-tarball.js` now. i think it is a bug in node. but npm should fix it anyway. :)

the more detail in these gists:

https://gist.github.com/dead-horse/c7030afa663fee61028b
https://gist.github.com/dead-horse/6705119f1a2d41c48899
