### PR TITLE
npm-registry-couchapp@2.5.3 for more reliable tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
   "devDependencies": {
     "marked": "~0.3.2",
     "nock": "~0.34.1",
-    "npm-registry-couchapp": "~2.5.0",
+    "npm-registry-couchapp": "~2.5.3",
     "npm-registry-mock": "~0.6.3",
     "require-inject": "~1.0.0",
     "ronn": "~0.3.6",


### PR DESCRIPTION
For the record, this brings in:
- bee49ef views: Exclude deprecated packages from browse views (isaacs on 2014-08-28)
- 829051e views: browseAuthorRecent should only show publisher, not all maintainers (isaacs on 2014-08-28)
- 7413b90 add tests for registry views (isaacs on 2014-08-28)
- dacd57e request update (isaacs on 2014-09-08)
- 63d7dd7 Bump the timeout for couch to startup to five minutes (iarna on 2014-09-09)

Though this is just a dev dependency– the key change is the timeout increase which will stop spurious errors on "slower" laptops and in places like Travis.
