### PR TITLE
Print original version range instead of expanded one on incompatible-version error

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -304,7 +304,7 @@ function addNonLocal (spec, cb) {
         maybeGithub(p.spec, cb)
         break
       default:
-        if (p.name) return addNamed(p.name, p.spec, null, cb)
+        if (p.name) return addNamed(p.name, p.rawSpec, null, cb)
 
         cb(new Error("couldn't figure out how to install " + spec))
     }

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -191,9 +191,10 @@ function addNameVersion (name, v, data, cb) {
 }
 
 function addNameRange (name, range, data, cb) {
+  var rawRange = range
   range = semver.validRange(range, true)
   if (range === null) return cb(new Error(
-    "Invalid version range: "+range))
+    "Invalid version range: "+rawRange))
 
   log.silly("addNameRange", {name:name, range:range, hasData:!!data})
 
@@ -234,7 +235,7 @@ function addNameRange (name, range, data, cb) {
     var versions = Object.keys(data.versions || {})
     var ms = semver.maxSatisfying(versions, range, true)
     if (!ms) {
-      return cb(installTargetsError(range, data))
+      return cb(installTargetsError(rawRange, data))
     }
 
     // if we don't have a registry connection, try to see if


### PR DESCRIPTION
This address Problem 2 of #6180. On an incompatible-version error, instead of printing the expanded range of the user's desired range (`>=1.9.0 <1.10.0` as opposed to `~1.9`), `npm` will now print the original range so that there's no confusion on the user's part as to what happened to their input.

So, instead of this:

``` bash
$ npm install phantomjs@~1.9
npm ERR! notarget No compatible version found: phantomjs@'>=1.9.0 <1.10.0'
```

The user will see this:

``` bash
$ npm install phantomjs@~1.9
npm ERR! notarget No compatible version found: phantomjs@'~1.9'
```
