### PR TITLE
npm-adduser update doc re email

### DIFF
--- a/doc/cli/npm-adduser.md
+++ b/doc/cli/npm-adduser.md
@@ -13,13 +13,16 @@ the default registry will be used (see `npm-config(7)`).
 
 The username, password, and email are read in from prompts.
 
-You may use this command to change your email address, but not username
-or password.
+You may use this command to change your email address **on a private repository**.
 
 To reset your password, go to <https://www.npmjs.org/forgot>
 
+To change your email address, go to <https://www.npmjs.org/email-edit>
+
 You may use this command multiple times with the same user account to
-authorize on a new machine.
+authorize on a new machine.  When authenticating on a new machine,
+the username, password **and email address** must all match with
+your existing record.
 
 `npm login` is an alias to `adduser` and behaves exactly the same way.
 

--- a/doc/cli/npm-adduser.md
+++ b/doc/cli/npm-adduser.md
@@ -13,15 +13,13 @@ the default registry will be used (see `npm-config(7)`).
 
 The username, password, and email are read in from prompts.
 
-You may use this command to change your email address **on a private repository**.
-
 To reset your password, go to <https://www.npmjs.org/forgot>
 
 To change your email address, go to <https://www.npmjs.org/email-edit>
 
 You may use this command multiple times with the same user account to
 authorize on a new machine.  When authenticating on a new machine,
-the username, password **and email address** must all match with
+the username, password and email address must all match with
 your existing record.
 
 `npm login` is an alias to `adduser` and behaves exactly the same way.


### PR DESCRIPTION
Docs are no longer accurate; updating email address via npm adduser gives 403 forbidden on public registry.

Quoting from: https://www.npmjs.org/doc/cli/npm-adduser.html

```
The username, password, and email are read in from prompts.

You may use this command to change your email address, but not username or password.

To reset your password, go to https://www.npmjs.org/forgot
```

(amended commit to fix typo)
