### PR TITLE
fix for npm bug #6951 - npm ERR! c:\node\node_modules\XXX is not a child of C:\node

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -115,7 +115,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     globalPrefix = process.env.PREFIX
   } else if (process.platform === "win32") {
     // c:\node\node.exe --> prefix=c:\node\
-    globalPrefix = path.dirname(process.execPath)
+    globalPrefix = path.normalize(path.dirname(process.execPath))
   } else {
     // /usr/local/bin/node --> prefix=/usr/local
     globalPrefix = path.dirname(path.dirname(process.execPath))


### PR DESCRIPTION
https://github.com/npm/npm/issues/6946
