### PR TITLE
Install fails when using local module and shrinkwrap. Because of missing file: in from key

### DIFF
--- a/lib/cache/add-local.js
+++ b/lib/cache/add-local.js
@@ -28,6 +28,7 @@ function addLocal (p, pkgData, cb_) {
     }
     if (data && !data._fromGithub) {
       data._from = path.relative(npm.prefix, p.spec) || "."
+      data._resolved = 'file:'+path.relative(npm.prefix, p.spec)
     }
     return cb_(er, data)
   }

--- a/test/tap/shrinkwrap-local-dependency.js
+++ b/test/tap/shrinkwrap-local-dependency.js
@@ -1,0 +1,80 @@
+var npm = npm = require("../../")
+var test = require("tap").test
+var path = require("path")
+var fs = require("fs")
+var osenv = require("osenv")
+var rimraf = require("rimraf")
+var mr = require("npm-registry-mock")
+var common = require("../common-tap.js")
+
+var pkg = path.resolve(__dirname, "shrinkwrap-local-dependency")
+var desiredResultsPath = path.resolve(pkg, "desired-shrinkwrap-results.json")
+
+test("shrinkwrap uses resolved with file: on local deps", function(t) {
+  t.plan(1)
+
+  setup(function(err) {
+    if (err) return t.fail(err)
+
+    common.npm(["install", "."], {}, function(err) {
+      if (err) return t.fail(err)
+
+      npm.shrinkwrap(".", true, function(err, results) {
+        if (err) return t.fail(err)
+
+        fs.readFile(desiredResultsPath, function(err, desired) {
+          if (err) return t.fail(err)
+
+          t.deepEqual(results, JSON.parse(desired))
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test('"npm install" should install local packages from shrinkwrap', function (t) {
+  cleanNodeModules();
+
+  common.npm(["install", "."], {}, function (err, code) {
+    t.ifError(err, "error should not exist")
+    t.notOk(code, "npm install exited with code 0")
+    var dependencyPackageJson = path.resolve(pkg, "node_modules/npm-test-shrinkwrap-local-dependency-dep/package.json")
+    t.ok(
+      JSON.parse(fs.readFileSync(dependencyPackageJson, "utf8")),
+      "package with local dependency installed from shrinkwrap"
+    )
+
+    t.end()
+  })
+})
+
+test("cleanup", function(t) {
+  cleanup()
+  t.end()
+})
+
+
+function setup(cb) {
+  cleanup()
+  process.chdir(pkg)
+
+  var allOpts = {
+    cache: path.resolve(pkg, "cache"),
+    registry: common.registry,
+    production: true
+  }
+
+  npm.load(allOpts, cb)
+}
+
+function cleanNodeModules() {
+  rimraf.sync(path.resolve(pkg, "node_modules"))
+}
+
+function cleanup() {
+  process.chdir(osenv.tmpdir())
+  cleanNodeModules();
+  rimraf.sync(path.resolve(pkg, "cache"))
+  rimraf.sync(path.resolve(pkg, "npm-shrinkwrap.json"))
+}

--- a/test/tap/shrinkwrap-local-dependency/dep/package.json
+++ b/test/tap/shrinkwrap-local-dependency/dep/package.json
@@ -1,0 +1,5 @@
+{
+  "author": "Thomas",
+  "name": "npm-test-shrinkwrap-local-dependency-dep",
+  "version": "0.0.0"
+}

--- a/test/tap/shrinkwrap-local-dependency/desired-shrinkwrap-results.json
+++ b/test/tap/shrinkwrap-local-dependency/desired-shrinkwrap-results.json
@@ -1,0 +1,11 @@
+{
+  "name": "npm-test-shrinkwrap-local-dependency",
+  "version": "0.0.0",
+  "dependencies": {
+    "npm-test-shrinkwrap-local-dependency-dep": {
+      "version": "0.0.0",
+      "from": "dep",
+      "resolved": "file:dep"
+    }
+  }
+}

--- a/test/tap/shrinkwrap-local-dependency/package.json
+++ b/test/tap/shrinkwrap-local-dependency/package.json
@@ -1,0 +1,8 @@
+{
+  "author": "Thomas Torp",
+  "name": "npm-test-shrinkwrap-local-dependency",
+  "version": "0.0.0",
+  "dependencies": {
+    "npm-test-shrinkwrap-local-dependency-dep": "./dep"
+  }
+}


### PR DESCRIPTION
When saving a local package to package.json it will add 'file:' as a prefix to the dependency.
"local-dependency": "file:plugin/local-dependency"

However, the installed dependency will only get "from" : "plugin/local-dependency".
Then when running npm shrinkwrap it only adds: "from": "plugin/local-dependency" to the dependency tree.

This will make the npm install from a npm-shrinkwrap.json fail with the error:
1388 error 404 'local-dependency' is not in the npm registry.

To reproduce:
npm install --save <some local dependency>
npm shrinkwrap
rm -rf node_modules
npm install

I have added some code that does make the npm install from npm-shrinkwrap.json work for me. Im not 100% sure about the implications of adding a "file:" as a prefix to the cache. However, all test should go run green.
