### PR TITLE
dedupe: decrease the log level of unavoidable conflicts

### DIFF
--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -171,8 +171,8 @@ function installAndRetest (set, filter, dir, unavoidable, silent, cb) {
 
     // nothing to be done here.  oh well.  just a conflict.
     if (!locMatch && !regMatch) {
-      log.warn("unavoidable conflict", item[0], item[1])
-      log.warn("unavoidable conflict", "Not de-duplicating")
+      log.info("unavoidable conflict", item[0], item[1])
+      log.info("unavoidable conflict", "Not de-duplicating")
       unavoidable[item[0]] = true
       return cb()
     }


### PR DESCRIPTION
Users running `npm dedupe` do not need to be informed about unavoidable conflicts, they are a part of regular process of dedupe, and are nothing of note.

In my personal opinion, this also aligns with semantic meaning. I was unable to find a detailed standard of log levels, thus I converged on an opinion that warnings require eventual attention, while infos are documenting regular behavior.

Feel free to reject this if your log level definition differs.
Consider that with #6912 the warnings will pop up for regular users during a simple install command.
