### PR TITLE
npm rm <noargs> should globally remove the local pkg

### DIFF
--- a/lib/uninstall.js
+++ b/lib/uninstall.js
@@ -28,12 +28,11 @@ function uninstall (args, cb) {
   if (args.length) return uninstall_(args, nm, cb)
 
   // remove this package from the global space, if it's installed there
-  if (npm.config.get("global")) return cb(uninstall.usage)
-  readJson(path.resolve(npm.prefix, "package.json"), function (er, pkg) {
+  readJson(path.resolve(npm.localPrefix, "package.json"), function (er, pkg) {
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     if (er) return cb(uninstall.usage)
     uninstall_( [pkg.name]
-              , npm.dir
+              , npm.globalDir
               , cb )
   })
 


### PR DESCRIPTION
(Creating this as a PR on isaac's behalf because there's no real reason not to land it. Needs a test and review but is otherwise good to go.)

Fix #4005 #6248

What's interesting is that the comment in the code seems to indicate
that this was _always_ the intent.  But somewhere along the line, that
seems to have broken.

This makes 'npm link' be un-done by running 'npm unlink'.
