### PR TITLE
Don't warn about identical duplicates between dependencies and devDependencies

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -283,7 +283,8 @@ function readDependencies (context, where, opts, cb) {
     if (opts && opts.dev) {
       if (!data.dependencies) data.dependencies = {}
       Object.keys(data.devDependencies || {}).forEach(function (k) {
-        if (data.dependencies[k]) {
+          if (data.dependencies[k] &&
+              data.dependencies[k] !== data.devDependencies[k]) {
           log.warn("package.json", "Dependency '%s' exists in both dependencies " +
                    "and devDependencies, using '%s@%s' from dependencies",
                     k, k, data.dependencies[k])


### PR DESCRIPTION
Sometimes the same package will be listed as both a dependency and a
devDependency. Currently `npm install` prints a warning about this and says it
will use the version listed under `dependencies`. This diff removes that warning
when the versions are the exact same so there's no chance of conflict.

The reason for suppressing the warning is that I think it is legit to have the
same package as a dependency and a devDependency so you can be explicit about
what uses the package. That way if you stop using the package in your published
code but still use it from your build code, you can just remove the entry from
`dependencies` and leave it in `devDependencies`.

Tested by running `node cli.js install` on a package.json file with the same
dependency (exact same version) under `dependencies` and `devDependencies`.
