### PR TITLE
Fixes #6759: Supports npm outdated include package type

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -52,6 +52,7 @@ function outdated (args, silent, cb) {
                       , "Wanted"
                       , "Latest"
                       , "Location"
+                      , "Package Type"
                      ]].concat(outList)
 
       if (npm.color) {
@@ -69,13 +70,14 @@ function outdated (args, silent, cb) {
   })
 }
 
-// [[ dir, dep, has, want, latest ]]
+// [[ dir, dep, has, want, latest, type ]]
 function makePretty (p) {
   var dep = p[1]
     , dir = path.resolve(p[0], "node_modules", dep)
     , has = p[2]
     , want = p[3]
     , latest = p[4]
+    , type = p[6]
 
   if (!npm.config.get("global")) {
     dir = path.relative(process.cwd(), dir)
@@ -86,6 +88,7 @@ function makePretty (p) {
                 , want
                 , latest
                 , dirToPrettyLocation(dir)
+                , type
                 ]
 
   if (npm.color) {
@@ -93,6 +96,7 @@ function makePretty (p) {
     columns[2] = color.green(columns[2]) // want
     columns[3] = color.magenta(columns[3]) // latest
     columns[4] = color.brightBlack(columns[4]) // dir
+    columns[5] = color.brightBlack(columns[5]) // type
   }
 
   return columns
@@ -116,11 +120,13 @@ function makeParseable (list) {
       , has = p[2]
       , want = p[3]
       , latest = p[4]
+      , type = p[6]
 
     return [ dir
            , dep + "@" + want
            , (has ? (dep + "@" + has) : "MISSING")
            , dep + "@" + latest
+           , type
            ].join(":")
   }).join(os.EOL)
 }
@@ -136,6 +142,7 @@ function makeJSON (list) {
                 , wanted: p[3]
                 , latest: p[4]
                 , location: dir
+                , type: p[6]
                 }
   })
   return JSON.stringify(out, null, 2)
@@ -154,13 +161,21 @@ function outdated_ (args, dir, parentHas, depth, cb) {
     return cb(null, [])
   }
   var deps = null
+  var types = {}
   readJson(path.resolve(dir, "package.json"), function (er, d) {
     d = d || {}
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     deps = (er) ? true : (d.dependencies || {})
+    Object.keys(deps).forEach(function (k) {
+      types[k] = 'dependencies'
+    });
 
     if (npm.config.get("save-dev")) {
       deps = d.devDependencies || {}
+      Object.keys(deps).forEach(function (k) {
+        types[k] = 'devDependencies'
+      });
+
       return next()
     }
 
@@ -174,6 +189,9 @@ function outdated_ (args, dir, parentHas, depth, cb) {
 
     if (npm.config.get("save-optional")) {
       deps = d.optionalDependencies || {}
+      Object.keys(deps).forEach(function (k) {
+        types[k] = 'optionalDependencies'
+      });
       return next()
     }
 
@@ -186,6 +204,7 @@ function outdated_ (args, dir, parentHas, depth, cb) {
       Object.keys(d.devDependencies || {}).forEach(function (k) {
         if (!(k in parentHas)) {
           deps[k] = d.devDependencies[k]
+          types[k] = 'devDependencies'
         }
       })
     }
@@ -236,12 +255,12 @@ function outdated_ (args, dir, parentHas, depth, cb) {
     // if has[dep] !== shouldHave[dep], then cb with the data
     // otherwise dive into the folder
     asyncMap(Object.keys(deps), function (dep, cb) {
-      shouldUpdate(args, dir, dep, has, deps[dep], depth, cb)
+      shouldUpdate(args, dir, dep, has, deps[dep], depth, types[dep], cb)
     }, cb)
   }
 }
 
-function shouldUpdate (args, dir, dep, has, req, depth, cb) {
+function shouldUpdate (args, dir, dep, has, req, depth, type, cb) {
   // look up the most recent version.
   // if that's what we already have, or if it's not on the args list,
   // then dive into it.  Otherwise, cb() with the data.
@@ -260,7 +279,7 @@ function shouldUpdate (args, dir, dep, has, req, depth, cb) {
   }
 
   function doIt (wanted, latest) {
-    cb(null, [[ dir, dep, curr && curr.version, wanted, latest, req ]])
+    cb(null, [[ dir, dep, curr && curr.version, wanted, latest, req, type]])
   }
 
   if (args.length && args.indexOf(dep) === -1) {

--- a/test/tap/outdated-depth.js
+++ b/test/tap/outdated-depth.js
@@ -20,7 +20,8 @@ test("outdated depth zero", function (t) {
     "1.3.1",
     "1.3.1",
     "1.5.1",
-    "1.3.1"
+    "1.3.1",
+    "dependencies"
   ]
 
   process.chdir(pkg)

--- a/test/tap/outdated-json.js
+++ b/test/tap/outdated-json.js
@@ -22,12 +22,14 @@ var expected = { underscore:
                  , wanted: "1.3.3"
                  , latest: "1.5.1"
                  , location: "node_modules" + path.sep + "underscore"
+                 , type: "dependencies"
                  }
                , request:
                  { current: "0.9.5"
                  , wanted: "0.9.5"
                  , latest: "2.27.0"
                  , location: "node_modules" + path.sep + "request"
+                 , type: "devDependencies"
                  }
                }
 

--- a/test/tap/outdated-private.js
+++ b/test/tap/outdated-private.js
@@ -39,7 +39,8 @@ test("outdated ignores private modules", function (t) {
               "1.3.1",
               "1.3.1",
               "1.5.1",
-              "file:underscore"
+              "file:underscore",
+              "dependencies"
             ]])
             s.close()
           })

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -20,13 +20,15 @@ test("it should not throw", function (t) {
                , path.resolve(__dirname, "outdated/node_modules/underscore")
                + ":underscore@1.3.1"
                + ":underscore@1.3.1"
-               + ":underscore@1.5.1" ]
+               + ":underscore@1.5.1"
+               + ":dependencies" ]
   var expData = [ [ path.resolve(__dirname, "outdated")
                   , "underscore"
                   , "1.3.1"
                   , "1.3.1"
                   , "1.5.1"
-                  , "1.3.1" ] ]
+                  , "1.3.1"
+                  , "dependencies" ] ]
 
   console.log = function () {
     output.push.apply(output, arguments)


### PR DESCRIPTION
Fixes #6759: Supports npm outdated include package type

```
> ./bin/npm-cli.js outdated --depth=0
Package                    Current  Wanted  Latest  Location                   Package Type
npm-package-arg              2.1.3   2.1.3   3.0.0  npm-package-arg            dependencies
realize-package-specifier    1.3.0   1.3.0   2.1.0  realize-package-specifier  dependencies
nock                        0.51.0  0.51.0  0.52.1  nock                       devDependencies
```
