### PR TITLE
call path.normalize() in gently-rm.js to fix windows drive letter case

### DIFF
--- a/lib/utils/gently-rm.js
+++ b/lib/utils/gently-rm.js
@@ -13,6 +13,7 @@ var npm = require("../npm.js")
   , vacuum = require("fs-vacuum")
   , some = require("async-some")
   , asyncMap = require("slide").asyncMap
+  , normalize = require("path").normalize
 
 function gentlyRm (path, gently, base, cb) {
   if (!cb) {
@@ -32,7 +33,7 @@ function gentlyRm (path, gently, base, cb) {
     npm.globalDir, npm.globalRoot, npm.globalBin, npm.globalPrefix
   ]
 
-  var resolved = resolve(path)
+  var resolved = normalize(resolve(path))
   if (prefixes.indexOf(resolved) !== -1) {
     log.verbose("gentlyRm", resolved, "is part of npm and can't be removed")
     return cb(new Error("May not delete: "+resolved))
@@ -40,14 +41,14 @@ function gentlyRm (path, gently, base, cb) {
 
   var options = {log : log.silly.bind(log, "gentlyRm")}
   if (npm.config.get("force") || !gently) options.purge = true
-  if (base) options.base = base
+  if (base) options.base = normalize(base)
 
   if (!gently) {
     log.verbose("gentlyRm", "vacuuming", resolved)
     return vacuum(resolved, options, cb)
   }
 
-  var parent = options.base = base ? base : npm.prefix
+  var parent = options.base = normalize(base ? base : npm.prefix)
   log.verbose("gentlyRm", "verifying that", parent, "is managed by npm")
   some(prefixes, isManaged(parent), function (er, matched) {
     if (er) return cb(er)


### PR DESCRIPTION
fix for https://github.com/npm/npm/issues/6951
