### PR TITLE
Allow view in global mode if pkg is specified

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -60,16 +60,16 @@ var npm = require("./npm.js")
 function view (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
 
-  if (npm.config.get("global") === true) {
-    return cb(new Error("Cannot use view command in global mode."))
-  }
-
   if (!args.length) args = ["."]
 
   var pkg = args.shift()
     , nv = npa(pkg)
     , name = nv.name
     , local = (name === "." || !name)
+
+  if (npm.config.get("global") === true && local) {
+    return cb(new Error("Cannot use view command in global mode."))
+  }
 
   if (local) {
     var dir = npm.prefix

--- a/test/tap/view.js
+++ b/test/tap/view.js
@@ -47,6 +47,20 @@ test("npm view . in global mode", function(t) {
   })
 })
 
+test("npm view --global", function(t) {
+  process.chdir(t1dir)
+  common.npm([
+    "view"
+  , "--registry=" + common.registry
+  , "--global"
+  ], { cwd: t1dir }, function(err, code, stdout, stderr) {
+    t.ifError(err, "error should not exist")
+    t.equal(code, 1, "exit not ok")
+    t.similar(stderr, /Cannot use view command in global mode./m)
+    t.end()
+  })
+})
+
 test("npm view . with no package.json", function(t) {
   process.chdir(t1dir)
   common.npm([
@@ -156,6 +170,24 @@ test("npm view <package name>", function(t) {
     common.npm([
       "view"
     , "underscore"
+    , "--registry=" + common.registry
+    ], { cwd: t2dir }, function(err, code, stdout) {
+      t.ifError(err, "error should not exist")
+      t.equal(code, 0, "exit ok")
+      var re = new RegExp("name: 'underscore'")
+      t.similar(stdout, re, "should have name `underscore`")
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test("npm view <package name> --global", function(t) {
+  mr(common.port, function(s) {
+    common.npm([
+      "view"
+    , "underscore"
+    , "--global"
     , "--registry=" + common.registry
     ], { cwd: t2dir }, function(err, code, stdout) {
       t.ifError(err, "error should not exist")


### PR DESCRIPTION
This allows `npm view <package> --global` while preventing `npm view . --global`
