### PR TITLE
never remove project directories

### DIFF
--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -27,7 +27,7 @@ function unbuild_ (silent) { return function (folder, cb_) {
   log.verbose("unbuild", folder.substr(npm.prefix.length + 1))
   readJson(path.resolve(folder, "package.json"), function (er, pkg) {
     // if no json, then just trash it, but no scripts or whatever.
-    if (er) return gentlyRm(folder, false, cb)
+    if (er) return gentlyRm(folder, false, npm.prefix, cb)
     readJson.cache.del(folder)
     chain
       ( [ [lifecycle, pkg, "preuninstall", folder, false, true]
@@ -38,7 +38,7 @@ function unbuild_ (silent) { return function (folder, cb_) {
           }
         , [rmStuff, pkg, folder]
         , [lifecycle, pkg, "postuninstall", folder, false, true]
-        , [gentlyRm, folder, undefined] ]
+        , [gentlyRm, folder, false, npm.prefix] ]
       , cb )
   })
 }}
@@ -63,15 +63,12 @@ function rmStuff (pkg, folder, cb) {
 function rmBins (pkg, folder, parent, top, cb) {
   if (!pkg.bin) return cb()
   var binRoot = top ? npm.bin : path.resolve(parent, ".bin")
-  log.verbose([binRoot, pkg.bin], "binRoot")
   asyncMap(Object.keys(pkg.bin), function (b, cb) {
     if (process.platform === "win32") {
-      chain([ [gentlyRm, path.resolve(binRoot, b) + ".cmd", undefined]
-            , [gentlyRm, path.resolve(binRoot, b), undefined] ], cb)
+      chain([ [gentlyRm, path.resolve(binRoot, b) + ".cmd", true]
+            , [gentlyRm, path.resolve(binRoot, b), true] ], cb)
     } else {
-      gentlyRm( path.resolve(binRoot, b)
-              , !npm.config.get("force") && folder
-              , cb )
+      gentlyRm(path.resolve(binRoot, b), true, cb)
     }
   }, cb)
 }
@@ -103,9 +100,7 @@ function rmMans (pkg, folder, parent, top, cb) {
                               : pkg.name + "-" + bn)
                               + "." + sxn + gz
                             )
-      gentlyRm( manDest
-              , !npm.config.get("force") && folder
-              , cb )
+      gentlyRm(manDest, true, cb)
     }
   }, cb)
 }

--- a/lib/utils/gently-rm.js
+++ b/lib/utils/gently-rm.js
@@ -11,13 +11,17 @@ var npm = require("../npm.js")
   , readlink = require("graceful-fs").readlink
   , isInside = require("path-is-inside")
   , vacuum = require("fs-vacuum")
-  , rimraf = require("rimraf")
   , some = require("async-some")
 
