### PR TITLE
Report success after handling error fixes #6684

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -31,11 +31,11 @@ function init (args, cb) {
   initJson(dir, initFile, npm.config, function (er, data) {
     log.resume()
     log.silly("package data", data)
-    log.info("init", "written successfully")
     if (er && er.message === "canceled") {
       log.warn("init", "canceled")
       return cb(null, data)
     }
+    log.info("init", "written successfully")
     cb(er, data)
   })
 }

--- a/test/tap/init-interrupt.js
+++ b/test/tap/init-interrupt.js
@@ -1,0 +1,51 @@
+// if "npm init" is interrupted with ^C, don't report
+// "init written successfully"
+var test = require("tap").test
+var path = require("path")
+var osenv = require("osenv")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var stream = require("stream")
+var common = require("../common-tap.js")
+var npmlog = require("npmlog")
+var requireInject = require("require-inject")
+
+var npm = require("../../lib/npm.js")
+
+var PKG_DIR = path.resolve(__dirname, "init-interrupt")
+
+test("issue #6684 remove confusing message", function (t) {
+
+  var initJsonMock = function (dir, input, config, cb) {
+    process.nextTick(function () {
+      cb({ message: "canceled" })
+    })
+  }              
+  initJsonMock.yes = function () { return true; }
+
+  npm.load({loglevel : "warn"}, function () {
+    var log = ""
+    var init = requireInject("../../lib/init", {
+        "init-package-json": initJsonMock
+    })
+
+    // capture log messages
+    npmlog.on('log', function (chunk) { log = log + chunk.message + "\n" } );
+
+    init([], function (err, code) {
+      t.notSimilar(log, /written successfully/)
+      t.similar(log, /canceled/)
+      t.end()
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup() {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(PKG_DIR)
+}


### PR DESCRIPTION
Left this unsquashed so you can see it as two separate commits:

first the unit test 
- creates a mock `init-package-json` which just immediately cancels (using @iarna 's excellent `requireInject()` module, thanks!) 
- calls init(), collecting log messages
- asserts that log message should contain 'canceled' but not 'written successfully'

This fails when run in the npm@2.1.8 repository.

The fix is just to move the log message about writing after the error handler.  Writing the repro case was much harder than fixing the bug 
