### PR TITLE
Fix 'er' vs 'err' typo and rename 'er'

### DIFF
--- a/node_modules/uid-number/uid-number.js
+++ b/node_modules/uid-number/uid-number.js
@@ -33,7 +33,7 @@ function uidNumber (uid, gid, cb) {
   child_process.execFile( process.execPath
                         , [getter, uid, gid]
                         , function (code, out, err) {
-    if (er) return cb(new Error("could not get uid/gid\n" + err))
+    if (err) return cb(new Error("could not get uid/gid\n" + err))
     try {
       out = JSON.parse(out+"")
     } catch (ex) {
@@ -41,9 +41,9 @@ function uidNumber (uid, gid, cb) {
     }
 
     if (out.error) {
-      var er = new Error(out.error)
-      er.errno = out.errno
-      return cb(er)
+      var outError = new Error(out.error)
+      outError.errno = out.errno
+      return cb(outError)
     }
 
     if (isNaN(out.uid) || isNaN(out.gid)) return cb(new Error(


### PR DESCRIPTION
The crucial element is a typographical error where `er` occurs instead of `err` on line 36.  This was difficult to detect because both `er` and `err` were valid variables in adjacent scopes.  

This typo is a bug that must be fixed regardless of who patches it.  The result will be an informative error message as originally intended.

In this particular patch, I have also renamed `er` to `outError` to prevent further mistakes, but I am unfamiliar with the project coding standards and do not know if this is conformant.
