### PR TITLE
Skip installation of installed scoped packages.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -562,25 +562,10 @@ function installManyTop_ (what, where, context, cb) {
       return !p.match(/^[\._-]/)
     })
 
-    // find scoped packages
-    var scopedPkgs = pkgs.filter(function (p) {
-      return p.match(/^@/)
-    }).map(function(p) {
-      return path.resolve(nm, p)
-    })
-    asyncMap(scopedPkgs, function(scopeDir, cb) {
-      fs.readdir(scopeDir, function (er, scopedPkgs) {
-        if (er) return cb(er)
-        scopedPkgs = scopedPkgs || []
-        scopedPkgs = scopedPkgs.map(function(p) {
-          return path.resolve(scopeDir, p)
-        })
-        cb(null, scopedPkgs)
-      })
-    }, function(er, scopedPkgs) {
+    findScopedPackages(pkgs, where, function(er, scopedpkgs) {
       if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
       // ignore error
-      pkgs = pkgs.concat(scopedPkgs || [])
+      pkgs = pkgs.concat(scopedpkgs || [])
       // handle all packages
       asyncMap(pkgs.map(function (p) {
         return path.resolve(nm, p, "package.json")
@@ -602,6 +587,29 @@ function installManyTop_ (what, where, context, cb) {
       })
     })
   })
+
+  function findScopedPackages(pkgs, where, cb) {
+    var nm = path.resolve(where, "node_modules")
+
+    // isolate scopes
+    var scopes = pkgs.filter(function (s) {
+      return s[0] === '@'
+    }).map(function(s) {
+      return path.resolve(nm, s)
+    })
+
+    // find packages in scopes
+    asyncMap(scopes, function(scope, cb) {
+      fs.readdir(scope, function (er, scopedpkgs) {
+        if (er) return cb(er)
+        scopedpkgs = scopedpkgs || []
+        scopedpkgs = scopedpkgs.map(function(p) {
+          return path.resolve(scope, p)
+        })
+        cb(null, scopedpkgs)
+      })
+    }, cb)
+  }
 }
 
 function installMany (what, where, context, cb) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -561,23 +561,45 @@ function installManyTop_ (what, where, context, cb) {
     pkgs = pkgs.filter(function (p) {
       return !p.match(/^[\._-]/)
     })
-    asyncMap(pkgs.map(function (p) {
-      return path.resolve(nm, p, "package.json")
-    }), function (jsonfile, cb) {
-      readJson(jsonfile, log.warn, function (er, data) {
-        if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
-        if (er) return cb(null, [])
-        return cb(null, [[data.name, data.version]])
+
+    // find scoped packages
+    var scopedPkgs = pkgs.filter(function (p) {
+      return p.match(/^@/)
+    }).map(function(p) {
+      return path.resolve(nm, p)
+    })
+    asyncMap(scopedPkgs, function(scopeDir, cb) {
+      fs.readdir(scopeDir, function (er, scopedPkgs) {
+        if (er) return cb(er)
+        scopedPkgs = scopedPkgs || []
+        scopedPkgs = scopedPkgs.map(function(p) {
+          return path.resolve(scopeDir, p)
+        })
+        cb(null, scopedPkgs)
       })
-    }, function (er, packages) {
-      // if there's nothing in node_modules, then don't freak out.
-      if (er) packages = []
-      // add all the existing packages to the family list.
-      // however, do not add to the ancestors list.
-      packages.forEach(function (p) {
-        context.family[p[0]] = p[1]
+    }, function(er, scopedPkgs) {
+      if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
+      // ignore error
+      pkgs = pkgs.concat(scopedPkgs || [])
+      // handle all packages
+      asyncMap(pkgs.map(function (p) {
+        return path.resolve(nm, p, "package.json")
+      }), function (jsonfile, cb) {
+        readJson(jsonfile, log.warn, function (er, data) {
+          if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
+          if (er) return cb(null, [])
+          return cb(null, [[data.name, data.version]])
+        })
+      }, function (er, packages) {
+        // if there's nothing in node_modules, then don't freak out.
+        if (er) packages = []
+        // add all the existing packages to the family list.
+        // however, do not add to the ancestors list.
+        packages.forEach(function (p) {
+          context.family[p[0]] = p[1]
+        })
+        return installMany(what, where, context, cb)
       })
-      return installMany(what, where, context, cb)
     })
   })
 }

--- a/test/tap/install-from-local/package-scoped-dependency/package.json
+++ b/test/tap/install-from-local/package-scoped-dependency/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scoped/package",
+  "version": "0.0.0",
+  "description": "Test for local installs"
+}

--- a/test/tap/install-from-local/package-with-scoped-paths/package.json
+++ b/test/tap/install-from-local/package-with-scoped-paths/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-with-scoped-paths",
+  "version": "0.0.0",
+  "dependencies": {
+    "package-local-dependency": "file:../package-local-dependency",
+    "@scoped/package-scoped-dependency": "file:../package-scoped-dependency"
+  }
+}

--- a/test/tap/install-scoped-already-installed.js
+++ b/test/tap/install-scoped-already-installed.js
@@ -1,0 +1,55 @@
+var exec = require("child_process").exec
+var existsSync = require("fs").existsSync
+var join = require("path").join
+
+var test = require("tap").test
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+
+var npm = require("../../")
+
+var pkg = join(__dirname, "install-from-local", "package-with-scoped-paths")
+var modules = join(pkg, "node_modules")
+
+test("setup", function (t) {
+  rimraf.sync(modules)
+  rimraf.sync(join(pkg, 'cache'))
+  process.chdir(pkg)
+  mkdirp.sync(modules)
+  t.end()
+})
+
+test("installing already installed local scoped package", function (t) {
+  npm.load({loglevel: 'info'}, function() {
+    npm.commands.install(function (err, arr, installed) {
+      t.ifError(err, "install ran to completion without error")
+      t.ok(
+        existsSync(join(modules, "@scoped", "package", "package.json")),
+        "package installed"
+      )
+      t.ok(installed['node_modules/@scoped/package'], 'installed @scoped/package')
+      t.ok(installed['node_modules/package-local-dependency'], 'installed package-local-dependency')
+
+      npm.commands.install(function (err, arr, installed) {
+
+        t.ifError(err, "install ran to completion without error")
+
+        t.ok(
+          existsSync(join(modules, "@scoped", "package", "package.json")),
+          "package installed"
+        )
+
+        t.notOk(installed['node_modules/@scoped/package'], 'did not reinstall @scoped/package')
+        t.notOk(installed['node_modules/package-local-dependency'], 'did not reinstall package-local-dependency')
+        t.end()
+      })
+    })
+  })
+})
+
+test("cleanup", function(t) {
+  process.chdir(__dirname)
+  rimraf.sync(join(modules))
+  rimraf.sync(join(pkg, 'cache'))
+  t.end()
+})


### PR DESCRIPTION
Currently scoped packages will be reinstalled regardless whether they already exist in the node_modules tree.

This makes scoped packages skip reinstallation the same way normal, unscoped packages do.

e.g. 
#### `package.json`

``` json
{
  "name": "scopedinstall",
  "version": "1.0.0",
  "dependencies": {
    "@fruit/apple": "file:apple",
    "cashew": "file:cashew"
  }
```
#### `./apple/package.json`

``` json
{
  "name": "@fruit/apple",
  "version": "1.0.0"
}
```
#### `./cashew/package.json`

``` json
{
  "name": "cashew",
  "version": "1.0.0"
}
```
## Before

Note `cashew` is only installed once, `@fruit/apple` is reinstalled every `npm install`.

```
> npm install --silent
cashew@1.0.0 node_modules/cashew

@fruit/apple@1.0.0 node_modules/@fruit/apple

> npm install --silent
@fruit/apple@1.0.0 node_modules/@fruit/apple

> npm install --silent
@fruit/apple@1.0.0 node_modules/@fruit/apple
```
## After

Note npm has ceased reinstalling `@fruit/apple` every `npm install`.

```
> npm install --silent
cashew@1.0.0 node_modules/cashew

@fruit/apple@1.0.0 node_modules/@fruit/apple
> npm install --silent

> npm install --silent

```
