### PR TITLE
Explain how to pass arguments to scripts

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -16,6 +16,13 @@ is provided, it will list the available top level scripts.
 It is used by the test, start, restart, and stop commands, but can be
 called directly, as well.
 
+As of [`npm@2.0.0`](http://blog.npmjs.org/post/98131109725/npm-2-0-0), you can
+use custom arguments when executing scripts. The special option `--` is used by
+[getopt](http://goo.gl/KxMmtG) to delimit the end of the options. npm will pass
+all the arguments after the `--` directly to your script:
+
+    npm run test -- --grep="pattern"
+
 ## SEE ALSO
 
 * npm-scripts(7)


### PR DESCRIPTION
This is a small addendum to https://www.npmjs.org/doc/cli/npm-run-script.html that elaborates on how to pass arguments to scripts.

Sources:
- https://github.com/npm/npm/pull/5518
- http://unix.stackexchange.com/questions/147143/when-and-how-was-the-double-dash-introduced-as-an-end-of-options-delimiter
