### PR TITLE
add smart `env` script if there is none present

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -11,10 +11,13 @@ npm-run-script(1) -- Run arbitrary package scripts
 This runs an arbitrary command from a package's `"scripts"` object.
 If no package name is provided, it will search for a `package.json`
 in the current folder and use its `"scripts"` object. If no `"command"`
-is provided, it will list the available top level scripts.
+is provided, it will list the available top level scripts. The `env` command
+can be used to list environment variables that will be available to the script
+at runtime. The `env` command can be overridden in your package but it is
+not recommended.
 
-It is used by the test, start, restart, and stop commands, but can be
-called directly, as well.
+`run[-script]` is used by the test, start, restart, and stop commands, but can
+be called directly, as well.
 
 As of [`npm@2.0.0`](http://blog.npmjs.org/post/98131109725/npm-2-0-0), you can
 use custom arguments when executing scripts. The special option `--` is used by

--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -13,8 +13,8 @@ If no package name is provided, it will search for a `package.json`
 in the current folder and use its `"scripts"` object. If no `"command"`
 is provided, it will list the available top level scripts. The `env` command
 can be used to list environment variables that will be available to the script
-at runtime. The `env` command can be overridden in your package but it is
-not recommended.
+at runtime. If an "env" command is defined in your package it will have
+precedence instead.
 
 `run[-script]` is used by the test, start, restart, and stop commands, but can
 be called directly, as well.

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -127,10 +127,12 @@ function run (pkg, wd, cmd, args, cb) {
       if (cmd === "test") {
         pkg.scripts.test = "echo \"Error: no test specified\""
       } else if (cmd === "env") {
-        log.verbose("run-script using default multiplatform env")
+        log.verbose("run-script using default multiplatform env:")
         if (process.platform === "win32") {
+          log.verbose("SET")
           pkg.scripts[cmd] = "SET"
         } else {
+          log.verbose("env")
           pkg.scripts[cmd] = "env"
         }
       } else {

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -126,6 +126,9 @@ function run (pkg, wd, cmd, args, cb) {
     if (!pkg.scripts[cmd]) {
       if (cmd === "test") {
         pkg.scripts.test = "echo \"Error: no test specified\"";
+      } else if (cmd === "env") {
+        log.verbose("run-script adding default multiplaform env")
+        pkg.scripts[cmd] = "env" // TODO: add windows
       } else {
         return cb(new Error("missing script: " + cmd));
       }

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -127,8 +127,12 @@ function run (pkg, wd, cmd, args, cb) {
       if (cmd === "test") {
         pkg.scripts.test = "echo \"Error: no test specified\""
       } else if (cmd === "env") {
-        log.verbose("run-script adding default multiplaform env")
-        pkg.scripts[cmd] = "env" // TODO: add windows
+        log.verbose("run-script using default multiplaform env")
+        if (process.platform === "win32") {
+          pkg.scripts[cmd] = "SET"
+        } else {
+          pkg.scripts[cmd] = "env"
+        }
       } else {
         return cb(new Error("missing script: " + cmd))
       }

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -125,12 +125,12 @@ function run (pkg, wd, cmd, args, cb) {
   } else {
     if (!pkg.scripts[cmd]) {
       if (cmd === "test") {
-        pkg.scripts.test = "echo \"Error: no test specified\"";
+        pkg.scripts.test = "echo \"Error: no test specified\""
       } else if (cmd === "env") {
         log.verbose("run-script adding default multiplaform env")
         pkg.scripts[cmd] = "env" // TODO: add windows
       } else {
-        return cb(new Error("missing script: " + cmd));
+        return cb(new Error("missing script: " + cmd))
       }
     }
     cmds = [cmd]

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -7,7 +7,7 @@ var lifecycle = require("./utils/lifecycle.js")
   , log = require("npmlog")
   , chain = require("slide").chain
 
-runScript.usage = "npm run-script <command>|env [-- <args>]"
+runScript.usage = "npm run-script <command> [-- <args>]"
 
 runScript.completion = function (opts, cb) {
 

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -7,7 +7,7 @@ var lifecycle = require("./utils/lifecycle.js")
   , log = require("npmlog")
   , chain = require("slide").chain
 
-runScript.usage = "npm run-script <command> [-- <args>]"
+runScript.usage = "npm run-script <command>|env [-- <args>]"
 
 runScript.completion = function (opts, cb) {
 
@@ -127,7 +127,7 @@ function run (pkg, wd, cmd, args, cb) {
       if (cmd === "test") {
         pkg.scripts.test = "echo \"Error: no test specified\""
       } else if (cmd === "env") {
-        log.verbose("run-script using default multiplaform env")
+        log.verbose("run-script using default multiplatform env")
         if (process.platform === "win32") {
           pkg.scripts[cmd] = "SET"
         } else {

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -89,9 +89,9 @@ test('npm run-script test', function (t) {
 
 test('npm run-script env', function (t) {
   common.npm(['run-script', 'env'], opts, function (er, code, stdout, stderr) {
-    if (er)
-      throw er
+    t.ifError(er, 'failed to find default env script');
     t.notOk(stderr, 'should not generate errors')
+    t.ok( stdout.indexOf('npm_config_init_version') > 0, 'expected values in var list' )
     t.end()
   })
 })

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -87,6 +87,15 @@ test('npm run-script test', function (t) {
   })
 })
 
+test('npm run-script env', function (t) {
+  common.npm(['run-script', 'env'], opts, function (er, code, stdout, stderr) {
+    if (er)
+      throw er
+    t.notOk(stderr, 'should not generate errors')
+    t.end()
+  })
+})
+
 test('npm run-script nonexistent-script', function (t) {
   common.npm(['run-script', 'nonexistent-script'], opts, function (er, code, stdout, stderr) {
     if (er)

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -89,7 +89,7 @@ test('npm run-script test', function (t) {
 
 test('npm run-script env', function (t) {
   common.npm(['run-script', 'env'], opts, function (er, code, stdout, stderr) {
-    t.ifError(er, 'failed to find default env script');
+    t.ifError(er, 'using default env script');
     t.notOk(stderr, 'should not generate errors')
     t.ok( stdout.indexOf('npm_config_init_version') > 0, 'expected values in var list' )
     t.end()


### PR DESCRIPTION
adding a "env":"env" run-script to my package every time i want to double check some environment var, and then removing to commit my changes, always feel awkward... but now that is a thing of the past! People from the future will be able to look at kids, raise their trembling canes, and say that in their time they had to add a 'env' rule to check their environment variables and that kids have it too easy today. I can't wait to have it too easy.

this little patch adds the ability to run `npm env` even if there is no such rule added to the package. and it also works across all platforms. (caveat, only tested on linux and windows7, but osx and others should also work with the linux rule)

PS: also removed a few `;` from the original code to conform to style guide.
