### PR TITLE
Put npm-debug.log file in the cache folder, not cwd

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -13,6 +13,10 @@ var cbCalled = false
   , chain = require("slide").chain
 
 
+function getLogFile () {
+  return path.resolve(npm.config.get("cache"), "npm-debug.log")
+}
+
 process.on("exit", function (code) {
   // console.error("exit", code)
   if (!npm.config || !npm.config.loaded) return
@@ -29,7 +33,7 @@ process.on("exit", function (code) {
 
       log.error("",
                 ["Please include the following file with any support request:"
-                ,"    " + path.resolve("npm-debug.log")
+                ,"    " + getLogFile()
                 ].join("\n"))
       wroteLogFile = false
     }
@@ -68,7 +72,7 @@ function exit (code, noLog) {
         if (!code) errorHandler(er)
         else reallyExit(er)
       } else {
-        rm("npm-debug.log", reallyExit)
+        rm(getLogFile(), reallyExit)
       }
     })
     rollbacks.length = 0
@@ -352,7 +356,8 @@ function writeLogFile (cb) {
   wroteLogFile = true
 
   var fs = require("graceful-fs")
-    , fstr = fs.createWriteStream("npm-debug.log")
+    , logFile = getLogFile()
+    , tmp = logFile + "." + process.pid
     , os = require("os")
     , out = ""
 
@@ -368,6 +373,8 @@ function writeLogFile (cb) {
     })
   })
 
-  fstr.end(out)
-  fstr.on("close", cb)
+  fs.writeFile(tmp, out, function (er) {
+    if (er) return cb(er)
+    fs.rename(tmp, logFile, cb)
+  })
 }


### PR DESCRIPTION
This should prevent mishaps like #1548, while avoiding overly
configurable options that make it hard to predict where the file
will show up.

Fix #1584
Close #5252
