### PR TITLE
Undo commits when git tag fails on npm version.

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -105,7 +105,14 @@ function checkGit (data, cb) {
 
           , git.chainableExec([ "tag", "v" + data.version, flag, message ]
             , {env: process.env}) ]
-        , cb )
+        , checkTag )
+      function checkTag(err) {
+        var re = /tag \'.*\' already/g
+        var args = arguments
+        if (re.test(err.message)) git.whichAndExec(["reset", "--hard", "HEAD^"], {env: process.env}, function() {
+          cb.apply(null, args)
+        })
+      }
     })
   })
 }


### PR DESCRIPTION
Sometimes I do `npm version something` and right away I realize I forgot something. So I run `git reset --hard HEAD^`, I do whatever I wanted to do, commit, and then run `npm version something` again. But I sometimes forget to remove the tag that `npm version` created, so npm fails because the tag already exists. 

That's perfectly fine, but the thing is that even though npm failed to create the tag, it still creates the commit and changed the package.json file. I think it should rollback the entire operation if it fails to create the tag and that's what this PR does.
