### PR TITLE
Error output cleanup

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -22,13 +22,18 @@ process.on("exit", function (code) {
     }
 
     if (wroteLogFile) {
-      log.error("", [""
-                ,"Additional logging details can be found in:"
+      // just a line break
+      if (log.levels[log.level] <= log.levels.error) console.error("")
+
+      log.error("",
+                ["Please include the following file with any support request:"
                 ,"    " + path.resolve("npm-debug.log")
                 ].join("\n"))
       wroteLogFile = false
     }
-    log.error("not ok", "code", code)
+    if (code) {
+      log.error("code", code)
+    }
   }
 
   var doExit = npm.config.get("_exit")
@@ -69,7 +74,6 @@ function exit (code, noLog) {
 
 
 function errorHandler (er) {
-  var printStack = false
   // console.error("errorHandler", er)
   if (!npm.config || !npm.config.loaded) {
     // logging won't work unless we pretend that it's ready
@@ -94,13 +98,55 @@ function errorHandler (er) {
   var m = er.code || er.message.match(/^(?:Error: )?(E[A-Z]+)/)
   if (m && !er.code) er.code = m
 
+  ; [ "type"
+    , "fstream_path"
+    , "fstream_unc_path"
+    , "fstream_type"
+    , "fstream_class"
+    , "fstream_finish_call"
+    , "fstream_linkpath"
+    , "stack"
+    , "fstream_stack"
+    , "statusCode"
+    , "pkgid"
+    ].forEach(function (k) {
+      var v = er[k]
+      if (!v) return
+      if (k === "fstream_stack") v = v.join("\n")
+      log.verbose(k, v)
+    })
+
+  log.verbose("cwd", process.cwd())
+
+  var os = require("os")
+  // log.error("System", os.type() + " " + os.release())
+  // log.error("command", process.argv.map(JSON.stringify).join(" "))
+  // log.error("node -v", process.version)
+  // log.error("npm -v", npm.version)
+  log.error("", os.type() + " " + os.release())
+  log.error("", process.argv.map(JSON.stringify).join(" "))
+  log.error("", "node " + process.version)
+  log.error("", "npm  " + npm.version)
+
+  ; [ "file"
+    , "path"
+    , "code"
+    , "errno"
+    , "syscall"
+    ].forEach(function (k) {
+      var v = er[k]
+      if (v) log.error(k, v)
+    })
+
+  // just a line break
+  if (log.levels[log.level] <= log.levels.error) console.error("")
+
   switch (er.code) {
   case "ECONNREFUSED":
     log.error("", er)
     log.error("", ["\nIf you are behind a proxy, please make sure that the"
               ,"'proxy' config is set properly.  See: 'npm help config'"
               ].join("\n"))
-    printStack = true
     break
 
   case "EACCES":
@@ -108,7 +154,6 @@ function errorHandler (er) {
     log.error("", er)
     log.error("", ["\nPlease try running this command again as root/Administrator."
               ].join("\n"))
-    printStack = true
     break
 
   case "ELIFECYCLE":
@@ -142,33 +187,28 @@ function errorHandler (er) {
               ].join("\n"), "JSON.parse")
     break
 
+  // TODO(isaacs)
+  // Add a special case here for E401 and E403 explaining auth issues?
+
   case "E404":
     var msg = [er.message]
     if (er.pkgid && er.pkgid !== "-") {
       msg.push("", "'"+er.pkgid+"' is not in the npm registry."
-              ,"You should bug the author to publish it")
+              ,"You should bug the author to publish it (or use the name yourself!)")
       if (er.parent) {
         msg.push("It was specified as a dependency of '"+er.parent+"'")
       }
-      if (er.pkgid.match(/^node[\.\-]|[\.\-]js$/)) {
-        var s = er.pkgid.replace(/^node[\.\-]|[\.\-]js$/g, "")
-        if (s !== er.pkgid) {
-          s = s.replace(/[^a-z0-9]/g, ' ')
-          msg.push("\nMaybe try 'npm search " + s + "'")
-        }
-      }
       msg.push("\nNote that you can also install from a"
-              ,"tarball, folder, or http url, or git url.")
+              ,"tarball, folder, http url, or git url.")
     }
+    // There's no need to have 404 in the message as well.
+    msg[0] = msg[0].replace(/^404\s+/, "")
     log.error("404", msg.join("\n"))
     break
 
   case "EPUBLISHCONFLICT":
     log.error("publish fail", ["Cannot publish over existing version."
               ,"Update the 'version' field in package.json and try again."
-              ,""
-              ,"If the previous version was published in error, see:"
-              ,"    npm help unpublish"
               ,""
               ,"To automatically increment version numbers, see:"
               ,"    npm help version"
@@ -277,49 +317,12 @@ function errorHandler (er) {
     break
 
   default:
-    log.error("", er.stack || er.message || er)
-    log.error("", ["If you need help, you may report this *entire* log,"
-                  ,"including the npm and node versions, at:"
+    log.error("", er.message || er)
+    log.error("", ["", "If you need help, you may report this error at:"
                   ,"    <http://github.com/npm/npm/issues>"
                   ].join("\n"))
-    printStack = false
     break
   }
-
-  var os = require("os")
-  // just a line break
-  if (log.levels[log.level] <= log.levels.error) console.error("")
-  log.error("System", os.type() + " " + os.release())
-  log.error("command", process.argv
-            .map(JSON.stringify).join(" "))
-  log.error("cwd", process.cwd())
-  log.error("node -v", process.version)
-  log.error("npm -v", npm.version)
-
-  ; [ "file"
-    , "path"
-    , "type"
-    , "syscall"
-    , "fstream_path"
-    , "fstream_unc_path"
-    , "fstream_type"
-    , "fstream_class"
-    , "fstream_finish_call"
-    , "fstream_linkpath"
-    , "code"
-    , "errno"
-    , "stack"
-    , "fstream_stack"
-    ].forEach(function (k) {
-      var v = er[k]
-      if (k === "stack") {
-        if (!printStack) return
-        if (!v) v = er.message
-      }
-      if (!v) return
-      if (k === "fstream_stack") v = v.join("\n")
-      log.error(k, v)
-    })
 
   exit(typeof er.errno === "number" ? er.errno : 1)
 }

--- a/test/tap/install-scoped-link.js
+++ b/test/tap/install-scoped-link.js
@@ -47,7 +47,6 @@ test("installing package with links", function (t) {
 
 test("cleanup", function(t) {
   process.chdir(__dirname)
-  rimraf.sync(modules)
-
+  rimraf.sync(work)
   t.end()
 })

--- a/test/tap/semver-tag.js
+++ b/test/tap/semver-tag.js
@@ -8,7 +8,7 @@ test("try to tag with semver range as tag name", function (t) {
     stdio: "pipe",
   }, function (er, code, so, se) {
     if (er) throw er
-    t.similar(se, /^npm ERR! Error: Tag name must not be a valid SemVer range/)
+    t.similar(se, /Tag name must not be a valid SemVer range: v2.x\n/)
     t.equal(code, 1)
     t.end()
   })


### PR DESCRIPTION
This does a few things to clean up the error output and make it a bit
more user-friendly (and maintainer friendly!)
1. Remove the 'npm ERR code 0' at the bottom.  We're not exiting with
   code 0, so that's just confusing and weird.  It just means that we don't
   YET have an error code, so it's better to just omit it.
2. Never print out stack traces at loglevel=error.  They're too verbose,
   and send users into a brain-shutdown-overload panic which is
   uncomfortable and not a very nice to do to them.
3. Since most users jump to the bottom of an error report and read
   increased importance in the last line, reorder the output a bit.
   
   a. The system/version/argv info is printed first, where it'll be
   mostly ignored by users but still output by default for the benefit of
   support staff.  This is useful for us, but just excess noise for them,
   since they presumably already know what operating system they're
   using, etc.
   
   b. Next, print out the human-friendly error message for things we
   know, like "the script exited with such and such error code, it's a
   bug with the fooblz package, get the owner info with blah blah", etc.
   
   c. Last, we print out the npm-debug.log file, but instead of just
   saying "Additional debugging info is available", we explicitly ask the
   user to attach it to any support request.  This is generally always
   the first thing we ask for, so we may as well just go ahead and ask
   for it here.
4. Corrected a few blatantly un-helpful suggestions (like using
   unpublish to get around a publish version conflict.)
