### PR TITLE
doc/tag: candidate explanation of tag workflow

### DIFF
--- a/doc/api/npm-tag.md
+++ b/doc/api/npm-tag.md
@@ -18,6 +18,6 @@ is the package name and version is the version number (much like installing a
 specific version).
 
 The second element is the name of the tag to tag this version with. If this
-parameter is missing or falsey (empty), the default froom the config will be
+parameter is missing or falsey (empty), the default from the config will be
 used. For more information about how to set this config, check
 `man 3 npm-config` for programmatic usage or `man npm-config` for cli usage.

--- a/doc/cli/npm-tag.md
+++ b/doc/cli/npm-tag.md
@@ -23,6 +23,29 @@ This also applies to `npm dedupe`.
 
 Publishing a package always sets the "latest" tag to the published version.
 
+## PURPOSE
+
+Tags can be used to provide an alias instead of version numbers.  For
+example, `npm` currently uses the tag "next" to identify the upcoming
+version, and the tag "latest" to identify the current version.
+
+A project might choose to have multiple streams of development, e.g.,
+"stable", "canary".
+
+## CAVEATS
+
+Tags must share a namespace with version numbers, because they are
+specified in the same slot: `npm install <pkg>@<version>` vs `npm
+install <pkg>@<tag>`.
+
+Tags that can be interpreted as valid semver ranges will be
+rejected. For example, `v1.4` cannot be used as a tag, because it is
+interpreted by semver as `>=1.4.0 <1.5.0`.  See
+<https://github.com/npm/npm/issues/6082>.
+
+The simplest way to avoid semver problems with tags is to use tags
+that do not begin with a number or the letter `v`.
+
 ## SEE ALSO
 
 * npm-publish(1)
@@ -31,4 +54,5 @@ Publishing a package always sets the "latest" tag to the published version.
 * npm-registry(7)
 * npm-config(1)
 * npm-config(7)
+* npm-tag(3)
 * npmrc(5)


### PR DESCRIPTION
Some suggestions re: tag workflow.  Open to major revision/bikeshedding.

There is a distinction between 'tag' (eg a git tag) which identifies a specific release (and is very closely related to 'version') and 'dist-tag' which identifies both a stream of releases and the most current version in that release, but I am having a hard time articulating it.

Is the name "tag" or "dist-tag" still open to bikeshedding or is it basically set in stone?
