### PR TITLE
Link to new npm registry URL

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -28,7 +28,7 @@ The name is what your thing is called.  Some tips:
 * The name will probably be passed as an argument to require(), so it should
   be something short, but also reasonably descriptive.
 * You may want to check the npm registry to see if there's something by that name
-  already, before you get too attached to it.  http://registry.npmjs.org/
+  already, before you get too attached to it.  https://www.npmjs.com
 
 A name can be optionally prefixed by a scope, e.g. `@myorg/mypackage`. See
 `npm-scope(7)` for more detail.


### PR DESCRIPTION
The link in the npm docs is to a JSON endpoint, and an old URL. This links to the current home for npm, `https://www.npmjs.com`.
