### PR TITLE
add script for updating AUTHORS file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,31 @@
+Arlo Breault <arlolra@gmail.com>
+Alex K. Wolfe <alexkwolfe@gmail.com>
+Andrew Lunny <alunny@gmail.com>
+Benjamin Coe <bencoe@gmail.com>
+Brian White <mscdex@mscdex.net> <mscdex@gmail.com>
+Charlie Robbins <charlie.robbins@gmail.com>
+Dalmais Maxence <root@ip-10-195-202-5.ec2.internal>
+David Beitey <david@davidjb.com>
+Domenic Denicola <domenic@domenicdenicola.com>
+Einar Otto Stangvik <einaros@gmail.com>
+Evan Lucas <evan@btc.com> <evanlucas@me.com> <evan.lucas@hattiesburgclinic.com>
+Faiq Raza <faiqrazarizvi@gmail.com>
+Forbes Lindesay <forbes@lindesay.co.uk>
+Forrest L. Norvell <forrest@npmjs.com> <ogd@aoaioxxysz.net>
+Gabriel Barros <descartavel1@gmail.com>
+Geoff Flarity <geoff.flarity@gmail.com> <gflarity@raptvm-x02.(none)>
+Isaac Z. Schlueter <i@izs.me> <i@foohack.com>
+Jake Verbaten <raynos2@gmail.com>
+James Sanders <jimmyjazz14@gmail.com>
+Jason Smith <jhs@iriscouch.com>
+Kris Windham <kriswindham@gmail.com>
+Lin Clark <lin.w.clark@gmail.com>
+Maciej Małecki <me@mmalecki.com> <maciej.malecki@notimplemented.org>
+Maximilian Antoni <mail@maxantoni.de> <maximilian.antoni@juliusbaer.com>
+Maxim Bogushevich <boga1@mail.ru>
+Max Goodman <c@chromakode.com>
+Nicolas Morel <marsup@gmail.com>
+Olivier Melcher <olivier.melcher@gmail.com>
+Visnu Pitiyanuvath <visnupx@gmail.com>
+Will Elwood <w.elwood08@gmail.com>
+Zeke Sikelianos <zeke@sikelianos.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,8 +4,6 @@ Steve Steiner <ssteinerX@gmail.com>
 Mikeal Rogers <mikeal.rogers@gmail.com>
 Aaron Blohowiak <aaron.blohowiak@gmail.com>
 Martyn Smith <martyn@dollyfish.net.nz>
-Mathias Pettersson <mape@mape.me>
-Brian Hammond <brian@fictorial.com>
 Charlie Robbins <charlie.robbins@gmail.com>
 Francisco Treacy <francisco.treacy@gmail.com>
 Cliffano Subagio <cliffano@gmail.com>
@@ -16,7 +14,6 @@ James Sanders <jimmyjazz14@gmail.com>
 Reid Burke <me@reidburke.com>
 Arlo Breault <arlolra@gmail.com>
 Timo Derstappen <teemow@gmail.com>
-Bradley Meck <bradley.meck@gmail.com>
 Bart Teeuwisse <bart.teeuwisse@thecodemill.biz>
 Ben Noordhuis <info@bnoordhuis.nl>
 Tor Valamo <tor.valamo@gmail.com>
@@ -25,12 +22,13 @@ Olivier Melcher <olivier.melcher@gmail.com>
 Tomaž Muraus <kami@k5-storitve.net>
 Evan Meagher <evan.meagher@gmail.com>
 Orlando Vazquez <ovazquez@gmail.com>
+Kai Chen <kaichenxyz@gmail.com>
 George Miroshnykov <gmiroshnykov@lohika.com>
 Geoff Flarity <geoff.flarity@gmail.com>
+Max Goodman <c@chromakode.com>
 Pete Kruckenberg <pete@kruckenberg.com>
 Laurie Harper <laurie@holoweb.net>
 Chris Wong <chris@chriswongstudio.com>
-Max Goodman <c@chromacode.com>
 Scott Bronson <brons_github@rinspin.com>
 Federico Romero <federomero@gmail.com>
 Visnu Pitiyanuvath <visnupx@gmail.com>
