### PR TITLE
Remove unused shell variable from ZSH completion

### DIFF
--- a/lib/utils/completion.sh
+++ b/lib/utils/completion.sh
@@ -24,13 +24,11 @@ if type complete &>/dev/null; then
   complete -F _npm_completion npm
 elif type compdef &>/dev/null; then
   _npm_completion() {
-    si=$IFS
     compadd -- $(COMP_CWORD=$((CURRENT-1)) \
                  COMP_LINE=$BUFFER \
                  COMP_POINT=0 \
                  npm completion -- "${words[@]}" \
                  2>/dev/null)
-    IFS=$si
   }
   compdef _npm_completion npm
 elif type compctl &>/dev/null; then


### PR DESCRIPTION
Since `$IFS` is not actually changed in the compadd version of ZSH completion, there's no need to save and restore it.

Right now calling `_npm_completion` leaves the global `$si` variable around.
