### PR TITLE
`npm ls --long --depth 0` breaks for deps with deps

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -250,8 +250,7 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
   if (data._found === true && data._id) {
     if (npm.color) {
       out.label = color.bgBlack(color.yellow(out.label.trim())) + " "
-    }
-    else {
+    } else {
       out.label = out.label.trim() + " "
     }
   }
@@ -291,10 +290,13 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
   }
 
   // now all the children.
-  out.nodes = Object.keys(data.dependencies || {})
-    .sort(alphasort).map(function (d) {
-      return makeArchy_(data.dependencies[d], long, dir, depth + 1, data, d)
-    })
+  out.nodes = []
+  if (depth <= npm.config.get("depth")) {
+    out.nodes = Object.keys(data.dependencies || {})
+      .sort(alphasort).map(function (d) {
+        return makeArchy_(data.dependencies[d], long, dir, depth + 1, data, d)
+      })
+  }
 
   if (out.nodes.length === 0 && data.path === dir) {
     out.nodes = ["(empty)"]

--- a/test/tap/ls-l-depth-0.js
+++ b/test/tap/ls-l-depth-0.js
@@ -1,0 +1,112 @@
+var cat = require("graceful-fs").writeFileSync
+var resolve = require("path").resolve
+
+var mkdirp = require("mkdirp")
+var mr = require("npm-registry-mock")
+var rimraf = require("rimraf")
+var test = require("tap").test
+var tmpdir = require("osenv").tmpdir
+
+var common = require("../common-tap.js")
+
+var pkg = resolve(__dirname, "ls-l-depth-0")
+var dep = resolve(pkg, "deps", "glock")
+var modules = resolve(pkg, "node_modules")
+
+var expected =
+  "\n│ /Users/ogd/Documents/projects/npm/npm/test/tap/ls-l-depth-0\n" +
+  "│ \n" +
+  "└── glock@1.8.7\n" +
+  "    an inexplicably hostile sample package\n" +
+  "    https://github.com/npm/glo.ck\n" +
+  "    https://glo.ck\n" +
+  "\n"
+
+var server
+
+var EXEC_OPTS = {
+  cwd : pkg
+}
+
+test("setup", function (t) {
+  setup()
+  mr(common.port, function (s) {
+    server = s
+
+    t.end()
+  })
+})
+
+test("#6311: npm ll --depth=0 duplicates listing", function (t) {
+  common.npm(
+    [
+      "--loglevel", "silent",
+      "install", dep
+    ],
+    EXEC_OPTS,
+    function (err, code, stdout, stderr) {
+      t.ifError(err,  "npm install ran without error")
+      t.notOk(code,   "npm install exited cleanly")
+      t.notOk(stderr, "npm install ran silently")
+      t.equal(
+        stdout.trim(),
+        "glock@1.8.7 node_modules/glock\n└── underscore@1.7.0",
+        "got expected install output"
+      )
+
+      common.npm(
+        [
+          "--loglevel", "silent",
+          "ls", "--long",
+          "--depth", "0"
+        ],
+        EXEC_OPTS,
+        function (err, code, stdout, stderr) {
+          t.ifError(err,  "npm ll ran without error")
+          t.notOk(code,   "npm ll exited cleanly")
+          t.notOk(stderr, "npm ll ran silently")
+          t.equal(
+            stdout,
+            expected,
+            "got expected package name"
+          )
+
+          t.end()
+        }
+      )
+    }
+  )
+})
+
+test("cleanup", function (t) {
+  cleanup()
+  server.close()
+
+  t.end()
+})
+
+var fixture = {
+  "name" : "glock",
+  "version" : "1.8.7",
+  "private" : true,
+  "description" : "an inexplicably hostile sample package",
+  "homepage" : "https://glo.ck",
+  "repository" : "https://github.com/npm/glo.ck",
+  "dependencies" : {
+    "underscore" : "^1.3.1"
+  }
+}
+
+function cleanup () {
+  process.chdir(tmpdir())
+  rimraf.sync(pkg)
+}
+
+function setup () {
+  cleanup()
+
+  mkdirp.sync(modules)
+  mkdirp.sync(dep)
+
+  cat(resolve(dep, "package.json"), JSON.stringify(fixture))
+}


### PR DESCRIPTION
Fixes #6311 by explicitly checking depth before adding children. This may not be the rootmost fix for this issue, but it works, not just with the test, but with all the example apps I throw at it (including my global install).

/cc @iarna for review
