### PR TITLE
Allow for setting always-auth with `--reg` CLI options for scoping.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,7 @@ var log = require("npmlog")
   , fs = require("graceful-fs")
   , writeFileAtomic = require("write-file-atomic")
   , npmconf = require("npmconf")
+  , toNerfDart = require("npmconf/lib/nerf-dart.js")
   , types = npmconf.defs.types
   , ini = require("ini")
   , editor = require("editor")
@@ -132,6 +133,15 @@ function set (key, val, cb) {
   val = val.trim()
   log.info("config", "set %j %j", key, val)
   var where = npm.config.get("global") ? "global" : "user"
+    , registry = npm.config.get('registry')
+
+  // When setting always-auth check for --reg
+  if (key === "always-auth" && registry) {
+    var nerfed = toNerfDart(registry)
+    key = nerfed + ":always-auth"
+    where = "user"
+  }
+
   npm.config.set(key, val, where)
   npm.config.save(where, cb)
 }


### PR DESCRIPTION
@othiym23 not exactly sure where to put this, but I wanted to get your thoughts on the implementation details before finishing this up with tests etc. It seems like there is a larger API surface area for "nerfed" configuration in general, but that might be better suited to `npmconf`. 

I wasn't sure how far you wanted to go with this, but I wanted to put my money where my mouth is for this in #6230 and #6263
