### PR TITLE
Scoped packages request doesn't escape slash for HTTP Requests

### DIFF
--- a/lib/owner.js
+++ b/lib/owner.js
@@ -215,7 +215,7 @@ function mutate (pkg, user, mutation, cb) {
                , _rev : data._rev
                , maintainers : m
                }
-        var dataPath = pkg + "/-rev/" + data._rev
+        var dataPath = uri + "/-rev/" + data._rev
         mapToRegistry(dataPath, npm.config, function (er, uri) {
           if (er) return cb(er)
 

--- a/lib/owner.js
+++ b/lib/owner.js
@@ -179,7 +179,6 @@ function rm (user, pkg, cb) {
 }
 
 function mutate (pkg, user, mutation, cb) {
-  pkg = pkg.replace('/', '%2f');
   if (user) {
     var byUser = "-/user/org.couchdb.user:" + user
     mapToRegistry(byUser, npm.config, function (er, uri) {

--- a/lib/owner.js
+++ b/lib/owner.js
@@ -179,6 +179,7 @@ function rm (user, pkg, cb) {
 }
 
 function mutate (pkg, user, mutation, cb) {
+  pkg = pkg.replace('/', '%2f');
   if (user) {
     var byUser = "-/user/org.couchdb.user:" + user
     mapToRegistry(byUser, npm.config, function (er, uri) {


### PR DESCRIPTION
npm owner add & npm owner rm doesn't  work because the URL uses the scoped name of package without escaping the slash
