### PR TITLE
npm version: handle checkGit errors

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -54,6 +54,8 @@ function version (args, silent, cb_) {
     data.version = newVersion
 
     checkGit(function (er, hasGit) {
+      if (er) return cb_(er)
+
       write(data, "package.json", function (er) {
         if (er) return cb_(er)
 

--- a/test/tap/version-git-not-clean.js
+++ b/test/tap/version-git-not-clean.js
@@ -1,0 +1,78 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var npm = require("../../")
+var osenv = require("osenv")
+var path = require("path")
+var fs = require("fs")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var which = require("which")
+var spawn = require("child_process").spawn
+
+var pkg = path.resolve(__dirname, "version-git-not-clean")
+var cache = path.resolve(pkg, "cache")
+
+test("npm version <semver> with working directory not clean", function (t) {
+  setup()
+  npm.load({ cache: cache, registry: common.registry}, function () {
+    which("git", function (err, git) {
+      t.ifError(err, "git found on system")
+      function gitInit(_cb) {
+        var child = spawn(git, ["init"])
+        var out = ""
+        child.stdout.on("data", function (d) {
+          out += d.toString()
+        })
+        child.on("exit", function () {
+          return _cb(out)
+        })
+      }
+      function addPackageJSON(_cb) {
+        var data = JSON.stringify({ name: "blah", version: "0.1.2" })
+        fs.writeFile("package.json", data, function() {
+          var child = spawn(git, ["add", "package.json"])
+          child.on("exit", function () {
+            var child2 = spawn(git, ["commit", "package.json", "-m", "init"])
+            var out = ""
+            child2.stdout.on("data", function (d) {
+              out += d.toString()
+            })
+            child2.on("exit", function () {
+              return _cb(out)
+            })
+          })
+        })
+      }
+
+      gitInit(function() {
+        addPackageJSON(function() {
+          var data = JSON.stringify({ name: "blah", version: "0.1.3" })
+          fs.writeFile("package.json", data, function() {
+            npm.commands.version(["patch"], function (err) {
+              if (!err) {
+                t.fail("should fail on non-clean working directory")
+              } else {
+                t.equal(err.message, "Git working directory not clean.\nM package.json")
+              }
+              t.end()
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  // windows fix for locked files
+  process.chdir(osenv.tmpdir())
+
+  rimraf.sync(pkg)
+  t.end()
+})
+
+function setup() {
+  mkdirp.sync(pkg)
+  mkdirp.sync(cache)
+  process.chdir(pkg)
+}


### PR DESCRIPTION
We seem to have a regression in https://github.com/npm/npm/commit/cb6ff8dace1b439851701d4784d2d719c22ca7a7. When npm checks whether git working directory is empty and errors out, this error gets ignored. Setup:

```
alex@y:/tmp$ mkdir test
alex@y:/tmp$ cd test
alex@y:/tmp/test$ git init
Initialized empty Git repository in /tmp/test/.git/
alex@y:/tmp/test$ echo '{"name":"foo","version":"1.2.3"}' > package.json
alex@y:/tmp/test$ git add package.json ; git commit -m init
[master (root-commit) 81af888] init
 1 file changed, 1 insertion(+)
 create mode 100644 package.json
alex@y:/tmp/test$ echo '{"name":"foox","version":"1.2.3"}' > package.json
alex@y:/tmp/test$ git status
On branch master
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

    modified:   package.json

no changes added to commit (use "git add" and/or "git commit -a")
```

Expected (version unchanged, npm errors out):

```
alex@y:/tmp/test$ ../node_modules/.bin/npm -v
2.1.0
alex@y:/tmp/test$ ../node_modules/.bin/npm version patch
npm ERR! Linux 3.16.0-25-generic
npm ERR! argv "node" "/tmp/test/node_modules/.bin/npm" "version" "patch"
npm ERR! node v0.10.25
npm ERR! npm  v2.1.0

npm ERR! Git working directory not clean.
npm ERR! M package.json
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /tmp/test/npm-debug.log
```

Actual (version bumped, no new git commits):

```
alex@y:/tmp/test$ ../node_modules/.bin/npm -v
2.1.14
alex@y:/tmp/test$ ../node_modules/.bin/npm version patch
v1.2.4
alex@y:/tmp/test$ git log
commit 81af88874960245e70fe709cfd03faabbf252a74
Author: Alex Kocharin <alex@kocharin.ru>
Date:   Tue Dec 23 02:06:58 2014 +0300

    init
```

Ping @othiym23.
