### PR TITLE
candidate fix for #2556 `install --link` with git dependency goes to registry

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -854,8 +854,10 @@ function targetResolver (where, context, deps) {
 function installOne (target, where, context, cb) {
   // the --link flag makes this a "link" command if it's at the
   // the top level.
+  var isGit = npa(target._resolved).type === "git"
+
   if (where === npm.prefix && npm.config.get("link")
-      && !npm.config.get("global")) {
+      && !npm.config.get("global") && !isGit) {
     return localLink(target, where, context, cb)
   }
   installOne_(target, where, context, function (er, installedWhat) {

--- a/test/tap/git-dependency-install-link.js
+++ b/test/tap/git-dependency-install-link.js
@@ -1,0 +1,184 @@
+var fs = require('fs')
+var resolve = require('path').resolve
+
+var chain = require('slide').chain
+var osenv = require('osenv')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var test = require('tap').test
+var readJson = require('read-package-json')
+var mr = require('npm-registry-mock')
+
+var npm = require('../../lib/npm.js')
+var common = require('../common-tap.js')
+
+var pkg = resolve(__dirname, 'git-dependency-install-link')
+var repo = resolve(__dirname, 'git-dependency-install-link-repo')
+var cache = resolve(pkg, 'cache')
+
+var daemon
+var daemonPID
+var git
+var mockRegistry
+
+var EXEC_OPTS = {
+  registry: common.registry,
+  cwd: pkg,
+  cache: cache
+}
+
+test('setup', function (t) {
+  bootstrap()
+  setup(function (er, r) {
+    t.ifError(er, 'git started up successfully')
+
+    if (!er) {
+      daemon = r[r.length - 2]
+      daemonPID = r[r.length - 1]
+    }
+
+    mr({
+      port: common.port
+    }, function (er, server) {
+      t.ifError(er, 'started mock registry')
+      mockRegistry = server
+
+      t.end()
+    })
+  })
+})
+
+test('install from git repo [no --link]', function (t) {
+  process.chdir(pkg)
+
+  common.npm(['install', '--loglevel', 'error'], EXEC_OPTS, function (err, code, stdout, stderr) {
+    t.ifError(err, 'npm install failed')
+
+    t.dissimilar(stderr, /Command failed:/, 'expect git to succeed')
+    t.dissimilar(stderr, /version not found/, 'should not go to repository')
+
+    readJson(resolve(pkg, 'node_modules', 'child', 'package.json'), function (err, data) {
+      t.ifError(err, 'error reading child package.json')
+
+      t.equal(data && data.version, '1.0.3')
+      t.end()
+    })
+  })
+})
+
+test('install from git repo [with --link]', function (t) {
+  process.chdir(pkg)
+  rimraf.sync(resolve(pkg, 'node_modules'))
+
+  common.npm(['install', '--link', '--loglevel', 'error'], EXEC_OPTS, function (err, code, stdout, stderr) {
+    t.ifError(err, 'npm install --link failed')
+
+    t.dissimilar(stderr, /Command failed:/, 'expect git to succeed')
+    t.dissimilar(stderr, /version not found/, 'should not go to repository')
+
+    readJson(resolve(pkg, 'node_modules', 'child', 'package.json'), function (err, data) {
+      t.ifError(err, 'error reading child package.json')
+
+      t.equal(data && data.version, '1.0.3')
+      t.end()
+    })
+  })
+})
+
+test('clean', function (t) {
+  mockRegistry.close()
+  daemon.on('close', function () {
+    cleanup()
+    t.end()
+  })
+  process.kill(daemonPID)
+})
+
+var pjParent = JSON.stringify({
+  name: 'parent',
+  version: '1.2.3',
+  dependencies: {
+    'child': 'git://localhost:1234/child.git'
+  }
+}, null, 2) + '\n'
+
+var pjChild = JSON.stringify({
+  name: 'child',
+  version: '1.0.3'
+}, null, 2) + '\n'
+
+function bootstrap () {
+  rimraf.sync(repo)
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  mkdirp.sync(cache)
+
+  fs.writeFileSync(resolve(pkg, 'package.json'), pjParent)
+}
+
+function setup (cb) {
+  mkdirp.sync(repo)
+  fs.writeFileSync(resolve(repo, 'package.json'), pjChild)
+  npm.load({
+    link: true,
+    prefix: pkg,
+    loglevel: 'silent'
+  }, function () {
+      git = require('../../lib/utils/git.js')
+
+      function startDaemon (cb) {
+        // start git server
+        var d = git.spawn(
+          [
+            'daemon',
+            '--verbose',
+            '--listen=localhost',
+            '--export-all',
+            '--base-path=.',
+            '--port=1234'
+          ],
+          {
+            cwd: pkg,
+            env: process.env,
+            stdio: ['pipe', 'pipe', 'pipe']
+          }
+        )
+        d.stderr.on('data', childFinder)
+
+        function childFinder (c) {
+          var cpid = c.toString().match(/^\[(\d+)\]/)
+          if (cpid[1]) {
+            this.removeListener('data', childFinder)
+            cb(null, [d, cpid[1]])
+          }
+        }
+      }
+
+      var opts = {
+        cwd: repo,
+        env: process.env
+      }
+
+      chain(
+        [
+          git.chainableExec(['init'], opts),
+          git.chainableExec(['config', 'user.name', 'PhantomFaker'], opts),
+          git.chainableExec(['config', 'user.email', 'nope@not.real'], opts),
+          git.chainableExec(['add', 'package.json'], opts),
+          git.chainableExec(['commit', '-m', 'stub package'], opts),
+          git.chainableExec(
+            ['clone', '--bare', repo, 'child.git'],
+            { cwd: pkg, env: process.env }
+          ),
+          startDaemon
+        ],
+        cb
+      )
+    })
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(repo)
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
This is an attempt at a failing test for #2556 .  I say "attempt" because although I can get a failure on the command line with this setup, I can't make it fail programmatically.

When run on the command-line, `installOne` is going into the `localLink` branch, which causes the failure.

However in the attached unit test, `installOne` just succeeds without going into the link branch.

Output of a successful test run and a failed command-line run in this gist: https://gist.github.com/smikes/daf021d1eb588536bad5
