### PR TITLE
Ensure that npm-debug.log file is created when rollbacks are done

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -67,17 +67,21 @@ function exit (code, noLog) {
       if (er) {
         log.error("error rolling back", er)
         if (!code) errorHandler(er)
-        else reallyExit(er)
+        else if (noLog) rm("npm-debug.log", reallyExit.bind(null, er))
+        else writeLogFile(reallyExit.bind(this, er))
       } else {
-        rm("npm-debug.log", reallyExit)
+        if (!noLog && code) writeLogFile(reallyExit)
+        else rm("npm-debug.log", reallyExit)
       }
     })
     rollbacks.length = 0
   }
   else if (code && !noLog) writeLogFile(reallyExit)
-  else reallyExit()
+  else rm("npm-debug.log", reallyExit)
 
-  function reallyExit() {
+  function reallyExit (er) {
+    if (er && !code) code = typeof er.errno === 'number' ? er.errno : 1
+
     // truncate once it's been written.
     log.record.length = 0
 


### PR DESCRIPTION
Fixes a regression when we cleaned up rollback behavior.

Re https://github.com/npm/npm/issues/6296
