### PR TITLE
Handle cache creation on Windows

### DIFF
--- a/lib/cache/add-local-tarball.js
+++ b/lib/cache/add-local-tarball.js
@@ -167,7 +167,7 @@ function addTmpTarball_ (tgz, data, shasum, cb) {
       if (er) return cb(er)
       var read = fs.createReadStream(tgz)
       var write = writeStream(target, { mode: npm.modes.file })
-      var fin = cs.uid && cs.gid ? chown : done
+      var fin = isNaN(cs.uid) || isNaN(cs.gid) ? done : chown
       read.on("error", cb).pipe(write).on("error", cb).on("close", fin)
     })
 

--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -68,7 +68,8 @@ function getGitDir (cb) {
     // We don't need global templates when cloning. Use an empty directory for
     // the templates, creating it (and setting its permissions) if necessary.
     mkdir(templates, function (er) {
-      if (er) return cb(er)
+      if (er || isNaN(st.uid) || isNaN(st.gid))
+        return cb(er, st)
 
       // Ensure that both the template and remotes directories have the correct
       // permissions.
@@ -157,6 +158,9 @@ function fetchRemote (p, u, co, origUrl, cb) {
             log.error("Could not get cache stat")
             return cb(er)
           }
+
+          if (isNaN(cs.uid) || isNaN(cs.gid))
+            return resolveHead(p, u, co, origUrl, cb)
 
           chownr(p, cs.uid, cs.gid, function (er) {
             if (er) {

--- a/lib/cache/caching-client.js
+++ b/lib/cache/caching-client.js
@@ -169,7 +169,9 @@ function get_ (uri, cachePath, params, cb) {
           if (er) return saved()
 
           writeFile(cachePath, JSON.stringify(data), function (er) {
-            if (er || st.uid === null || st.gid === null) return saved()
+            if (er || st.uid === null || st.gid === null ||
+                st.uid === undefined || st.gid === undefined)
+              return saved()
 
             chownr(made || cachePath, st.uid, st.gid, saved)
           })

--- a/lib/cache/caching-client.js
+++ b/lib/cache/caching-client.js
@@ -169,9 +169,7 @@ function get_ (uri, cachePath, params, cb) {
           if (er) return saved()
 
           writeFile(cachePath, JSON.stringify(data), function (er) {
-            if (er || st.uid === null || st.gid === null ||
-                st.uid === undefined || st.gid === undefined)
-              return saved()
+            if (er || isNaN(st.uid) || isNaN(st.gid)) return saved()
 
             chownr(made || cachePath, st.uid, st.gid, saved)
           })

--- a/lib/cache/update-index.js
+++ b/lib/cache/update-index.js
@@ -50,6 +50,8 @@ function updateIndex (uri, params, cb) {
           })
         }
         var t = +data._updated || 0
+        if (isNaN(st.uid) || isNaN(st.gid))
+          return updateIndex_(uri, params, t, data, cachePath, cb)
         chownr(made || cachePath, st.uid, st.gid, function (er) {
           if (er) return cb(er)
 
@@ -91,6 +93,7 @@ function updateIndex_ (uri, params, t, data, cachePath, cb) {
       fs.writeFile(cachePath, JSON.stringify(data), function (er) {
         delete data._updated
         if (er) return cb(er)
+        if (isNaN(st.uid) || isNaN(st.gid)) return cb(er, data)
         chownr(cachePath, st.uid, st.gid, function (er) {
           cb(er, data)
         })

--- a/test/tap/cache-posix.js
+++ b/test/tap/cache-posix.js
@@ -1,0 +1,66 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var cacheFile = require("npm-cache-filename")
+var npm = require("../../")
+var rimraf = require("rimraf")
+var path = require("path")
+var mr = require("npm-registry-mock")
+var fs = require("graceful-fs")
+
+function fakeGetuid() {
+  return 0;
+}
+
+var TIMEOUT  = 3600
+var FOLLOW   = false
+var STALE_OK = true
+var TOKEN    = "lolbutts"
+var AUTH     = {
+  token   : TOKEN
+}
+var PARAMS   = {
+  timeout : TIMEOUT,
+  follow  : FOLLOW,
+  staleOk : STALE_OK,
+  auth    : AUTH
+}
+var PKG_DIR = path.resolve(__dirname, "cache-posix")
+var CACHE_DIR = path.resolve(PKG_DIR, "cache")
+
+// mock server reference
+var server
+
+var mapper = cacheFile(CACHE_DIR)
+
+function getCachePath (uri) {
+  return path.join(mapper(uri), ".cache.json")
+}
+
+test("with getuid", function (t) {
+  process.getuid = process.getuid || fakeGetuid
+  rimraf.sync(CACHE_DIR)
+
+  mr({ port: common.port }, function (s) {
+    npm.load({cache: CACHE_DIR, registry: common.registry}, function (err) {
+      t.ifError(err)
+      server = s
+
+      var versioned = common.registry + "/underscore/1.3.3"
+      npm.registry.get(versioned, PARAMS, function (er, data) {
+        t.ifError(er, "loaded specified version underscore data")
+        t.equal(data.version, "1.3.3")
+        fs.stat(getCachePath(versioned), function (er) {
+          t.ifError(er, "underscore 1.3.3 cache data written")
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  server.close()
+  rimraf.sync(PKG_DIR)
+
+  t.end()
+})

--- a/test/tap/cache-windows.js
+++ b/test/tap/cache-windows.js
@@ -1,0 +1,64 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var cacheFile = require("npm-cache-filename")
+var npm = require("../../")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+var path = require("path")
+var mr = require("npm-registry-mock")
+var fs = require("graceful-fs")
+
+var URI      = "https://npm.registry:8043/rewrite"
+var TIMEOUT  = 3600
+var FOLLOW   = false
+var STALE_OK = true
+var TOKEN    = "lolbutts"
+var AUTH     = {
+  token   : TOKEN
+}
+var PARAMS   = {
+  timeout : TIMEOUT,
+  follow  : FOLLOW,
+  staleOk : STALE_OK,
+  auth    : AUTH
+}
+var PKG_DIR = path.resolve(__dirname, "cache-posix")
+var CACHE_DIR = path.resolve(PKG_DIR, "cache")
+
+// mock server reference
+var server
+
+var mapper = cacheFile(CACHE_DIR)
+
+function getCachePath (uri) {
+  return path.join(mapper(uri), ".cache.json")
+}
+
+test("without getuid", function (t) {
+  process.getuid = null
+  rimraf.sync(CACHE_DIR)
+
+  mr({ port: common.port }, function (s) {
+    npm.load({cache: CACHE_DIR, registry: common.registry}, function (err) {
+      t.ifError(err)
+      server = s
+
+      var versioned = common.registry + "/underscore/1.3.3"
+      npm.registry.get(versioned, PARAMS, function (er, data) {
+        t.ifError(er, "loaded specified version underscore data")
+        t.equal(data.version, "1.3.3")
+        fs.stat(getCachePath(versioned), function (er) {
+          t.ifError(er, "underscore 1.3.3 cache data written")
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test("cleanup", function (t) {
+  server.close()
+  rimraf.sync(PKG_DIR)
+
+  t.end()
+})


### PR DESCRIPTION
On windows there is no `process.getuid`, causing `makeCacheDir()` to pass `{}` to its callback.

When this result makes its way to `saveToCache()`, it passed the `.uid === null` guard which results in `chown()` being called with `undefined` for the uid and gid, which triggers the error.

This behaviour was introduced in 34570414cd528debeb22943873440594d7f47abf which suggests the issue is present in every release from v2.1.7 onward for anyone running Windows.

I believe this is the root cause behind #6995, #6980, and probably [others](https://github.com/npm/npm/search?q=uid+must+be+an+unsigned+int&type=Issues).

@othiym23 the tests are just a quick hack'n'paste and I'm not sure they're really even appropriate for this sort of regression... but they're there if you want 'em!
