### PR TITLE
`npm version` should work in a git directory w/o git

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -84,6 +84,15 @@ function checkGit (data, cb) {
 
   // check for git
   git.whichAndExec(args, options, function (er, stdout) {
+    if (er && er.code === "ENOGIT") {
+      log.warn(
+        "version",
+        "This is a Git checkout, but the git command was not found.",
+        "npm could not create a Git tag for this release!"
+      )
+      return write(data, cb)
+    }
+
     var lines = stdout.trim().split("\n").filter(function (line) {
       return line.trim() && !line.match(/^\?\? /)
     }).map(function (line) {

--- a/test/tap/version-no-git.js
+++ b/test/tap/version-no-git.js
@@ -1,0 +1,54 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var npm = require("../../")
+var osenv = require("osenv")
+var path = require("path")
+var fs = require("fs")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var requireInject = require("require-inject")
+
+var pkg = path.resolve(__dirname, "version-no-git")
+var cache = path.resolve(pkg, "cache")
+var gitDir = path.resolve(pkg, ".git")
+
+test("npm version <semver> in a git repo without the git binary", function(t) {
+  setup()
+  npm.load({cache: cache, registry: common.registry}, function() {
+    var version = requireInject("../../lib/version", {
+      which: function(cmd, cb) {
+        process.nextTick(function() {
+          cb(new Error('ENOGIT!'))
+        })
+      }
+    })
+
+    version(["patch"], function(err) {
+      if (err) return t.fail("Error performing version patch")
+      var p = path.resolve(pkg, "package")
+      var testPkg = require(p)
+      t.equal("0.0.1", testPkg.version, "\"" + testPkg.version+"\" === \"0.0.1\"")
+      t.end()
+    })
+  })
+})
+
+test("cleanup", function(t) {
+  process.chdir(osenv.tmpdir())
+
+  rimraf.sync(pkg)
+  t.end()
+})
+
+function setup() {
+  mkdirp.sync(pkg)
+  mkdirp.sync(cache)
+  mkdirp.sync(gitDir)
+  fs.writeFileSync(path.resolve(pkg, "package.json"), JSON.stringify({
+    author: "Terin Stock",
+    name: "version-no-git-test",
+    version: "0.0.0",
+    description: "Test for npm version if git binary doesn't exist"
+  }), "utf8")
+  process.chdir(pkg)
+}


### PR DESCRIPTION
If a package seemed to be located in a git directory (for example, if it
was alongside a ".git" directory), but the user did not have git on
their path, npm would throw a cryptic error about calling trim on
undefined.

With this patch, npm will log that git was not found, and that tagging
the version was skipped, but otherwise go on to updating the
package.json file.

This was probably primarily felt by Windows users, where git might be
located within a GUI client, but would be using npm from the command
prompt.
