### PR TITLE
write builtin config on any global npm install

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -25,3 +25,5 @@ html/*.png
 /npm-*.tgz
 
 *.pyc
+
+/test/tap/builtin-config

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ latest:
 	@echo "in this folder that you're looking at right now."
 	node cli.js install -g -f npm
 
-install: docclean all
+install: all
 	node cli.js install -g -f
 
 # backwards compat

--- a/lib/build.js
+++ b/lib/build.js
@@ -19,6 +19,8 @@ var npm = require("./npm.js")
   , cmdShim = require("cmd-shim")
   , cmdShimIfExists = cmdShim.ifExists
   , asyncMap = require("slide").asyncMap
+  , ini = require("ini")
+  , writeFile = require("write-file-atomic")
 
 module.exports = build
 build.usage = "npm build <folder>\n(this is plumbing)"
@@ -49,7 +51,7 @@ function build_ (global, didPre, didRB) { return function (folder, cb) {
     chain
       ( [ !didPre && [lifecycle, pkg, "preinstall", folder]
         , [linkStuff, pkg, folder, global, didRB]
-        , pkg.name === "npm" && [writeBuiltinConf, folder]
+        , [writeBuiltinConf, pkg, folder]
         , didPre !== build._noLC && [lifecycle, pkg, "install", folder]
         , didPre !== build._noLC && [lifecycle, pkg, "postinstall", folder]
         , didPre !== build._noLC
@@ -59,14 +61,21 @@ function build_ (global, didPre, didRB) { return function (folder, cb) {
   })
 }}
 
-function writeBuiltinConf (folder, cb) {
-  // the builtin config is "sticky". Any time npm installs itself,
-  // it puts its builtin config file there, as well.
-  if (!npm.config.usingBuiltin
-      || folder !== path.dirname(__dirname)) {
+function writeBuiltinConf (pkg, folder, cb) {
+  // the builtin config is "sticky". Any time npm installs
+  // itself globally, it puts its builtin config file there
+  var parent = path.dirname(folder)
+  var dir = npm.globalDir
+
+  if (pkg.name !== "npm" ||
+      !npm.config.get("global") ||
+      !npm.config.usingBuiltin ||
+      dir !== parent) {
     return cb()
   }
-  npm.config.save("builtin", cb)
+
+  var data = ini.stringify(npm.config.sources.builtin.data)
+  writeFile(path.resolve(folder, "npmrc"), data, cb)
 }
 
 function linkStuff (pkg, folder, global, didRB, cb) {

--- a/test/tap/builtin-config.js
+++ b/test/tap/builtin-config.js
@@ -1,0 +1,125 @@
+var fs = require("fs")
+
+if (process.argv[2] === "write-builtin") {
+  var pid = process.argv[3]
+  fs.writeFileSync("npmrc", "foo=bar\npid=" + pid + "\n")
+  return
+}
+
+var rcdata = "foo=bar\npid=" + process.pid + "\n"
+var common = require("../common-tap.js")
+var path = require("path")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var folder = path.resolve(__dirname, "builtin-config")
+var test = require("tap").test
+var npm = path.resolve(__dirname, "../..")
+var spawn = require("child_process").spawn
+var node = process.execPath
+
+test("setup", function (t) {
+  rimraf.sync(folder)
+  mkdirp.sync(folder + "/first")
+  mkdirp.sync(folder + "/second")
+  mkdirp.sync(folder + "/cache")
+  mkdirp.sync(folder + "/tmp")
+
+  t.pass("finished setup")
+  t.end()
+})
+
+
+test("install npm into first folder", function (t) {
+  var args = ["install", npm, "-g",
+              "--prefix=" + folder + "/first",
+              "--cache=" + folder + "/cache",
+              "--no-spin",
+              "--loglevel=silent",
+              "--tmp=" + folder + "/tmp"]
+  common.npm(args, {stdio: "inherit"}, function (er, code) {
+    if (er) throw er
+    t.equal(code, 0)
+    t.end()
+  })
+})
+
+test("write npmrc file", function (t) {
+  common.npm(["explore", "npm", "-g",
+              "--prefix=" + folder + "/first",
+              "--cache=" + folder + "/cache",
+              "--tmp=" + folder + "/tmp",
+              "--no-spin",
+              "--",
+              node, __filename, "write-builtin", process.pid
+             ],
+             {"stdio": "inherit"},
+             function (er, code) {
+    if (er) throw er
+    t.equal(code, 0)
+    t.end()
+  })
+})
+
+test("use first npm to install second npm", function (t) {
+  // get the root location
+  common.npm([ "root", "-g",
+               "--prefix=" + folder + "/first",
+               "--cache=" + folder + "/cache",
+               "--tmp=" + folder + "/tmp",
+               "--no-spin"
+             ], {}, function (er, code, so) {
+    if (er) throw er
+    t.equal(code, 0)
+    var root = so.trim()
+    t.ok(fs.statSync(root).isDirectory())
+
+    var bin = path.resolve(root, "npm/bin/npm-cli.js")
+    spawn( node
+         , [ bin
+           , "install", npm
+           , "-g"
+           , "--prefix=" + folder + "/second"
+           , "--cache=" + folder + "/cache"
+           , "--tmp=" + folder + "/tmp"
+           , "--no-spin"
+           ])
+    .on("error", function (er) { throw er })
+    .on("close", function (code) {
+      t.equal(code, 0, "code is zero")
+      t.end()
+    })
+  })
+})
+
+test("verify that the builtin config matches", function (t) {
+  common.npm([ "root", "-g",
+               "--prefix=" + folder + "/first",
+               "--cache=" + folder + "/cache",
+               "--tmp=" + folder + "/tmp"
+             ], {}, function (er, code, so) {
+    if (er) throw er
+    t.equal(code, 0)
+    var firstRoot = so.trim()
+    common.npm([ "root", "-g",
+                 "--prefix=" + folder + "/second",
+                 "--cache=" + folder + "/cache",
+                 "--tmp=" + folder + "/tmp"
+               ], {}, function (er, code, so) {
+      if (er) throw er
+      t.equal(code, 0)
+      var secondRoot = so.trim()
+      var firstRc = path.resolve(firstRoot, "npm", "npmrc")
+      var secondRc = path.resolve(secondRoot, "npm", "npmrc")
+      var firstData = fs.readFileSync(firstRc, "utf8")
+      var secondData = fs.readFileSync(secondRc, "utf8")
+      t.equal(firstData, secondData)
+      t.end()
+    })
+  })
+})
+
+
+test("clean", function (t) {
+  rimraf.sync(folder)
+  t.end()
+})


### PR DESCRIPTION
This is literally how it's always _supposed_ to have been working.  Yet,
mysteriously, it has not been.
