### PR TITLE
Fix leak into global scope (Fix reversion in #3908)

### DIFF
--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -5,7 +5,7 @@ var _spawn = require("child_process").spawn,
 
 function spawn (cmd, args, options) {
   var raw = _spawn(cmd, args, options)
-      cooked = new EventEmitter()
+    , cooked = new EventEmitter()
 
   raw.on("error", function (er) {
     er.file = cmd

--- a/test/tap/spawn-enoent-help.js
+++ b/test/tap/spawn-enoent-help.js
@@ -23,6 +23,7 @@ test("enoent help", function (t) {
     }
   }, function (er, code, sout, serr) {
     t.similar(serr, /Check if the file 'emacsclient' is present./)
+    t.equal(global.cooked, undefined, "Don't leak into global scope")
     t.end()
   })
 })


### PR DESCRIPTION
Here is a candidate fix.

I am a bit stumped on the test because I'm on my windows machine right now and I'm getting intermittent tap failures, but I took a stab at a test that guards against `cooked` leaking into the global scope.
