### PR TITLE
Log retries when fetch fails

### DIFF
--- a/lib/cache/add-remote-tarball.js
+++ b/lib/cache/add-remote-tarball.js
@@ -62,10 +62,14 @@ function addRemoteTarball_ (u, tmp, shasum, auth, cb) {
       // Only retry on 408, 5xx or no `response`.
       var sc = response && response.statusCode
       var statusRetry = !sc || (sc === 408 || sc >= 500)
-      if (er && statusRetry && operation.retry(er)) {
-        log.info("retry", "will retry, error on last attempt: " + er)
-        return
-      }
+      if (er) {
+        if (statusRetry && operation.retry(er)) {
+          log.error("fetch failed, will retry", u)
+          log.info("retry", "will retry, error on last attempt: " + er)
+          return
+        } else{
+          log.error("fetch failed", u)
+        }
       cb(er, response, shasum)
     })
   })
@@ -74,7 +78,6 @@ function addRemoteTarball_ (u, tmp, shasum, auth, cb) {
 function fetchAndShaCheck (u, tmp, shasum, auth, cb) {
   npm.registry.fetch(u, { auth : auth }, function (er, response) {
     if (er) {
-      log.error("fetch failed", u)
       return cb(er, response)
     }
 


### PR DESCRIPTION
Fixes #6644. 
Error message for a failed fetch will tell whether npm will make another attempt.
