### PR TITLE
Fix `npm dedupe` for private repositories

### DIFF
--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -86,7 +86,7 @@ function dedupe_ (dir, filter, unavoidable, dryrun, silent, cb) {
         return d && d.parent && !d.parent.duplicate && !d.unavoidable
       }).map(function M (d) {
         return [d.path, d.version, d.dependents.map(function (k) {
-          return [k.path, k.version, k.dependencies[d.name] || ""]
+          return [k.path, k.version, k.dependencies[d.name] || "", d._from, d.private]
         })]
       })]
     }).map(function (item) {
@@ -105,6 +105,20 @@ function dedupe_ (dir, filter, unavoidable, dryrun, silent, cb) {
         return v !== false
       })
 
+      var froms = set.map(function (i) {
+        return i[2].map(function (d) {
+          if (d[4]) return d[3]
+        })
+      }).reduce(function (l, r) {
+        return l.concat(r)
+      }, [])
+       .map(function (v, i, set) {
+       if (set.indexOf(v) !== i) return false
+       return v
+      }).filter(function (v) {
+        return v !== false
+      })
+     
       var locs = set.map(function (i) {
         return i[0]
       })
@@ -138,6 +152,7 @@ function dedupe_ (dir, filter, unavoidable, dryrun, silent, cb) {
       }) : undefined
 
       return [item[0], { item: item
+                       , froms: froms
                        , ranges: ranges
                        , locs: locs
                        , loc: loc
@@ -168,9 +183,11 @@ function installAndRetest (set, filter, dir, unavoidable, silent, cb) {
     var locMatch = item[3]
     var regMatch = item[4]
     var others = item[5]
+    var fromMatch = item[6]
 
     // nothing to be done here.  oh well.  just a conflict.
-    if (!locMatch && !regMatch) {
+
+    if (!locMatch && !regMatch && !fromMatch) {
       log.warn("unavoidable conflict", item[0], item[1])
       log.warn("unavoidable conflict", "Not de-duplicating")
       unavoidable[item[0]] = true
@@ -178,7 +195,7 @@ function installAndRetest (set, filter, dir, unavoidable, silent, cb) {
     }
 
     // nothing to do except to clean up the extraneous deps
-    if (locMatch && has[where] === locMatch) {
+    if ((locMatch && has[where] === locMatch) || fromMatch) {
       remove.push.apply(remove, others)
       return cb()
     }
@@ -221,6 +238,7 @@ function findVersions (npm, summary, cb) {
     var name = item[0]
     var data = item[1]
     var loc = data.loc
+    var froms = data.froms
     var locs = data.locs.filter(function (l) {
       return l !== loc
     })
@@ -259,7 +277,9 @@ function findVersions (npm, summary, cb) {
         regMatch = bestMatch(regVersions, ranges)
       }
 
-      cb(null, [[name, has, loc, locMatch, regMatch, locs]])
+      var fromMatch = matchFrom(name, froms, ranges)
+
+      cb(null, [[name, has, loc, locMatch, regMatch, locs, fromMatch]])
     }
   }, cb)
 }
@@ -269,6 +289,21 @@ function matches (version, ranges) {
     return !semver.satisfies(version, r, true)
   })
 }
+
+function matchFrom (name, locations, ranges) {
+  locations = locations || []
+
+  ranges = ranges.map(function(m) {
+    return name + "@" + m
+  }) 
+ 
+  return locations.filter(function (v) {
+    return ranges.filter(function(r) {
+      return r != v; 
+    })
+  }).pop()
+}
+
 
 function bestMatch (versions, ranges) {
   return versions.filter(function (v) {
@@ -290,8 +325,11 @@ function readInstalled (dir, counter, parent, cb) {
     if (er) return cb() // not a package, probably.
     counter[data.name] = counter[data.name] || 0
     counter[data.name]++
+
     pkg =
       { _id: data._id
+      , _from: data._from
+      , private: data.private
       , name: data.name
       , version: data.version
       , dependencies: data.dependencies || {}


### PR DESCRIPTION
Fixes an issue where `npm dedupe` does not de-duplicate any private git
repositories.

Consider a tree like this:

```
- proj/
    package.json
    node_modules/
      proj2/
        node_modules/
          private_dep/
      private_dep/
```

Where:
- 'proj/package.json' has a dependency to 'private_dep' that is installed
  with path "git+ssh://git@github.com:acct/private_dep.git#0.1.0", e.g.:
  
  "dependencies": {
   "private_dep": "git+ssh://git@github.com:acct/private_dep.git#0.1.0"
  }
- proj2, which is a dependency of proj, also has a dependency to
  private_dep at the same version and path (with the exact same config
  in its package.json)

Technically 'private_dep' is the same version, but npm dedupe uses the
version in private_dep/package.json (e.g. 0.1.0) to do the resolution
rather than the path.

This code will use the git paths in node_modules/ package.json and
the calculated '_from' field to do the comparisons:

  "_from":  "git+ssh://git@github.com:acct/private_dep.git#0.1.0"

*\* PLEASE VERIFY I AM DOING THIS IN A LOGICAL WAY, NOT SURE IF I HAVE UNTANGLED THE RUBE GOLDBERG MACHINE CORRECTLY **
