### PR TITLE
For loop optimization

### DIFF
--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -38,7 +38,7 @@ var loading = false
 var loadCbs = []
 function load () {
   var cli, builtin, cb
-  for (var i = 0; i < arguments.length; i++)
+  for (var i = 0, l = arguments.length; i < l; i++)
     switch (typeof arguments[i]) {
       case "string": builtin = arguments[i]; break
       case "object": cli = arguments[i]; break

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -208,7 +208,7 @@ function filterFound (root, args) {
 
     // see if this one itself matches
     var found = false
-    for (var i = 0; !found && i < args.length; i ++) {
+    for (var i = 0, l=args.length; !found && i < l; i ++) {
       if (d === args[i][0]) {
         found = semver.satisfies(dep.version, args[i][1], true)
       }

--- a/test/tap/config-meta.js
+++ b/test/tap/config-meta.js
@@ -78,7 +78,7 @@ test("get lines", function (t) {
 test("get docs", function (t) {
   var d = fs.readFileSync(doc, "utf8").split(/\r|\n/)
   // walk down until the "## Config Settings" section
-  for (var i = 0; i < d.length && d[i] !== "## Config Settings"; i++);
+  for (var i = 0, l = d.length; i < l && d[i] !== "## Config Settings"; i++);
   i++
   // now gather up all the ^###\s lines until the next ^##\s
   for (; i < d.length && !d[i].match(/^## /); i++) {

--- a/test/tap/install-scoped-already-installed.js
+++ b/test/tap/install-scoped-already-installed.js
@@ -73,7 +73,7 @@ test("cleanup", function (t) {
 })
 
 function contains(list, element) {
-  for (var i=0; i < list.length; ++i) {
+  for (var i=0, l = list.length; i < l; ++i) {
     if (list[i] === element) {
       return true
     }

--- a/test/tap/outdated-new-versions.js
+++ b/test/tap/outdated-new-versions.js
@@ -19,7 +19,7 @@ test("dicovers new versions in outdated", function (t) {
   mr(common.port, function (s) {
     npm.load({cache: cache, registry: common.registry}, function () {
       npm.outdated(function (er, d) {
-        for (var i = 0; i < d.length; i++) {
+        for (var i = 0, l=d.length ; i < l; i++) {
           if (d[i][1] === "underscore")
             t.equal("1.5.1", d[i][4])
           if (d[i][1] === "request")


### PR DESCRIPTION
Checking the .length property in the second argument for a for loop is
costly and can add up.  Thus I changed the corresponding for loops to
check .length in the first argument and assign them to var l.  The loops
then proceed to check against l each run through.
