### PR TITLE
remove need{Name,Version} in favor of inlining

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -145,14 +145,15 @@ function read (name, ver, forceBypass, cb) {
   }
 
   readJson(path.join(root, "package", "package.json"), function (er, data) {
-    er = needName(er, data)
-    er = needVersion(er, data)
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
+
+    if (data) {
+      if (!data.name) return cb(new Error("No name provided"))
+      if (!data.version) return cb(new Error("No version provided"))
+    }
+
     if (er) return addNamed(name, ver, null, c)
-
-    deprCheck(data)
-
-    c(er, data)
+    else c(er, data)
   })
 }
 
@@ -342,15 +343,3 @@ function afterAdd (cb) { return function (er, data) {
     })
   })
 }}
-
-function needName (er, data) {
-  return er ? er
-       : (data && !data.name) ? new Error("No name provided")
-       : null
-}
-
-function needVersion (er, data) {
-  return er ? er
-       : (data && !data.version) ? new Error("No version provided")
-       : null
-}

--- a/lib/cache/add-local.js
+++ b/lib/cache/add-local.js
@@ -52,24 +52,27 @@ function addLocalDirectory (p, pkgData, shasum, cb) {
     "Adding a cache directory to the cache will make the world implode."))
 
   readJson(path.join(p, "package.json"), false, function (er, data) {
-    er = needName(er, data)
-    er = needVersion(er, data)
-
-    // check that this is what we expected.
-    if (!er && pkgData.name && pkgData.name !== data.name) {
-      er = new Error( "Invalid Package: expected "
-                    + pkgData.name + " but found "
-                    + data.name )
-    }
-
-    if (!er && pkgData.version && pkgData.version !== data.version) {
-      er = new Error( "Invalid Package: expected "
-                    + pkgData.name + "@" + pkgData.version
-                    + " but found "
-                    + data.name + "@" + data.version )
-    }
-
     if (er) return cb(er)
+
+    if (!data.name) {
+      return cb(new Error("No name provided in package.json"))
+    }
+    else if (pkgData.name && pkgData.name !== data.name) {
+      return cb(new Error(
+        "Invalid package: expected " + pkgData.name + " but found " + data.name
+      ))
+    }
+
+    if (!data.version) {
+      return cb(new Error("No version provided in package.json"))
+    }
+    else if (pkgData.version && pkgData.version !== data.version) {
+      return cb(new Error(
+        "Invalid package: expected " + pkgData.name + "@" + pkgData.version +
+          " but found " + data.name + "@" + data.version
+      ))
+    }
+
     deprCheck(data)
 
     // pack to {cache}/name/ver/package.tgz
@@ -110,16 +113,4 @@ function addLocalDirectory (p, pkgData, shasum, cb) {
       }
     }
   })
-}
-
-function needName(er, data) {
-  return er ? er
-       : (data && !data.name) ? new Error("No name provided")
-       : null
-}
-
-function needVersion(er, data) {
-  return er ? er
-       : (data && !data.version) ? new Error("No version provided")
-       : null
 }

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -148,16 +148,21 @@ function addNameVersion (name, v, data, cb) {
     fs.stat(pkgtgz, function (er) {
       if (!er) {
         readJson(pkgjson, function (er, data) {
-          er = needName(er, data)
-          er = needVersion(er, data)
-          if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR")
-            return cb(er)
+          if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
+
+          if (data) {
+            if (!data.name) return cb(new Error("No name provided"))
+            if (!data.version) return cb(new Error("No version provided"))
+
+            // check the SHA of the package we have, to ensure it wasn't installed
+            // from somewhere other than the registry (eg, a fork)
+            if (data._shasum && dist.shasum && data._shasum !== dist.shasum) {
+              return fetchit()
+            }
+          }
+
           if (er) return fetchit()
-          // check the SHA of the package we have, to ensure it wasn't installed
-          // from somewhere other than the registry (eg, a fork)
-          if (data._shasum && dist.shasum && data._shasum !== dist.shasum)
-            return fetchit()
-          return cb(null, data)
+            else return cb(null, data)
         })
       } else return fetchit()
     })
@@ -192,7 +197,8 @@ function addNameVersion (name, v, data, cb) {
 function addNameRange (name, range, data, cb) {
   range = semver.validRange(range, true)
   if (range === null) return cb(new Error(
-    "Invalid version range: "+range))
+    "Invalid version range: " + range
+  ))
 
   log.silly("addNameRange", {name:name, range:range, hasData:!!data})
 
@@ -269,16 +275,4 @@ function errorResponse (name, response) {
     er.pkgid = name
   }
   return er
-}
-
-function needName(er, data) {
-  return er ? er
-       : (data && !data.name) ? new Error("No name provided")
-       : null
-}
-
-function needVersion(er, data) {
-  return er ? er
-       : (data && !data.version) ? new Error("No version provided")
-       : null
 }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -36,14 +36,18 @@ function publish (args, isRetry, cb) {
   var arg = args[0]
   // if it's a local folder, then run the prepublish there, first.
   readJson(path.resolve(arg, "package.json"), function (er, data) {
-    er = needVersion(er, data)
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
-    // error is ok.  could be publishing a url or tarball
-    // however, that means that we will not have automatically run
-    // the prepublish script, since that gets run when adding a folder
-    // to the cache.
+
+    if (data) {
+      if (!data.name) return cb(new Error("No name provided"))
+      if (!data.version) return cb(new Error("No version provided"))
+    }
+
+    // Error is OK. Could be publishing a URL or tarball, however, that means
+    // that we will not have automatically run the prepublish script, since
+    // that gets run when adding a folder to the cache.
     if (er) return cacheAddPublish(arg, false, isRetry, cb)
-    cacheAddPublish(arg, true, isRetry, cb)
+    else cacheAddPublish(arg, true, isRetry, cb)
   })
 }
 
@@ -126,10 +130,4 @@ function publish_ (arg, data, isRetry, cachedir, cb) {
       cb()
     })
   })
-}
-
-function needVersion(er, data) {
-  return er ? er
-       : (data && !data.version) ? new Error("No version provided")
-       : null
 }


### PR DESCRIPTION
Lil thinger to simplify / clarify package metadata verification a little. Can probably by DRYed up into a little helper module, but it's actually pretty helpful to have the explicit conditional flow right there in the function. I think?
