### PR TITLE
efficiently validate tmp tarballs, safely

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -224,7 +224,6 @@ cache.add = function (pkg, ver, where, scrub, cb) {
       add([pkg, ver], where, cb)
     })
   }
-  log.verbose("cache add", [pkg, ver])
   return add([pkg, ver], where, cb)
 }
 
@@ -249,6 +248,8 @@ function add (args, where, cb) {
     , spec
     , p
 
+  log.silly("cache add", "args", args)
+
   if (args[1] === undefined) args[1] = null
 
   // at this point the args length must ==2
@@ -258,7 +259,7 @@ function add (args, where, cb) {
     spec = args[0]
   }
 
-  log.verbose("cache add", "spec=%j args=%j", spec, args)
+  log.verbose("cache add", "spec", spec)
 
   if (!spec) return cb(usage)
 
@@ -272,7 +273,7 @@ function add (args, where, cb) {
   // normalization
   p = npa(spec)
   if (p.type === "local" && where) spec = path.resolve(where, p.spec)
-  log.verbose("parsed spec", p)
+  log.silly("cache add", "parsed spec", p)
 
   // short-circuit local installs
   fs.stat(spec, function (er, s) {
@@ -292,7 +293,7 @@ function addAndLogLocal (spec, cb) {
 
 function addNonLocal (spec, cb) {
     var p = npa(spec)
-    log.verbose("parsed spec", p)
+    log.silly("addNonLocal", "parsed spec", p)
 
     switch (p.type) {
       case "remote":

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -80,6 +80,7 @@ var npm = require("./npm.js")
   , inflight = require("inflight")
   , npa = require("npm-package-arg")
   , getStat = require("./cache/get-stat.js")
+  , cachedPackageRoot = require("./cache/cached-package-root.js")
 
 cache.usage = "npm cache add <tarball file>"
             + "\nnpm cache add <folder>"
@@ -130,7 +131,7 @@ function read (name, ver, forceBypass, cb) {
 
   if (forceBypass === undefined || forceBypass === null) forceBypass = true
 
-  var jsonFile = path.join(npm.cache, name, ver, "package", "package.json")
+  var root = cachedPackageRoot({name : name, version : ver})
   function c (er, data) {
     if (data) deprCheck(data)
 
@@ -142,7 +143,7 @@ function read (name, ver, forceBypass, cb) {
     return addNamed(name, ver, null, c)
   }
 
-  readJson(jsonFile, function (er, data) {
+  readJson(path.join(root, "package", "package.json"), function (er, data) {
     er = needName(er, data)
     er = needVersion(er, data)
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
@@ -325,7 +326,7 @@ function unpack (pkg, ver, unpackTarget, dMode, fMode, uid, gid, cb) {
     }
     npm.commands.unbuild([unpackTarget], true, function (er) {
       if (er) return cb(er)
-      tar.unpack( path.join(npm.cache, pkg, ver, "package.tgz")
+      tar.unpack( path.join(cachedPackageRoot({name : pkg, version : ver}), "package.tgz")
                 , unpackTarget
                 , dMode, fMode
                 , uid, gid
@@ -345,9 +346,7 @@ function afterAdd (cb) { return function (er, data) {
 
   // Save the resolved, shasum, etc. into the data so that the next
   // time we load from this cached data, we have all the same info.
-  var name = data.name
-  var ver = data.version
-  var pj = path.join(npm.cache, name, ver, "package", "package.json")
+  var pj = path.join(cachedPackageRoot(data), "package", "package.json")
 
   var done = inflight(pj, cb)
 

--- a/lib/cache/add-local-tarball.js
+++ b/lib/cache/add-local-tarball.js
@@ -9,6 +9,7 @@ var mkdir = require("mkdirp")
   , tar = require("../utils/tar.js")
   , pathIsInside = require("path-is-inside")
   , getCacheStat = require("./get-stat.js")
+  , cachedPackageRoot = require("./cached-package-root.js")
   , chownr = require("chownr")
   , inflight = require("inflight")
   , once = require("once")
@@ -60,10 +61,7 @@ function addPlacedTarball (p, pkgData, shasum, cb) {
 }
 
 function addPlacedTarball_ (p, pkgData, uid, gid, resolvedSum, cb) {
-  // now we know it's in place already as .cache/name/ver/package.tgz
-  var name = pkgData.name
-    , version = pkgData.version
-    , folder = path.join(npm.cache, name, version, "package")
+  var folder = path.join(cachedPackageRoot(pkgData), "package")
 
   // First, make sure we have the shasum, if we don't already.
   if (!resolvedSum) {
@@ -144,12 +142,10 @@ function addTmpTarball_ (tgz, data, shasum, cb) {
   assert(typeof cb === "function", "must have callback function")
   cb = once(cb)
 
-  var name = data.name
-  var version = data.version
-  assert(name, "should have package name by now")
-  assert(version, "should have package version by now")
+  assert(data.name, "should have package name by now")
+  assert(data.version, "should have package version by now")
 
-  var root = path.resolve(npm.cache, name, version)
+  var root = cachedPackageRoot(data)
   var pkg = path.resolve(root, "package")
   var target = path.resolve(root, "package.tgz")
   getCacheStat(function (er, cs) {

--- a/lib/cache/add-local-tarball.js
+++ b/lib/cache/add-local-tarball.js
@@ -2,10 +2,10 @@ var mkdir = require("mkdirp")
   , assert = require("assert")
   , fs = require("graceful-fs")
   , writeFileAtomic = require("write-file-atomic")
-  , readJson = require("read-package-json")
   , path = require("path")
   , sha = require("sha")
   , npm = require("../npm.js")
+  , log = require("npmlog")
   , tar = require("../utils/tar.js")
   , pathIsInside = require("path-is-inside")
   , getCacheStat = require("./get-stat.js")
@@ -13,62 +13,39 @@ var mkdir = require("mkdirp")
   , inflight = require("inflight")
   , once = require("once")
   , writeStream = require("fs-write-stream-atomic")
+  , randomBytes = require("crypto").pseudoRandomBytes // only need uniqueness
 
 module.exports = addLocalTarball
 
-function addLocalTarball (p, pkgData, shasum, cb_) {
+function addLocalTarball (p, pkgData, shasum, cb) {
   assert(typeof p === "string", "must have path")
-  assert(typeof cb_ === "function", "must have callback")
+  assert(typeof cb === "function", "must have callback")
 
   if (!pkgData) pkgData = {}
-  var name = pkgData.name || ""
 
-  // If we don't have a shasum yet, then get the shasum now.
+  // If we don't have a shasum yet, compute it.
   if (!shasum) {
     return sha.get(p, function (er, shasum) {
-      if (er) return cb_(er)
-      addLocalTarball(p, pkgData, shasum, cb_)
+      if (er) return cb(er)
+      log.silly("addLocalTarball", "shasum (computed)", shasum)
+      addLocalTarball(p, pkgData, shasum, cb)
     })
   }
 
-  // if it's a tar, and not in place,
-  // then unzip to .tmp, add the tmp folder, and clean up tmp
-  if (pathIsInside(p, npm.tmp))
-    return addTmpTarball(p, pkgData, shasum, cb_)
-
   if (pathIsInside(p, npm.cache)) {
-    if (path.basename(p) !== "package.tgz") return cb_(new Error(
-      "Not a valid cache tarball name: "+p))
-    return addPlacedTarball(p, pkgData, shasum, cb_)
+    if (path.basename(p) !== "package.tgz") {
+      return cb(new Error("Not a valid cache tarball name: "+p))
+    }
+    log.verbose("addLocalTarball", "adding from inside cache", p)
+    return addPlacedTarball(p, pkgData, shasum, cb)
   }
 
-  function cb (er, data) {
+  addTmpTarball(p, pkgData, shasum, function (er, data) {
     if (data) {
       data._resolved = p
       data._shasum = data._shasum || shasum
     }
-    return cb_(er, data)
-  }
-
-  // just copy it over and then add the temp tarball file.
-  var tmp = path.join(npm.tmp, name + Date.now()
-                             + "-" + Math.random(), "tmp.tgz")
-  mkdir(path.dirname(tmp), function (er) {
-    if (er) return cb(er)
-    var from = fs.createReadStream(p)
-      , to = writeStream(tmp, { mode: npm.modes.file })
-      , errState = null
-    function errHandler (er) {
-      if (errState) return
-      cb(errState = er)
-    }
-    from.on("error", errHandler)
-    to.on("error", errHandler)
-    to.on("close", function () {
-      if (errState) return
-      addTmpTarball(tmp, pkgData, shasum, cb)
-    })
-    from.pipe(to)
+    return cb(er, data)
   })
 }
 
@@ -109,54 +86,58 @@ function addPlacedTarball_ (p, pkgData, uid, gid, resolvedSum, cb) {
 
 function addTmpTarball (tgz, pkgData, shasum, cb) {
   assert(typeof cb === "function", "must have callback function")
-  assert(shasum, "should have shasum by now")
+  assert(shasum, "must have shasum by now")
 
   cb = inflight("addTmpTarball:" + tgz, cb)
-  if (!cb) return
+  if (!cb) return undefined
 
   // we already have the package info, so just move into place
   if (pkgData && pkgData.name && pkgData.version) {
-    addTmpTarball_(tgz, pkgData, shasum, cb)
+    log.verbose("addTmpTarball", "already have metadata; skipping unpack")
+    return addTmpTarball_(tgz, pkgData, shasum, cb)
   }
 
-  // This is a tarball we probably downloaded from the internet.
-  // The shasum's already been checked, but we haven't ever had
-  // a peek inside, so we unpack it here just to make sure it is
-  // what it says it is.
-  // Note: we might not have any clue what we think it is, for
-  // example if the user just did `npm install ./foo.tgz`
+  // This is a tarball we probably downloaded from the internet.  The shasum's
+  // already been checked, but we haven't ever had a peek inside, so we unpack
+  // it here just to make sure it is what it says it is.
+  //
+  // NOTE: we might not have any clue what we think it is, for example if the
+  // user just did `npm install ./foo.tgz`
 
-  var target = tgz + "-unpack"
-  getCacheStat(function (er, cs) {
-    tar.unpack(tgz, target, null, null, cs.uid, cs.gid, next)
-  })
-
-  function next (er) {
+  // generate a unique filename
+  randomBytes(6, function (er, random) {
     if (er) return cb(er)
-    var pj = path.join(target, "package.json")
-    readJson(pj, function (er, data) {
-      // XXX dry with similar stanza in add-local.js
-      er = needName(er, data)
-      er = needVersion(er, data)
-      // check that this is what we expected.
-      if (!er && pkgData.name && pkgData.name !== data.name) {
-        er = new Error( "Invalid Package: expected "
-                      + pkgData.name + " but found "
-                      + data.name )
-      }
 
-      if (!er && pkgData.version && pkgData.version !== data.version) {
-        er = new Error( "Invalid Package: expected "
-                      + pkgData.name + "@" + pkgData.version
-                      + " but found "
-                      + data.name + "@" + data.version )
-      }
-
+    var target = path.join(npm.tmp, "unpack-" + random.toString("hex"))
+    getCacheStat(function (er, cs) {
       if (er) return cb(er)
 
-      addTmpTarball_(tgz, data, shasum, cb)
+      log.verbose("addTmpTarball", "validating metadata from", tgz)
+      tar.unpack(tgz, target, null, null, cs.uid, cs.gid, function (er, data) {
+        if (er) return cb(er)
+
+        // check that this is what we expected.
+        if (!data.name) {
+          return cb(new Error("No name provided"))
+        }
+        else if (pkgData.name && data.name !== pkgData.name) {
+          return cb(new Error("Invalid Package: expected " + pkgData.name +
+                              " but found " + data.name))
+        }
+
+        if (!data.version) {
+          return cb(new Error("No version provided"))
+        }
+        else if (pkgData.version && data.version !== pkgData.version) {
+          return cb(new Error("Invalid Package: expected " +
+                              pkgData.name + "@" + pkgData.version +
+                              " but found " + data.name + "@" + data.version))
+        }
+
+        addTmpTarball_(tgz, data, shasum, cb)
+      })
     })
-  }
+  })
 }
 
 function addTmpTarball_ (tgz, data, shasum, cb) {
@@ -195,16 +176,4 @@ function addTmpTarball_ (tgz, data, shasum, cb) {
     data._shasum = data._shasum || shasum
     cb(null, data)
   }
-}
-
-function needName(er, data) {
-  return er ? er
-       : (data && !data.name) ? new Error("No name provided")
-       : null
-}
-
-function needVersion(er, data) {
-  return er ? er
-       : (data && !data.version) ? new Error("No version provided")
-       : null
 }

--- a/lib/cache/add-local.js
+++ b/lib/cache/add-local.js
@@ -10,6 +10,7 @@ var fs = require("graceful-fs")
   , tar = require("../utils/tar.js")
   , deprCheck = require("../utils/depr-check.js")
   , getCacheStat = require("./get-stat.js")
+  , cachedPackageRoot = require("./cached-package-root.js")
   , addLocalTarball = require("./add-local-tarball.js")
   , sha = require("sha")
 
@@ -73,9 +74,9 @@ function addLocalDirectory (p, pkgData, shasum, cb) {
     deprCheck(data)
 
     // pack to {cache}/name/ver/package.tgz
-    var croot = path.resolve(npm.cache, data.name, data.version)
-    var tgz = path.resolve(croot, "package.tgz")
-    var pj = path.resolve(croot, "package/package.json")
+    var root = cachedPackageRoot(data)
+    var tgz = path.resolve(root, "package.tgz")
+    var pj = path.resolve(root, "package/package.json")
     getCacheStat(function (er, cs) {
       mkdir(path.dirname(pj), function (er, made) {
         if (er) return cb(er)

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -11,6 +11,7 @@ var path = require("path")
   , deprCheck = require("../utils/depr-check.js")
   , inflight = require("inflight")
   , addRemoteTarball = require("./add-remote-tarball.js")
+  , cachedPackageRoot = require("./cached-package-root.js")
   , mapToRegistry = require("../utils/map-to-registry.js")
 
 
@@ -141,7 +142,7 @@ function addNameVersion (name, v, data, cb) {
     }
 
     // we got cached data, so let's see if we have a tarball.
-    var pkgroot = path.join(npm.cache, name, ver)
+    var pkgroot = cachedPackageRoot({name : name, version : ver})
     var pkgtgz = path.join(pkgroot, "package.tgz")
     var pkgjson = path.join(pkgroot, "package", "package.json")
     fs.stat(pkgtgz, function (er) {

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -21,9 +21,9 @@ function addNamed (name, version, data, cb_) {
   assert(typeof name === "string", "must have module name")
   assert(typeof cb_ === "function", "must have callback")
 
-  log.verbose("addNamed", [name, version])
-
   var key = name + "@" + version
+  log.verbose("addNamed", key)
+
   function cb (er, data) {
     if (data && !data._fromGithub) data._from = key
     cb_(er, data)
@@ -33,7 +33,8 @@ function addNamed (name, version, data, cb_) {
 
   if (!cb_) return
 
-  log.verbose("addNamed", [semver.valid(version), semver.validRange(version)])
+  log.silly("addNamed", "semver.valid", semver.valid(version))
+  log.silly("addNamed", "semver.validRange", semver.validRange(version))
   var fn = ( semver.valid(version, true) ? addNameVersion
            : semver.validRange(version, true) ? addNameRange
            : addNameTag

--- a/lib/cache/cached-package-root.js
+++ b/lib/cache/cached-package-root.js
@@ -1,0 +1,14 @@
+var assert = require("assert")
+var resolve = require("path").resolve
+
+var npm = require("../npm.js")
+
+module.exports = getCacheRoot
+
+function getCacheRoot (data) {
+  assert(data, "must pass package metadata")
+  assert(data.name, "package metadata must include name")
+  assert(data.version, "package metadata must include version")
+
+  return resolve(npm.cache, data.name, data.version)
+}

--- a/lib/install.js
+++ b/lib/install.js
@@ -302,11 +302,9 @@ function readDependencies (context, where, opts, cb) {
     var wrapfile = path.resolve(where, "npm-shrinkwrap.json")
 
     fs.readFile(wrapfile, "utf8", function (er, wrapjson) {
-      if (er) {
-        log.verbose("readDependencies", "using package.json deps")
-        return cb(null, data, null)
-      }
+      if (er) return cb(null, data, null)
 
+      log.verbose("readDependencies", "npm-shrinkwrap.json is overriding dependencies")
       var newwrap
       try {
         newwrap = JSON.parse(wrapjson)
@@ -652,7 +650,7 @@ function installMany (what, where, context, cb) {
       targets.forEach(function (t) {
         newPrev[t.name] = t.version
       })
-      log.silly("resolved", targets)
+      log.silly("install resolved", targets)
       targets.filter(function (t) { return t }).forEach(function (t) {
         log.info("install", "%s into %s", t._id, where)
       })

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -424,11 +424,7 @@ Object.defineProperty(npm, "cache",
   })
 
 var tmpFolder
-var crypto = require("crypto")
-var rand = crypto.randomBytes(6)
-                 .toString("base64")
-                 .replace(/\//g, '_')
-                 .replace(/\+/, '-')
+var rand = require("crypto").randomBytes(4).toString("hex")
 Object.defineProperty(npm, "tmp",
   { get : function () {
       if (!tmpFolder) tmpFolder = "npm-" + process.pid + "-" + rand

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -12,6 +12,7 @@ var npm = require("./npm.js")
   , path = require("path")
   , cwd = process.cwd()
   , writeStream = require('fs-write-stream-atomic')
+  , cachedPackageRoot = require("./cache/cached-package-root.js")
 
 pack.usage = "npm pack <pkg>"
 
@@ -44,15 +45,12 @@ function pack_ (pkg, cb) {
   cache.add(pkg, null, null, false, function (er, data) {
     if (er) return cb(er)
 
-    var name = data.name
     // scoped packages get special treatment
+    var name = data.name
     if (name[0] === "@") name = name.substr(1).replace(/\//g, "-")
-
     var fname = name + "-" + data.version + ".tgz"
-      , cached = path.resolve( npm.cache
-                             , data.name
-                             , data.version
-                             , "package.tgz" )
+
+    var cached = path.join(cachedPackageRoot(data), "package.tgz")
       , from = fs.createReadStream(cached)
       , to = writeStream(fname)
       , errState = null

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -11,6 +11,7 @@ var url = require("url")
   , Conf = require("npmconf").Conf
   , RegClient = require("npm-registry-client")
   , mapToRegistry = require("./utils/map-to-registry.js")
+  , cachedPackageRoot = require("./cache/cached-package-root.js")
 
 publish.usage = "npm publish <tarball>"
               + "\nnpm publish <folder>"
@@ -55,10 +56,7 @@ function cacheAddPublish (dir, didPre, isRetry, cb) {
   npm.commands.cache.add(dir, null, null, false, function (er, data) {
     if (er) return cb(er)
     log.silly("publish", data)
-    var cachedir = path.resolve( npm.cache
-                               , data.name
-                               , data.version
-                               , "package" )
+    var cachedir = path.resolve(cachedPackageRoot(data), "package")
     chain([ !didPre &&
           [lifecycle, data, "prepublish", cachedir]
         , [publish_, dir, data, isRetry, cachedir]

--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -24,7 +24,7 @@ function unbuild_ (silent) { return function (folder, cb_) {
   }
   folder = path.resolve(folder)
   delete build._didBuild[folder]
-  log.verbose(folder.substr(npm.prefix.length + 1), "unbuild")
+  log.verbose("unbuild", folder.substr(npm.prefix.length + 1))
   readJson(path.resolve(folder, "package.json"), function (er, pkg) {
     // if no json, then just trash it, but no scripts or whatever.
     if (er) return gentlyRm(folder, false, cb)
@@ -53,7 +53,8 @@ function rmStuff (pkg, folder, cb) {
 
   readJson.cache.del(path.resolve(folder, "package.json"))
 
-  log.verbose([top, gnm, parent], "unbuild " + pkg._id)
+  log.verbose("unbuild rmStuff", pkg._id, "from", gnm)
+  if (!top) log.verbose("unbuild rmStuff", "in", parent)
   asyncMap([rmBins, rmMans], function (fn, cb) {
     fn(pkg, folder, parent, top, cb)
   }, cb)

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -11,7 +11,7 @@ var cbCalled = false
   , exitCode = 0
   , rollbacks = npm.rollbacks
   , chain = require("slide").chain
-  , writeStream = require('fs-write-stream-atomic')
+  , writeStream = require("fs-write-stream-atomic")
 
 
 process.on("exit", function (code) {
@@ -80,7 +80,7 @@ function exit (code, noLog) {
   else rm("npm-debug.log", reallyExit)
 
   function reallyExit (er) {
-    if (er && !code) code = typeof er.errno === 'number' ? er.errno : 1
+    if (er && !code) code = typeof er.errno === "number" ? er.errno : 1
 
     // truncate once it's been written.
     log.record.length = 0
@@ -356,8 +356,7 @@ function writeLogFile (cb) {
   writingLogFile = true
   wroteLogFile = true
 
-  var fs = require("graceful-fs")
-    , fstr = writeStream("npm-debug.log")
+  var fstr = writeStream("npm-debug.log")
     , os = require("os")
     , out = ""
 

--- a/lib/utils/locker.js
+++ b/lib/utils/locker.js
@@ -10,9 +10,8 @@ var installLocks = {}
 function lockFileName (base, name) {
   var c = name.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "")
     , h = crypto.createHash("sha1").update(name).digest("hex")
-  var generated = "." + h.substr(0, 8) + "-" + c.substr(-32)
-  log.silly("lockFile", generated, name)
-  return path.resolve(base, generated + ".lock")
+
+  return path.resolve(base, "."+h.substr(0, 8)+"-"+c.substr(-32)+".lock")
 }
 
 function lock (base, name, cb) {
@@ -23,7 +22,7 @@ function lock (base, name, cb) {
                , retries: npm.config.get("cache-lock-retries")
                , wait:    npm.config.get("cache-lock-wait") }
     var lf = lockFileName(base, name)
-    log.verbose("lock", name, lf)
+    log.verbose("locking", name, "with", lf)
     lockfile.lock(lf, opts, function(er) {
       if (!er) installLocks[lf] = true
       cb(er)
@@ -38,6 +37,7 @@ function unlock (base, name, cb) {
     return process.nextTick(cb)
   }
   else if (locked === true) {
+    log.verbose("unlocking", name, "from", lf)
     installLocks[lf] = false
     lockfile.unlock(lf, cb)
   }

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -75,7 +75,8 @@ function pack_ (tarball, folder, pkg, cb) {
 
 
 function unpack (tarball, unpackTarget, dMode, fMode, uid, gid, cb) {
-  log.verbose("tar unpack", tarball)
+  log.verbose("tar", "unpack", tarball)
+  log.verbose("tar", "unpacking to", unpackTarget)
   if (typeof cb !== "function") cb = gid, gid = null
   if (typeof cb !== "function") cb = uid, uid = null
   if (typeof cb !== "function") cb = fMode, fMode = npm.modes.file


### PR DESCRIPTION
Fixes #6329 by pretty comprehensively cleaning up how the cache deals with local tarballs. Among other things, it makes sure that each tarball being verified is being written to a unique directory, but it also removes an extraneous operation (copying local tarballs – which will only be read – into the run's temporary directory). So: safer and faster, both things I like.
