### PR TITLE
Replace instances of 'hash' with 'object' in documentation

### DIFF
--- a/doc/api/npm-load.md
+++ b/doc/api/npm-load.md
@@ -10,9 +10,9 @@ npm-load(3) -- Load config settings
 npm.load() must be called before any other function call.  Both parameters are
 optional, but the second is recommended.
 
-The first parameter is an object hash of command-line config params, and the
-second parameter is a callback that will be called when npm is loaded and
-ready to serve.
+The first parameter is an object containing command-line config params, and the
+second parameter is a callback that will be called when npm is loaded and ready
+to serve.
 
 The first parameter should follow a similar structure as the package.json
 config object.

--- a/doc/api/npm.md
+++ b/doc/api/npm.md
@@ -25,13 +25,12 @@ This is the API documentation for npm.
 To find documentation of the command line
 client, see `npm(1)`.
 
-Prior to using npm's commands, `npm.load()` must be called.
-If you provide `configObject` as an object hash of top-level
-configs, they override the values stored in the various config
-locations. In the npm command line client, this set of configs
-is parsed from the command line options. Additional configuration
-params are loaded from two configuration files. See `npm-config(1)`,
-`npm-config(7)`, and `npmrc(5)` for more information.
+Prior to using npm's commands, `npm.load()` must be called.  If you provide
+`configObject` as an object map of top-level configs, they override the values
+stored in the various config locations. In the npm command line client, this
+set of configs is parsed from the command line options. Additional
+configuration params are loaded from two configuration files. See
+`npm-config(1)`, `npm-config(7)`, and `npmrc(5)` for more information.
 
 After that, each of the functions are accessible in the
 commands object: `npm.commands.<cmd>`.  See `npm-index(7)` for a list of
@@ -88,9 +87,9 @@ command.
 
 ## MAGIC
 
-For each of the methods in the `npm.commands` hash, a method is added to
-the npm object, which takes a set of positional string arguments rather
-than an array and a callback.
+For each of the methods in the `npm.commands` object, a method is added to the
+npm object, which takes a set of positional string arguments rather than an
+array and a callback.
 
 If the last argument is a callback, then it will use the supplied
 callback.  However, if no callback is provided, then it will print out

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -231,10 +231,10 @@ with the lib folder in any way, but it's useful meta info.
 
 ### directories.bin
 
-If you specify a "bin" directory, then all the files in that folder will
-be used as the "bin" object.
+If you specify a `bin` directory, then all the files in that folder will
+be added as children of the `bin` path.
 
-If you have a "bin" object already, then this has no effect.
+If you have a `bin` path already, then this has no effect.
 
 ### directories.man
 
@@ -274,7 +274,7 @@ html project page that you put in your browser.  It's for computers.
 
 ## scripts
 
-The "scripts" member is an object containing script commands that are run
+The "scripts" property is a dictionary containing script commands that are run
 at various times in the lifecycle of your package.  The key is the lifecycle
 event, and the value is the command to run at that point.
 
@@ -282,9 +282,9 @@ See `npm-scripts(7)` to find out more about writing package scripts.
 
 ## config
 
-A "config" object can be used to set configuration
-parameters used in package scripts that persist across upgrades.  For
-instance, if a package had the following:
+A "config" object can be used to set configuration parameters used in package
+scripts that persist across upgrades.  For instance, if a package had the
+following:
 
     { "name" : "foo"
     , "config" : { "port" : "8080" } }
@@ -298,10 +298,10 @@ configs.
 
 ## dependencies
 
-Dependencies are specified with a simple object that maps package name to
+Dependencies are specified in a simple object that maps a package name to a
 version range. The version range is a string which has one or more
-space-separated descriptors.  Dependencies can also be identified with
-a tarball or git URL.
+space-separated descriptors.  Dependencies can also be identified with a
+tarball or git URL.
 
 **Please do not put test harnesses or transpilers in your
 `dependencies` object.**  See `devDependencies`, below.
@@ -408,8 +408,8 @@ If someone is planning on downloading and using your module in their
 program, then they probably don't want or need to download and build
 the external test or documentation framework that you use.
 
-In this case, it's best to list these additional items in a
-`devDependencies` object.
+In this case, it's best to map these additional items in a `devDependencies`
+object.
 
 These things will be installed when doing `npm link` or `npm install`
 from the root of a package, and can be managed like any other npm
@@ -480,11 +480,11 @@ If this is spelled `"bundleDependencies"`, then that is also honorable.
 
 ## optionalDependencies
 
-If a dependency can be used, but you would like npm to proceed if it
-cannot be found or fails to install, then you may put it in the
-`optionalDependencies` object.  This is a map of package name to version
-or url, just like the `dependencies` object.  The difference is that
-failure is tolerated.
+If a dependency can be used, but you would like npm to proceed if it cannot be
+found or fails to install, then you may put it in the `optionalDependencies`
+object.  This is a map of package name to version or url, just like the
+`dependencies` object.  The difference is that build failures do not cause
+installation to fail.
 
 It is still your program's responsibility to handle the lack of the
 dependency.  For example, something like this:
