### PR TITLE
realize-package-specifier@1.1.0

### DIFF
--- a/node_modules/realize-package-specifier/index.js
+++ b/node_modules/realize-package-specifier/index.js
@@ -5,7 +5,7 @@ var dz = require("dezalgo")
 var npa = require("npm-package-arg")
 
 module.exports = function (spec, where, cb) {
-  if (where instanceof Function) cb = where, where = null
+  if (where instanceof Function) { cb = where; where = null }
   if (where == null) where = "."
   cb = dz(cb)
   try {
@@ -14,7 +14,9 @@ module.exports = function (spec, where, cb) {
   catch (e) {
     return cb(e)
   }
-  var specpath = path.resolve(where, dep.type == "local" ? dep.spec : spec)
+  var specpath = dep.type == "local"
+               ? path.resolve(where, dep.spec)
+               : path.resolve(spec)
   fs.stat(specpath, function (er, s) {
     if (er) return finalize()
     if (!s.isDirectory()) return finalize("local")

--- a/node_modules/realize-package-specifier/package.json
+++ b/node_modules/realize-package-specifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realize-package-specifier",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Like npm-package-arg, but more so, producing full file paths and differentiating local tar and directory sources.",
   "main": "index.js",
   "scripts": {
@@ -27,11 +27,11 @@
   },
   "readme": "realize-package-specifier\n-------------------------\n\nParse a package specifier, peeking at the disk to differentiate between\nlocal tarballs, directories and named modules.  This implements the logic\nused by `npm install` and `npm cache` to determine where to get packages\nfrom.\n\n```javascript\nvar realizePackageSpecifier = require(\"realize-package-specifier\")\nrealizePackageSpecifier(\"foo.tar.gz\", \".\", function (err, package) {\n    …\n})\n```\n\n* realizePackageSpecifier(*spec*, [*where*,] *callback*)\n\nParses *spec* using `npm-package-arg` and then uses stat to check to see if\nit refers to a local tarball or package directory.  Stats are done relative\nto *where*.  If it does then the local module is loaded.  If it doesn't then\ntarget is left as a remote package specifier.  Package directories are\nrecognized by the presence of a package.json in them.\n\n*spec* -- a package specifier, like: `foo@1.2`, or `foo@user/foo`, or\n`http://x.com/foo.tgz`, or `git+https://github.com/user/foo`\n\n*where* (optional, default: .) -- The directory in which we should look for\nlocal tarballs or package directories.\n\n*callback* function(*err*, *result*) -- Called once we've determined what\nkind of specifier this is.  The *result* object will be very like the one\nreturned by `npm-package-arg` except with three differences: 1) There's a\nnew type of `directory`.  2) The `local` type only refers to tarballs.  2)\nFor all `local` and `directory` type results spec will contain the full path of\nthe local package.\n\n## Result Objects\n\nThe full definition of the result object is:\n\n* `name` - If known, the `name` field expected in the resulting pkg.\n* `type` - One of the following strings:\n  * `git` - A git repo\n  * `github` - A github shorthand, like `user/project`\n  * `tag` - A tagged version, like `\"foo@latest\"`\n  * `version` - A specific version number, like `\"foo@1.2.3\"`\n  * `range` - A version range, like `\"foo@2.x\"`\n  * `local` - A local file path\n  * `directory` - A local package directory\n  * `remote` - An http url (presumably to a tgz)\n* `spec` - The \"thing\".  URL, the range, git repo, etc.\n* `raw` - The original un-modified string that was provided.\n* `rawSpec` - The part after the `name@...`, as it was originally\n  provided.\n* `scope` - If a name is something like `@org/module` then the `scope`\n  field will be set to `org`.  If it doesn't have a scoped name, then\n  scope is `null`.\n\n",
   "readmeFilename": "README.md",
-  "gitHead": "dfcebc3f870afbb4b9428bc8f5f87f27504a9f2b",
+  "gitHead": "7243d67f21a089b0670f3f3e254b98475b232b0b",
   "bugs": {
     "url": "https://github.com/npm/realize-package-specifier/issues"
   },
-  "_id": "realize-package-specifier@1.0.2",
-  "_shasum": "4933772f74d7b8181b483171d53051a9f15f0009",
-  "_from": "../realize-package-specifier"
+  "_id": "realize-package-specifier@1.1.0",
+  "_shasum": "b6922638b7224186ae9278bdebbb63cba23a0160",
+  "_from": "realize-package-specifier@1.1.0"
 }

--- a/node_modules/realize-package-specifier/test/basic.js
+++ b/node_modules/realize-package-specifier/test/basic.js
@@ -9,7 +9,10 @@ var re = {
   packagejson: /[\/\\]b[\/\\]package.json$/,
   nonpackagedir: /[\/\\]c$/,
   nopackagejson: /[\/\\]c[\/\\]package.json$/,
-  remotename: /[\/\\]d$/
+  remotename: /[\/\\]d$/,
+  packagedirlikegithub: /[\/\\]e[\/\\]1$/,
+  packagejsonlikegithub: /[\/\\]e[\/\\]1[\/\\]package.json$/,
+  github: /[\/\\]e[\/\\]2$/
 }
 
 var rps = requireInject("../index", {
@@ -33,6 +36,15 @@ var rps = requireInject("../index", {
       else if (re.remotename.test(path)) {
         callback(new Error("EFILENOTFOUND"))
       }
+      else if (re.packagedirlikegithub.test(path)) {
+        callback(null,{isDirectory:function(){ return true }})
+      }
+      else if (re.packagejsonlikegithub.test(path)) {
+        callback(null,{})
+      }
+      else if (re.github.test(path)) {
+        callback(new Error("EFILENOTFOUND"))
+      }
       else {
         throw new Error("Unknown stat fixture path: "+path)
       }
@@ -41,7 +53,7 @@ var rps = requireInject("../index", {
 })
 
 test("realize-package-specifier", function (t) {
-  t.plan(8)
+  t.plan(10)
   rps("a.tar.gz", function (err, result) {
     t.is(result.type, "local", "local tarball")
   })
@@ -65,5 +77,11 @@ test("realize-package-specifier", function (t) {
   })
   rps("file:./d", function (err, result) {
     t.is(result.type, "local", "no local directory, specified with a file URL")
+  })
+  rps("e/1", function (err, result) {
+    t.is(result.type, "directory", "local package directory")
+  })
+  rps("e/2", function (err, result) {
+    t.is(result.type, "github", "github package dependency")
   })
 })

--- a/node_modules/realize-package-specifier/test/npa-basic.js
+++ b/node_modules/realize-package-specifier/test/npa-basic.js
@@ -1,5 +1,5 @@
-var test = require('tap').test;
-var rps = require('../index.js')
+var test = require("tap").test;
+var rps = require("../index.js")
 var path = require("path")
 
 test("npa-basic", function (t) {
@@ -103,21 +103,21 @@ test("npa-basic", function (t) {
     "file:path/to/foo": {
       name: null,
       type: "local",
-      spec: "path/to/foo",
+      spec: path.resolve(__dirname,"..","path/to/foo"),
       raw: "file:path/to/foo"
     },
 
     "file:~/path/to/foo": {
       name: null,
       type: "local",
-      spec: "~/path/to/foo",
+      spec: path.resolve(__dirname,"..","~/path/to/foo"),
       raw: "file:~/path/to/foo"
     },
 
     "file:../path/to/foo": {
       name: null,
       type: "local",
-      spec: "../path/to/foo",
+      spec: path.resolve(__dirname,"..","../path/to/foo"),
       raw: "file:../path/to/foo"
     },
 
@@ -188,7 +188,7 @@ test("npa-basic", function (t) {
   t.plan( 2 + Object.keys(tests).length * 3 )
 
   Object.keys(tests).forEach(function (arg) {
-    rps(arg, function(err, res) {
+    rps(arg, path.resolve(__dirname,'..'), function(err, res) {
       t.notOk(err, "No error")
       t.type(res, "Result")
       t.has(res, tests[arg])
@@ -196,11 +196,11 @@ test("npa-basic", function (t) {
   })
 
   // Completely unreasonable invalid garbage throws an error
-  rps("this is not a \0 valid package name or url", function (err) {
+  rps("this is not a \0 valid package name or url", path.resolve(__dirname,'..'), function (err) {
     t.ok(err, "error")
   })
 
-  rps("gopher://yea right", function (err) {
+  rps("gopher://yea right", path.resolve(__dirname,'..'), function (err) {
     t.ok(err, "Unsupported URL Type: gopher://yea right")
   })
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "read-installed": "~3.1.2",
     "read-package-json": "~1.2.7",
     "readable-stream": "~1.0.32",
-    "realize-package-specifier": "~1.0.2",
+    "realize-package-specifier": "~1.1.0",
     "request": "~2.44.0",
     "retry": "~0.6.0",
     "rimraf": "~2.2.8",


### PR DESCRIPTION
Fix my misunderstanding of the difference between file: urls and local
paths.  The former are typically in package.json files and are relative to
the package root, where as local paths are typically specificied on the
command line and are relative to the current working directory.
