### PR TITLE
.npmignore isn't respected for git repos

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -1,20 +1,18 @@
 var mkdir = require("mkdirp")
   , assert = require("assert")
   , git = require("../utils/git.js")
-  , once = require("once")
   , fs = require("graceful-fs")
   , log = require("npmlog")
   , path = require("path")
   , url = require("url")
   , chownr = require("chownr")
-  , zlib = require("zlib")
   , crypto = require("crypto")
   , npm = require("../npm.js")
   , rm = require("../utils/gently-rm.js")
   , inflight = require("inflight")
   , getCacheStat = require("./get-stat.js")
-  , addLocalTarball = require("./add-local-tarball.js")
-  , writeStream = require("fs-write-stream-atomic")
+  , addLocal = require("./add-local.js")
+  , realizePackageSpecifier = require("realize-package-specifier")
 
 
 // 1. cacheDir = path.join(cache,'_git-remotes',sha1(u))
@@ -81,23 +79,23 @@ function checkGitDir (p, u, co, origUrl, silent, cb) {
       cloneGitRemote(p, u, co, origUrl, silent, cb)
     })
 
-    var args = [ "config", "--get", "remote.origin.url" ]
-    var env = gitEnv()
-
-    // check for git
-    git.whichAndExec(args, {cwd: p, env: env}, function (er, stdout, stderr) {
-      var stdoutTrimmed = (stdout + "\n" + stderr).trim()
-      if (er || u !== stdout.trim()) {
-        log.warn( "`git config --get remote.origin.url` returned "
-                + "wrong result ("+u+")", stdoutTrimmed )
-        return rm(p, function (er){
-          if (er) return cb(er)
-          cloneGitRemote(p, u, co, origUrl, silent, cb)
-        })
+    git.whichAndExec(
+      [ "config", "--get", "remote.origin.url" ],
+      { cwd : p, env : gitEnv },
+      function (er, stdout, stderr) {
+        var stdoutTrimmed = (stdout + "\n" + stderr).trim()
+        if (er || u !== stdout.trim()) {
+          log.warn( "`git config --get remote.origin.url` returned "
+                  + "wrong result ("+u+")", stdoutTrimmed )
+          return rm(p, function (er){
+            if (er) return cb(er)
+            cloneGitRemote(p, u, co, origUrl, silent, cb)
+          })
+        }
+        log.verbose("git remote.origin.url", stdoutTrimmed)
+        fetchRemote(p, u, co, origUrl, cb)
       }
-      log.verbose("git remote.origin.url", stdoutTrimmed)
-      archiveGitRemote(p, u, co, origUrl, cb)
-    })
+    )
   })
 }
 
