### PR TITLE
update npmjs.org to npmjs.com in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ for testing, or running stuff without actually installing npm itself.)
 
 ## Windows Install or Upgrade
 
-You can download a zip file from <https://www.npmjs.com/package/dist/>, and unpack it
+You can download a zip file from <https://github.com/npm/npm/releases>, and unpack it
 in the same folder where node.exe lives.
 
 The latest version in a zip file is 1.4.12.  To upgrade to npm 2, follow the

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ paths, etc.) then read on.
 ## Fancy Install (Unix)
 
 There's a pretty robust install script at
-<https://www.npmjs.org/install.sh>.  You can download that and run it.
+<https://www.npmjs.com/install.sh>.  You can download that and run it.
 
 Here's an example using curl:
 
-    curl -L https://npmjs.org/install.sh | sh
+    curl -L https://npmjs.com/install.sh | sh
 
 ### Slightly Fancier
 
@@ -64,7 +64,7 @@ for testing, or running stuff without actually installing npm itself.)
 
 ## Windows Install or Upgrade
 
-You can download a zip file from <https://npmjs.org/dist/>, and unpack it
+You can download a zip file from <https://www.npmjs.com/package/dist/>, and unpack it
 in the same folder where node.exe lives.
 
 The latest version in a zip file is 1.4.12.  To upgrade to npm 2, follow the
@@ -178,13 +178,13 @@ help config` to learn about all the options you can set there.
 
 ## More Docs
 
-Check out the [docs](https://www.npmjs.org/doc/),
-especially the [faq](https://www.npmjs.org/doc/faq.html).
+Check out the [docs](https://docs.npmjs.com/),
+especially the [faq](https://docs.npmjs.com/misc/faq).
 
 You can use the `npm help` command to read any of them.
 
 If you're a developer, and you want to use npm to publish your program,
-you should [read this](https://www.npmjs.org/doc/developers.html)
+you should [read this](https://docs.npmjs.com/misc/developers)
 
 ## Legal Stuff
 
@@ -204,7 +204,7 @@ specific purpose, or lack of malice in any given npm package.
 
 If you have a complaint about a package in the public npm registry,
 and cannot [resolve it with the package
-owner](https://www.npmjs.org/doc/misc/npm-disputes.html), please email
+owner](https://docs.npmjs.com/misc/disputes), please email
 <support@npmjs.com> and explain the situation.
 
 Any data published to The npm Registry (including user account

--- a/doc/cli/npm-adduser.md
+++ b/doc/cli/npm-adduser.md
@@ -13,9 +13,9 @@ the default registry will be used (see `npm-config(7)`).
 
 The username, password, and email are read in from prompts.
 
-To reset your password, go to <https://www.npmjs.org/forgot>
+To reset your password, go to <https://www.npmjs.com/forgot>
 
-To change your email address, go to <https://www.npmjs.org/email-edit>
+To change your email address, go to <https://www.npmjs.com/email-edit>
 
 You may use this command multiple times with the same user account to
 authorize on a new machine.  When authenticating on a new machine,

--- a/doc/misc/npm-coding-style.md
+++ b/doc/misc/npm-coding-style.md
@@ -10,7 +10,7 @@ designed to reduce visual clutter and make bugs more apparent.
 If you want to contribute to npm (which is very encouraged), you should
 make your code conform to npm's style.
 
-Note: this concerns npm's code not the specific packages at npmjs.org
+Note: this concerns npm's code not the specific packages that you can download from the npm registry.
 
 ## Line Length
 

--- a/doc/misc/npm-faq.md
+++ b/doc/misc/npm-faq.md
@@ -3,7 +3,7 @@ npm-faq(7) -- Frequently Asked Questions
 
 ## Where can I find these docs in HTML?
 
-<https://www.npmjs.org/doc/>, or run:
+<https://docs.npmjs.com/>, or run:
 
     npm config set viewer browser
 
@@ -80,7 +80,7 @@ Usually, no. Allow npm to resolve dependencies for your packages.
 For packages you **deploy**, such as websites and apps,
 you should use npm shrinkwrap to lock down your full dependency tree:
 
-<https://www.npmjs.org/doc/cli/npm-shrinkwrap.html>
+<https://docs.npmjs.com/cli/shrinkwrap>
 
 If you are paranoid about depending on the npm ecosystem,
 you should run a private npm mirror or a private cache.
@@ -147,7 +147,7 @@ command.)
 
 In those cases, you can do this:
 
-    curl https://www.npmjs.org/install.sh | sh
+    curl https://www.npmjs.com/install.sh | sh
 
 ## What is a `package`?
 
@@ -307,7 +307,7 @@ See `npm-registry(7)`.
 
 ## I forgot my password, and can't publish.  How do I reset it?
 
-Go to <https://npmjs.org/forgot>.
+Go to <https://npmjs.com/forgot>.
 
 ## I get ECONNREFUSED a lot.  What's up?
 
@@ -366,7 +366,7 @@ npm was originally written by Isaac Z. Schlueter, and many others have
 contributed to it, some of them quite substantially.
 
 The npm open source project, The npm Registry, and [the community
-website](https://www.npmjs.org) are maintained and operated by the
+website](https://www.npmjs.com) are maintained and operated by the
 good folks at [npm, Inc.](http://www.npmjs.com)
 
 ## I have a question or request not addressed here. Where should I put it?

--- a/doc/misc/npm-registry.md
+++ b/doc/misc/npm-registry.md
@@ -57,7 +57,7 @@ effectively implement the entire CouchDB API anyway.
 
 ## Is there a website or something to see package docs and such?
 
-Yes, head over to <https://npmjs.org/>
+Yes, head over to <https://npmjs.com/>
 
 ## SEE ALSO
 

--- a/node_modules/node-gyp/lib/install.js
+++ b/node_modules/node-gyp/lib/install.js
@@ -39,7 +39,7 @@ function install (gyp, argv, callback) {
     }
   }
 
-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'http://nodejs.org/dist'
+  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://github.com/npm/npm/releases'
 
 
   // Determine which node dev files version we are installing

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "config": {
     "publishtest": false
   },
-  "homepage": "https://npmjs.org/doc/",
+  "homepage": "https://docs.npmjs.com/",
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some of the docs pages are pulled directly from the package, so they need to be updated here.
