### PR TITLE
docs: fix default version in npm-config(7)

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -55,7 +55,6 @@ The following shorthands are parsed on the command-line:
 * `-m`: `--message`
 * `-p`, `--porcelain`: `--parseable`
 * `-reg`: `--registry`
-* `-v`: `--version`
 * `-f`: `--force`
 * `-desc`: `--description`
 * `-S`: `--save`
@@ -433,7 +432,7 @@ The value `npm init` should use by default for the package license.
 
 ### init-version
 
-* Default: "0.0.0"
+* Default: "1.0.0"
 * Type: semver
 
 The value that `npm init` should use by default for the package
@@ -690,7 +689,7 @@ Only works if there is already a package.json file present.
 Configure how versions of packages installed to a package.json file via
 `--save` or `--save-dev` get prefixed.
 
-For example if a package has version `1.2.3`, by default it's version is
+For example if a package has version `1.2.3`, by default its version is
 set to `^1.2.3` which allows minor upgrades for that package, but after
 `npm config set save-prefix='~'` it would be set to `~1.2.3` which only allows
 patch upgrades.
@@ -886,7 +885,6 @@ Set to `"browser"` to view html help content in the default web browser.
 ## SEE ALSO
 
 * npm-config(1)
-* npm-config(7)
 * npmrc(5)
 * npm-scripts(7)
 * npm-folders(5)


### PR DESCRIPTION
I was browsing through the `npm-config` docs and noticed the default version is no longer correct. Other changes:
- the `-v` shorthand was listed twice
- minor spelling mistake
- doc/misc/npm-config _is_ `npm-config(7)`, so mentioning it in “see also” seems redundant.
