### PR TITLE
Run commands in prefix, not cwd

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -50,6 +50,7 @@ The following shorthands are parsed on the command-line:
 * `-dd`, `--verbose`: `--loglevel verbose`
 * `-ddd`: `--loglevel silly`
 * `-g`: `--global`
+* `-C`: `--prefix`
 * `-l`: `--long`
 * `-m`: `--message`
 * `-p`, `--porcelain`: `--parseable`

--- a/lib/build.js
+++ b/lib/build.js
@@ -95,7 +95,7 @@ function linkStuff (pkg, folder, global, didRB, cb) {
 function shouldWarn(pkg, folder, global, cb) {
   var parent = path.dirname(folder)
     , top = parent === npm.dir
-    , cwd = process.cwd()
+    , cwd = npm.localPrefix
 
   readJson(path.resolve(cwd, "package.json"), function(er, topPkg) {
     if (er) return cb(er)

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -41,7 +41,7 @@ function docs (args, cb) {
 
 function getDoc (project, cb) {
   project = project || '.'
-  var package = path.resolve(process.cwd(), "package.json")
+  var package = path.resolve(npm.localPrefix, "package.json")
 
   if (project === '.' || project === './') {
     var json

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -21,7 +21,7 @@ runScript.completion = function (opts, cb) {
   if (argv.length === 3) {
     // either specified a script locally, in which case, done,
     // or a package, in which case, complete against its scripts
-    var json = path.join(npm.prefix, "package.json")
+    var json = path.join(npm.localPrefix, "package.json")
     return readJson(json, function (er, d) {
       if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
       if (er) d = {}
@@ -30,7 +30,7 @@ runScript.completion = function (opts, cb) {
       if (scripts.indexOf(argv[2]) !== -1) return cb()
       // ok, try to find out which package it was, then
       var pref = npm.config.get("global") ? npm.config.get("prefix")
-               : npm.prefix
+               : npm.localPrefix
       var pkgDir = path.resolve( pref, "node_modules"
                                , argv[2], "package.json" )
       readJson(pkgDir, function (er, d) {
@@ -54,7 +54,7 @@ runScript.completion = function (opts, cb) {
   })
 
   if (npm.config.get("global")) scripts = [], next()
-  else readJson(path.join(npm.prefix, "package.json"), function (er, d) {
+  else readJson(path.join(npm.localPrefix, "package.json"), function (er, d) {
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     d = d || {}
     scripts = Object.keys(d.scripts || {})
@@ -70,7 +70,7 @@ runScript.completion = function (opts, cb) {
 function runScript (args, cb) {
   if (!args.length) return list(cb)
 
-  var pkgdir = process.cwd()
+  var pkgdir = npm.localPrefix
     , cmd = args.shift()
 
   readJson(path.resolve(pkgdir, "package.json"), function (er, d) {
@@ -80,7 +80,7 @@ function runScript (args, cb) {
 }
 
 function list(cb) {
-  var json = path.join(npm.prefix, 'package.json')
+  var json = path.join(npm.localPrefix, 'package.json')
   return readJson(json, function(er, d) {
     if (er && er.code !== 'ENOENT' && er.code !== 'ENOTDIR') return cb(er)
     if (er) d = {}

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -65,10 +65,10 @@ function unpublish (args, cb) {
              + unpublish.usage)
   }
 
-  if (!project || path.resolve(project) === npm.prefix) {
+  if (!project || path.resolve(project) === npm.localPrefix) {
     // if there's a package.json in the current folder, then
     // read the package name and version out of that.
-    var cwdJson = path.join(process.cwd(), "package.json")
+    var cwdJson = path.join(npm.localPrefix, "package.json")
     return readJson(cwdJson, function (er, data) {
       if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
       if (er) return cb("Usage:\n" + unpublish.usage)

--- a/lib/version.js
+++ b/lib/version.js
@@ -23,7 +23,7 @@ version.usage = "npm version [<newversion> | major | minor | patch | prerelease 
 function version (args, silent, cb_) {
   if (typeof cb_ !== "function") cb_ = silent, silent = false
   if (args.length > 1) return cb_(version.usage)
-  fs.readFile(path.join(process.cwd(), "package.json"), function (er, data) {
+  fs.readFile(path.join(npm.localPrefix, "package.json"), function (er, data) {
     if (!args.length) {
       var v = {}
       Object.keys(process.versions).forEach(function (k) {
@@ -63,7 +63,7 @@ function version (args, silent, cb_) {
     if (data.version === newVer) return cb_(new Error("Version not changed"))
     data.version = newVer
 
-    fs.stat(path.join(process.cwd(), ".git"), function (er, s) {
+    fs.stat(path.join(npm.localPrefix, ".git"), function (er, s) {
       function cb (er) {
         if (!er && !silent) console.log("v" + newVer)
         cb_(er)
@@ -111,7 +111,7 @@ function checkGit (data, cb) {
 }
 
 function write (data, cb) {
-  fs.writeFile( path.join(process.cwd(), "package.json")
+  fs.writeFile( path.join(npm.localPrefix, "package.json")
               , new Buffer(JSON.stringify(data, null, 2) + "\n")
               , cb )
 }

--- a/node_modules/npmconf/config-defs.js
+++ b/node_modules/npmconf/config-defs.js
@@ -364,4 +364,5 @@ exports.shorthands =
   , y : ["--yes"]
   , n : ["--no-yes"]
   , B : ["--save-bundle"]
+  , C : ["--prefix"]
   }

--- a/node_modules/npmconf/node_modules/config-chain/node_modules/proto-list/package.json
+++ b/node_modules/npmconf/node_modules/config-chain/node_modules/proto-list/package.json
@@ -46,6 +46,5 @@
     "tarball": "http://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
   },
   "directories": {},
-  "_resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz",
-  "readme": "ERROR: No README data found!"
+  "_resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
 }

--- a/node_modules/npmconf/package.json
+++ b/node_modules/npmconf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npmconf",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "The config thing npm uses",
   "main": "npmconf.js",
   "directories": {
@@ -40,14 +40,32 @@
     "url": "http://blog.izs.me"
   },
   "license": "BSD",
-  "readme": "# npmconf\n\nThe config thing npm uses\n\nIf you are interested in interacting with the config settings that npm\nuses, then use this module.\n\nHowever, if you are writing a new Node.js program, and want\nconfiguration functionality similar to what npm has, but for your\nown thing, then I'd recommend using [rc](https://github.com/dominictarr/rc),\nwhich is probably what you want.\n\nIf I were to do it all over again, that's what I'd do for npm.  But,\nalas, there are many systems depending on many of the particulars of\nnpm's configuration setup, so it's not worth the cost of changing.\n\n## USAGE\n\n```javascript\nvar npmconf = require('npmconf')\n\n// pass in the cli options that you read from the cli\n// or whatever top-level configs you want npm to use for now.\nnpmconf.load({some:'configs'}, function (er, conf) {\n  // do stuff with conf\n  conf.get('some', 'cli') // 'configs'\n  conf.get('username') // 'joebobwhatevers'\n  conf.set('foo', 'bar', 'user')\n  conf.save('user', function (er) {\n    // foo = bar is now saved to ~/.npmrc or wherever\n  })\n})\n```\n",
-  "readmeFilename": "README.md",
-  "gitHead": "c745674aac4c3e475ce3c09207459cb836c76493",
+  "gitHead": "cc04391ca4fe2607600f7a54c1534339a22b0a6e",
   "bugs": {
     "url": "https://github.com/isaacs/npmconf/issues"
   },
   "homepage": "https://github.com/isaacs/npmconf",
-  "_id": "npmconf@2.0.6",
-  "_shasum": "623ce5bda6c66a72ba1a1b0419e95700e2eac784",
-  "_from": "npmconf@>=2.0.4-0 <2.1.0-0"
+  "_id": "npmconf@2.0.7",
+  "_shasum": "c105834cb24d87e94f638fd334590a74fe415843",
+  "_from": "npmconf@>=2.0.7-0 <2.1.0-0",
+  "_npmVersion": "2.0.0-beta.1",
+  "_npmUser": {
+    "name": "isaacs",
+    "email": "i@izs.me"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    },
+    {
+      "name": "othiym23",
+      "email": "ogd@aoaioxxysz.net"
+    }
+  ],
+  "dist": {
+    "shasum": "c105834cb24d87e94f638fd334590a74fe415843",
+    "tarball": "http://registry.npmjs.org/npmconf/-/npmconf-2.0.7.tgz"
+  },
+  "_resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.7.tgz"
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "npm-package-arg": "~2.0.4",
     "npm-registry-client": "~3.1.5",
     "npm-user-validate": "~0.1.0",
-    "npmconf": "~2.0.6",
+    "npmconf": "~2.0.7",
     "npmlog": "~0.1.1",
     "once": "~1.3.0",
     "opener": "~1.3.0",

--- a/test/run.js
+++ b/test/run.js
@@ -81,7 +81,10 @@ function exec (cmd, cwd, shouldFail, cb) {
   cmd = cmd.replace(/^npm /, npmReplace + " ")
   cmd = cmd.replace(/^node /, nodeReplace + " ")
 
+  console.error("$$$$$$ cd %s; PATH=%s %s", cwd, env.PATH, cmd)
+
   child_process.exec(cmd, {cwd: cwd, env: env}, function (er, stdout, stderr) {
+    console.error("$$$$$$ after command", cmd, cwd)
     if (stdout) {
       console.error(prefix(stdout, " 1> "))
     }
@@ -155,7 +158,7 @@ function main (cb) {
               return [ "npm install packages/"+p, testdir ]
             }) ]
         , [ execChain, packages.map(function (p) {
-              return [ "npm test", path.resolve(base, p) ]
+              return [ "npm test -ddd", path.resolve(base, p) ]
             }) ]
         , [ execChain, packagesToRm.map(function (p) {
               return [ "npm rm "+p, root ]

--- a/test/tap/pwd-prefix.js
+++ b/test/tap/pwd-prefix.js
@@ -1,0 +1,35 @@
+// This test ensures that a few commands do the same
+// thing when the cwd is where package.json is, and when
+// the package.json is one level up.
+
+var test = require("tap").test
+var common = require("../common-tap.js")
+var path = require("path")
+var root = path.resolve(__dirname, "../..")
+var lib = path.resolve(root, "lib")
+var commands = ["run", "version"]
+
+commands.forEach(function (cmd) {
+  // Should get the same stdout and stderr each time
+  var stdout, stderr
+
+  test(cmd + " in root", function (t) {
+    common.npm([cmd], {cwd: root}, function(er, code, so, se) {
+      if (er) throw er
+      t.equal(code, 0)
+      stdout = so
+      stderr = se
+      t.end()
+    })
+  })
+
+  test(cmd + " in lib", function (t) {
+    common.npm([cmd], {cwd: lib}, function(er, code, so, se) {
+      if (er) throw er
+      t.equal(code, 0)
+      t.equal(so, stdout)
+      t.equal(se, stderr)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
In general, we should never be relying on {cwd}/package.json.

The current working directory should be used for printing out relative
paths for human consumption, but npm should always walk up the directory
tree to find its working dir for _doing_ stuff.

Fix #6059
