### PR TITLE
fixed naked tar detection to look for magic number. Fixes #6868

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -228,8 +228,19 @@ function gunzTarPerm (tarball, target, dMode, fMode, uid, gid, cb_) {
             cb(er)
           })
           .on("close", cb)
-      } else if (c.toString().match(/^package\//) ||
-                 c.toString().match(/^pax_global_header/)) {
+      } else if (c[257] === 0x75 &&
+                 c[258] === 0x73 &&
+                 c[259] === 0x74 &&
+                 c[260] === 0x61 &&
+                 c[261] === 0x72 &&
+
+               ((c[262] === 0x00 &&
+                 c[263] === 0x30 &&
+                 c[264] === 0x30) ||
+
+                (c[262] === 0x20 &&
+                 c[263] === 0x20 &&
+                 c[264] === 0x00))) { //tar archives have 7573746172 at position 257 and 003030 or 202000 at position 262
         // naked tar
         fst
           .pipe(tar.Extract(extractOpts))


### PR DESCRIPTION
This change offers better detection of tar archives by using the tar [magic number](http://en.wikipedia.org/wiki/List_of_file_signatures) instead of regex. Fixes a problem I encountered with a "naked" tarball url.
