### PR TITLE
Update semver.md statement regarding rubygems ~> operator

### DIFF
--- a/doc/misc/semver.md
+++ b/doc/misc/semver.md
@@ -161,7 +161,8 @@ comparator.  Allows minor-level changes if not.
   `1.2.4-beta.2` would not, because it is a prerelease of a
   different `[major, minor, patch]` tuple.
 
-Note: this is the same as the `~>` operator in rubygems.
+Note: this differs from the `~>` operator in rubygems which behaves
+more like the caret ranges described in the next section.
 
 #### Caret Ranges `^1.2.3` `^0.2.5` `^0.0.4`
 

--- a/doc/misc/semver.md
+++ b/doc/misc/semver.md
@@ -161,9 +161,6 @@ comparator.  Allows minor-level changes if not.
   `1.2.4-beta.2` would not, because it is a prerelease of a
   different `[major, minor, patch]` tuple.
 
-Note: this differs from the `~>` operator in rubygems which behaves
-more like the caret ranges described in the next section.
-
 #### Caret Ranges `^1.2.3` `^0.2.5` `^0.0.4`
 
 Allows changes that do not modify the left-most non-zero digit in the


### PR DESCRIPTION
The `~` specifier in node-semver does not behave the same as the `~>` operator in rubygems.  The statement that previously suggested this has been changed to point users towards the `^` specifier instead.
