### PR TITLE
add warning and document --dev flag

### DIFF
--- a/doc/cli/npm-update.md
+++ b/doc/cli/npm-update.md
@@ -10,13 +10,24 @@ npm-update(1) -- Update a package
 This command will update all the packages listed to the latest version
 (specified by the `tag` config).
 
-It will also install missing packages.
+It will also install missing packages. As with all commands that install
+packages, the `--dev` flag will cause `devDependencies` to be processed
+as well.
 
 If the `-g` flag is specified, this command will update globally installed
 packages.
 
 If no package name is specified, all packages in the specified location (global
 or local) will be updated.
+
+## WARNING
+
+By design, this command does **NOT** respect semantic versioning.  Running
+`npm update` may break the current package by upgrading to incompatible newer
+versions of dependencies.
+
+Running `npm update -g` may break all globally installed packages, including
+npm itself.
 
 ## SEE ALSO
 

--- a/doc/cli/npm-update.md
+++ b/doc/cli/npm-update.md
@@ -20,15 +20,6 @@ packages.
 If no package name is specified, all packages in the specified location (global
 or local) will be updated.
 
-## WARNING
-
-By design, this command does **NOT** respect semantic versioning.  Running
-`npm update` may break the current package by upgrading to incompatible newer
-versions of dependencies.
-
-Running `npm update -g` may break all globally installed packages, including
-npm itself.
-
 ## SEE ALSO
 
 * npm-install(1)


### PR DESCRIPTION
add warning re `npm update -g`
document --dev flag

Fix for #6745.  A mild warning about `npm update -g` was added, as well.