@@ -40,20 +38,25 @@ Zearin <zearin@gonk.net>
 Iain Sproat <iainsproat@gmail.com>
 Trent Mick <trentm@gmail.com>
 Felix Geisendörfer <felix@debuggable.com>
-Conny Brunnkvist <cbrunnkvist@gmail.com>
+Jameson Little <t.jameson.little@gmail.com>
+Conny Brunnkvist <conny@fuchsia.se>
 Will Elwood <w.elwood08@gmail.com>
+Dean Landolt <dean@deanlandolt.com>
 Oleg Efimov <efimovov@gmail.com>
 Martin Cooper <mfncooper@gmail.com>
-Jameson Little <t.jameson.little@gmail.com>
+Jann Horn <jannhorn@googlemail.com>
 cspotcode <cspotcode@gmail.com>
-Maciej Małecki <maciej.malecki@notimplemented.org>
+Maciej Małecki <me@mmalecki.com>
 Stephen Sugden <glurgle@gmail.com>
+Michael Budde <mbudde@gmail.com>
+Jason Smith <jhs@iriscouch.com>
 Gautham Pai <buzypi@gmail.com>
 David Trejo <david.daniel.trejo@gmail.com>
 Paul Vorbach <paul@vorb.de>
 George Ornbo <george@shapeshed.com>
 Tim Oxley <secoif@gmail.com>
 Tyler Green <tyler.green2@gmail.com>
+Dave Pacheco <dap@joyent.com>
 atomizer <danila.gerasimov@gmail.com>
 Rod Vagg <rod@vagg.org>
 Christian Howe <coderarity@gmail.com>
@@ -63,26 +66,26 @@ Adam Blackburn <regality@gmail.com>
 Kris Windham <kriswindham@gmail.com>
 Jens Grunert <jens.grunert@gmail.com>
 Joost-Wim Boekesteijn <joost-wim@boekesteijn.nl>
-Dalmais Maxence <github@maxired.fr>
+Dalmais Maxence <root@ip-10-195-202-5.ec2.internal>
 Marcus Ekwall <marcus.ekwall@gmail.com>
 Aaron Stacy <aaron.r.stacy@gmail.com>
 Phillip Howell <phowell@cothm.org>
 Domenic Denicola <domenic@domenicdenicola.com>
 James Halliday <mail@substack.net>
 Jeremy Cantrell <jmcantrell@gmail.com>
+Trent Mick <trent.mick@joyent.com>
 Ribettes <patlogan29@gmail.com>
-Einar Otto Stangvik <einaros@gmail.com>
 Don Park <donpark@docuverse.com>
+Einar Otto Stangvik <einaros@gmail.com>
 Kei Son <heyacct@gmail.com>
 Nicolas Morel <marsup@gmail.com>
 Mark Dube <markisdee@gmail.com>
 Nathan Rajlich <nathan@tootallnate.net>
 Maxim Bogushevich <boga1@mail.ru>
-Justin Beckwith <justbe@microsoft.com>
 Meaglin <Meaglin.wasabi@gmail.com>
 Ben Evans <ben@bensbit.co.uk>
 Nathan Zadoks <nathan@nathan7.eu>
-Brian White <mscdex@gmail.com>
+Brian White <mscdex@mscdex.net>
 Jed Schmidt <tr@nslator.jp>
 Ian Livingstone <ianl@cs.dal.ca>
 Patrick Pfeiffer <patrick@buzzle.at>
@@ -90,69 +93,142 @@ Paul Miller <paul@paulmillr.com>
 seebees <seebees@gmail.com>
 Carl Lange <carl@flax.ie>
 Jan Lehnardt <jan@apache.org>
