### PR TITLE
Make sure that Windows gets the correct Git parameters.

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -159,13 +159,13 @@ function fetchRemote (p, u, co, origUrl, cb) {
         resolveHead(p, u, co, origUrl, cb)
       }
       else {
-        getGitDir(function(er, cs) {
+        getGitDir(function (er, cs) {
           if (er) {
             log.error("Could not get cache stat")
             return cb(er)
           }
 
-          chownr(p, cs.uid, cs.gid, function(er) {
+          chownr(p, cs.uid, cs.gid, function (er) {
             if (er) {
               log.error("Failed to change folder ownership under npm cache for %s", p)
               return cb(er)

--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -156,7 +156,7 @@ function fetchRemote (p, u, co, origUrl, cb) {
 
       if (process.platform === "win32") {
         log.silly("verifyOwnership", "skipping for windows")
-        resolveHead()
+        resolveHead(p, u, co, origUrl, cb)
       }
       else {
         getGitDir(function(er, cs) {

--- a/lib/utils/git.js
+++ b/lib/utils/git.js
@@ -13,30 +13,30 @@ var exec = require("child_process").execFile
   , assert = require("assert")
   , log = require("npmlog")
 
-function prefixGitArgs() {
+function prefixGitArgs () {
   return process.platform === "win32" ? ["-c", "core.longpaths=true"] : []
 }
 
-function execGit(args, options, cb) {
+function execGit (args, options, cb) {
   log.info("git", args)
   return exec(git, prefixGitArgs().concat(args || []), options, cb)
 }
 
-function spawnGit(args, options, cb) {
+function spawnGit (args, options) {
   log.info("git", args)
   return spawn(git, prefixGitArgs().concat(args || []), options)
 }
 
-function chainableExec() {
+function chainableExec () {
   var args = Array.prototype.slice.call(arguments)
   return [execGit].concat(args)
 }
 
-function whichGit(cb) {
+function whichGit (cb) {
   return which(git, cb)
 }
 
-function whichAndExec(args, options, cb) {
+function whichAndExec (args, options, cb) {
   assert.equal(typeof cb, "function", "no callback provided")
   // check for git
   whichGit(function (err) {

--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -17,6 +17,7 @@ function spawn (cmd, args, options) {
   cooked.stdin = raw.stdin
   cooked.stdout = raw.stdout
   cooked.stderr = raw.stderr
+  cooked.kill = function (sig) { return raw.kill(sig) }
 
   return cooked
 }

--- a/test/tap/add-remote-git-fake-windows.js
+++ b/test/tap/add-remote-git-fake-windows.js
@@ -1,0 +1,126 @@
+var fs = require("fs")
+var resolve = require("path").resolve
+
+var chain = require("slide").chain
+var osenv = require("osenv")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var test = require("tap").test
+
+var npm = require("../../lib/npm.js")
+var common = require("../common-tap.js")
+
+var pkg = resolve(__dirname, "add-remote-git")
+var repo = resolve(__dirname, "add-remote-git-repo")
+
+var daemon
+var git
+
+test("setup", function (t) {
+  bootstrap()
+  setup(function (er, r) {
+    t.ifError(er, "git started up successfully")
+
+    if (!er) daemon = r[r.length - 1]
+
+    t.end()
+  })
+})
+
+test("install from repo on 'Windows'", function (t) {
+  // before we confuse everything by switching the platform
+  require("../../lib/install.js")
+  require("../../lib/unbuild.js")
+  process.platform = "win32"
+  process.chdir(pkg)
+  npm.commands.install(".", [], function (er) {
+    t.ifError(er, "npm installed via git")
+
+    t.end()
+  })
+})
+
+test("clean", function (t) {
+  daemon.on("close", function () {
+    cleanup()
+    t.end()
+  })
+  daemon.kill("SIGINT")
+})
+
+var pjParent = JSON.stringify({
+  name         : "parent",
+  version      : "1.2.3",
+  dependencies : {
+    "child" : "git://localhost:1234/child.git"
+  }
+}, null, 2) + "\n"
+
+var pjChild = JSON.stringify({
+  name    : "child",
+  version : "1.0.3"
+}, null, 2) + "\n"
+
+function bootstrap () {
+  mkdirp.sync(pkg)
+  fs.writeFileSync(resolve(pkg, "package.json"), pjParent)
+}
+
+function setup (cb) {
+  mkdirp.sync(repo)
+  fs.writeFileSync(resolve(repo, "package.json"), pjChild)
+  npm.load({ registry : common.registry, loglevel : "silent" }, function () {
+    // some really cheesy monkeypatching
+    require("module")._cache[require.resolve("which")] = {
+      exports : function (_, cb) { cb() }
+    }
+    git = require("../../lib/utils/git.js")
+
+    function startDaemon (cb) {
+      // start git server
+      var d = git.spawn(
+        [
+          "daemon",
+          "--listen=localhost",
+          "--export-all",
+          "--base-path=.",
+          "--port=1234"
+        ],
+        {
+          cwd   : pkg,
+          env   : process.env,
+          stdio : ["pipe", "pipe", "pipe"]
+        }
+      )
+
+      cb(null, d)
+    }
+
+    var opts = {
+      cwd : repo,
+      env : process.env
+    }
+
+    chain(
+      [
+        git.chainableExec(["init"], opts),
+        git.chainableExec(["config", "user.name", "PhantomFaker"], opts),
+        git.chainableExec(["config", "user.email", "nope@not.real"], opts),
+        git.chainableExec(["add", "package.json"], opts),
+        git.chainableExec(["commit", "-m", "stub package"], opts),
+        git.chainableExec(
+          ["clone", "--bare", repo, "child.git"],
+          { cwd : pkg, env : process.env }
+        ),
+        startDaemon
+      ],
+      cb
+    )
+  })
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(repo)
+  rimraf.sync(pkg)
+}

--- a/test/tap/add-remote-git.js
+++ b/test/tap/add-remote-git.js
@@ -1,0 +1,119 @@
+var fs = require("fs")
+var resolve = require("path").resolve
+
+var chain = require("slide").chain
+var osenv = require("osenv")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var test = require("tap").test
+
+var npm = require("../../lib/npm.js")
+var common = require("../common-tap.js")
+
+var pkg = resolve(__dirname, "add-remote-git")
+var repo = resolve(__dirname, "add-remote-git-repo")
+
+var daemon
+var git
+
+test("setup", function (t) {
+  bootstrap()
+  setup(function (er, r) {
+    t.ifError(er, "git started up successfully")
+
+    if (!er) daemon = r[r.length - 1]
+
+    t.end()
+  })
+})
+
+test("install from repo on 'OS X'", function (t) {
+  process.platform = "darwin"
+  process.chdir(pkg)
+  npm.commands.install(".", [], function (er) {
+    t.ifError(er, "npm installed via git")
+
+    t.end()
+  })
+})
+
+test("clean", function (t) {
+  daemon.on("close", function () {
+    cleanup()
+    t.end()
+  })
+  daemon.kill("SIGINT")
+})
+
+var pjParent = JSON.stringify({
+  name         : "parent",
+  version      : "1.2.3",
+  dependencies : {
+    "child" : "git://localhost:1234/child.git"
+  }
+}, null, 2) + "\n"
+
+var pjChild = JSON.stringify({
+  name    : "child",
+  version : "1.0.3"
+}, null, 2) + "\n"
+
+function bootstrap () {
+  mkdirp.sync(pkg)
+  fs.writeFileSync(resolve(pkg, "package.json"), pjParent)
+}
+
+function setup (cb) {
+  mkdirp.sync(repo)
+  fs.writeFileSync(resolve(repo, "package.json"), pjChild)
+  npm.load({ registry : common.registry, loglevel : "silent" }, function () {
+    git = require("../../lib/utils/git.js")
+
+    function startDaemon (cb) {
+      // start git server
+      var d = git.spawn(
+        [
+          "daemon",
+          "--listen=localhost",
+          "--export-all",
+          "--base-path=.",
+          "--port=1234"
+        ],
+        {
+          cwd   : pkg,
+          env   : process.env,
+          stdio : ["pipe", "pipe", "pipe"]
+        }
+      )
+
+      cb(null, d)
+    }
+
+    var opts = {
+      cwd : repo,
+      env : process.env
+    }
+
+    chain(
+      [
+        git.chainableExec(["init"], opts),
+        git.chainableExec(["config", "user.name", "PhantomFaker"], opts),
+        git.chainableExec(["config", "user.email", "nope@not.real"], opts),
+        git.chainableExec(["add", "package.json"], opts),
+        git.chainableExec(["commit", "-m", "stub package"], opts),
+        git.chainableExec(
+          ["clone", "--bare", repo, "child.git"],
+          { cwd : pkg, env : process.env }
+        ),
+        startDaemon
+      ],
+      cb
+    )
+  })
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(repo)
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
This needs a test before landing. Anyone got any good ideas? We currently have no coverage around `lib/cache/add-remote-git.js` in the tap tests, so my idea of snowcloning an existing test and adding `process.platform = "win32"` at the beginning (which, sadly, works) isn't going to work.

I don't really like the idea of making this test depend on GitHub's availability, but I don't know how to run up a git server very fast, either.