@@ -105,66 +103,69 @@ function cloneGitRemote (p, u, co, origUrl, silent, cb) {
   mkdir(p, function (er) {
     if (er) return cb(er)
 
-    var args = [ "clone", "--template=" + path.join(npm.config.get("cache"),
-      "_git_remotes", "_templates"), "--mirror", u, p ]
-    var env = gitEnv()
-
-    // check for git
-    git.whichAndExec(args, {cwd: p, env: env}, function (er, stdout, stderr) {
-      stdout = (stdout + "\n" + stderr).trim()
-      if (er) {
-        if (silent) {
-          log.verbose("git clone " + u, stdout)
-        } else {
-          log.error("git clone " + u, stdout)
+    var templates = path.join(npm.config.get("cache"), "_git_remotes", "_templates")
+    git.whichAndExec(
+      [ "clone", "--template=" + templates, "--mirror", u, p ],
+      { cwd : p, env : gitEnv() },
+      function (er, stdout, stderr) {
+        stdout = (stdout + "\n" + stderr).trim()
+        if (er) {
+          if (silent) {
+            log.verbose("git clone " + u, stdout)
+          } else {
+            log.error("git clone " + u, stdout)
+          }
+          return cb(er)
         }
-        return cb(er)
+        log.verbose("git clone " + u, stdout)
+        fetchRemote(p, u, co, origUrl, cb)
       }
-      log.verbose("git clone " + u, stdout)
-      archiveGitRemote(p, u, co, origUrl, cb)
-    })
+    )
   })
 }
 
-function archiveGitRemote (p, u, co, origUrl, cb) {
-  var archive = [ "fetch", "-a", "origin" ]
-  var resolve = [ "rev-list", "-n1", co ]
-  var env = gitEnv()
+function fetchRemote (p, u, co, origUrl, cb) {
+  git.whichAndExec(
+    [ "fetch", "-a", "origin" ],
+    { cwd : p, env : gitEnv() },
+    function (er, stdout, stderr) {
+      stdout = (stdout + "\n" + stderr).trim()
+      if (er) {
+        log.error("git fetch -a origin ("+u+")", stdout)
+        return cb(er)
+      }
+      log.verbose("git fetch -a origin ("+u+")", stdout)
 
-  var resolved = null
-  var tmp
-
-  git.whichAndExec(archive, {cwd: p, env: env}, function (er, stdout, stderr) {
-    stdout = (stdout + "\n" + stderr).trim()
-    if (er) {
-      log.error("git fetch -a origin ("+u+")", stdout)
-      return cb(er)
-    }
-    log.verbose("git fetch -a origin ("+u+")", stdout)
-    tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), "tmp.tgz")
-
-    if (process.platform === "win32") {
-      log.silly("verifyOwnership", "skipping for windows")
-      resolveHead()
-    } else {
-      getCacheStat(function(er, cs) {
-        if (er) {
-          log.error("Could not get cache stat")
-          return cb(er)
-        }
-        chownr(p, cs.uid, cs.gid, function(er) {
+      if (process.platform === "win32") {
+        log.silly("verifyOwnership", "skipping for windows")
+        resolveHead()
+      }
+      else {
+        getCacheStat(function(er, cs) {
           if (er) {
-            log.error("Failed to change folder ownership under npm cache for %s", p)
+            log.error("Could not get cache stat")
             return cb(er)
           }
-          resolveHead()
-        })
-      })
-    }
-  })
 
-  function resolveHead () {
-    git.whichAndExec(resolve, {cwd: p, env: env}, function (er, stdout, stderr) {
+          chownr(p, cs.uid, cs.gid, function(er) {
+            if (er) {
+              log.error("Failed to change folder ownership under npm cache for %s", p)
+              return cb(er)
+            }
+
+            resolveHead(p, u, co, origUrl, cb)
+          })
+        })
+      }
+    }
+  )
+}
+
+function resolveHead (p, u, co, origUrl, cb) {
+  git.whichAndExec(
+    [ "rev-list", "-n1", co ],
+    { cwd : p, env : gitEnv() },
+    function (er, stdout, stderr) {
       stdout = (stdout + "\n" + stderr).trim()
       if (er) {
         log.error("Failed resolving git HEAD (" + u + ")", stderr)
@@ -173,48 +174,73 @@ function archiveGitRemote (p, u, co, origUrl, cb) {
       log.verbose("git rev-list -n1 " + co, stdout)
       var parsed = url.parse(origUrl)
       parsed.hash = stdout
-      resolved = url.format(parsed)
+      var resolved = url.format(parsed)
 
-      if (parsed.protocol !== "git:") {
-        resolved = "git+" + resolved
-      }
+      if (parsed.protocol !== "git:") resolved = "git+" + resolved
 
       // https://github.com/npm/npm/issues/3224
-      // node incorrectly sticks a / at the start of the path
-      // We know that the host won't change, so split and detect this
+      // node incorrectly sticks a / at the start of the path We know that the
+      // host won't change, so split and detect this
       var spo = origUrl.split(parsed.host)
       var spr = resolved.split(parsed.host)
-      if (spo[1].charAt(0) === ":" && spr[1].charAt(0) === "/")
+      if (spo[1].charAt(0) === ":" && spr[1].charAt(0) === "/") {
         spr[1] = spr[1].slice(1)
+      }
       resolved = spr.join(parsed.host)
 
       log.verbose("resolved git url", resolved)
-      next()
-    })
-  }
+      cache(p, u, stdout, resolved, cb)
+    }
+  )
+}
 
-  function next () {
-    mkdir(path.dirname(tmp), function (er) {
-      if (er) return cb(er)
-      var gzip = zlib.createGzip({ level: 9 })
-      var args = ["archive", co, "--format=tar", "--prefix=package/"]
-      var out = writeStream(tmp)
-      var env = gitEnv()
-      cb = once(cb)
-      var cp = git.spawn(args, { env: env, cwd: p })
-      cp.on("error", cb)
-      cp.stderr.on("data", function(chunk) {
-        log.silly(chunk.toString(), "git archive")
-      })
+/**
+ * Make an actual clone from the bare (mirrored) cache. There is no safe way to
+ * do a one-step clone to a treeish that isn't guaranteed to be a branch, so
+ * this has to be two steps.
+ */
+function cache (p, u, treeish, resolved, cb) {
+  var tmp = path.join(npm.tmp, Date.now()+"-"+Math.random(), treeish)
+  git.whichAndExec(
+    [ "clone", p, tmp ],
+    { cwd : p, env : gitEnv() },
+    function (er, stdout, stderr) {
+      stdout = (stdout + "\n" + stderr).trim()
+      if (er) {
+        log.error("Failed to clone "+resolved+" from "+u, stderr)
+        return cb(er)
+      }
+      log.verbose("git clone", "from", p)
+      log.verbose("git clone", stdout)
 
-      cp.stdout.pipe(gzip).pipe(out).on("close", function() {
-        addLocalTarball(tmp, null, null, function(er, data) {
-          if (data) data._resolved = resolved
-          cb(er, data)
-        })
-      })
-    })
-  }
+      git.whichAndExec(
+        [ "checkout", treeish ],
+        { cwd : tmp, env : gitEnv() },
+        function (er, stdout, stderr) {
+          stdout = (stdout + "\n" + stderr).trim()
+          if (er) {
+            log.error("Failed to check out "+treeish, stderr)
+            return cb(er)
+          }
+          log.verbose("git checkout", stdout)
+
+          realizePackageSpecifier(tmp, function (er, spec) {
+            if (er) {
+              log.error("Failed to map", tmp, "to a package specifier")
+              return cb(er)
+            }
+
+            // https://github.com/npm/npm/issues/6400
+            // ensure pack logic is applied
+            addLocal(spec, null, function (er, data) {
+              if (data) data._resolved = resolved
+              cb(er, data)
+            })
+          })
+        }
+      )
+    }
+  )
 }
 
 var gitEnv_

--- a/test/tap/git-npmignore.js
+++ b/test/tap/git-npmignore.js
@@ -1,0 +1,172 @@
+var cat = require("graceful-fs").writeFileSync
+var exec = require("child_process").exec
+var readdir = require("graceful-fs").readdirSync
+var resolve = require("path").resolve
+
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var test = require("tap").test
+var tmpdir = require("osenv").tmpdir
+var which = require("which")
+
+var common = require("../common-tap.js")
+
+var pkg = resolve(__dirname, "git-npmignore")
+var dep = resolve(pkg, "deps", "gitch")
+var packname = "gitch-1.0.0.tgz"
+var packed = resolve(pkg, packname)
+var modules = resolve(pkg, "node_modules")
+var installed = resolve(modules, "gitch")
+var expected = [
+  "a.js",
+  "package.json",
+  ".npmignore"
+].sort()
+
+var EXEC_OPTS = {
+  cwd : pkg
+}
+
+test("setup", function (t) {
+  setup(function (er) {
+    t.ifError(er, "setup ran OK")
+
+    t.end()
+  })
+})
+
+test("npm pack directly from directory", function (t) {
+  packInstallTest(dep, t)
+})
+
+test("npm pack via git", function (t) {
+  packInstallTest("git+file://"+dep, t)
+})
+
+test("cleanup", function (t) {
+  cleanup()
+
+  t.end()
+})
+
+function packInstallTest (spec, t) {
+  common.npm(
+    [
+      "--loglevel", "silent",
+      "pack", spec
+    ],
+    EXEC_OPTS,
+    function (err, code, stdout, stderr) {
+      t.ifError(err,  "npm pack ran without error")
+      t.notOk(code,   "npm pack exited cleanly")
+      t.notOk(stderr, "npm pack ran silently")
+      t.equal(stdout.trim(), packname, "got expected package name")
+
+      common.npm(
+        [
+          "--loglevel", "silent",
+          "install", packed
+        ],
+        EXEC_OPTS,
+        function (err, code, stdout, stderr) {
+          t.ifError(err,  "npm install ran without error")
+          t.notOk(code,   "npm install exited cleanly")
+          t.notOk(stderr, "npm install ran silently")
+
+          var actual = readdir(installed).sort()
+          t.same(actual, expected, "no unexpected files in packed directory")
+
+          rimraf(packed, function () {
+            t.end()
+          })
+        }
+      )
+    }
+  )
+}
+
+var gitignore = "node_modules/\n"
+var npmignore = "t.js\n"
+
+var a = "console.log('hi');"
+var t = "require('tap').test(function (t) { t.pass('I am a test!'); t.end(); });"
+var fixture = {
+  "name" : "gitch",
+  "version" : "1.0.0",
+  "private" : true,
+  "main" : "a.js"
+}
+
+function cleanup () {
+  process.chdir(tmpdir())
+  rimraf.sync(pkg)
+}
+
+function setup (cb) {
+  cleanup()
+
+  mkdirp.sync(modules)
+  mkdirp.sync(dep)
+
+  process.chdir(dep)
+
+  cat(resolve(dep, ".npmignore"), npmignore)
+  cat(resolve(dep, ".gitignore"), gitignore)
+  cat(resolve(dep, "a.js"), a)
+  cat(resolve(dep, "t.js"), t)
+  cat(resolve(dep, "package.json"), JSON.stringify(fixture))
+
+  common.npm(
+    [
+      "--loglevel", "silent",
+      "cache", "clean"
+    ],
+    EXEC_OPTS,
+    function (er, code, _, stderr) {
+      if (er) return cb(er)
+      if (code) return cb(new Error("npm cache nonzero exit: "+code))
+      if (stderr) return cb(new Error("npm cache clean error: "+stderr))
+
+      which("git", function found (er, git) {
+        if (er) return cb(er)
+
+        exec(git+" init", init)
+
+        function init (er, _, stderr) {
+          if (er) return cb(er)
+          if (stderr) return cb(new Error("git init error: "+stderr))
+
+          exec(git+" config user.name 'Phantom Faker'", user)
+        }
+
+        function user (er, _, stderr) {
+          if (er) return cb(er)
+          if (stderr) return cb(new Error("git config error: "+stderr))
+
+          exec(git+" config user.email nope@not.real", email)
+        }
+
+        function email (er, _, stderr) {
+          if (er) return cb(er)
+          if (stderr) return cb(new Error("git config error: "+stderr))
+
+          exec(git+" add .", addAll)
+        }
+
+        function addAll (er, _, stderr) {
+          if (er) return cb(er)
+          if (stderr) return cb(new Error("git add . error: "+stderr))
+
+          exec(git+" commit -m boot", commit)
+        }
+
+        function commit (er, _, stderr) {
+          if (er) return cb(er)
+          if (stderr) return cb(new Error("git commit error: "+stderr))
+
+          cb()
+        }
+      })
+    }
+  )
+}


### PR DESCRIPTION
This fixes #6400. Replaces `git archive` + `addLocalTarball()`  with `git clone && git checkout` + `addLocal()`, which ensures that all of the `npm pack` rules aren't circumvented and `.npmignore` exclusions are applied (among other things). Includes two tests: one to ensure that caching an ordinary (git checkout) directory (still) works, and another to ensure that caching a git repo works correctly.

/cc @iarna for review, who should tell me if I'm using `realizePackageSpecifier()` correctly.