-Alexey Kreschuk <akrsch@gmail.com>
-Di Wu <dwu@palantir.com>
-Florian Margaine <florian@margaine.com>
-Forbes Lindesay <forbes@lindesay.co.uk>
-Ian Babrou <ibobrik@gmail.com>
-Jaakko Manninen <jaakko@rocketpack.fi>
-Johan Nordberg <its@johan-nordberg.com>
-Johan Sköld <johan@skold.cc>
-Larz Conwell <larz@larz-laptop.(none)>
-Luke Arduini <luke.arduini@gmail.com>
-Marcel Klehr <mklehr@gmx.net>
-Mathias Bynens <mathias@qiwi.be>
-Matt Lunn <matt@mattlunn.me.uk>
-Matt McClure <matt.mcclure@mapmyfitness.com>
-Nirk Niggler <nirk.niggler@gmail.com>
-Paolo Fragomeni <paolo@async.ly>
-Jake Verbaten (Raynos) <raynos2@gmail.com>
-Robert Kowalski <rok@kowalski.gd>
-Schabse Laks <Dev@SLaks.net>
-Stuart Knightley <stuart@stuartk.com>
 Stuart P. Bentley <stuart@testtrack4.com>
+Johan Sköld <johan@skold.cc>
+Stuart Knightley <stuart@stuartk.com>
+Niggler <nirk.niggler@gmail.com>
+Paolo Fragomeni <paolo@async.ly>
+Jaakko Manninen <jaakko@rocketpack.fi>
+Luke Arduini <luke.arduini@gmail.com>
+Larz Conwell <larz@larz-laptop.(none)>
+Marcel Klehr <mklehr@gmx.net>
+Robert Kowalski <rok@kowalski.gd>
+Forbes Lindesay <forbes@lindesay.co.uk>
 Vaz Allen <vaz@tryptid.com>
-elisee <elisee@sparklin.org>
-Evan You <yyx990803@gmail.com>
-Wil Moore III <wil.moore@wilmoore.com>
-Dylan Greene <dylang@gmail.com>
-zeke <zeke@sikelianos.com>
-Andrew Horton <andrew.j.horton@gmail.com>
-Denis Gladkikh <outcoldman@gmail.com>
-Daniel Santiago <daniel.santiago@highlevelwebs.com>
-Alex Kocharin <alex@kocharin.ru>
-Evan Lucas <evanlucas@me.com>
-Steve Mason <stevem@brandwatch.com>
-Quinn Slack <qslack@qslack.com>
-Sébastien Santoro <dereckson@espace-win.org>
-CamilleM <camille.moulin@alterway.fr>
-Tom Huang <hzlhu.dargon@gmail.com>
-Sergey Belov <peimei@ya.ru>
-Younghoon Park <sola92@gmail.com>
-Yazhong Liu <yorkiefixer@gmail.com>
-Mikola Lysenko <mikolalysenko@gmail.com>
-Rafael de Oleza <rafa@spotify.com>
-Yeonghoon Park <sola92@gmail.com>
-Franck Cuny <franck.cuny@gmail.com>
-Alan Shaw <alan@freestyle-developments.co.uk>
-Alex Rodionov <p0deje@gmail.com>
-Alexej Yaroshevich <alex@qfox.ru>
-Elan Shanker <elan.shanker@gmail.com>
-François Frisch <francoisfrisch@gmail.com>
-Gabriel Falkenberg <gabriel.falkenberg@gmail.com>
-Jason Diamond <jason@diamond.name>
-Jess Martin <jessmartin@gmail.com>
-Jon Spencer <jon@jonspencer.ca>
-Matt Colyer <matt@colyer.name>
+Jake Verbaten <raynos2@gmail.com>
+Schabse Laks <Dev@SLaks.net>
+Florian Margaine <florian@margaine.com>
+Johan Nordberg <its@johan-nordberg.com>
+Ian Babrou <ibobrik@gmail.com>
+Di Wu <dwu@palantir.com>
+Mathias Bynens <mathias@qiwi.be>
 Matt McClure <matt.mcclure@mapmyfitness.com>
-Maximilian Antoni <maximilian.antoni@juliusbaer.com>
+Matt Lunn <matt@mattlunn.me.uk>
+Alexey Kreschuk <akrsch@gmail.com>
+elisee <elisee@sparklin.org>
+Robert Gieseke <robert.gieseke@gmail.com>
+François Frisch <francoisfrisch@gmail.com>
+Trevor Burnham <tburnham@hubspot.com>
+Alan Shaw <alan@freestyle-developments.co.uk>
+TJ Holowaychuk <tj@vision-media.ca>
+Luke Arduini <luke.arduini@me.com>
 Nicholas Kinsey <pyro@feisty.io>
 Paulo Cesar <pauloc062@gmail.com>
