### PR TITLE
scripts: use full path for cmd.exe on Win32

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -198,7 +198,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
   var shFlag = "-c"
 
   if (process.platform === "win32") {
-    sh = "cmd"
+    sh = process.env.comspec || "cmd"
     shFlag = "/c"
     conf.windowsVerbatimArguments = true
   }

--- a/test/tap/lifecycle-path.js
+++ b/test/tap/lifecycle-path.js
@@ -6,11 +6,13 @@ var pkg = path.resolve(__dirname, "lifecycle-path")
 var fs = require("fs")
 var link = path.resolve(pkg, "node-bin")
 
-// Without the path to the shell, nothing works usually.
 var PATH
 if (process.platform === "win32") {
-  PATH = "C:\\Windows\\system32;C:\\Windows"
+  // On Windows the 'comspec' environment variable is used,
+  // so cmd.exe does not need to be on the path.
+  PATH = "C:\\foo\\bar"
 } else {
+  // On non-Windows, without the path to the shell, nothing usually works.
   PATH = "/bin:/usr/bin"
 }
 


### PR DESCRIPTION
Currently lifecycle.js assumes that Window's cmd.exe is on the PATH,
and fails with a spawn ENOENT error if it is not.

The Windows 'comspec' environment variable contains the full filepath
to the default command interpreter, eg "C:\Windows\System32\cmd.exe".
Should it not be set, we fall-back to using 'cmd' from PATH, as before.

Fixes https://github.com/npm/npm/issues/5267
