### PR TITLE
Removed "overwrites" part of npm-publish.md

### DIFF
--- a/doc/api/npm-publish.md
+++ b/doc/api/npm-publish.md
@@ -21,7 +21,7 @@ If the package array is empty, npm will try to publish something in the
 current working directory.
 
 This command could fails if one of the packages specified already exists in
-the registry.  Overwrites when the "force" environment variable is set.
+the registry.
 
 ## SEE ALSO
 


### PR DESCRIPTION
There is no more such feature as [force publish](https://github.com/npm/npm-registry-couchapp/issues/148).
