### PR TITLE
Jeffjo/clarify docs for ca param

### DIFF
--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -30,6 +30,12 @@ Each of these files is loaded, and config options are resolved in
 priority order.  For example, a setting in the userconfig file would
 override the setting in the globalconfig file.
 
+Array values are specified by adding "[]" after the key name. For
+example:
+
+    key[] = "first value"
+    key[] = "second value"
+
 ### Per-project config file
 
 When working locally in a project, a `.npmrc` file in the root of the

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -137,13 +137,21 @@ The browser that is called by the `npm docs` command to open websites.
 ### ca
 
 * Default: The npm CA certificate
-* Type: String or null
+* Type: String, Array or null
 
 The Certificate Authority signing certificate that is trusted for SSL
-connections to the registry.
+connections to the registry. Values should be in PEM format with newlines
+replaced by the string "\n". For example:
+
+    ca="-----BEGIN CERTIFICATE-----\nXXXX\nXXXX\n-----END CERTIFICATE-----"
 
 Set to `null` to only allow "known" registrars, or to a specific CA cert
 to trust only that specific signing authority.
+
+Multiple CAs can be trusted by specifying an array of certificates:
+
+    ca[]="..."
+    ca[]="..."
 
 See also the `strict-ssl` config.
 


### PR DESCRIPTION
This documentation would have been immensely helpful while I was configuring the NPM client to use our internal corporate NPM mirror.
