### PR TITLE
Simple fix to address bug #6325.  Added a limit to number of concurrent git commands

### DIFF
--- a/lib/utils/git.js
+++ b/lib/utils/git.js
@@ -17,9 +17,38 @@ function prefixGitArgs() {
   return process.platform === "win32" ? ["-c", "core.longpaths=true"] : []
 }
 
+var execCount = 0,
+    maxConcurrent = +(npm.config.get("git-max-concurrent") || 10),
+    execQueue = []
+
 function execGit(args, options, cb) {
   log.info("git", args)
-  return exec(git, prefixGitArgs().concat(args || []), options, cb)
+  if (execCount >= maxConcurrent) {
+    if (maxConcurrent == -1) {
+      // No concurrent connection limit, fallback to old way and use callback directly
+      return exec(git, prefixGitArgs().concat(args || []), options, cb)
+    }
+    else {
+      // If we are over the limit of concurrent git executions, then push this one onto a FIFO
+      // queue for later execution once the inflight ones have completed
+      log.info("git", "more than "+maxConcurrent+" concurrent git executions, deferring: " + args)
+      execQueue.push([args, options, cb])
+    }
+  }
+  else {
+    // If we are under the concurrent execution limit, the execute git but wrap callback
+    // with a new one that will check and drain the queue of waiting git calls
+    execCount++
+    var drainAndCallback = function() {
+      execCount--
+      if (execQueue.length > 0) {
+        log.info("git", "executing queued git command: " + args)
+        execGit.apply(null, execQueue.shift())
+      }
+      cb.apply(this, arguments);
+    };
+    return exec(git, prefixGitArgs().concat(args || []), options, drainAndCallback)
+  }
 }
 
 function spawnGit(args, options, cb) {


### PR DESCRIPTION
This is a simple patch that limits the number of git commands that can run at once. Default is 10 or the value of the "git-max-concurrent" config property.  This will resolve the bug where "npm install" will exceed the maximum connections of the SSH server and give the "ssh_exchange_identification: read: Connection reset by peer" error.