@@ -586,11 +586,11 @@ does help prevent some confusion if it doesn't work as expected.
 If you set `"private": true` in your package.json, then npm will refuse
 to publish it.
 
-This is a way to prevent accidental publication of private repositories.
-If you would like to ensure that a given package is only ever published
-to a specific registry (for example, an internal registry),
-then use the `publishConfig` object described below
-to override the `registry` config param at publish-time.
+This is a way to prevent accidental publication of private repositories.  If
+you would like to ensure that a given package is only ever published to a
+specific registry (for example, an internal registry), then use the
+`publishConfig` dictionary described below to override the `registry` config
+param at publish-time.
 
 ## publishConfig
 

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -219,7 +219,7 @@ will create entries for `man foo` and `man 2 foo`
 
 The CommonJS [Packages](http://wiki.commonjs.org/wiki/Packages/1.0) spec details a
 few ways that you can indicate the structure of your package using a `directories`
-hash. If you look at [npm's package.json](http://registry.npmjs.org/npm/latest),
+object. If you look at [npm's package.json](http://registry.npmjs.org/npm/latest),
 you'll see that it has directories for doc, lib, and man.
 
 In the future, this information may be used in other creative ways.
@@ -232,9 +232,9 @@ with the lib folder in any way, but it's useful meta info.
 ### directories.bin
 
 If you specify a "bin" directory, then all the files in that folder will
-be used as the "bin" hash.
+be used as the "bin" object.
 
-If you have a "bin" hash already, then this has no effect.
+If you have a "bin" object already, then this has no effect.
 
 ### directories.man
 
@@ -274,7 +274,7 @@ html project page that you put in your browser.  It's for computers.
 
 ## scripts
 
-The "scripts" member is an object hash of script commands that are run
+The "scripts" member is an object containing script commands that are run
 at various times in the lifecycle of your package.  The key is the lifecycle
 event, and the value is the command to run at that point.
 
@@ -282,7 +282,7 @@ See `npm-scripts(7)` to find out more about writing package scripts.
 
 ## config
 
-A "config" hash can be used to set configuration
+A "config" object can be used to set configuration
 parameters used in package scripts that persist across upgrades.  For
 instance, if a package had the following:
 
@@ -298,13 +298,13 @@ configs.
 
 ## dependencies
 
-Dependencies are specified with a simple hash of package name to
+Dependencies are specified with a simple object that maps package name to
 version range. The version range is a string which has one or more
 space-separated descriptors.  Dependencies can also be identified with
 a tarball or git URL.
 
 **Please do not put test harnesses or transpilers in your
-`dependencies` hash.**  See `devDependencies`, below.
+`dependencies` object.**  See `devDependencies`, below.
 
 See semver(7) for more details about specifying version ranges.
 
@@ -409,7 +409,7 @@ program, then they probably don't want or need to download and build
 the external test or documentation framework that you use.
 
 In this case, it's best to list these additional items in a
-`devDependencies` hash.
+`devDependencies` object.
 
 These things will be installed when doing `npm link` or `npm install`
 from the root of a package, and can be managed like any other npm
@@ -482,8 +482,8 @@ If this is spelled `"bundleDependencies"`, then that is also honorable.
 
 If a dependency can be used, but you would like npm to proceed if it
 cannot be found or fails to install, then you may put it in the
-`optionalDependencies` hash.  This is a map of package name to version
-or url, just like the `dependencies` hash.  The difference is that
+`optionalDependencies` object.  This is a map of package name to version
+or url, just like the `dependencies` object.  The difference is that
 failure is tolerated.
 
 It is still your program's responsibility to handle the lack of the
@@ -532,12 +532,12 @@ field is advisory only.
 ## engineStrict
 
 If you are sure that your module will *definitely not* run properly on
-versions of Node/npm other than those specified in the `engines` hash,
+versions of Node/npm other than those specified in the `engines` object,
 then you can set `"engineStrict": true` in your package.json file.
 This will override the user's `engine-strict` config setting.
 
 Please do not do this unless you are really very very sure.  If your
-engines hash is something overly restrictive, you can quite easily and
+engines object is something overly restrictive, you can quite easily and
 inadvertently lock yourself into obscurity and prevent your users from
 updating to new versions of Node.  Consider this choice carefully.  If
 people abuse it, it will be removed in a future version of npm.
@@ -589,7 +589,7 @@ to publish it.
 This is a way to prevent accidental publication of private repositories.
 If you would like to ensure that a given package is only ever published
 to a specific registry (for example, an internal registry),
-then use the `publishConfig` hash described below
+then use the `publishConfig` object described below
 to override the `registry` config param at publish-time.
 
 ## publishConfig

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -510,7 +510,7 @@ Any "%s" in the message will be replaced with the version number.
 * Default: process.version
 * Type: semver or false
 
-The node version to use when checking package's "engines" hash.
+The node version to use when checking package's "engines" object.
 
 ### npat
 
@@ -532,7 +532,7 @@ usage.
 * Default: true
 * Type: Boolean
 
-Attempt to install packages in the `optionalDependencies` hash.  Note
+Attempt to install packages in the `optionalDependencies` object.  Note
 that if these packages fail to install, the overall installation
 process is not aborted.
 
@@ -611,7 +611,7 @@ Remove failed installs.
 Save installed packages to a package.json file as dependencies.
 
 When used with the `npm rm` command, it removes it from the dependencies
-hash.
+object.
 
 Only works if there is already a package.json file present.
 
@@ -635,7 +635,7 @@ bundledDependencies list.
 Save installed packages to a package.json file as devDependencies.
 
 When used with the `npm rm` command, it removes it from the
-devDependencies hash.
+devDependencies object.
 
 Only works if there is already a package.json file present.
 
@@ -657,7 +657,7 @@ Save installed packages to a package.json file as
 optionalDependencies.
 
 When used with the `npm rm` command, it removes it from the
-devDependencies hash.
+devDependencies object.
 
 Only works if there is already a package.json file present.
 
@@ -849,7 +849,7 @@ Only relevant when specified explicitly on the command line.
 * Type: boolean
 
 If true, output the npm version as well as node's `process.versions`
-hash, and exit successfully.
+object, and exit successfully.
 
 Only relevant when specified explicitly on the command line.
 

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -510,7 +510,7 @@ Any "%s" in the message will be replaced with the version number.
 * Default: process.version
 * Type: semver or false
 
-The node version to use when checking package's "engines" object.
+The node version to use when checking a package's `engines` map.
 
 ### npat
 
@@ -610,7 +610,7 @@ Remove failed installs.
 
 Save installed packages to a package.json file as dependencies.
 
-When used with the `npm rm` command, it removes it from the dependencies
+When used with the `npm rm` command, it removes it from the `dependencies`
 object.
 
 Only works if there is already a package.json file present.
@@ -632,10 +632,10 @@ bundledDependencies list.
 * Default: false
 * Type: Boolean
 
-Save installed packages to a package.json file as devDependencies.
+Save installed packages to a package.json file as `devDependencies`.
 
 When used with the `npm rm` command, it removes it from the
-devDependencies object.
+`devDependencies` object.
 
 Only works if there is already a package.json file present.
 
@@ -657,7 +657,7 @@ Save installed packages to a package.json file as
 optionalDependencies.
 
 When used with the `npm rm` command, it removes it from the
-devDependencies object.
+`devDependencies` object.
 
 Only works if there is already a package.json file present.
 
@@ -848,8 +848,8 @@ Only relevant when specified explicitly on the command line.
 * Default: false
 * Type: boolean
 
-If true, output the npm version as well as node's `process.versions`
-object, and exit successfully.
+If true, output the npm version as well as node's `process.versions` map, and
+exit successfully.
 
 Only relevant when specified explicitly on the command line.
 

--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -76,7 +76,7 @@ least, you need:
 
 * scripts:
   If you have a special compilation or installation script, then you
-  should put it in the `scripts` hash.  You should definitely have at
+  should put it in the `scripts` object.  You should definitely have at
   least a basic smoke-test command as the "scripts.test" field.
   See npm-scripts(7).
 
@@ -86,7 +86,7 @@ least, you need:
   then you need to specify that in the "main" field.
 
 * directories:
-  This is a hash of folders.  The best ones to include are "lib" and
+  This is an object of folders.  The best ones to include are "lib" and
   "doc", but if you specify a folder full of man pages in "man", then
   they'll get installed just like these ones.
 

--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -86,8 +86,8 @@ least, you need:
   then you need to specify that in the "main" field.
 
 * directories:
-  This is an object of folders.  The best ones to include are "lib" and
-  "doc", but if you specify a folder full of man pages in "man", then
+  This is an object mapping names to folders.  The best ones to include are
+  "lib" and "doc", but if you use "man" to specify a folder full of man pages,
   they'll get installed just like these ones.
 
 You can use `npm init` in the root of your package in order to get you

--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -137,7 +137,7 @@ Configuration parameters are put in the environment with the
 `npm_config_` prefix. For instance, you can view the effective `root`
 config by checking the `npm_config_root` environment variable.
 
-### Special: package.json "config" hash
+### Special: package.json "config" object
 
 The package.json "config" keys are overwritten in the environment if
 there is a config param of `<name>[@<version>]:<key>`.  For example,

--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -3,7 +3,7 @@ npm-scripts(7) -- How npm handles the "scripts" field
 
 ## DESCRIPTION
 
-npm supports the "scripts" member of the package.json script, for the
+npm supports the "scripts" property of the package.json script, for the
 following scripts:
 
 * prepublish:


### PR DESCRIPTION
Context: https://twitter.com/mvirkkunen/status/506796515982311424

Many of us programmers know what "hashes" are in the general sense, but the word is not part of the JavaScript vernacular and could be unfamiliar to newcomers. This PR replaces instances of "hash" with "object" in various markdown documents.
