### PR TITLE
Tweaks doc style and js

### DIFF
--- a/html/static/style.css
+++ b/html/static/style.css
@@ -111,7 +111,7 @@ h1, h2 {
 i, em, cite {
     font-style:italic;
 }
-b, strong { 
+b, strong {
     font-weight:bold;
 }
 i, em, cite, b, strong, small {
@@ -285,13 +285,13 @@ input.submit, input#submit, input.button, button, input[type=submit] {
 }
 
 #toc {
-  position:absolute;
+  position:fixed;
   top:0;
   right:0;
   padding:40px 0 40px 20px;
   margin:0;
   width:200px;
-  opacity:0.2;
+  opacity:0.5;
   z-index:-1;
 }
 #toc:hover {

--- a/html/static/toc.js
+++ b/html/static/toc.js
@@ -1,4 +1,4 @@
-;(function () {
+window.onload = function () {
 var wrapper = document.getElementById("wrapper")
 var els = Array.prototype.slice.call(wrapper.getElementsByTagName("*"), 0)
   .filter(function (el) {
@@ -26,4 +26,4 @@ toc.innerHTML = els.map(function (el) {
 }).join("\n")
 toc.id = "toc"
 document.body.appendChild(toc)
-})();
+};


### PR DESCRIPTION
# Tweaks doc style and js

Hi. I did tweak the following two feature to doc.
- Every time I need a head line's link, I made a hash link by myself. But, I noticed today that there is a toc menu. So I would like to stand out a little bit more this.
- When I debugging doc, sometimes toc menu had may not be rendered due to the timing of the DOM loaded.
## Compare preview
- Current: https://www.npmjs.org/doc/cli/npm.html
- My fixed: http://watilde.github.io/npm/html/doc/api/npm.html
### Notes

Since this problem might be a matter of preference, please close it if unnecessary likely.

Thanks!