-function gentlyRm (path, gently, cb) {
+function gentlyRm (path, gently, base, cb) {
+  if (!cb) {
+    cb = base
+    base = undefined
+  }
+
   if (!cb) {
     cb = gently
-    gently = null
+    gently = false
   }
 
   // never rm the root, prefix, or bin dirs.
@@ -35,13 +39,14 @@ function gentlyRm (path, gently, cb) {
 
   var options = {log : log.silly.bind(log, "gentlyRm")}
   if (npm.config.get("force") || !gently) options.purge = true
+  if (base) options.base = base
 
   if (!gently) {
     log.verbose("gentlyRm", "vacuuming", resolved)
     return vacuum(resolved, options, cb)
   }
 
-  var parent = resolve(gently)
+  var parent = options.base = base ? base : npm.prefix
   log.verbose("gentlyRm", "verifying that", parent, "is managed by npm")
   some(prefixes, isManaged(parent), function (er, matched) {
     if (er) return cb(er)
@@ -56,7 +61,6 @@ function gentlyRm (path, gently, cb) {
     if (isInside(resolved, parent)) {
       log.silly("gentlyRm", resolved, "is under", parent)
       log.verbose("gentlyRm", "vacuuming", resolved, "up to", parent)
-      options.base = parent
       return vacuum(resolved, options, cb)
     }
 
@@ -94,7 +98,7 @@ function gentlyRm (path, gently, cb) {
           if (matched) {
             log.silly("gentlyRm", source, "is under", matched)
             log.verbose("gentlyRm", "removing", resolved)
-            rimraf(resolved, cb)
+            vacuum(resolved, options, cb)
           }
 
           log.verbose("gentlyRm", source, "is not managed by npm")

--- a/node_modules/fs-vacuum/package.json
+++ b/node_modules/fs-vacuum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-vacuum",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "recursively remove empty directories -- to a point",
   "main": "vacuum.js",
   "scripts": {
@@ -27,7 +27,7 @@
   "devDependencies": {
     "mkdirp": "^0.5.0",
     "tap": "^0.4.11",
-    "tmp": "0.0.23"
+    "tmp": "0.0.24"
   },
   "dependencies": {
     "graceful-fs": "^3.0.2",
@@ -35,8 +35,8 @@
   },
   "readme": "# fs-vacuum\n\nRemove the empty branches of a directory tree, optionally up to (but not\nincluding) a specified base directory. Optionally nukes the leaf directory.\n\n## Usage\n\n```javascript\nvar logger = require(\"npmlog\");\nvar vacuum = require(\"fs-vacuum\");\n\nvar options = {\n  base  : \"/path/to/my/tree/root\",\n  purge : true,\n  log   : logger.silly.bind(logger, \"myCleanup\")\n};\n\n/* Assuming there are no other files or directories in \"out\", \"to\", or \"my\",\n * the final path will just be \"/path/to/my/tree/root\".\n */\nvacuum(\"/path/to/my/tree/root/out/to/my/files\", function (error) {\n  if (error) console.error(\"Unable to cleanly vacuum:\", error.message);\n});\n```\n# vacuum(directory, options, callback)\n\n* `directory` {String} Leaf node to remove. **Must be a directory, symlink, or file.**\n* `options` {Object}\n  * `base` {String} No directories at or above this level of the filesystem will be removed.\n  * `purge` {Boolean} If set, nuke the whole leaf directory, including its contents.\n  * `log` {Function} A logging function that takes `npmlog`-compatible argument lists.\n* `callback` {Function} Function to call once vacuuming is complete.\n  * `error` {Error} What went wrong along the way, if anything.\n",
   "readmeFilename": "README.md",
-  "gitHead": "bad24b21c45d86b3da991f2c3d058ef03546d83e",
-  "_id": "fs-vacuum@1.2.1",
-  "_shasum": "1bc3c62da30d6272569b8b9089c9811abb0a600b",
-  "_from": "fs-vacuum@>=1.2.1-0 <1.3.0-0"
+  "gitHead": "c788fcc30fe8e73725f4f202d86c51d23d9f3378",
+  "_id": "fs-vacuum@1.2.2",
+  "_shasum": "0e26ca2b14eb4ceb4b590a92aad585756ed18e40",
+  "_from": "fs-vacuum@>=1.2.2 <1.3.0"
 }

--- a/node_modules/fs-vacuum/vacuum.js
+++ b/node_modules/fs-vacuum/vacuum.js
@@ -90,7 +90,14 @@ function vacuum(leaf, options, cb) {
         var remove = stat.isDirectory() ? rmdir : unlink
         remove(branch, function (error) {
           if (error) {
-            if (error.code === "ENOENT") return cb(null)
+            if (error.code === "ENOENT") {
+              log("quitting because lost the race to remove", branch)
+              return cb(null)
+            }
+            if (error.code === "ENOTEMPTY") {
+              log("quitting because new (racy) entries in", branch)
+              return cb(null)
+            }
 
             log("unable to remove", branch, "due to", error.message)
             return cb(error)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "config-chain": "~1.1.8",
     "dezalgo": "~1.0.1",
     "editor": "~0.1.0",
-    "fs-vacuum": "~1.2.1",
+    "fs-vacuum": "~1.2.2",
     "fs-write-stream-atomic": "~1.0.2",
     "fstream": "~1.0.2",
     "fstream-npm": "~1.0.1",

--- a/test/tap/gently-rm-overeager.js
+++ b/test/tap/gently-rm-overeager.js
@@ -1,0 +1,61 @@
+var resolve = require("path").resolve
+var fs = require("graceful-fs")
+var test = require("tap").test
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+
+var common = require("../common-tap.js")
+
+var pkg = resolve(__dirname, "gently-rm-overeager")
+var dep = resolve(__dirname, "test-whoops")
+
+var EXEC_OPTS = {
+  cwd : pkg
+}
+
+test("setup", function (t) {
+  nuke()
+  bootstrap()
+  t.end()
+})
+
+test("cache add", function (t) {
+  common.npm(["install", "../test-whoops"], EXEC_OPTS, function (er, c) {
+    t.ifError(er, "test-whoops install didn't explode")
+    t.ok(c, "test-whoops install also failed")
+    fs.readdir(pkg, function (er, files) {
+      t.ifError(er, "package directory is still there")
+      t.deepEqual(files, ["npm-debug.log"], "only debug log remains")
+
+      t.end()
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  nuke()
+
+  t.end()
+})
+
+
+var fixture = {
+  name: "@test/whoops",
+  version: "1.0.0",
+  scripts: {
+    postinstall: "echo \"nope\" && exit 1"
+  }
+}
+
+function nuke () {
+  rimraf.sync(pkg)
+  rimraf.sync(dep)
+}
+
+function bootstrap () {
+  mkdirp.sync(pkg)
+  // so it doesn't try to install into npm's own node_modules
+  mkdirp.sync(resolve(pkg, "node_modules"))
+  mkdirp.sync(dep)
+  fs.writeFileSync(resolve(dep, "package.json"), JSON.stringify(fixture))
+}


### PR DESCRIPTION
A failed install could cause the removal of an empty (new) project directory because fs-vacuum wasn't being told where to stop vacuuming up empty directories. Pass in the project path to provide a hard backstop for fs-vacuum, and be more careful to specify which things should be gently removed during unbuilding.

Closes #5754.
