### PR TITLE
Pass auth parameters to requestAll_ for alwaysAuth.

### DIFF
--- a/lib/cache/update-index.js
+++ b/lib/cache/update-index.js
@@ -16,9 +16,9 @@ var fs = require("graceful-fs")
  * because it is a monster.
  */
 function updateIndex (uri, params, cb) {
-  assert(typeof uri === "string", "must pass registry URI to getAll")
-  assert(params && typeof params === "object", "must pass params to getAll")
-  assert(typeof cb === "function", "must pass callback to getAll")
+  assert(typeof uri === "string", "must pass registry URI to updateIndex")
+  assert(params && typeof params === "object", "must pass params to updateIndex")
+  assert(typeof cb === "function", "must pass callback to updateIndex")
 
   var parsed = url.parse(uri)
   assert(
@@ -37,7 +37,7 @@ function updateIndex (uri, params, cb) {
       if (er) return cb(er)
 
       fs.readFile(cachePath, function (er, data) {
-        if (er) return requestAll_(uri, 0, {}, cachePath, cb)
+        if (er) return requestAll_(uri, params, 0, {}, cachePath, cb)
 
         try {
           data = JSON.parse(data)
@@ -46,21 +46,21 @@ function updateIndex (uri, params, cb) {
           fs.writeFile(cachePath, "{}", function (er) {
             if (er) return cb(new Error("Broken cache."))
 
-            return requestAll_(uri, 0, {}, cachePath, cb)
+            return requestAll_(uri, params, 0, {}, cachePath, cb)
           })
         }
         var t = +data._updated || 0
         chownr(made || cachePath, st.uid, st.gid, function (er) {
           if (er) return cb(er)
 
-          requestAll_(uri, t, data, cachePath, cb)
+          requestAll_(uri, params, t, data, cachePath, cb)
         })
       })
     })
   })
 }
 
-function requestAll_ (uri, t, data, cachePath, cb) {
+function requestAll_ (uri, params, t, data, cachePath, cb) {
   // use the cache and update in the background if it's not too old
   if (Date.now() - t < 60000) {
     cb(null, data)
@@ -76,7 +76,7 @@ function requestAll_ (uri, t, data, cachePath, cb) {
     full = url.resolve(uri, "/-/all/since?stale=update_after&startkey=" + t)
   }
 
-  npm.registry.request(full, {}, function (er, updates, _, res) {
+  npm.registry.request(full, params, function (er, updates, _, res) {
     if (er) return cb(er, data)
 
     var headers = res.headers

--- a/lib/cache/update-index.js
+++ b/lib/cache/update-index.js
@@ -37,7 +37,7 @@ function updateIndex (uri, params, cb) {
       if (er) return cb(er)
 
       fs.readFile(cachePath, function (er, data) {
-        if (er) return requestAll_(uri, params, 0, {}, cachePath, cb)
+        if (er) return updateIndex_(uri, params, 0, {}, cachePath, cb)
 
         try {
           data = JSON.parse(data)
@@ -46,21 +46,21 @@ function updateIndex (uri, params, cb) {
           fs.writeFile(cachePath, "{}", function (er) {
             if (er) return cb(new Error("Broken cache."))
 
-            return requestAll_(uri, params, 0, {}, cachePath, cb)
+            return updateIndex_(uri, params, 0, {}, cachePath, cb)
           })
         }
         var t = +data._updated || 0
         chownr(made || cachePath, st.uid, st.gid, function (er) {
           if (er) return cb(er)
 
-          requestAll_(uri, params, t, data, cachePath, cb)
+          updateIndex_(uri, params, t, data, cachePath, cb)
         })
       })
     })
   })
 }
 
-function requestAll_ (uri, params, t, data, cachePath, cb) {
+function updateIndex_ (uri, params, t, data, cachePath, cb) {
   // use the cache and update in the background if it's not too old
   if (Date.now() - t < 60000) {
     cb(null, data)

--- a/test/tap/update-index.js
+++ b/test/tap/update-index.js
@@ -16,7 +16,7 @@ var server
 function setup (t, mock) {
   mkdirp.sync(CACHE_DIR)
   mr({ port: common.port, mocks: mock }, function (s) {
-    npm.load({cache: CACHE_DIR, registry: common.registry}, function (err) {
+    npm.load({ cache: CACHE_DIR, registry: common.registry }, function (err) {
       t.ifError(err, "no error")
       server = s
       t.end()
@@ -79,8 +79,9 @@ var mocks = {
     server.get("/-/all").reply(200, allMock)
   },
   auth: function(server) {
-    var littleBobbyTablesAuth = new Buffer('bobby:tables').toString('base64')
-    server.get("/-/all", {authorization: "Basic " + littleBobbyTablesAuth}).reply(200, allMock)
+    var littleBobbyTablesAuth = new Buffer("bobby:tables").toString("base64")
+    var auth = "Basic " + littleBobbyTablesAuth
+    server.get("/-/all", { authorization: auth }).reply(200, allMock)
     server.get("/-/all").reply(401, {
       error: "unauthorized",
       reason: "You are not authorized to access this db."


### PR DESCRIPTION
I'm not a huge fan of the current `npm search`, due too its documented issues with the public reigstry. I was looking for the name of an internal package today, and I expected it to be the friendliest solution. Unfortunately, it failed with an unauthorized error.

I noticed that auth from "map-to-registry" was being provided as a parameter to updateIndex, but that these parameters weren't being passed through to request.

Added an updateIndex scenario, attempting to replicate the situation.
