### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,31 +79,6 @@ git, and mess with it directly.
 
 No.
 
-## Permissions when Using npm to Install Other Stuff
-
-**tl;dr**
-
-* Use `sudo` for greater safety.  Or don't, if you prefer not to.
-* npm will downgrade permissions if it's root before running any build
-  scripts that package authors specified.
-
-### More details...
-
-As of version 0.3, it is recommended to run npm as root.
-This allows npm to change the user identifier to the `nobody` user prior
-to running any package build or test commands.
-
-If you are not the root user, or if you are on a platform that does not
-support uid switching, then npm will not attempt to change the userid.
-
-If you would like to ensure that npm **always** runs scripts as the
-"nobody" user, and have it fail if it cannot downgrade permissions, then
-set the following configuration param:
-
-    npm config set unsafe-perm false
-
-This will prevent running in unsafe mode, even as non-root users.
-
 ## Uninstalling
 
 So sad to see you go.

--- a/README.md
+++ b/README.md
@@ -208,8 +208,6 @@ When you find issues, please report them:
 
 * web:
   <https://github.com/npm/npm/issues>
-* email:
-  <npm-@googlegroups.com>
 
 Be sure to include *all* of the output from the npm command that didn't work
 as expected.  The `npm-debug.log` file is also helpful to provide.


### PR DESCRIPTION
This contains two changes:
- remove the old google usergroup
- remove the advice to run npm always as root
