### PR TITLE
remove references to Node Package Manager

### DIFF
--- a/doc/api/npm.md
+++ b/doc/api/npm.md
@@ -1,5 +1,5 @@
-npm(3) -- node package manager
-==============================
+npm(3) -- javascript package manager
+====================================
 
 ## SYNOPSIS
 

--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -1,5 +1,5 @@
-npm(1) -- node package manager
-==============================
+npm(1) -- javascript package manager
+====================================
 
 ## SYNOPSIS
 

--- a/html/index.html
+++ b/html/index.html
@@ -52,7 +52,7 @@ code { background:#fff ; outline: 1px solid #ccc; padding:0 2px; }
 }
 
 </style>
-	<title>npm - Node Package Manager</title>
+	<title>npm - JavaScript Package Manager</title>
 </head>
 <h1>npm</h1>
 


### PR DESCRIPTION
As pointed out in https://twitter.com/trevordmiller/status/550051232253882368, there is some inconsistency as far as the name goes. This removes usages of the deprecated name.
