### PR TITLE
No root owned cache files

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -78,6 +78,7 @@ var npm = require("./npm.js")
   , maybeGithub = require("./cache/maybe-github.js")
   , inflight = require("inflight")
   , npa = require("npm-package-arg")
+  , getStat = require("./cache/get-stat.js")
 
 cache.usage = "npm cache add <tarball file>"
             + "\nnpm cache add <folder>"
@@ -353,8 +354,17 @@ function afterAdd (cb) { return function (er, data) {
 
   fs.writeFile(tmp, JSON.stringify(data), "utf8", function (er) {
     if (er) return done(er)
-    fs.rename(tmp, pj, function (er) {
-      done(er, data)
+    getStat(function (er, cs) {
+      if (er) return done(er)
+      fs.rename(tmp, pj, function (er) {
+        if (cs.uid && cs.gid) {
+          fs.chown(pj, cs.uid, cs.gid, function (er) {
+            return done(er, data)
+          })
+        } else {
+          done(er, data)
+        }
+      })
     })
   })
 }}

--- a/lib/cache/add-local-tarball.js
+++ b/lib/cache/add-local-tarball.js
@@ -193,9 +193,11 @@ function addTmpTarball_ (tgz, data, shasum, cb) {
     if (er) return cb(er)
     mkdir(pkg, function (er, created) {
 
-      // chown starting from the first dir created by mkdirp
-      function chown () {
-        chownr(created, cs.uid, cs.gid, done)
+      // chown starting from the first dir created by mkdirp,
+      // or the root dir, if none had to be created, so that
+      // we know that we get all the children.
+      function chown (er) {
+        chownr(created || root, cs.uid, cs.gid, done)
       }
 
       if (er) return cb(er)

--- a/lib/cache/add-local-tarball.js
+++ b/lib/cache/add-local-tarball.js
@@ -191,7 +191,13 @@ function addTmpTarball_ (tgz, data, shasum, cb) {
   var target = path.resolve(root, "package.tgz")
   getCacheStat(function (er, cs) {
     if (er) return cb(er)
-    mkdir(pkg, function (er) {
+    mkdir(pkg, function (er, created) {
+
+      // chown starting from the first dir created by mkdirp
+      function chown () {
+        chownr(created, cs.uid, cs.gid, done)
+      }
+
       if (er) return cb(er)
       var read = fs.createReadStream(tgz)
       var write = fs.createWriteStream(target)
@@ -199,9 +205,6 @@ function addTmpTarball_ (tgz, data, shasum, cb) {
       read.on("error", cb).pipe(write).on("error", cb).on("close", fin)
     })
 
-    function chown () {
-      chownr(root, cs.uid, cs.gid, done)
-    }
   })
 
   function done() {

--- a/lib/cache/get-stat.js
+++ b/lib/cache/get-stat.js
@@ -24,7 +24,9 @@ module.exports = function getCacheStat (cb) {
 }
 
 function makeCacheDir (cb) {
-  if (!process.getuid) return mkdir(npm.cache, cb)
+  if (!process.getuid) return mkdir(npm.cache, function (er) {
+    return cb(er, {})
+  })
 
   var uid = +process.getuid()
     , gid = +process.getgid()


### PR DESCRIPTION
Here's how I'm testing this:

```
sudo rm -r ~/.npm; sudo npm cache add abbrev -ddd; find ~/.npm -user 0
```

I'm not sure how to go about doing that in a test, unless we can somehow either fake running as root, or expect to be able to use `sudo` in a child process, or some other craziness.
