### PR TITLE
Ensure cleanup executes for scripts-whitespace-windows test.

### DIFF
--- a/test/tap/scripts-whitespace-windows.js
+++ b/test/tap/scripts-whitespace-windows.js
@@ -31,7 +31,7 @@ test('setup', function (t) {
 
   child.stdout.setEncoding('utf8')
   child.stderr.on('data', function(chunk) {
-    throw new Error('got stderr data: ' + JSON.stringify('' + chunk))
+    t.fail('got stderr data: ' + JSON.stringify('' + chunk))
   })
   child.on('close', function () {
     t.end()
@@ -47,7 +47,7 @@ test('test', function (t) {
 
   child.stdout.setEncoding('utf8')
   child.stderr.on('data', function(chunk) {
-    throw new Error('got stderr data: ' + JSON.stringify('' + chunk))
+    t.fail('got stderr data: ' + JSON.stringify('' + chunk))
   })
   child.stdout.on('data', ondata)
   child.on('close', onend)


### PR DESCRIPTION
Test failure was leaving an assortment of files dangling around:

```
 test/tap/scripts-whitespace-windows/cache/scripts-whitespace-windows-dep/0.0.1/package.tgz
 test/tap/scripts-whitespace-windows/cache/scripts-whitespace-windows-dep/0.0.1/package/package.json
```