-Quim Calpe <quim@kalpe.com>
-Robert Gieseke <robert.gieseke@gmail.com>
-Spain Train <michael.spainhower@opower.com>
-TJ Holowaychuk <tj@vision-media.ca>
+Elan Shanker <elan.shanker@gmail.com>
+Jon Spencer <jon@jonspencer.ca>
+Jason Diamond <jason@diamond.name>
+Maximilian Antoni <mail@maxantoni.de>
 Thom Blake <tblake@brightroll.com>
-Trevor Burnham <tburnham@hubspot.com>
+Jess Martin <jessmartin@gmail.com>
+Spain Train <michael.spainhower@opower.com>
+Alex Rodionov <p0deje@gmail.com>
+Matt Colyer <matt@colyer.name>
+Evan You <yyx990803@gmail.com>
 bitspill <bitspill+github@bitspill.net>
+Gabriel Falkenberg <gabriel.falkenberg@gmail.com>
+Alexej Yaroshevich <alex@qfox.ru>
+Quim Calpe <quim@kalpe.com>
+Steve Mason <stevem@brandwatch.com>
+Wil Moore III <wil.moore@wilmoore.com>
+Sergey Belov <peimei@ya.ru>
+Tom Huang <hzlhu.dargon@gmail.com>
+CamilleM <camille.moulin@alterway.fr>
+Sébastien Santoro <dereckson@espace-win.org>
+Evan Lucas <evan@btc.com>
+Quinn Slack <qslack@qslack.com>
+Alex Kocharin <alex@kocharin.ru>
+Evan Lucas <evan.lucas@hattiesburgclinic.com>
+Daniel Santiago <daniel.santiago@highlevelwebs.com>
+Denis Gladkikh <outcoldman@gmail.com>
+Andrew Horton <andrew.j.horton@gmail.com>
+Zeke Sikelianos <zeke@sikelianos.com>
+Dylan Greene <dylang@gmail.com>
+Franck Cuny <franck.cuny@gmail.com>
+Yeonghoon Park <sola92@gmail.com>
+Rafael de Oleza <rafa@spotify.com>
+Mikola Lysenko <mikolalysenko@gmail.com>
+Yazhong Liu <yorkiefixer@gmail.com>
 Neil Gentleman <ngentleman@gmail.com>
