### PR TITLE
ensure lifecycle spawn errors caught properly

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -205,12 +205,17 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
   }
 
   var proc = spawn(sh, [shFlag, cmd], conf)
+  proc.on("error", procError)
   proc.on("close", function (code, signal) {
     if (signal) {
       process.kill(process.pid, signal);
     } else if (code) {
       var er = new Error("Exit status " + code)
     }
+    procError(er)
+  })
+
+  function procError (er) {
     if (er && !npm.ROLLBACK) {
       log.info(pkg._id, "Failed to exec "+stage+" script")
       er.message = pkg._id + " "
@@ -230,7 +235,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
       return cb()
     }
     cb(er)
-  })
+  }
 }
 
 

--- a/test/tap/spawn-enoent.js
+++ b/test/tap/spawn-enoent.js
@@ -1,0 +1,40 @@
+var path = require("path")
+var test = require("tap").test
+var fs = require("fs")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var common = require("../common-tap.js")
+
+var pkg = path.resolve(__dirname, "spawn-enoent")
+var pj = JSON.stringify({
+  name:"x",
+  version: "1.2.3",
+  scripts: { start: "wharble-garble-blorst" }
+}, null, 2) + "\n"
+
+
+test("setup", function (t) {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  fs.writeFileSync(pkg + "/package.json", pj)
+  t.end()
+})
+
+test("enoent script", function (t) {
+  common.npm(["start"], {
+    cwd: pkg,
+    env: {
+      PATH: process.env.PATH,
+      Path: process.env.Path,
+      npm_config_loglevel: "warn"
+    }
+  }, function (er, code, sout, serr) {
+    t.similar(serr, /npm ERR! Failed at the x@1\.2\.3 start script\./)
+    t.end()
+  })
+})
+
+test("clean", function (t) {
+  rimraf.sync(pkg)
+  t.end()
+})


### PR DESCRIPTION
Possibly related to #5987 #6029

Not sure if this is a new thing in a Windows 8 system update, or a new
Node bug, but the contract whereby ENOENT spawn errors trigger a
simulated failure-exit in Node (and thus `exit` and `close` events)
seems to have changed recently.

Handle this by catching error events that are fired on the child
process, so that at least we can print out the script and package that
we were TRYING to execute, and debug it at all.

Note: We should also back port to 1.4
