### PR TITLE
add documentation about .npmignore pattern rules

### DIFF
--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -102,6 +102,14 @@ ignore the stuff matched by the `.gitignore` file.  If you *want* to
 include something that is excluded by your `.gitignore` file, you can
 create an empty `.npmignore` file to override it.
 
+`.npmignore` files follow the [same pattern rules](http://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#Ignoring-Files)
+as `.gitignore` files:
+
+* Blank lines or lines starting with `#` are ignored.
+* Standard glob patterns work.
+* You can end patterns with a forward slash `/` to specify a directory.
+* You can negate a pattern by starting it with an exclamation point `!`.
+
 By default, the following paths and files are ignored, so there's no
 need to add them to `.npmignore` explicitly:
 


### PR DESCRIPTION
I set about using npmignore for the first time recently (https://github.com/npm/npm-expansions/pull/201) and was a little unsure about the file format, but I got an answer (https://github.com/npm/docs.npmjs.com/issues/93).

This patch just adds some documentation about how npmignore files are pretty much that same as gitignore files.
