### PR TITLE
added er.parent logging to ETARGET error

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -304,11 +304,15 @@ function errorHandler (er) {
     break
 
   case "ETARGET":
-    log.error("notarget", [er.message
+    var msg = [er.message
               ,"This is most likely not a problem with npm itself."
               ,"In most cases you or one of your dependencies are requesting"
               ,"a package version that doesn't exist."
-              ].join("\n"))
+              ]
+      if (er.parent) {
+        msg.push("\nIt was specified as a dependency of '"+er.parent+"'\n")
+      }
+      log.error("notarget", msg.join("\n"))
     break
 
   case "ENOTSUP":


### PR DESCRIPTION
Just adding in `er.parent` similar to the `E404` error so that you can track down version issues when installing modules.

I didn't see any tests dealing with the logging so I didn't add one. All tests pass locally tho :smile:
