### PR TITLE
install peerDependencies from top

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -148,6 +148,22 @@ function install (args, cb_) {
         }
         var deps = Object.keys(data.dependencies || {})
         log.verbose("install", "where, deps", [where, deps])
+
+        // FIXME: Install peerDependencies as direct dependencies, but only at
+        // the top level. Should only last until peerDependencies are nerfed to
+        // no longer implicitly install themselves.
+        var peers = []
+        Object.keys(data.peerDependencies || {}).forEach(function (dep) {
+          if (!data.dependencies[dep]) {
+            log.verbose(
+              "install",
+              "peerDependency", dep, "wasn't going to be installed; adding"
+            )
+            peers.push(dep)
+          }
+        })
+        log.verbose("install", "where, peers", [where, peers])
+
         var context = { family: {}
                       , ancestors: {}
                       , explicit: false
@@ -165,9 +181,11 @@ function install (args, cb_) {
 
         installManyTop(deps.map(function (dep) {
           var target = data.dependencies[dep]
-          target = dep + "@" + target
-          return target
-        }), where, context, function(er, results) {
+          return dep + "@" + target
+        }).concat(peers.map(function (dep) {
+          var target = data.peerDependencies[dep]
+          return dep + "@" + target
+        })), where, context, function(er, results) {
           if (er || npm.config.get("production")) return cb(er, results)
           lifecycle(data, "prepublish", where, function(er) {
             return cb(er, results)

--- a/test/tap/peer-deps-toplevel.js
+++ b/test/tap/peer-deps-toplevel.js
@@ -7,24 +7,24 @@ var rimraf = require("rimraf")
 var mr = require("npm-registry-mock")
 var common = require("../common-tap.js")
 
-var pkg = path.resolve(__dirname, "peer-deps")
+var pkg = path.resolve(__dirname, "peer-deps-toplevel")
 var desiredResultsPath = path.resolve(pkg, "desired-ls-results.json")
 
 test("installs the peer dependency directory structure", function (t) {
   mr(common.port, function (s) {
     setup(function (err) {
-      if (err) return t.fail(err)
+      t.ifError(err, "setup ran successfully")
 
       npm.install(".", function (err) {
-        if (err) return t.fail(err)
+        t.ifError(err, "packages were installed")
 
         npm.commands.ls([], true, function (err, _, results) {
-          if (err) return t.fail(err)
+          t.ifError(err, "listed tree without problems")
 
           fs.readFile(desiredResultsPath, function (err, desired) {
-            if (err) return t.fail(err)
+            t.ifError(err, "read desired results")
 
-            t.deepEqual(results, JSON.parse(desired))
+            t.deepEqual(results, JSON.parse(desired), "got expected output from ls")
             s.close()
             t.end()
           })

--- a/test/tap/peer-deps-toplevel/desired-ls-results.json
+++ b/test/tap/peer-deps-toplevel/desired-ls-results.json
@@ -1,0 +1,20 @@
+{
+  "name": "npm-test-peer-deps-toplevel",
+  "version": "0.0.0",
+  "dependencies": {
+    "npm-test-peer-deps": {
+      "version": "0.0.0",
+      "dependencies": {
+        "underscore": {
+          "version": "1.3.1"
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.3.5"
+    },
+    "request": {
+      "version": "0.9.5"
+    }
+  }
+}

--- a/test/tap/peer-deps-toplevel/package.json
+++ b/test/tap/peer-deps-toplevel/package.json
@@ -1,0 +1,11 @@
+{
+  "author": "Domenic Denicola",
+  "name": "npm-test-peer-deps-toplevel",
+  "version": "0.0.0",
+  "dependencies": {
+    "npm-test-peer-deps": "*"
+  },
+  "peerDependencies": {
+    "mkdirp": "*"
+  }
+}


### PR DESCRIPTION
The simplest possible change to ensure that peerDependencies get installed properly – be sure to install them at the top level if they're included at the top level. Fixes #6323.
