### PR TITLE
partially centralize issues url

### DIFF
--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -130,7 +130,7 @@ easily by doing `npm view npm contributors`.
 If you would like to contribute, but don't know what to work on, check
 the issues list or ask on the mailing list.
 
-* <http://github.com/npm/npm/issues>
+* <@ISSUES@>
 * <npm-@googlegroups.com>
 
 ## BUGS
@@ -138,7 +138,7 @@ the issues list or ask on the mailing list.
 When you find issues, please report them:
 
 * web:
-  <http://github.com/npm/npm/issues>
+  <@ISSUES@>
 * email:
   <npm-@googlegroups.com>
 

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -134,6 +134,14 @@ ostensibly Unix systems.
 
 The browser that is called by the `npm docs` command to open websites.
 
+### bugs
+
+* Default: `@ISSUES@`
+* Type: String
+
+The URL for the npm package issue-tracker.  This is where you go to
+report bugs in npm itself.
+
 ### ca
 
 * Default: The npm CA certificate

--- a/doc/misc/npm-faq.md
+++ b/doc/misc/npm-faq.md
@@ -318,7 +318,7 @@ To check if the registry is down, open up
 you if you are just unable to access the internet for some reason.
 
 If the registry IS down, let us know by emailing <support@npmjs.com>
-or posting an issue at <https://github.com/npm/npm/issues>.  If it's
+or posting an issue at <@ISSUES@>.  If it's
 down for the world (and not just on your local network) then we're
 probably already being pinged about it.
 
@@ -373,7 +373,7 @@ good folks at [npm, Inc.](http://www.npmjs.com)
 
 Post an issue on the github project:
 
-* <https://github.com/npm/npm/issues>
+* <@ISSUES@>
 
 ## Why does npm hate me?
 

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -130,6 +130,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     "always-auth" : false
     , "bin-links" : true
     , browser : null
+    , bugs : "https://github.com/npm/npm/issues"
 
     , ca: null
     , cafile: null
@@ -239,6 +240,7 @@ exports.types =
   { "always-auth" : Boolean
   , "bin-links": Boolean
   , browser : [null, String]
+  , bugs : [null, String]
   , ca: [null, String, Array]
   , cafile : path
   , cache : path

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -350,7 +350,7 @@ function errorHandler (er) {
   default:
     log.error("", er.message || er)
     log.error("", ["", "If you need help, you may report this error at:"
-                  ,"    <http://github.com/npm/npm/issues>"
+                  ,"    <" + npm.config.get("bugs") + ">"
                   ].join("\n"))
     break
   }

--- a/scripts/doc-build.sh
+++ b/scripts/doc-build.sh
@@ -63,6 +63,8 @@ dest=$2
 name=$(basename ${src%.*})
 date=$(date -u +'%Y-%M-%d %H:%m:%S')
 version=$(node cli.js -v)
+issues=$(node cli.js config get bugs)
+man_issues=$(echo $issues | sed -e 's|\.|\\\\.|')
 
 mkdir -p $(dirname $dest)
 
@@ -72,6 +74,7 @@ html_replace_tokens () {
 	| sed "s|@DATE@|$date|g" \
 	| sed "s|@URL@|$url|g" \
 	| sed "s|@VERSION@|$version|g" \
+        | sed "s|@ISSUES@|$issues|g" \
 	| perl -p -e 's/<h1([^>]*)>([^\(]*\([0-9]\)) -- (.*?)<\/h1>/<h1>\2<\/h1> <p>\3<\/p>/g' \
 	| perl -p -e 's/npm-npm/npm/g' \
 	| perl -p -e 's/([^"-])(npm-)?README(?!\.html)(\(1\))?/\1<a href="..\/..\/doc\/README.html">README<\/a>/g' \
@@ -90,6 +93,7 @@ html_replace_tokens () {
 
 man_replace_tokens () {
 	sed "s|@VERSION@|$version|g" \
+        | sed "s|@ISSUES@|$man_issues|g" \
 	| perl -p -e 's/(npm\\-)?([a-zA-Z\\\.\-]*)\(1\)/npm help \2/g' \
 	| perl -p -e 's/(npm\\-)?([a-zA-Z\\\.\-]*)\(([57])\)/npm help \3 \2/g' \
 	| perl -p -e 's/(npm\\-)?([a-zA-Z\\\.\-]*)\(3\)/npm apihelp \2/g' \


### PR DESCRIPTION
remove literal "https://github.com/npm/npm/issues" where possible
  create new config 'bugs' defaulted to "https://github.com/npm/npm/issues"
  use '@ISSUES' in doc/*_/_.md in place of literal
  change doc-build.sh to replace @ISSUES@ with `npm config get bugs`
  ensure that "." is escaped in generated man pages
  use npm.config.get("bugs") instead of literal in error-handler.js

There are still 3 independent places where "https://github.com/npm/npm/issues" appears
as a literal:

  package.json - as 'url' for 'bugs'
  README.md - near the end, "When you find issues, please report them"
  lib/config/defaults.js - as default value for 'bugs'

So it's not quite DRY, but a bit less damp.
