### PR TITLE
add 'npm dist-tag {add,del,list}'

### DIFF
--- a/doc/cli/npm-dist-tag.md
+++ b/doc/cli/npm-dist-tag.md
@@ -1,0 +1,72 @@
+npm-dist-tag(1) -- Modify package distribution tags
+===================================================
+
+## SYNOPSIS
+
+    npm dist-tag add <pkg>@<version> [<tag>]
+    npm dist-tag rm <pkg> <tag>
+    npm dist-tag ls [<pkg>]
+
+## DESCRIPTION
+
+Add, remove, and enumerate distribution tags on a package:
+
+* add:
+  Tags the specified version of the package with the specified tag, or the
+  `--tag` config if not specified.
+
+* rm:
+  Clear a tag that is no longer in use from the package.
+
+* ls:
+  Show all of the dist-tags for a package, defaulting to the package in
+  the curren prefix.
+
+A tag can be used when installing packages as a reference to a version instead
+of using a specific version number:
+
+    npm install <name>@<tag>
+
+When installing dependencies, a preferred tagged version may be specified:
+
+    npm install --tag <tag>
+
+This also applies to `npm dedupe`.
+
+Publishing a package always sets the "latest" tag to the published version.
+
+## PURPOSE
+
+Tags can be used to provide an alias instead of version numbers.  For
+example, `npm` currently uses the tag "next" to identify the upcoming
+version, and the tag "latest" to identify the current version.
+
+A project might choose to have multiple streams of development, e.g.,
+"stable", "canary".
+
+## CAVEATS
+
+This command used to be known as `npm tag`, which only created new tags, and so
+had a different syntax.
+
+Tags must share a namespace with version numbers, because they are specified in
+the same slot: `npm install <pkg>@<version>` vs `npm install <pkg>@<tag>`.
+
+Tags that can be interpreted as valid semver ranges will be rejected. For
+example, `v1.4` cannot be used as a tag, because it is interpreted by semver as
+`>=1.4.0 <1.5.0`.  See <https://github.com/npm/npm/issues/6082>.
+
+The simplest way to avoid semver problems with tags is to use tags that do not
+begin with a number or the letter `v`.
+
+## SEE ALSO
+
+* npm-tag(1)
+* npm-publish(1)
+* npm-install(1)
+* npm-dedupe(1)
+* npm-registry(7)
+* npm-config(1)
+* npm-config(7)
+* npm-tag(3)
+* npmrc(5)

--- a/doc/cli/npm-tag.md
+++ b/doc/cli/npm-tag.md
@@ -7,6 +7,8 @@ npm-tag(1) -- Tag a published version
 
 ## DESCRIPTION
 
+THIS COMMAND IS DEPRECATED. See npm-dist-tag(1) for details.
+
 Tags the specified version of the package with the specified tag, or the
 `--tag` config if not specified.
 

