### PR TITLE
spawn: include cmd in child errors fixes #3908

### DIFF
--- a/lib/explore.js
+++ b/lib/explore.js
@@ -6,7 +6,7 @@ explore.usage = "npm explore <pkg> [ -- <cmd>]"
 explore.completion = require("./utils/completion/installed-shallow.js")
 
 var npm = require("./npm.js")
-  , spawn = require("child_process").spawn
+  , spawn = require("./utils/spawn")
   , path = require("path")
   , fs = require("graceful-fs")
 

--- a/lib/help.js
+++ b/lib/help.js
@@ -7,7 +7,7 @@ help.completion = function (opts, cb) {
 }
 
 var path = require("path")
-  , spawn = require("child_process").spawn
+  , spawn = require("./utils/spawn")
   , npm = require("./npm.js")
   , log = require("npmlog")
   , opener = require("opener")

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -181,7 +181,7 @@ function errorHandler (er) {
 
   case "ELIFECYCLE":
     log.error("", er.message)
-    log.error("", ["","Failed at the "+er.pkgid+" "+er.stage+" script."
+    log.error("", ["","Failed at the "+er.pkgid+" "+er.stage+" script '"+er.script+"'."
               ,"This is most likely a problem with the "+er.pkgname+" package,"
               ,"not with npm itself."
               ,"Tell the author that this fails on your system:"
@@ -336,6 +336,14 @@ function errorHandler (er) {
               ,"and is related to the file system being read-only."
               ,"\nOften virtualized file systems, or other file systems"
               ,"that don't support symlinks, give this error."
+              ].join("\n"))
+    break
+
+  case "ENOENT":
+    log.error("enoent", [er.message
+              ,"This is most likely not a problem with npm itself"
+              ,"and is related to npm not being able to find a file."
+              ,er.file?"\nCheck if the file '"+er.file+"' is present.":""
               ].join("\n"))
     break
 

--- a/lib/utils/git.js
+++ b/lib/utils/git.js
@@ -6,7 +6,7 @@ exports.chainableExec = chainableExec
 exports.whichAndExec = whichAndExec
 
 var exec = require("child_process").execFile
-  , spawn = require("child_process").spawn
+  , spawn = require("./spawn")
   , npm = require("../npm.js")
   , which = require("which")
   , git = npm.config.get("git")

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -3,7 +3,7 @@ exports.cmd = cmd
 exports.makeEnv = makeEnv
 
 var log = require("npmlog")
-  , spawn = require("child_process").spawn
+  , spawn = require("./spawn")
   , npm = require("../npm.js")
   , path = require("path")
   , fs = require("graceful-fs")

--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -1,0 +1,22 @@
+module.exports = spawn
+
+var _spawn = require("child_process").spawn,
+     EventEmitter = require("events").EventEmitter
+
+function spawn (cmd, args, options) {
+  var raw = _spawn(cmd, args, options)
+      cooked = new EventEmitter()
+
+  raw.on("error", function (er) {
+    er.file = cmd
+    cooked.emit("error", er)
+  }).on("close", function (code, signal) {
+    cooked.emit("close", code, signal)
+  })
+
+  cooked.stdin = raw.stdin
+  cooked.stdout = raw.stdout
+  cooked.stderr = raw.stderr
+
+  return cooked
+}

--- a/test/tap/spawn-enoent-help.js
+++ b/test/tap/spawn-enoent-help.js
@@ -1,0 +1,34 @@
+var path = require("path")
+var test = require("tap").test
+var fs = require("fs")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var common = require("../common-tap.js")
+
+var pkg = path.resolve(__dirname, "spawn-enoent-help")
+
+test("setup", function (t) {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  t.end()
+})
+
+test("enoent help", function (t) {
+  common.npm(["help", "config"], {
+    cwd: pkg,
+    env: {
+      PATH: "",
+      Path: "",
+      "npm_config_loglevel": "warn",
+      "npm_config_viewer": "woman"      
+    }
+  }, function (er, code, sout, serr) {
+    t.similar(serr, /Check if the file 'emacsclient' is present./)
+    t.end()
+  })
+})
+
+test("clean", function (t) {
+  rimraf.sync(pkg)
+  t.end()
+})

--- a/test/tap/spawn-enoent.js
+++ b/test/tap/spawn-enoent.js
@@ -29,7 +29,7 @@ test("enoent script", function (t) {
       "npm_config_loglevel": "warn"
     }
   }, function (er, code, sout, serr) {
-    t.similar(serr, /npm ERR! Failed at the x@1\.2\.3 start script\./)
+    t.similar(serr, /npm ERR! Failed at the x@1\.2\.3 start script 'wharble-garble-blorst'\./)
     t.end()
   })
 })


### PR DESCRIPTION
factor to centralize
wrap child, make it aware of filename

Some work has already been done to report the name of a missing lifecycle script.
Extended lifecycle script ENOENT reporting to add missing script name on summary err line, 

npm ERR! Failed at the x@1.2.3 start script 'wharble-garble-blorst'

Centralized all calls to spawn, they now go through lib/utils/spawn.js

Added "ENOENT" case to error-handler, added test to exercise it by simulating missing `emacsclient`
