### PR TITLE
you can now pass quoted args to run-script

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -125,11 +125,20 @@ function run (pkg, wd, cmd, args, cb) {
   log.verbose("run-script", cmds)
   chain(cmds.map(function (c) {
     // pass cli arguments after -- to script.
-    if (args.length && pkg.scripts[c]) {
-      pkg.scripts[c] = pkg.scripts[c] + " " + args.join(" ")
-    }
+    if (pkg.scripts[c]) pkg.scripts[c] = pkg.scripts[c] + joinArgs(args)
 
     // when running scripts explicitly, assume that they're trusted.
     return [lifecycle, pkg, c, wd, true]
   }), cb)
+}
+
+// join arguments after '--' and pass them to script,
+// handle special characters such as ', ", ' '.
+function joinArgs (args) {
+  var joinedArgs = ''
+  args.forEach(function(arg, i) {
+    if (arg.match(/[ '"]/)) arg = '"' + arg.replace(/"/g, '\\"') + '"'
+    joinedArgs += ' ' + arg
+  })
+  return joinedArgs
 }

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -41,7 +41,19 @@ test('npm run-script', function (t) {
 })
 
 test('npm run-script with args', function (t) {
-  common.npm(["run-script", "start", "--", "-e 'console.log(\"stop\")'"], opts, testOutput.bind(null, t, "stop"))
+  common.npm(["run-script", "start", "--", "stop"], opts, testOutput.bind(null, t, "stop"))
+})
+
+test('npm run-script with args that contain spaces', function(t) {
+  common.npm(["run-script", "start", "--", "hello world"], opts, testOutput.bind(null, t, "hello world"))
+})
+
+test('npm run-script with args that contain single quotes', function(t) {
+  common.npm(["run-script", "start", "--", "they're awesome"], opts, testOutput.bind(null, t, "they're awesome"))
+})
+
+test('npm run-script with args that contain double quotes', function(t) {
+  common.npm(["run-script", "start", "--", "what's \"up\"?"], opts, testOutput.bind(null, t, "what's \"up\"?"))
 })
 
 test('cleanup', function (t) {

--- a/test/tap/run-script/package.json
+++ b/test/tap/run-script/package.json
@@ -1,6 +1,6 @@
 {"name":"runscript"
 ,"version":"1.2.3"
 ,"scripts":{
-  "start":"node -e 'console.log(\"start\")'"
+  "start":"node -e 'console.log(process.argv[1] || \"start\")'"
   }
 }


### PR DESCRIPTION
There was a bug when passing args of the form, `npm run-script foo -- --e "my quoted string"`.

This exact use-case comes up a lot when running unit tests:

`npm test -- --grep 'should generate interview'`

I've added support for passing quoted environment variables to run-scripts, and some tests.
