### PR TITLE
Prevent people from overwriting their npm install

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -154,12 +154,12 @@ command name to local file name. On install, npm will symlink that file into
 installs.
 
 
-For example, npm has this:
+For example, myapp could have this:
 
-    { "bin" : { "npm" : "./cli.js" } }
+    { "bin" : { "myapp" : "./cli.js" } }
 
-So, when you install npm, it'll create a symlink from the `cli.js` script to
-`/usr/local/bin/npm`.
+So, when you install myapp, it'll create a symlink from the `cli.js` script to
+`/usr/local/bin/myapp`.
 
 If you have a single executable, and its name should be the name
 of the package, then you can just supply it as a string.  For example:


### PR DESCRIPTION
When I first tried to install my app into the global bin folder, I used the code sample provided:
    { "bin" : { "npm" : "./cli.js" } }

Unfortunately, I forgot to replace npm with myapp. This replaced my installation of npm with myapp and I had to reinstall nodejs again scratch.