--- a/lib/dist-tag.js
+++ b/lib/dist-tag.js
@@ -1,0 +1,151 @@
+module.exports = distTag
+
+var log = require("npmlog")
+var npa = require("npm-package-arg")
+var semver = require("semver")
+
+var npm = require("./npm.js")
+var mapToRegistry = require("./utils/map-to-registry.js")
+var readLocalPkg = require("./utils/read-local-package.js")
+
+distTag.usage = "npm dist-tag add <pkg>@<version> [<tag>]"
+              + "\nnpm dist-tag rm <pkg> <tag>"
+              + "\nnpm dist-tag ls [<pkg>]"
+
+distTag.completion = function (opts, cb) {
+  var argv = opts.conf.argv.remain
+  if (argv.length === 2) {
+    return cb(null, ["add", "rm", "ls"])
+  }
+
+  switch (argv[2]) {
+    default:
+      return cb()
+  }
+}
+
+function distTag (args, cb) {
+  var cmd = args.shift()
+  switch (cmd) {
+    case "add": case "a": case "set": case "s":
+      return add(args[0], args[1], cb)
+    case "rm":  case "r": case "del": case "d": case "remove":
+      return remove(args[1], args[0], cb)
+    case "ls":  case "l": case "sl": case "list":
+      return list(args[0], cb)
+    default:
+      return cb("Usage:\n"+distTag.usage)
+  }
+}
+
+function add (spec, tag, cb) {
+  var thing = npa(spec || "")
+  var pkg = thing.name
+  var version = thing.rawSpec
+  var t = (tag || npm.config.get("tag")).trim()
+
+  log.verbose("dist-tag add", t, "to", pkg+"@"+version)
+
+  if (!pkg || !version || !t) return cb("Usage:\n"+distTag.usage)
+
+  if (semver.validRange(t)) {
+    var er = new Error("Tag name must not be a valid SemVer range: " + t)
+    return cb(er)
+  }
+
+  fetchTags(pkg, function (er, tags) {
+    if (er) return cb(er)
+
+    if (tags[t] === version) {
+      log.warn("dist-tag add", t, "is already set to version", version)
+      return cb()
+    }
+    tags[t] = version
+
+    mapToRegistry(pkg, npm.config, function (er, uri, auth, base) {
+      var params = {
+        package : pkg,
+        distTag : t,
+        version : version,
+        auth : auth
+      }
+
+      npm.registry.distTags.add(base, params, function (er) {
+        if (er) return cb(er)
+
+        console.log("+"+t+": "+pkg+"@"+version)
+        cb()
+      })
+    })
+  })
+}
+
+function remove (tag, pkg, cb) {
+  log.verbose("dist-tag del", tag, "from", pkg)
+
+  fetchTags(pkg, function (er, tags) {
+    if (er) return cb(er)
+
+    if (!tags[tag]) {
+      log.info("dist-tag del", tag, "is not a dist-tag on", pkg)
+      return cb(new Error(tag+" is not a dist-tag on "+pkg))
+    }
+
+    var version = tags[tag]
+    delete tags[tag]
+
+    mapToRegistry(pkg, npm.config, function (er, uri, auth, base) {
+      var params = {
+        package : pkg,
+        distTag : tag,
+        auth : auth
+      }
+
+      npm.registry.distTags.rm(base, params, function (er) {
+        if (er) return cb(er)
+
+        console.log("-"+tag+": "+pkg+"@"+version)
+        cb()
+      })
+    })
+  })
+}
+
+function list (pkg, cb) {
+  if (!pkg) return readLocalPkg(function (er, pkg) {
+    if (er) return cb(er)
+    if (!pkg) return cb(distTag.usage)
+    list(pkg, cb)
+  })
+
+  fetchTags(pkg, function (er, tags) {
+    if (er) {
+      log.error("dist-tag ls", "Couldn't get dist-tag data for", pkg)
+      return cb(er)
+    }
+    var msg = Object.keys(tags).map(function (k) {
+      return k+": "+tags[k]
+    }).sort().join("\n")
+    console.log(msg)
+    cb(er, tags)
+  })
+}
+
+function fetchTags (pkg, cb) {
+  mapToRegistry(pkg, npm.config, function (er, uri, auth, base) {
+    if (er) return cb(er)
+
+    var params = {
+      package : pkg,
+      auth : auth
+    }
+    npm.registry.distTags.fetch(base, params, function (er, tags) {
+      if (er) return cb(er)
+      if (!tags || !Object.keys(tags).length) {
+        return cb(new Error("No dist-tags found for " + pkg))
+      }
+
+      cb(null, tags)
+    })
+  })
+}

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -67,6 +67,7 @@ var commandCache = {}
               , "isntall" : "install"
               , "up" : "update"
               , "c" : "config"
+              , "dist-tags" : "dist-tag"
               , "info" : "view"
               , "show" : "view"
               , "find" : "search"
@@ -132,6 +133,7 @@ var commandCache = {}
               , "prefix"
               , "bin"
               , "whoami"
+              , "dist-tag"
 
               , "test"
               , "stop"

