### PR TITLE
1999 restart docs

### DIFF
--- a/doc/api/npm-restart.md
+++ b/doc/api/npm-restart.md
@@ -1,5 +1,5 @@
-npm-restart(3) -- Start a package
-=================================
+npm-restart(3) -- Restart a package
+===================================
 
 ## SYNOPSIS
 
@@ -7,14 +7,33 @@ npm-restart(3) -- Start a package
 
 ## DESCRIPTION
 
-This runs a package's "restart" script, if one was provided.
-Otherwise it runs package's "stop" script, if one was provided, and then
-the "start" script.
+This restarts a package (or multiple packages).
+
+This runs a package's "stop", "restart", and "start" scripts, and associated
+pre- and post- scripts, in the order given below:
+
+1. prerestart
+2. prestop
+3. stop
+4. poststop
+5. restart
+6. prestart
+7. start
+8. poststart
+9. postrestart
 
 If no version is specified, then it restarts the "active" version.
 
-npm can run tests on multiple packages. Just specify multiple packages
-in the `packages` parameter.
+npm can restart multiple packages. Just specify multiple packages in
+the `packages` parameter.
+
+## NOTE
+
+Note that the "restart" script is run **in addition to** the "stop"
+and "start" scripts, not instead of them.
+
+This is the behavior as of `npm` major version 2.  A change in this
+behavior will be accompanied by an increase in major version number
 
 ## SEE ALSO
 

--- a/doc/api/npm-start.md
+++ b/doc/api/npm-start.md
@@ -9,5 +9,5 @@ npm-start(3) -- Start a package
 
 This runs a package's "start" script, if one was provided.
 
-npm can run tests on multiple packages. Just specify multiple packages
-in the `packages` parameter.
+npm can start multiple packages. Just specify multiple packages in the
+`packages` parameter.

--- a/doc/cli/npm-restart.md
+++ b/doc/cli/npm-restart.md
@@ -1,5 +1,5 @@
-npm-restart(1) -- Start a package
-=================================
+npm-restart(1) -- Restart a package
+===================================
 
 ## SYNOPSIS
 
@@ -7,8 +7,28 @@ npm-restart(1) -- Start a package
 
 ## DESCRIPTION
 
-This runs a package's "restart" script, if one was provided.  Otherwise it runs
-package's "stop" script, if one was provided, and then the "start" script.
+This restarts a package.
+
+This runs a package's "stop", "restart", and "start" scripts, and associated
+pre- and post- scripts, in the order given below:
+
+1. prerestart
+2. prestop
+3. stop
+4. poststop
+5. restart
+6. prestart
+7. start
+8. poststart
+9. postrestart
+
+## NOTE
+
+Note that the "restart" script is run **in addition to** the "stop"
+and "start" scripts, not instead of them.
+
+This is the behavior as of `npm` major version 2.  A change in this
+behavior will be accompanied by an increase in major version number
 
 ## SEE ALSO
 
@@ -17,3 +37,4 @@ package's "stop" script, if one was provided, and then the "start" script.
 * npm-test(1)
 * npm-start(1)
 * npm-stop(1)
+* npm-restart(3)


### PR DESCRIPTION
Fix issue #1999 by documenting what `restart` actually does.
Add note re possible breaking changes in future major versions.
Fix `start` doc which refers to tests instead of starting servers.
