### PR TITLE
Print a success message on `npm owner {add,rm}`

### DIFF
--- a/lib/owner.js
+++ b/lib/owner.js
@@ -160,7 +160,7 @@ function rm (user, pkg, cb) {
   })
 
   log.verbose("owner rm", "%s from %s", user, pkg)
-  mutate(pkg, null, function (u, owners) {
+  mutate(pkg, user, function (u, owners) {
     var found = false
       , m = owners.filter(function (o) {
           var match = (o.name === user)
@@ -207,6 +207,12 @@ function mutate (pkg, user, mutation, cb) {
           log.error("owner mutate", "Error getting package data for %s", pkg)
           return cb(er)
         }
+
+        // save the number of maintainers before mutation so that we can figure
+        // out if maintainers were added or removed and print a friendly message
+        // accordingly
+        var beforeMutation = data.maintainers.length
+
         var m = mutation(u, data.maintainers)
         if (!m) return cb() // handled
         if (m instanceof Error) return cb(m) // error
@@ -229,6 +235,18 @@ function mutate (pkg, user, mutation, cb) {
             )
             if (er) {
               log.error("owner mutate", "Failed to update package metadata")
+            }
+            else {
+
+              // an owner was added
+              if (m.length > beforeMutation) {
+                console.log("Added %s as an owner of %s", user, pkg)
+              }
+
+              // an owner was removed
+              else if (m.length < beforeMutation) {
+                console.log("Removed %s as an owner of %s", user, pkg)
+              }
             }
             cb(er, data)
           })


### PR DESCRIPTION
Originally, I had a `console.log` in both `add()` and `rm()`, but I noticed that after the message was printed there was a pause while `npm` actually hit CouchDB to update the maintainer list. So, technically, there's no success until after the record is updated, so I decided to have the message be logged after the registry is hit (somewhere in `mutate_()`). Biggest issue then was figuring out if we were adding or removing an owner, so now the count of maintainers before and after the record mutation is compared to figure out if an owner was added or removed.

Open to review :)

Closes #6169
