### PR TITLE
Put npm-debug.log file in the cache folder, not cwd

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -11,8 +11,8 @@ var cbCalled = false
   , exitCode = 0
   , rollbacks = npm.rollbacks
   , chain = require("slide").chain
-  , writeStream = require("fs-write-stream-atomic")
-
+  , fs = require("graceful-fs") 
+  , logfile = require("./logfile.js")
 
 process.on("exit", function (code) {
   // console.error("exit", code)
@@ -30,7 +30,7 @@ process.on("exit", function (code) {
 
       log.error("",
                 ["Please include the following file with any support request:"
-                ,"    " + path.resolve("npm-debug.log")
+               ,"    " + logfile.getName()
                 ].join("\n"))
       wroteLogFile = false
     }
@@ -38,6 +38,8 @@ process.on("exit", function (code) {
       log.error("code", code)
     }
   }
+
+  if (!code) logfile.pruneLogs()
 
   var doExit = npm.config.get("_exit")
   if (doExit) {
@@ -67,17 +69,17 @@ function exit (code, noLog) {
       if (er) {
         log.error("error rolling back", er)
         if (!code) errorHandler(er)
-        else if (noLog) rm("npm-debug.log", reallyExit.bind(null, er))
+        else if (noLog) rm(logfile.getName(), reallyExit.bind(null, er))
         else writeLogFile(reallyExit.bind(this, er))
       } else {
         if (!noLog && code) writeLogFile(reallyExit)
-        else rm("npm-debug.log", reallyExit)
+        else rm(logfile.getName(), reallyExit)
       }
     })
     rollbacks.length = 0
   }
   else if (code && !noLog) writeLogFile(reallyExit)
-  else rm("npm-debug.log", reallyExit)
+  else rm(logfile.getName(), reallyExit)
 
   function reallyExit (er) {
     if (er && !code) code = typeof er.errno === "number" ? er.errno : 1
@@ -217,7 +219,8 @@ function errorHandler (er) {
     var msg = [er.message]
     if (er.pkgid && er.pkgid !== "-") {
       msg.push("", "'"+er.pkgid+"' is not in the npm registry."
-              ,"You should bug the author to publish it (or use the name yourself!)")
+              ,"You should bug the author to publish it"
+              ,"(or use the name yourself!)")
       if (er.parent) {
         msg.push("It was specified as a dependency of '"+er.parent+"'")
       }
@@ -364,8 +367,7 @@ function writeLogFile (cb) {
   writingLogFile = true
   wroteLogFile = true
 
-  var fstr = writeStream("npm-debug.log")
-    , os = require("os")
+  var os = require("os")
     , out = ""
 
   log.record.forEach(function (m) {
@@ -380,6 +382,5 @@ function writeLogFile (cb) {
     })
   })
 
-  fstr.end(out)
-  fstr.on("close", cb)
+  logfile.writeLogFile(out, cb)
 }

--- a/lib/utils/logfile.js
+++ b/lib/utils/logfile.js
@@ -1,0 +1,85 @@
+module.exports.getName = getLogFile
+module.exports.getLogDir = getLogDir
+module.exports.pruneLogs = pruneLogs
+module.exports.writeLogFile = writeLogFile
+module.exports.logsToRemove = logsToRemove
+module.exports.findLogs = findLogs
+
+var path = require("path")
+  , rm = require("rimraf")
+  , path = require("path")
+  , fs = require("graceful-fs") 
+  , npm = require("../npm.js")
+  , getLogFile = require("./logfile.js")
+
+  
+function getLogDir () {
+  return path.resolve(path.join(npm.config.get("cache"), "_logs"))
+}
+
+function logsToRemove(logs) {
+  var lastWeek = new Date().getTime() - 604800000
+    , toRemove = []
+
+    if (logs.length > 20) {
+      // save newest ten
+      logs.sort(function (a, b) { return b.ctime.getTime() - a.ctime.getTime() })
+      toRemove = logs.slice(10)
+      logs = logs.slice(0, 10)
+    }
+
+    logs.forEach(function (s) {
+      if (s.ctime.getTime() < lastWeek) toRemove.push(s)
+      if (s.size > 10*1024*1024) toRemove.push(s)
+    })
+
+    return toRemove
+}
+
+function findLogs(dir, cb) {
+  fs.readdir(dir, function (er, logfiles) {
+    if (er) return cb(er)
+
+    var logs = logfiles.map(function StatEach(f) {
+        var n = path.join(getLogDir(), f)
+          , s = fs.statSync(n)
+
+        s.name = n;
+        return s;
+    }).filter(function (s) { return s.isFile() })
+
+    cb(null, logs)
+  })
+}
+
+function pruneLogs (cb) {
+  // deliberately ignoring errors here - cleanup function
+  findLogs(getLogDir(), function (er, logs) {
+    if (er) return cb ? cb(er) : er
+    var toRemove = logsToRemove(log)
+
+    toRemove.forEach(function (s) { rm(s.name, function (er) {
+// ? log.info("removed log " + s.name)   
+      })
+    })
+    if (cb) cb()
+  })
+}
+
+function getLogFile () {
+  return path.resolve(getLogDir(), "npm-debug." + process.pid + ".log")
+}
+
+function writeLogFile (out, cb) {
+  var logFile = getLogFile()
+    , tmp = logFile + "." + process.pid
+
+  fs.mkdir(getLogDir(), function (er) {
+    if (er) return cb(er)
+
+    fs.writeFile(tmp, out, function (er) {
+      if (er) return cb(er)
+      fs.rename(tmp, logFile, cb)
+    })
+  })
+}

--- a/test/tap/gently-rm-overeager.js
+++ b/test/tap/gently-rm-overeager.js
@@ -25,8 +25,7 @@ test("cache add", function (t) {
     t.ok(c, "test-whoops install also failed")
     fs.readdir(pkg, function (er, files) {
       t.ifError(er, "package directory is still there")
-      t.deepEqual(files, ["npm-debug.log"], "only debug log remains")
-
+      t.same(files, [], "only debug log remains")
       t.end()
     })
   })

--- a/test/tap/logfile-finds-logfiles.js
+++ b/test/tap/logfile-finds-logfiles.js
@@ -1,0 +1,51 @@
+var path = require("path")
+var test = require("tap").test
+var fs = require("fs")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var common = require("../common-tap.js")
+var npm = require("../../")
+var fs = require("graceful-fs")
+
+var getLogDir = require("../../lib/utils/logfile").getLogDir
+var findLogs = require("../../lib/utils/logfile").findLogs
+
+var pkg = path.resolve(__dirname, "logfile-finds-logfiles")
+var cache = path.resolve(pkg, "cache")
+
+test("setup", function (t) {
+  cleanup()
+  mkdirp.sync(cache)
+  t.end()
+})
+
+test("finds logfiles", function (t) {
+  npm.load({cache: cache}, function () {
+    var logdir = getLogDir()
+
+    // create some stale logfiles
+    mkdirp.sync(logdir)
+    fs.writeFileSync(path.join(logdir, "npm-debug-1.log"),
+                     "log file content")
+    fs.writeFileSync(path.join(logdir, "npm-debug-2.log"),
+                     "more log file content")
+
+    findLogs(logdir, function (er, logs) {
+      t.notOk(er, "error finding logs")
+      t.equal(2, logs.length, "expected 2 log files")
+      t.equal(logs[0].name
+            , path.resolve(logdir, "npm-debug-1.log")
+            , "expected named log file")
+      t.end()
+    })
+  })
+})
+
+function cleanup () {
+  rimraf.sync(pkg)
+}
+
+test("clean", function (t) {
+  cleanup()
+  t.end()
+})

--- a/test/tap/logfile-to-remove.js
+++ b/test/tap/logfile-to-remove.js
@@ -1,0 +1,64 @@
+var common = require("../common-tap")
+var test = require("tap").test
+var path = require("path")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+
+var pkg = path.resolve(__dirname, "logfile-to-remove")
+
+var logsToRemove = require("../../lib/utils/logfile").logsToRemove
+
+test("setup", function (t) {
+  cleanup()
+  mkdirp.sync(pkg)
+  t.end()
+})
+
+test("chooses large logfiles to remove", function (t) {
+  var now = new Date()
+  var big = 12*1024*1024
+
+  t.deepEqual([{ctime: now, size: big}]
+            , logsToRemove([{ctime: now, size: big},
+                           ,{ctime: now, size: 20}])
+            , "expected large logfile to be removed")
+  t.end()
+})
+
+test("chooses old logfiles to remove", function (t) {
+  var now = new Date()
+  var then = new Date(2003,10,29)
+
+  t.deepEqual([{ctime: then, size: 30}]
+            , logsToRemove([{ctime: then, size: 30},
+                           ,{ctime: now, size: 20}])
+            , "expected old logfile to be removed")
+  t.end()
+})
+
+test("chooses old logfiles to remove", function (t) {
+  var now = new Date()
+  var logs = []
+  var i
+  var expected = []
+
+  for (i = 0; i < 30; i += 1) {
+    logs[i] = {ctime: new Date(now.getTime() - i), size: i}
+  }
+  expected = logs.slice(10)
+
+  t.deepEqual(expected
+            , logsToRemove(logs)
+            , "expected oldest logfiles to be removed")
+
+  t.end()
+})
+
+function cleanup() {
+  rimraf.sync(pkg)
+}
+
+test("clean", function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
This should prevent mishaps like #1548, while avoiding overly
configurable options that make it hard to predict where the file
will show up.

Fix #1584
Close #5252

update test for new behavior

smikes:
- strawman version of multiple logs
- add unit tests for prune, findLogs