--- a/lib/owner.js
+++ b/lib/owner.js
@@ -6,8 +6,8 @@ owner.usage = "npm owner add <username> <pkg>"
 
 var npm = require("./npm.js")
   , log = require("npmlog")
-  , readJson = require("read-package-json")
   , mapToRegistry = require("./utils/map-to-registry.js")
+  , readLocalPkg = require("./utils/read-local-package.js")
 
 owner.completion = function (opts, cb) {
   var argv = opts.conf.argv.remain
@@ -250,14 +250,6 @@ function mutate (pkg, user, mutation, cb) {
       })
     })
   }
-}
-
-function readLocalPkg (cb) {
-  if (npm.config.get("global")) return cb()
-  var path = require("path")
-  readJson(path.resolve(npm.prefix, "package.json"), function (er, d) {
-    return cb(er, d && d.name)
-  })
 }
 
 function unknown (action, cb) {

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -9,6 +9,7 @@ var npm = require("./npm.js")
   , mapToRegistry = require("./utils/map-to-registry.js")
   , npa = require("npm-package-arg")
   , semver = require("semver")
+  , log = require("npmlog")
 
 function tag (args, cb) {
   var thing = npa(args.shift() || "")
@@ -24,6 +25,8 @@ function tag (args, cb) {
     var er = new Error("Tag name must not be a valid SemVer range: " + t)
     return cb(er)
   }
+
+  log.warn("tag", "This command is deprecated. Use `npm dist-tag` instead.")
 
   mapToRegistry(project, npm.config, function (er, uri, auth) {
     if (er) return cb(er)

--- a/lib/utils/read-local-package.js
+++ b/lib/utils/read-local-package.js
@@ -1,0 +1,12 @@
+exports = module.exports = readLocalPkg
+
+var npm = require("../npm.js")
+  , readJson = require("read-package-json")
+
+function readLocalPkg (cb) {
+  if (npm.config.get("global")) return cb()
+  var path = require("path")
+  readJson(path.resolve(npm.prefix, "package.json"), function (er, d) {
+    return cb(er, d && d.name)
+  })
+}

--- a/test/tap/dist-tag.js
+++ b/test/tap/dist-tag.js
@@ -1,0 +1,195 @@
+var fs = require("fs")
+var path = require("path")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var mr = require("npm-registry-mock")
+
+var test = require("tap").test
+var common = require("../common-tap.js")
+
+var pkg = path.resolve(__dirname, "dist-tag")
+var server
+
+var scoped = {
+  name : "@scoped/pkg",
+  version : "1.1.1"
+}
+
+function mocks (server) {
+  // ls current package
+  server.get("/-/package/@scoped%2fpkg/dist-tags")
+    .reply(200, { latest : "1.0.0", a : "0.0.1", b : "0.5.0" })
+
+  // ls named package
+  server.get("/-/package/@scoped%2fanother/dist-tags")
+    .reply(200, { latest : "2.0.0", a : "0.0.2", b : "0.6.0" })
+
+  // add c
+  server.get("/-/package/@scoped%2fanother/dist-tags")
+    .reply(200, { latest : "2.0.0", a : "0.0.2", b : "0.6.0" })
+  server.put("/-/package/@scoped%2fanother/dist-tags/c", "7.7.7")
+    .reply(200, { latest : "7.7.7", a : "0.0.2", b : "0.6.0", c : "7.7.7" })
+
+  // set same version
+  server.get("/-/package/@scoped%2fanother/dist-tags")
+    .reply(200, { latest : "2.0.0", b : "0.6.0" })
+
+  // rm
+  server.get("/-/package/@scoped%2fanother/dist-tags")
+    .reply(200, { latest : "2.0.0", a : "0.0.2", b : "0.6.0", c : "7.7.7" })
+  server.delete("/-/package/@scoped%2fanother/dist-tags/c")
+    .reply(200, { c : "7.7.7" })
+
+  // rm
+  server.get("/-/package/@scoped%2fanother/dist-tags")
+    .reply(200, { latest : "4.0.0" })
+}
+
+test("setup", function (t) {
+  mkdirp(pkg, function (er) {
+    t.ifError(er, pkg + " made successfully")
+
+    mr({port : common.port, mocks : mocks}, function (s) {
+      server = s
+
+      fs.writeFile(
+        path.join(pkg, "package.json"),
+        JSON.stringify(scoped),
+        function (er) {
+          t.ifError(er, "wrote package.json")
+          t.end()
+        }
+      )
+    })
+  })
+})
+
+test("npm dist-tags ls in current package", function (t) {
+  common.npm(
+    [
+      "dist-tags", "ls",
+      "--registry", common.registry,
+      "--loglevel", "silent"
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, "npm access")
+      t.notOk(code, "exited OK")
+      t.notOk(stderr, "no error output")
+      t.equal(stdout, "a: 0.0.1\nb: 0.5.0\nlatest: 1.0.0\n")
+
+      t.end()
+    }
+  )
+})
+
+test("npm dist-tags ls on named package", function (t) {
+  common.npm(
+    [
+      "dist-tags",
+      "ls", "@scoped/another",
+      "--registry", common.registry,
+      "--loglevel", "silent"
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, "npm access")
+      t.notOk(code, "exited OK")
+      t.notOk(stderr, "no error output")
+      t.equal(stdout, "a: 0.0.2\nb: 0.6.0\nlatest: 2.0.0\n")
+
+      t.end()
+    }
+  )
+})
+
+test("npm dist-tags add @scoped/another@7.7.7 c", function (t) {
+  common.npm(
+    [
+      "dist-tags",
+      "add", "@scoped/another@7.7.7", "c",
+      "--registry", common.registry,
+      "--loglevel", "silent"
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, "npm access")
+      t.notOk(code, "exited OK")
+      t.notOk(stderr, "no error output")
+      t.equal(stdout, "+c: @scoped/another@7.7.7\n")
+
+      t.end()
+    }
+  )
+})
+
+test("npm dist-tags set same version", function (t) {
+  common.npm(
+    [
+      "dist-tag",
+      "set", "@scoped/another@0.6.0", "b",
+      "--registry", common.registry,
+      "--loglevel", "warn"
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, "npm access")
+      t.notOk(code, "exited OK")
+      t.equal(
+        stderr,
+        "npm WARN dist-tag add b is already set to version 0.6.0\n",
+        "warned about setting same version"
+      )
+      t.notOk(stdout, "only expecting warning message")
+
+      t.end()
+    }
+  )
+})
+
+test("npm dist-tags rm @scoped/another c", function (t) {
+  common.npm(
+    [
+      "dist-tags",
+      "rm", "@scoped/another", "c",
+      "--registry", common.registry,
+      "--loglevel", "silent"
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, "npm access")
+      t.notOk(code, "exited OK")
+      t.notOk(stderr, "no error output")
+      t.equal(stdout, "-c: @scoped/another@7.7.7\n")
+
+      t.end()
+    }
+  )
+})
+
+test("npm dist-tags rm @scoped/another nonexistent", function (t) {
+  common.npm(
+    [
+      "dist-tags",
+      "rm", "@scoped/another", "nonexistent",
+      "--registry", common.registry,
+      "--loglevel", "silent"
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, "npm dist-tag")
+      t.ok(code, "expecting nonzero exit code")
+      t.notOk(stderr, "no error output")
+      t.notOk(stdout, "not expecting output")
+
+      t.end()
+    }
+  )
+})
+
+test("cleanup", function (t) {
+  t.pass("cleaned up")
+  rimraf.sync(pkg)
+  server.close()
+  t.end()
+})


### PR DESCRIPTION
Needs a test and changes to `npm-registry-client` and `npm-registry-couchapp`. The current approach may work, but it's not as clean as the way `npm tag` just pushes the tag data to the version right now.
