### PR TITLE
Make `toNerfDart` ignore `query`, `search`, `hash`

### DIFF
--- a/lib/config/nerf-dart.js
+++ b/lib/config/nerf-dart.js
@@ -16,6 +16,9 @@ function toNerfDart(uri) {
   parsed.pathname = "/"
   delete parsed.protocol
   delete parsed.auth
+  delete parsed.query
+  delete parsed.search
+  delete parsed.hash
 
   return url.format(parsed)
 }

--- a/test/tap/config-nerf-dart.js
+++ b/test/tap/config-nerf-dart.js
@@ -1,0 +1,20 @@
+
+var tap = require("tap")
+var toNerfDart = require('../../lib/config/nerf-dart');
+
+function validNerfDart (uri, valid) {
+  tap.test(uri, function (t) {
+    t.plan(1);
+    t.equal(toNerfDart(uri), valid);
+    t.end();
+  });
+}
+
+var valid = '//registry.npmjs.org/'
+
+validNerfDart('http://registry.npmjs.org', valid);
+validNerfDart('http://registry.npmjs.org/some-package', valid);
+validNerfDart('http://registry.npmjs.org/some-package?write=true', valid);
+validNerfDart('http://user:pass@registry.npmjs.org/some-package?write=true', valid);
+validNerfDart('http://registry.npmjs.org/#random-hash', valid);
+validNerfDart('http://registry.npmjs.org/some-package#random-hash', valid);


### PR DESCRIPTION
@othiym23 corresponding fix for https://github.com/npm/npm-registry-client/pull/74, and not necessarily mutually exclusive. The `toNerfDart` implementation is duplicated across `npm/npm` and `npm/npm-registry-client` and has the same bug. 
- https://github.com/npm/npm/blob/master/lib/config/nerf-dart.js
- https://github.com/npm/npm-registry-client/blob/master/lib/util/nerf-dart.js