+Kris Kowal <kris.kowal@cixar.com>
+Alex Gorbatchev <alex.gorbatchev@gmail.com>
+Shawn Wildermuth <shawn@wildermuth.com>
+Wesley de Souza <wesleywex@gmail.com>
+yoyoyogi <yogesh.k@gmail.com>
+J. Tangelder <j.tangelder@gmail.com>
+Jean Lauliac <jean@lauliac.com>
+Andrey Kislyuk <kislyuk@gmail.com>
+Thorsten Lorenz <thlorenz@gmx.de>
+Julian Gruber <julian@juliangruber.com>
+Benjamin Coe <bencoe@gmail.com>
+Alex Ford <Alex.Ford@CodeTunnel.com>
+Matt Hickford <matt.hickford@gmail.com>
+Sean McGivern <sean.mcgivern@rightscale.com>
+C J Silverio <ceejceej@gmail.com>
+Robin Tweedie <robin@songkick.com>
+Miroslav Bajtoš <miroslav@strongloop.com>
+David Glasser <glasser@davidglasser.net>
+Gianluca Casati <casati_gianluca@yahoo.it>
+Forrest L Norvell <forrest@npmjs.com>
+Karsten Tinnefeld <k.tinnefeld@googlemail.com>
+Bryan Burgers <bryan@burgers.io>
+David Beitey <david@davidjb.com>
+Evan You <yyou@google.com>
+Zach Pomerantz <zmp@umich.edu>
+Chris Williams <cwilliams88@gmail.com>
+sudodoki <smd.deluzion@gmail.com>
+Mick Thompson <dthompson@gmail.com>
+Felix Rabe <felix@rabe.io>
+Michael Hayes <michael@hayes.io>
+Chris Dickinson <christopher.s.dickinson@gmail.com>
+Bradley Meck <bradley.meck@gmail.com>
+GeJ <geraud@gcu.info>
+Andrew Terris <atterris@gmail.com>
+Michael Nisi <michael.nisi@gmail.com>
+fengmk2 <fengmk2@gmail.com>
+Adam Meadows <adam.meadows@gmail.com>
+Chulki Lee <chulki.lee@gmail.com>
+不四 <busi.hyy@taobao.com>
+dead_horse <dead_horse@qq.com>
+Kenan Yildirim <kenan@kenany.me>
+Laurie Voss <git@seldo.com>
+Rebecca Turner <turner@mikomi.org>
+Hunter Loftis <hunter@hunterloftis.com>
+Peter Richardson <github@zoomy.net>
+Jussi Kalliokoski <jussi.kalliokoski@gmail.com>
+Filip Weiss <me@fiws.net>
+timoweiss <timoweiss@Timo-MBP.local>
+Christopher Hiller <chiller@badwing.com>
+Jérémy Lal <kapouer@melix.org>
+Anders Janmyr <anders@janmyr.com>
+Chris Meyers <chris.meyers.fsu@gmail.com>
+Ludwig Magnusson <ludwig@mediatool.com>
+wmertens <Wout.Mertens@gmail.com>
+Nick Santos <nick@medium.com>
+Terin Stock <terinjokes@gmail.com>
+Faiq Raza <faiqrazarizvi@gmail.com>
+Thomas Torp <thomas@erupt.no>
+Sam Mikes <smikes@cubane.com>
+Mat Tyndall <mat.tyndall@gmail.com>
+Tauren Mills <tauren@sportzing.com>
+Ron Martinez <ramartin.net@gmail.com>
+Kazuhito Hokamura <k.hokamura@gmail.com>
+Tristan Davies <github@tristan.io>
+David Volm <david@volminator.com>
+Lin Clark <lin.w.clark@gmail.com>
+Ben Page <bpage@dewalch.com>
+Jeff Jo <jeffjo@squareup.com>
+martinvd <martinvdpub@gmail.com>
+Mark J. Titorenko <nospam-github.com@titorenko.net>
+Oddur Sigurdsson <oddurs@gmail.com>
+Eric Mill <eric@konklone.com>
+Gabriel Barros <descartavel1@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,12 @@ test: doc
 tag:
 	npm tag npm@$(PUBLISHTAG) latest
 
-publish: link doc
+authors:
+	@bash scripts/update-authors.sh &&\
+	git add AUTHORS &&\
+	git commit -m "update AUTHORS"
+
+publish: link doc authors
 	@git push origin :v$(shell npm -v) 2>&1 || true
 	git clean -fd &&\
 	git push origin $(BRANCH) &&\
@@ -243,4 +248,4 @@ release:
 sandwich:
 	@[ $$(whoami) = "root" ] && (echo "ok"; echo "ham" > sandwich) || (echo "make it yourself" && exit 13)
 
-.PHONY: all latest install dev link doc clean uninstall test man doc-clean docclean release
+.PHONY: all latest install dev link doc clean uninstall test man doc-clean docclean release authors

--- a/scripts/update-authors.sh
+++ b/scripts/update-authors.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+git log --reverse --format='%aN <%aE>' | awk '
+BEGIN {
+  print "# Authors sorted by whether or not they'\''re me";
+}
+
+{
+  if (all[$NF] != 1) {
+    all[$NF] = 1;
+    ordered[length(all)] = $0;
+  }
+}
+
+END {
+  for (i in ordered) {
+    print ordered[i];
+  }
+}
+' > AUTHORS


### PR DESCRIPTION
Since a patch seems to be welcome for https://github.com/npm/npm/issues/4829, I decided to take a stab at it.

`.mailmap` file removes duplicates for contributors with multiple emails. There are perhaps more lines to be added to this file but for the time being I'm submitting this for review to see if it is even desired anymore :)
