### PR TITLE
inflight installs, prevent peerDependency problems

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -85,6 +85,7 @@ var npm = require("./npm.js")
   , sortedObject = require("sorted-object")
   , mapToRegistry = require("./utils/map-to-registry.js")
   , npa = require("npm-package-arg")
+  , inflight = require("inflight")
   , locker = require("./utils/locker.js")
   , lock = locker.lock
   , unlock = locker.unlock
@@ -882,14 +883,7 @@ function resultList (target, where, parentId) {
          , target._from ]
 }
 
-// name => install locations
-var installOnesInProgress = Object.create(null)
 var installed = Object.create(null)
-
-function isIncompatibleInstallOneInProgress(target, where) {
-  return target.name in installOnesInProgress &&
-         installOnesInProgress[target.name].indexOf(where) !== -1
-}
 
 function installOne_ (target, where, context, cb_) {
   var nm = path.resolve(where, "node_modules")
@@ -899,11 +893,19 @@ function installOne_ (target, where, context, cb_) {
 
   if (prettyWhere === ".") prettyWhere = null
 
-  if (isIncompatibleInstallOneInProgress(target, where)) {
-    // just call back, with no error.  the error will be detected in the
-    // final check for peer-invalid dependencies
-    return cb_()
-  }
+  cb_ = inflight(target.name + ":" + where, cb_)
+  if (!cb_) return log.verbose(
+    "installOne",
+    "of", target.name,
+    "to", where,
+    "already in flight; waiting"
+  )
+  else log.verbose(
+    "installOne",
+    "of", target.name,
+    "to", where,
+    "not in flight; installing"
+  )
 
   function cb(er, data) {
     unlock(nm, target.name, function () { cb_(er, data) })
@@ -921,12 +923,7 @@ function installOne_ (target, where, context, cb_) {
       installed[targetFolder] = [target.version]
     }
 
-    if (!(target.name in installOnesInProgress)) {
-      installOnesInProgress[target.name] = []
-    }
-    installOnesInProgress[target.name].push(where)
-    var indexOfIOIP = installOnesInProgress[target.name].length - 1
-      , force = npm.config.get("force")
+    var force = npm.config.get("force")
       , nodeVersion = npm.config.get("node-version")
       , strict = npm.config.get("engine-strict")
       , c = npmInstallChecks
@@ -938,8 +935,6 @@ function installOne_ (target, where, context, cb_) {
         , [c.checkGit, targetFolder]
         , [write, target, targetFolder, context] ]
       , function (er, d) {
-          installOnesInProgress[target.name].splice(indexOfIOIP, 1)
-
           if (er) return cb(er)
 
           d.push(resultList(target, where, parent && parent._id))
@@ -967,6 +962,7 @@ function write (target, targetFolder, context, cb_) {
 
   var bundled = []
 
+  log.silly("install write", "writing", target.name, target.version, "to", targetFolder)
   chain(
       [ [ cache.unpack, target.name, target.version, targetFolder
         , null, null, user, group ]
@@ -1003,14 +999,27 @@ function write (target, targetFolder, context, cb_) {
                           , explicit: false
                           , wrap: wrap }
 
+        var actions =
+          [ [ installManyAndBuild, deps, depsTargetFolder, depsContext ] ]
+
+        // FIXME: This is an accident waiting to happen!
+        //
+        // 1. If multiple children at the same level of the tree share a
+        //    peerDependency that's not in the parent's dependencies, because
+        //    the peerDeps don't get added to the family, they will keep
+        //    getting reinstalled (worked around by inflighting installOne).
+        // 2. The installer can't safely build at the parent level because
+        //    that's already being done by the parent's installAndBuild. This
+        //    runs the risk of the peerDependency never getting built.
+        //
+        //  The fix: Don't install peerDependencies; require them to be
+        //  included as explicit dependencies / devDependencies, and warn
+        //  or error when they're missing. See #5080 for more arguments in
+        //  favor of killing implicit peerDependency installs with fire.
         var peerDeps = prepareForInstallMany(data, "peerDependencies", bundled,
             wrap, family)
         var pdTargetFolder = path.resolve(targetFolder, "..", "..")
         var pdContext = context
-
-        var actions =
-          [ [ installManyAndBuild, deps, depsTargetFolder, depsContext ] ]
-
         if (peerDeps.length > 0) {
           actions.push(
             [ installMany, peerDeps, pdTargetFolder, pdContext ]
@@ -1053,8 +1062,9 @@ function prepareForInstallMany (packageData, depsKey, bundled, wrap, family) {
       return !semver.satisfies(family[d], packageData[depsKey][d], true)
     return true
   }).map(function (d) {
-    var t = packageData[depsKey][d]
-    t = d + "@" + t
+    var v = packageData[depsKey][d]
+    var t = d + "@" + v
+    log.silly("prepareForInstallMany", "adding", t, "from", packageData.name, depsKey)
     return t
   })
 }


### PR DESCRIPTION
Because of the cheesy backdoor mechanics peerDependencies use to get themselves installed, it's possible that more than one install to the same place can get queued up when peerDependencies aren't otherwise depended on. See the comment in the commit for details, and start getting used to explicitly depending on your peerDependencies, because that's the future.

The future is saner than now.
