### PR TITLE
Issue 6409 - document commit-ish with github URLs

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -366,13 +366,15 @@ an argument to `git checkout`.  The default is `master`.
 
 ## GitHub URLs
 
-As of version 1.1.65, you can refer to GitHub urls as just "foo": "user/foo-project". For example:
+As of version 1.1.65, you can refer to GitHub urls as just "foo": "user/foo-project". 
+Just as with git URLs, a `commit-ish` suffix can be included.  For example:
 
     {
       "name": "foo",
       "version": "0.0.0",
       "dependencies": {
-        "express": "visionmedia/express"
+        "express": "visionmedia/express",
+        "mocha": "visionmedia/mocha#4727d357ea"
       }
     }
 


### PR DESCRIPTION
Implement doc change suggested in issue 6409, explicitly mention
that commit-ish suffixes can be attached to github URLs in dependencies.
