### PR TITLE
inflight by URL rather than package spec; improve logging

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -134,6 +134,9 @@ function read (name, ver, forceBypass, cb) {
 
   var root = cachedPackageRoot({name : name, version : ver})
   function c (er, data) {
+    log.silly("cache", "addNamed cb", name+"@"+ver)
+    if (er) log.verbose("cache", "addNamed error for", name+"@"+ver, er)
+
     if (data) deprCheck(data)
 
     return cb(er, data)
@@ -268,7 +271,7 @@ function add (args, where, cb) {
   if (adding <= 0) {
     npm.spinner.start()
   }
-  adding ++
+  adding++
   cb = afterAdd(cb)
 
   realizePackageSpecifier(spec, where, function (err, p) {
@@ -322,24 +325,23 @@ function unpack (pkg, ver, unpackTarget, dMode, fMode, uid, gid, cb) {
 
 function afterAdd (cb) { return function (er, data) {
   adding--
-  if (adding <= 0) {
-    npm.spinner.stop()
-  }
-  if (er || !data || !data.name || !data.version) {
-    return cb(er, data)
-  }
+  if (adding <= 0) npm.spinner.stop()
+
+  if (er || !data || !data.name || !data.version) return cb(er, data)
+  log.silly("cache", "afterAdd", data.name+"@"+data.version)
 
   // Save the resolved, shasum, etc. into the data so that the next
   // time we load from this cached data, we have all the same info.
   var pj = path.join(cachedPackageRoot(data), "package", "package.json")
 
   var done = inflight(pj, cb)
-  if (!done) return log.verbose("afterAdd", pj, "already in flight; waiting")
+  if (!done) return log.verbose("afterAdd", pj, "already in flight; not writing")
   log.verbose("afterAdd", pj, "not in flight; writing")
 
   getStat(function (er, cs) {
     if (er) return done(er)
     writeFileAtomic(pj, JSON.stringify(data), {chown : cs}, function (er) {
+      if (!er) log.verbose("afterAdd", pj, "written")
       return done(er, data)
     })
   })

--- a/lib/cache/add-local-tarball.js
+++ b/lib/cache/add-local-tarball.js
@@ -87,12 +87,16 @@ function addTmpTarball (tgz, pkgData, shasum, cb) {
   assert(shasum, "must have shasum by now")
 
   cb = inflight("addTmpTarball:" + tgz, cb)
-  if (!cb) return log.verbose("addTmpTarball", tgz, "already in flight; waiting")
-  log.verbose("addTmpTarball", tgz, "not in flight; verifying")
+  if (!cb) return log.verbose("addTmpTarball", tgz, "already in flight; not adding")
+  log.verbose("addTmpTarball", tgz, "not in flight; adding")
 
   // we already have the package info, so just move into place
   if (pkgData && pkgData.name && pkgData.version) {
-    log.verbose("addTmpTarball", "already have metadata; skipping unpack")
+    log.verbose(
+      "addTmpTarball",
+      "already have metadata; skipping unpack for",
+      pkgData.name + "@" + pkgData.version
+    )
     return addTmpTarball_(tgz, pkgData, shasum, cb)
   }
 

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -17,6 +17,19 @@ var path = require("path")
 
 module.exports = addNamed
 
+function getOnceFromRegistry (name, from, next, done) {
+  mapToRegistry(name, npm.config, function (er, uri) {
+    if (er) return done(er)
+
+    var key = "registry:" + uri
+    next = inflight(key, next)
+    if (!next) return log.verbose(from, key, "already in flight; waiting")
+    else log.verbose(from, key, "not in flight; fetching")
+
+    registry.get(uri, null, next)
+  })
+}
+
 function addNamed (name, version, data, cb_) {
   assert(typeof name === "string", "must have module name")
   assert(typeof cb_ === "function", "must have callback")
@@ -28,10 +41,6 @@ function addNamed (name, version, data, cb_) {
     if (data && !data._fromGithub) data._from = key
     cb_(er, data)
   }
-
-  cb_ = inflight("addName:" + key, cb_)
-  if (!cb_) return log.verbose("addNamed", key, "already in flight; waiting")
-  log.verbose("addNamed", key, "not in flight; adding")
 
   log.silly("addNamed", "semver.valid", semver.valid(version))
   log.silly("addNamed", "semver.validRange", semver.validRange(version))
@@ -50,17 +59,14 @@ function addNameTag (name, tag, data, cb) {
     tag = npm.config.get("tag")
   }
 
-  mapToRegistry(name, npm.config, function (er, uri) {
-    if (er) return cb(er)
-
-    registry.get(uri, null, next)
-  })
+  getOnceFromRegistry(name, "addNameTag", next, cb)
 
   function next (er, data, json, resp) {
-    if (!er) {
-      er = errorResponse(name, resp)
-    }
+    if (!er) er = errorResponse(name, resp)
     if (er) return cb(er)
+
+    log.silly("addNameTag", "next cb for", name, "with tag", tag)
+
     engineFilter(data)
     if (data["dist-tags"] && data["dist-tags"][tag]
         && data.versions[data["dist-tags"][tag]]) {
@@ -105,11 +111,7 @@ function addNameVersion (name, v, data, cb) {
     return next()
   }
 
-  mapToRegistry(name, npm.config, function (er, uri) {
-    if (er) return cb(er)
-
-    registry.get(uri, null, setData)
-  })
+  getOnceFromRegistry(name, "addNameVersion", setData, cb)
 
   function setData (er, d, json, resp) {
     if (!er) {
@@ -203,11 +205,7 @@ function addNameRange (name, range, data, cb) {
 
   if (data) return next()
 
-  mapToRegistry(name, npm.config, function (er, uri) {
-    if (er) return cb(er)
-
-    registry.get(uri, null, setData)
-  })
+  getOnceFromRegistry(name, "addNameRange", setData, cb)
 
   function setData (er, d, json, resp) {
     if (!er) {

--- a/lib/utils/locker.js
+++ b/lib/utils/locker.js
@@ -29,10 +29,14 @@ function lock (base, name, cb) {
                  , retries: npm.config.get("cache-lock-retries")
                  , wait:    npm.config.get("cache-lock-wait") }
       var lf = lockFileName(base, name)
-      log.verbose("lock", "using", lf, "for", resolve(base, name))
-      lockfile.lock(lf, opts, function(er) {
-        if (er) log.warn("locking", "failed", er)
-        if (!er) installLocks[lf] = true
+      lockfile.lock(lf, opts, function (er) {
+        if (er) log.warn("locking", lf, "failed", er)
+
+        if (!er) {
+          log.verbose("lock", "using", lf, "for", resolve(base, name))
+          installLocks[lf] = true
+        }
+
         cb(er)
       })
     })
@@ -46,9 +50,17 @@ function unlock (base, name, cb) {
     return process.nextTick(cb)
   }
   else if (locked === true) {
-    log.verbose("unlock", "done using", lf, "for", resolve(base, name))
-    installLocks[lf] = false
-    lockfile.unlock(lf, cb)
+    lockfile.unlock(lf, function (er) {
+      if (er) {
+        log.warn("unlocking", lf, "failed", er)
+      }
+      else {
+        installLocks[lf] = false
+        log.verbose("unlock", "done using", lf, "for", resolve(base, name))
+      }
+
+      cb(er)
+    })
   }
   else {
     throw new Error(

--- a/node_modules/inflight/inflight.js
+++ b/node_modules/inflight/inflight.js
@@ -14,20 +14,31 @@ function inflight (key, cb) {
   }
 }
 
-function makeres(key) {
-  return once(function RES (error, data) {
+function makeres (key) {
+  return once(function RES () {
     var cbs = reqs[key]
     var len = cbs.length
+    var args = slice(arguments)
     for (var i = 0; i < len; i++) {
-      cbs[i](error, data)
+      cbs[i].apply(null, args)
     }
     if (cbs.length > len) {
       // added more in the interim.
       // de-zalgo, just in case, but don't call again.
       cbs.splice(0, len)
-      process.nextTick(RES.bind(this, error, data))
+      process.nextTick(function () {
+        RES.apply(null, args)
+      })
     } else {
       delete reqs[key]
     }
   })
+}
+
+function slice (args) {
+  var length = args.length
+  var array = []
+
+  for (var i = 0; i < length; i++) array[i] = args[i]
+  return array
 }

--- a/node_modules/inflight/package.json
+++ b/node_modules/inflight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inflight",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Add callbacks to requests in flight to avoid async duplication",
   "main": "inflight.js",
   "dependencies": {
@@ -29,8 +29,8 @@
   "license": "ISC",
   "readme": "# inflight\n\nAdd callbacks to requests in flight to avoid async duplication\n\n## USAGE\n\n```javascript\nvar inflight = require('inflight')\n\n// some request that does some stuff\nfunction req(key, callback) {\n  // key is any random string.  like a url or filename or whatever.\n  //\n  // will return either a falsey value, indicating that the\n  // request for this key is already in flight, or a new callback\n  // which when called will call all callbacks passed to inflightk\n  // with the same key\n  callback = inflight(key, callback)\n\n  // If we got a falsey value back, then there's already a req going\n  if (!callback) return\n\n  // this is where you'd fetch the url or whatever\n  // callback is also once()-ified, so it can safely be assigned\n  // to multiple events etc.  First call wins.\n  setTimeout(function() {\n    callback(null, key)\n  }, 100)\n}\n\n// only assigns a single setTimeout\n// when it dings, all cbs get called\nreq('foo', cb1)\nreq('foo', cb2)\nreq('foo', cb3)\nreq('foo', cb4)\n```\n",
   "readmeFilename": "README.md",
-  "gitHead": "a10cb02457ed415c9019d185902ec3db85b03984",
-  "_id": "inflight@1.0.3",
-  "_shasum": "70374be8ef3316248f37fa81276b6b329b95ff49",
-  "_from": "inflight@>=1.0.3 <1.1.0"
+  "gitHead": "c7b5531d572a867064d4a1da9e013e8910b7d1ba",
+  "_id": "inflight@1.0.4",
+  "_shasum": "6cbb4521ebd51ce0ec0a936bfd7657ef7e9b172a",
+  "_from": "inflight@>=1.0.4 <1.1.0"
 }

--- a/node_modules/inflight/test.js
+++ b/node_modules/inflight/test.js
@@ -73,3 +73,25 @@ test('timing', function (t) {
 
   process.nextTick(log.bind(null, 'tick'))
 })
+
+test('parameters', function (t) {
+  t.plan(8)
+
+  var a = inf('key', function (first, second, third) {
+    t.equal(first, 1)
+    t.equal(second, 2)
+    t.equal(third, 3)
+  })
+  t.ok(a, 'first returned cb function')
+
+  var b = inf('key', function (first, second, third) {
+    t.equal(first, 1)
+    t.equal(second, 2)
+    t.equal(third, 3)
+  })
+  t.notOk(b, 'second should get falsey inflight response')
+
+  setTimeout(function () {
+    a(1, 2, 3)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "github-url-from-username-repo": "~1.0.2",
     "glob": "~4.0.5",
     "graceful-fs": "~3.0.0",
-    "inflight": "~1.0.3",
+    "inflight": "~1.0.4",
     "inherits": "~2.0.1",
     "ini": "~1.2.0",
     "init-package-json": "~1.1.0",


### PR DESCRIPTION
This is a work in progress to map in-flight deferral to actual network requests, by using as the inflight key the actual registry URL being called. Also includes some better logging, and a version of inflight upgraded to pass all of a callback's parameters to the proxied calls.
