### PR TITLE
Put npm-debug.log file in the cache folder, not cwd

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -14,6 +14,10 @@ var cbCalled = false
   , writeStream = require("fs-write-stream-atomic")
 
 
+function getLogFile () {
+  return path.resolve(npm.config.get("cache"), "npm-debug.log")
+}
+
 process.on("exit", function (code) {
   // console.error("exit", code)
   if (!npm.config || !npm.config.loaded) return
@@ -30,7 +34,7 @@ process.on("exit", function (code) {
 
       log.error("",
                 ["Please include the following file with any support request:"
-                ,"    " + path.resolve("npm-debug.log")
+                ,"    " + getLogFile()
                 ].join("\n"))
       wroteLogFile = false
     }
@@ -71,7 +75,7 @@ function exit (code, noLog) {
         else writeLogFile(reallyExit.bind(this, er))
       } else {
         if (!noLog && code) writeLogFile(reallyExit)
-        else rm("npm-debug.log", reallyExit)
+        else rm(getLogFile(), reallyExit)
       }
     })
     rollbacks.length = 0
@@ -217,7 +221,8 @@ function errorHandler (er) {
     var msg = [er.message]
     if (er.pkgid && er.pkgid !== "-") {
       msg.push("", "'"+er.pkgid+"' is not in the npm registry."
-              ,"You should bug the author to publish it (or use the name yourself!)")
+              ,"You should bug the author to publish it"
+              ,"(or use the name yourself!)")
       if (er.parent) {
         msg.push("It was specified as a dependency of '"+er.parent+"'")
       }
@@ -364,7 +369,9 @@ function writeLogFile (cb) {
   writingLogFile = true
   wroteLogFile = true
 
-  var fstr = writeStream("npm-debug.log")
+  var fs = require("graceful-fs")
+    , logFile = getLogFile()
+    , tmp = logFile + "." + process.pid
     , os = require("os")
     , out = ""
 
@@ -380,6 +387,8 @@ function writeLogFile (cb) {
     })
   })
 
-  fstr.end(out)
-  fstr.on("close", cb)
+  fs.writeFile(tmp, out, function (er) {
+    if (er) return cb(er)
+    fs.rename(tmp, logFile, cb)
+  })
 }

--- a/test/tap/gently-rm-overeager.js
+++ b/test/tap/gently-rm-overeager.js
@@ -25,9 +25,12 @@ test("cache add", function (t) {
     t.ok(c, "test-whoops install also failed")
     fs.readdir(pkg, function (er, files) {
       t.ifError(er, "package directory is still there")
-      t.deepEqual(files, ["npm-debug.log"], "only debug log remains")
+      t.same(files, [], "only debug log remains")
+      fs.exists(resolve(common.npm_config_cache, "npm-debug.log"), function (p) {
+        t.ok(p, "debug log is saved")
 
-      t.end()
+        t.end()
+      })
     })
   })
 })


### PR DESCRIPTION
New version of #6181: This should prevent mishaps like #1548, while avoiding overly configurable options that make it hard to predict where the file will show up.

Fix #1584
Close #5252
