### PR TITLE
Run script arguments are no longer passed to pre and post scripts

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -23,6 +23,9 @@ all the arguments after the `--` directly to your script:
 
     npm run test -- --grep="pattern"
 
+The arguments will only be passed to the script specified after ```npm run``` 
+and not to any pre or post script.
+
 ## SEE ALSO
 
 * npm-scripts(7)

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -134,7 +134,7 @@ function run (pkg, wd, cmd, args, cb) {
   log.verbose("run-script", cmds)
   chain(cmds.map(function (c) {
     // pass cli arguments after -- to script.
-    if (pkg.scripts[c]) pkg.scripts[c] = pkg.scripts[c] + joinArgs(args)
+    if (pkg.scripts[c] && c === cmd) pkg.scripts[c] = pkg.scripts[c] + joinArgs(args)
 
     // when running scripts explicitly, assume that they're trusted.
     return [lifecycle, pkg, c, wd, true]

--- a/test/tap/run-script/package.json
+++ b/test/tap/run-script/package.json
@@ -1,6 +1,13 @@
 {"name":"runscript"
 ,"version":"1.2.3"
 ,"scripts":{
-  "start":"node -e 'console.log(process.argv[1] || \"start\")'"
+  "start":"node -e 'console.log(process.argv[1] || \"start\")'",
+  "prewith-pre":"node -e 'console.log(process.argv[1] || \"pre\")'",
+  "with-pre":"node -e 'console.log(process.argv[1] || \"main\")'",
+  "with-post":"node -e 'console.log(process.argv[1] || \"main\")'",
+  "postwith-post":"node -e 'console.log(process.argv[1] || \"post\")'",
+  "prewith-both":"node -e 'console.log(process.argv[1] || \"pre\")'",
+  "with-both":"node -e 'console.log(process.argv[1] || \"main\")'",
+  "postwith-both":"node -e 'console.log(process.argv[1] || \"post\")'"
   }
 }


### PR DESCRIPTION
  When the arguments after "--" are joined with the command to be
  executed, a check is added to make sure that they are only added to
  the exact comman specified by the user.

Rewrote assert function for run-script tests.

  The assert function for run script previously only checked the last
  line of output which made it difficult to test pre and posts scripts.
  This change takes all output lines, removes empty lines and lines starting
  with '>' (npm output) and joins the remainder with ';'. All tests still
  pass unchanged and it should now be possible to test logging in pre and post
  scripts where the output would be "pre script output;main output;post
  script output".

Added tests for pre and post scripts.

  Added tests for what has worked before but has not been tested. (that
  pre and post scripts are executed along with the main script).

Added test running pre script explicitly with arguments

  Test to make sure that if a pre script is exeuted explicitly, e.g.
  "npm run prestart" it shoul accept arguments from the command line.

Added documentation for npm run-script.
