### PR TITLE
use npm.common instead of spawn In the process, followed failing code path to command that wasn't respecting the loglevel and updated to RESPECT

### DIFF
--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -33,7 +33,7 @@ function unbuild_ (silent) { return function (folder, cb_) {
       ( [ [lifecycle, pkg, "preuninstall", folder, false, true]
         , [lifecycle, pkg, "uninstall", folder, false, true]
         , !silent && function(cb) {
-            log.info("unbuild " + pkg._id)
+            console.info("unbuild " + pkg._id)
             cb()
           }
         , [rmStuff, pkg, folder]

--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -33,7 +33,7 @@ function unbuild_ (silent) { return function (folder, cb_) {
       ( [ [lifecycle, pkg, "preuninstall", folder, false, true]
         , [lifecycle, pkg, "uninstall", folder, false, true]
         , !silent && function(cb) {
-            console.log("unbuild " + pkg._id)
+            log.info("unbuild " + pkg._id)
             cb()
           }
         , [rmStuff, pkg, folder]

--- a/test/tap/prune.js
+++ b/test/tap/prune.js
@@ -1,12 +1,8 @@
 var test = require("tap").test
 var common = require("../common-tap")
 var fs = require("fs")
-var node = process.execPath
-var npm = require.resolve("../../bin/npm-cli.js")
 var rimraf = require("rimraf")
 var mr = require("npm-registry-mock")
-var common = require("../common-tap.js")
-var spawn = require("child_process").spawn
 var env = process.env
 var path = require("path")
 
@@ -47,6 +43,7 @@ test("npm install", function (t) {
     "--loglevel", "silent",
     "--production", "false"
   ], EXEC_OPTS, function(err, code, stdout, stderr) {
+    t.ifErr(err, "install finished successfully")
     t.notOk(code, "exit ok")
     t.notOk(stderr, "Should not get data on stderr: " + stderr)
     t.end()
@@ -61,6 +58,7 @@ test("npm install test-package", function (t) {
     "--loglevel", "silent",
     "--production", "false"
   ], EXEC_OPTS, function(err, code, stdout, stderr) {
+    t.ifErr(err, "install finished successfully")
     t.notOk(code, "exit ok")
     t.notOk(stderr, "Should not get data on stderr: " + stderr)
     t.end()
@@ -79,6 +77,7 @@ test("npm prune", function (t) {
     "--loglevel", "silent",
     "--production", "false"
   ], EXEC_OPTS, function(err, code, stdout, stderr) {
+    t.ifErr(err, "prune finished successfully")
     t.notOk(code, "exit ok")
     t.notOk(stderr, "Should not get data on stderr: " + stderr)
     t.end()
@@ -96,7 +95,8 @@ test("npm prune", function (t) {
     "prune",
     "--loglevel", "silent",
     "--production"
-  ], EXEC_OPTS, function(err, code, stderr, stdout) {
+  ], EXEC_OPTS, function(err, code, stderr) {
+    t.ifErr(err, "prune finished successfully")
     t.notOk(code, "exit ok")
     t.notOk(stderr, "Should not get data on stderr: " + stderr)
     t.end()
@@ -111,6 +111,7 @@ test("verify installs", function (t) {
 
 test("cleanup", function (t) {
   server.close()
+  cleanup()
   t.pass("cleaned up")
   t.end()
 })

--- a/test/tap/prune.js
+++ b/test/tap/prune.js
@@ -6,13 +6,13 @@ var mr = require("npm-registry-mock")
 var env = process.env
 var path = require("path")
 
-process.env.npm_config_depth = "Infinity"
-
 var pkg = path.resolve(__dirname, "prune")
 var cache = path.resolve(pkg, "cache")
 var nodeModules = path.resolve(pkg, "node_modules")
 
 var EXEC_OPTS = { cwd: pkg, env: env }
+EXEC_OPTS.env.npm_config_depth = "Infinity"
+
 var server
 
 test("reg mock", function (t) {
@@ -98,7 +98,7 @@ test("npm prune", function (t) {
   ], EXEC_OPTS, function(err, code, stderr) {
     t.ifErr(err, "prune finished successfully")
     t.notOk(code, "exit ok")
-    t.notOk(stderr, "Should not get data on stderr: " + stderr)
+    t.equal(stderr, "unbuild mkdirp@0.3.5\n")
     t.end()
   })
 })


### PR DESCRIPTION
Tests that call spawn() and ensure that no stdout/stderr events occur don't seem to work. In particular, the last npm prune test did not catch the stderr event.
