### PR TITLE
fix: npm run fails silently. closes #2959

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -1,4 +1,3 @@
-
 module.exports = runScript
 
 var lifecycle = require("./utils/lifecycle.js")
@@ -124,6 +123,13 @@ function run (pkg, wd, cmd, args, cb) {
       "prestart", "start", "poststart"
     ]
   } else {
+    if (!pkg.scripts[cmd]) {
+      if (cmd === "test") {
+        pkg.scripts.test = "echo \"Error: no test specified\"";
+      } else {
+        return cb(new Error("missing script: " + cmd));
+      }
+    }
     cmds = [cmd]
   }
 

--- a/test/tap/ignore-scripts/package.json
+++ b/test/tap/ignore-scripts/package.json
@@ -9,6 +9,7 @@
     "preinstall": "exit 123",
     "postinstall": "exit 123",
     "preuninstall": "exit 123",
+    "install": "exit 123",
     "uninstall": "exit 123",
     "postuninstall": "exit 123",
     "preupdate": "exit 123",

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -78,7 +78,25 @@ test("npm run-script explicitly call pre script with arg", function (t) {
   common.npm(["run-script", "prewith-pre", "--", "an arg"], opts, testOutput.bind(null, t, "an arg"))
 })
 
-test("cleanup", function (t) {
+test('npm run-script test', function (t) {
+  common.npm(['run-script', 'test'], opts, function (er, code, stdout, stderr) {
+    if (er)
+      throw er
+    t.notOk(stderr, 'should not generate errors')
+    t.end()
+  })
+})
+
+test('npm run-script nonexistent-script', function (t) {
+  common.npm(['run-script', 'nonexistent-script'], opts, function (er, code, stdout, stderr) {
+    if (er)
+      throw er
+    t.ok(stderr, 'should generate errors')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
   cleanup()
   t.end()
 })


### PR DESCRIPTION
if the missing command is "test", logs a text error, otherwise creates an actual error.
fixed so test always "passes" and doesn't exit
Fix ignore-scripts test
Add unit tests

This is a squashed and rebased version of a PR initially created by @flipside as PR #4546
approved by @isaacs here (https://github.com/npm/npm/pull/4546#issuecomment-42875006)
with unit tests by @thomblake as PR #5814

Now squashed and rebased against current npm/npm#master, all unit tests passing.
