### PR TITLE
[WIP] use npm-registry-mock@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "marked-man": "~0.1.4",
     "nock": "~0.59.0",
     "npm-registry-couchapp": "~2.6.2",
-    "npm-registry-mock": "~0.6.3",
+    "npm-registry-mock": "1.0.0",
     "require-inject": "~1.1.0",
     "tap": "~0.5.0"
   },

--- a/test/disabled/outdated-depth-integer.js
+++ b/test/disabled/outdated-depth-integer.js
@@ -24,7 +24,7 @@ test('outdated depth integer', function (t) {
 
   process.chdir(pkg)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (s) {
     npm.load({
       cache: pkg + '/cache'
     , loglevel: 'silent'

--- a/test/tap/404-parent.js
+++ b/test/tap/404-parent.js
@@ -40,8 +40,13 @@ function setup() {
   process.chdir(pkg)
 }
 
-function performInstall(cb) {
-  mr(common.port, function (s) { // create mock registry.
+function plugin (server) {
+  server.get("/test-npm-404-parent-test")
+    .reply(404, {"error": "version not found"})
+}
+
+function performInstall (cb) {
+  mr({port : common.port, plugin : plugin}, function (er, s) { // create mock registry.
     npm.load({registry: common.registry}, function () {
       npm.commands.install(pkg, [], function (err) {
         cb(err)

--- a/test/tap/access.js
+++ b/test/tap/access.js
@@ -30,7 +30,7 @@ test("setup", function (t) {
   mkdirp(pkg, function (er) {
     t.ifError(er, pkg + " made successfully")
 
-    mr({port : common.port, mocks : mocks}, function (s) {
+    mr({port : common.port, plugin : mocks}, function (err, s) {
       server = s
 
       fs.writeFile(

--- a/test/tap/adduser-always-auth.js
+++ b/test/tap/adduser-always-auth.js
@@ -25,7 +25,7 @@ function mocks(server) {
 }
 
 test("npm login", function (t) {
-  mr({port : common.port, mocks : mocks}, function (s) {
+  mr({port : common.port, plugin : mocks}, function (er, s) {
     var runner = common.npm(
     [
       "login",
@@ -61,7 +61,7 @@ test("npm login", function (t) {
 })
 
 test("npm login --always-auth", function (t) {
-  mr({port : common.port, mocks : mocks}, function (s) {
+  mr({port : common.port, plugin : mocks}, function (er, s) {
     var runner = common.npm(
     [
       "login",
@@ -98,7 +98,7 @@ test("npm login --always-auth", function (t) {
 })
 
 test("npm login --no-always-auth", function (t) {
-  mr({port : common.port, mocks : mocks}, function (s) {
+  mr({port : common.port, plugin : mocks}, function (er, s) {
     var runner = common.npm(
     [
       "login",

--- a/test/tap/adduser-legacy-auth.js
+++ b/test/tap/adduser-legacy-auth.js
@@ -47,7 +47,7 @@ test("setup", function (t) {
 })
 
 test("npm login", function (t) {
-  mr({port : common.port, mocks : mocks}, function (s) {
+  mr({port : common.port, plugin : mocks}, function (er, s) {
     var runner = common.npm(
     [
       "login",

--- a/test/tap/bugs.js
+++ b/test/tap/bugs.js
@@ -25,7 +25,7 @@ test("setup", function (t) {
 })
 
 test("npm bugs underscore", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       "bugs", "underscore",
       "--registry=" + common.registry,
@@ -45,7 +45,7 @@ test("npm bugs underscore", function (t) {
 })
 
 test("npm bugs optimist - github (https://)", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       "bugs", "optimist",
       "--registry=" + common.registry,
@@ -65,7 +65,7 @@ test("npm bugs optimist - github (https://)", function (t) {
 })
 
 test("npm bugs npm-test-peer-deps - no repo", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       "bugs", "npm-test-peer-deps",
       "--registry=" + common.registry,
@@ -85,7 +85,7 @@ test("npm bugs npm-test-peer-deps - no repo", function (t) {
 })
 
 test("npm bugs test-repo-url-http - non-github (http://)", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       "bugs", "test-repo-url-http",
       "--registry=" + common.registry,
@@ -105,7 +105,7 @@ test("npm bugs test-repo-url-http - non-github (http://)", function (t) {
 })
 
 test("npm bugs test-repo-url-https - non-github (https://)", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       "bugs", "test-repo-url-https",
       "--registry=" + common.registry,
@@ -125,7 +125,7 @@ test("npm bugs test-repo-url-https - non-github (https://)", function (t) {
 })
 
 test("npm bugs test-repo-url-ssh - non-github (ssh://)", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       "bugs", "test-repo-url-ssh",
       "--registry=" + common.registry,

--- a/test/tap/cache-shasum-fork.js
+++ b/test/tap/cache-shasum-fork.js
@@ -16,7 +16,7 @@ test("mock reg", function (t) {
   mkdirp.sync(cache)
   rimraf.sync(cwd)
   mkdirp.sync(path.join(cwd, "node_modules"))
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     server = s
     t.pass("ok")
     t.end()

--- a/test/tap/cache-shasum.js
+++ b/test/tap/cache-shasum.js
@@ -13,7 +13,7 @@ var server
 test("mock reg", function (t) {
   rimraf.sync(cache)
   mkdirp.sync(cache)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     server = s
     t.pass("ok")
     t.end()

--- a/test/tap/circular-dep.js
+++ b/test/tap/circular-dep.js
@@ -35,7 +35,7 @@ function setup (cb) {
   process.chdir(path.resolve(pkg, "minimist"))
 
   fs.mkdirSync(path.resolve(pkg, "minimist/node_modules"))
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     server = s
     npm.load({
       loglevel: "silent",

--- a/test/tap/dedupe.js
+++ b/test/tap/dedupe.js
@@ -33,7 +33,7 @@ test("dedupe finds the common module and moves it up one level", function (t) {
 
 function setup (cb) {
   process.chdir(path.join(__dirname, "dedupe"))
-  mr(common.port, function (s) { // create mock registry.
+  mr({port : common.port}, function (er, s) { // create mock registry.
     rimraf.sync(path.join(__dirname, "dedupe", "node_modules"))
     fs.mkdirSync(path.join(__dirname, "dedupe", "node_modules"))
     cb(s)

--- a/test/tap/dist-tag.js
+++ b/test/tap/dist-tag.js
@@ -49,7 +49,7 @@ test("setup", function (t) {
   mkdirp(pkg, function (er) {
     t.ifError(er, pkg + " made successfully")
 
-    mr({port : common.port, mocks : mocks}, function (s) {
+    mr({port : common.port, plugin : mocks}, function (er, s) {
       server = s
 
       fs.writeFile(

--- a/test/tap/false_name.js
+++ b/test/tap/false_name.js
@@ -28,7 +28,7 @@ test("setup", function(t) {
 
 test("not every pkg.name can be required", function (t) {
   t.plan(3)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       "install", ".",
       "--cache", cache,

--- a/test/tap/get.js
+++ b/test/tap/get.js
@@ -49,7 +49,7 @@ function getCachePath (uri) {
 test("setup", function (t) {
   mkdirp.sync(CACHE_DIR)
 
-  mr({port: common.port, mocks: mocks}, function (s) {
+  mr({port: common.port, mocks: mocks}, function (err, s) {
     npm.load({cache: CACHE_DIR, registry: common.registry}, function (err) {
       t.ifError(err)
       server = s

--- a/test/tap/ignore-shrinkwrap.js
+++ b/test/tap/ignore-shrinkwrap.js
@@ -16,7 +16,7 @@ var customMocks = {
 }
 
 test("ignore-shrinkwrap: using the option", function (t) {
-  mr({port: common.port, mocks: customMocks}, function (s) {
+  mr({port: common.port, mocks: customMocks}, function (err, s) {
     s._server.on("request", function (req) {
       switch (req.url) {
         case "/shrinkwrap.js":
@@ -35,7 +35,7 @@ test("ignore-shrinkwrap: using the option", function (t) {
 })
 
 test("ignore-shrinkwrap: NOT using the option", function (t) {
-  mr({port: common.port, mocks: customMocks}, function (s) {
+  mr({port: common.port, mocks: customMocks}, function (err, s) {
     s._server.on("request", function (req) {
       switch (req.url) {
         case "/shrinkwrap.js":

--- a/test/tap/install-cli-unicode.js
+++ b/test/tap/install-cli-unicode.js
@@ -15,7 +15,7 @@ var EXEC_OPTS = {
 
 test("does not use unicode with --unicode false", function (t) {
   t.plan(5)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm(["install", "--unicode", "false", "read"], EXEC_OPTS, function (err, code, stdout) {
       t.ifError(err, "install package read without unicode success")
       t.notOk(code, "npm install exited with code 0")
@@ -28,7 +28,7 @@ test("does not use unicode with --unicode false", function (t) {
 })
 
 test("cleanup", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm(["uninstall", "read"], EXEC_OPTS, function (err, code) {
       t.ifError(err, "uninstall read package success")
       t.notOk(code, "npm uninstall exited with code 0")

--- a/test/tap/install-save-exact.js
+++ b/test/tap/install-save-exact.js
@@ -17,7 +17,7 @@ test("setup", function (t) {
 
 test("\"npm install --save --save-exact\" should install local pkg", function (t) {
   resetPackageJSON(pkg)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache: pkg + "/cache",
       loglevel: "silent",
@@ -46,7 +46,7 @@ test("\"npm install --save --save-exact\" should install local pkg", function (t
 test("\"npm install --save-dev --save-exact\" should install local pkg", function (t) {
   resetPackageJSON(pkg)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache: pkg + "/cache",
       loglevel: "silent",

--- a/test/tap/install-save-prefix.js
+++ b/test/tap/install-save-prefix.js
@@ -17,7 +17,7 @@ test("setup", function (t) {
 
 test("npm install --save with default save-prefix should install local pkg versioned to allow minor updates", function (t) {
   resetPackageJSON(pkg)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache: pkg + "/cache",
       loglevel: "silent",
@@ -43,7 +43,7 @@ test("npm install --save with default save-prefix should install local pkg versi
 
 test("npm install --save-dev with default save-prefix should install local pkg to dev dependencies versioned to allow minor updates", function (t) {
   resetPackageJSON(pkg)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache: pkg + "/cache",
       loglevel: "silent",
@@ -69,7 +69,7 @@ test("npm install --save-dev with default save-prefix should install local pkg t
 
 test("npm install --save with \"~\" save-prefix should install local pkg versioned to allow patch updates", function (t) {
   resetPackageJSON(pkg)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache: pkg + "/cache",
       loglevel: "silent",
@@ -96,7 +96,7 @@ test("npm install --save with \"~\" save-prefix should install local pkg version
 
 test("npm install --save-dev with \"~\" save-prefix should install local pkg to dev dependencies versioned to allow patch updates", function (t) {
   resetPackageJSON(pkg)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache: pkg + "/cache",
       loglevel: "silent",

--- a/test/tap/install-with-dev-dep-duplicate.js
+++ b/test/tap/install-with-dev-dep-duplicate.js
@@ -13,7 +13,7 @@ var desiredResultsPath = path.resolve(pkg, "desired-ls-results.json")
 test("prefers version from dependencies over devDependencies", function (t) {
   t.plan(1)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     setup(function (err) {
       if (err) return t.fail(err)
 

--- a/test/tap/ls-depth-cli.js
+++ b/test/tap/ls-depth-cli.js
@@ -20,7 +20,7 @@ test("setup", function (t) {
   cleanup()
   mkdirp.sync(pkg + "/cache")
   mkdirp.sync(pkg + "/tmp")
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     var cmd = ["install", "--registry=" + common.registry]
     common.npm(cmd, opts, function (er, c) {
       if (er) throw er

--- a/test/tap/ls-depth-unmet.js
+++ b/test/tap/ls-depth-unmet.js
@@ -23,7 +23,7 @@ test("setup", function (t) {
   cleanup()
   mkdirp.sync(cache)
   mkdirp.sync(tmp)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     var cmd = ["install", "underscore@1.3.1", "mkdirp", "test-package-with-one-dep", "--registry=" + common.registry]
     common.npm(cmd, opts, function (er, c) {
       if (er) throw er

--- a/test/tap/ls-l-depth-0.js
+++ b/test/tap/ls-l-depth-0.js
@@ -31,7 +31,7 @@ var EXEC_OPTS = {
 
 test("setup", function (t) {
   setup()
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     server = s
 
     t.end()

--- a/test/tap/noargs-install-config-save.js
+++ b/test/tap/noargs-install-config-save.js
@@ -52,7 +52,7 @@ test("does not update the package.json with empty arguments", function (t) {
   writePackageJson()
   t.plan(1)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     var child = createChild([npm, "install"])
     child.on("close", function () {
       var text = JSON.stringify(fs.readFileSync(pkg + "/package.json", "utf8"))
@@ -67,7 +67,7 @@ test("updates the package.json (adds dependencies) with an argument", function (
   writePackageJson()
   t.plan(1)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     var child = createChild([npm, "install", "underscore"])
     child.on("close", function () {
       var text = JSON.stringify(fs.readFileSync(pkg + "/package.json", "utf8"))

--- a/test/tap/outdated-color.js
+++ b/test/tap/outdated-color.js
@@ -28,7 +28,7 @@ function ansiTrim (str) {
 // it"s not running in a tty
 test("does not use ansi styling", function (t) {
   t.plan(4)
-  mr(common.port, function (s) { // create mock registry.
+  mr({port : common.port}, function (er, s) { // create mock registry.
     common.npm(
     [
       "outdated",

--- a/test/tap/outdated-depth.js
+++ b/test/tap/outdated-depth.js
@@ -25,7 +25,7 @@ test("outdated depth zero", function (t) {
 
   process.chdir(pkg)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache: cache
     , loglevel: "silent"

--- a/test/tap/outdated-include-devdependencies.js
+++ b/test/tap/outdated-include-devdependencies.js
@@ -13,7 +13,7 @@ mkdirp.sync(cache)
 
 test("includes devDependencies in outdated", function (t) {
   process.chdir(pkg)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({cache: cache, registry: common.registry}, function () {
       npm.outdated(function (er, d) {
         t.equal("1.5.1", d[0][3])

--- a/test/tap/outdated-json.js
+++ b/test/tap/outdated-json.js
@@ -35,7 +35,7 @@ test("it should log json data", function (t) {
   cleanup()
   process.chdir(pkg)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache: pkg + "/cache",
       loglevel: "silent",

--- a/test/tap/outdated-long.js
+++ b/test/tap/outdated-long.js
@@ -35,7 +35,7 @@ test("it should not throw", function (t) {
   console.log = function () {
     output.push.apply(output, arguments)
   }
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache : "cache",
       loglevel : "silent",

--- a/test/tap/outdated-new-versions.js
+++ b/test/tap/outdated-new-versions.js
@@ -16,7 +16,7 @@ test("dicovers new versions in outdated", function (t) {
   process.chdir(pkg)
   t.plan(2)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({cache: cache, registry: common.registry}, function () {
       npm.outdated(function (er, d) {
         for (var i = 0; i < d.length; i++) {

--- a/test/tap/outdated-notarget.js
+++ b/test/tap/outdated-notarget.js
@@ -14,7 +14,7 @@ var mr = require("npm-registry-mock")
 test("outdated-target: if no viable version is found, show error", function (t) {
   t.plan(1)
   setup()
-  mr({port: common.port}, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({ cache: cache, registry: common.registry}, function () {
       npm.commands.update(function (er) {
         t.equal(er.code, "ETARGET")

--- a/test/tap/outdated-private.js
+++ b/test/tap/outdated-private.js
@@ -21,7 +21,7 @@ test("setup", function (t) {
 test("outdated ignores private modules", function (t) {
   t.plan(3)
   process.chdir(pkg)
-  mr({ port : common.port }, function (s) {
+  mr({ port : common.port }, function (err, s) {
     npm.load(
       {
         loglevel  : "silent",

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -31,7 +31,7 @@ test("it should not throw", function (t) {
   console.log = function () {
     output.push.apply(output, arguments)
   }
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     npm.load({
       cache: "cache",
       loglevel: "silent",

--- a/test/tap/owner.js
+++ b/test/tap/owner.js
@@ -73,7 +73,7 @@ test("setup", function (t) {
       t.ifError(err,  "npm cache clean ran without error")
       t.notOk(code,   "npm cache clean exited cleanly")
 
-      mr({ port : common.port, mocks : mocks }, function (s) {
+      mr({ port : common.port, plugin : mocks }, function (err, s) {
         server = s
         t.end()
       })

--- a/test/tap/peer-deps-invalid.js
+++ b/test/tap/peer-deps-invalid.js
@@ -23,7 +23,7 @@ test("installing dependencies that have conflicting peerDependencies", function 
       "/invalid.js": [200, failFile]
     }
   }
-  mr({port: common.port, mocks: customMocks}, function (s) { // create mock registry.
+  mr({port: common.port, mocks: customMocks}, function (err, s) { // create mock registry.
     npm.load({
       cache: cache,
       registry: common.registry

--- a/test/tap/peer-deps-toplevel.js
+++ b/test/tap/peer-deps-toplevel.js
@@ -11,7 +11,7 @@ var pkg = path.resolve(__dirname, "peer-deps-toplevel")
 var desiredResultsPath = path.resolve(pkg, "desired-ls-results.json")
 
 test("installs the peer dependency directory structure", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     setup(function (err) {
       t.ifError(err, "setup ran successfully")
 

--- a/test/tap/peer-deps-without-package-json.js
+++ b/test/tap/peer-deps-without-package-json.js
@@ -23,7 +23,7 @@ test("installing a peerDependencies-using package without a package.json present
       "/ok.js": [200, js]
     }
   }
-  mr({port: common.port, mocks: customMocks}, function (s) { // create mock registry.
+  mr({port: common.port, mocks: customMocks}, function (err, s) { // create mock registry.
     npm.load({
       registry: common.registry,
       cache: cache

--- a/test/tap/peer-deps.js
+++ b/test/tap/peer-deps.js
@@ -11,7 +11,7 @@ var pkg = path.resolve(__dirname, "peer-deps")
 var desiredResultsPath = path.resolve(pkg, "desired-ls-results.json")
 
 test("installs the peer dependency directory structure", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     setup(function (err) {
       if (err) return t.fail(err)
 

--- a/test/tap/prune.js
+++ b/test/tap/prune.js
@@ -16,7 +16,7 @@ EXEC_OPTS.env.npm_config_depth = "Infinity"
 var server
 
 test("reg mock", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     server = s
     t.pass("registry mock started")
     t.end()

--- a/test/tap/repo.js
+++ b/test/tap/repo.js
@@ -27,7 +27,7 @@ test("setup", function (t) {
 })
 
 test("npm repo underscore", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       'repo', 'underscore',
       '--registry=' + common.registry,
@@ -46,7 +46,7 @@ test("npm repo underscore", function (t) {
 
 
 test('npm repo optimist - github (https://)', function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       'repo', 'optimist',
       '--registry=' + common.registry,
@@ -64,7 +64,7 @@ test('npm repo optimist - github (https://)', function (t) {
 })
 
 test("npm repo npm-test-peer-deps - no repo", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       'repo', 'npm-test-peer-deps',
       '--registry=' + common.registry,
@@ -79,7 +79,7 @@ test("npm repo npm-test-peer-deps - no repo", function (t) {
 })
 
 test("npm repo test-repo-url-http - non-github (http://)", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       'repo', 'test-repo-url-http',
       '--registry=' + common.registry,
@@ -97,7 +97,7 @@ test("npm repo test-repo-url-http - non-github (http://)", function (t) {
 })
 
 test("npm repo test-repo-url-https - non-github (https://)", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       'repo', 'test-repo-url-https',
       '--registry=' + common.registry,
@@ -115,7 +115,7 @@ test("npm repo test-repo-url-https - non-github (https://)", function (t) {
 })
 
 test("npm repo test-repo-url-ssh - non-github (ssh://)", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     common.npm([
       'repo', 'test-repo-url-ssh',
       '--registry=' + common.registry,

--- a/test/tap/search.js
+++ b/test/tap/search.js
@@ -56,7 +56,7 @@ var mocks = {
 test("No previous cache, init cache triggered by first search", function(t) {
   cleanupCache()
 
-  mr({ port: common.port, mocks: mocks.allFutureUpdatedOnly }, function (s) {
+  mr({ port: common.port, plugin: mocks.allFutureUpdatedOnly }, function (err, s) {
     common.npm([
       "search", "do not do extra search work on my behalf",
       "--registry", common.registry,
@@ -88,7 +88,7 @@ test("previous cache, _updated set, should trigger since request", function(t) {
       m(server)
     })
   }
-  mr({ port: common.port, mocks: m }, function (s) {
+  mr({ port: common.port, plugin: m }, function (err, s) {
     common.npm([
       "search", "do not do extra search work on my behalf",
       "--registry", common.registry,
@@ -129,7 +129,7 @@ var searches = [
 searches.forEach(function(search) {
   test(search.description + " search in color", function(t) {
     cleanupCache()
-    mr({ port: common.port, mocks: mocks.all }, function (s) {
+    mr({ port: common.port, plugin: mocks.all }, function (er, s) {
       common.npm([
         "search", search.term,
         "--registry", common.registry,

--- a/test/tap/shrinkwrap-dev-dependency.js
+++ b/test/tap/shrinkwrap-dev-dependency.js
@@ -13,7 +13,7 @@ var desiredResultsPath = path.resolve(pkg, "desired-shrinkwrap-results.json")
 test("shrinkwrap doesn't strip out the dependency", function (t) {
   t.plan(1)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     setup({ production: true }, function (err) {
       if (err) return t.fail(err)
 

--- a/test/tap/shrinkwrap-empty-deps.js
+++ b/test/tap/shrinkwrap-empty-deps.js
@@ -14,7 +14,7 @@ test("returns a list of removed items", function (t) {
 
   cleanup()
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     setup(function () {
       npm.shrinkwrap([], function (err) {
         if (err) return t.fail(err)

--- a/test/tap/shrinkwrap-scoped-auth.js
+++ b/test/tap/shrinkwrap-scoped-auth.js
@@ -33,7 +33,7 @@ function mocks (server) {
 }
 
 test("setup", function (t) {
-  mr({ port : common.port, mocks : mocks }, function (s) {
+  mr({ port : common.port, plugin : mocks }, function (err, s) {
     server = s
     t.ok(s, "set up mock registry")
     setup()

--- a/test/tap/shrinkwrap-shared-dev-dependency.js
+++ b/test/tap/shrinkwrap-shared-dev-dependency.js
@@ -13,7 +13,7 @@ var desiredResultsPath = path.resolve(pkg, "desired-shrinkwrap-results.json")
 test("shrinkwrap doesn't strip out the shared dependency", function (t) {
   t.plan(1)
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     setup(function (err) {
       if (err) return t.fail(err)
 

--- a/test/tap/sorted-package-json.js
+++ b/test/tap/sorted-package-json.js
@@ -24,7 +24,7 @@ test("sorting dependencies", function (t) {
 
   var before = JSON.parse(fs.readFileSync(packageJson).toString())
 
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     // underscore is already in the package.json,
     // but --save will trigger a rewrite with sort
     var child = spawn(node, [npm, "install", "--save", "underscore@1.3.3"], {

--- a/test/tap/uninstall-package.js
+++ b/test/tap/uninstall-package.js
@@ -8,7 +8,7 @@ var test = require("tap").test
 
 test("returns a list of removed items", function (t) {
   t.plan(1)
-  mr(common.port, function (s) {
+  mr({port : common.port}, function (er, s) {
     setup(function () {
       npm.install(".", function (err) {
         if (err) return t.fail(err)

--- a/test/tap/update-index.js
+++ b/test/tap/update-index.js
@@ -15,7 +15,7 @@ var server
 
 function setup (t, mock) {
   mkdirp.sync(CACHE_DIR)
-  mr({ port: common.port, mocks: mock }, function (s) {
+  mr({ port: common.port, plugin: mock }, function (er, s) {
     npm.load({ cache: CACHE_DIR, registry: common.registry }, function (err) {
       t.ifError(err, "no error")
       server = s

--- a/test/tap/update-save.js
+++ b/test/tap/update-save.js
@@ -38,7 +38,7 @@ var s // mock server reference
 test("setup", function (t) {
   resetPackage()
 
-  mr(common.port, function (server) {
+  mr({port : common.port}, function (er, server) {
     npm.load({cache: CACHE_DIR, registry: common.registry}, function (err) {
       t.ifError(err)
       s = server

--- a/test/tap/url-dependencies.js
+++ b/test/tap/url-dependencies.js
@@ -45,7 +45,7 @@ function tarballWasFetched(output){
 }
 
 function performInstall (t, cb) {
-  mr({port: common.port, mocks: mockRoutes}, function (s) {
+  mr({port: common.port, mocks: mockRoutes}, function (er, s) {
     var opts = {
       cwd : pkg,
       env: {

--- a/test/tap/view.js
+++ b/test/tap/view.js
@@ -32,6 +32,13 @@ test("setup", function (t) {
   t.end()
 })
 
+function plugin (server) {
+  server
+    .get("/biscuits")
+    .many()
+    .reply(404, {"error": "version not found"})
+}
+
 test("npm view . in global mode", function (t) {
   process.chdir(t1dir)
   common.npm([
@@ -42,6 +49,7 @@ test("npm view . in global mode", function (t) {
   ], { cwd: t1dir }, function (err, code, stdout, stderr) {
     t.ifError(err, "view command finished successfully")
     t.equal(code, 1, "exit not ok")
+    console.log(stderr)
     t.similar(stderr, /Cannot use view command in global mode./m)
     t.end()
   })
@@ -77,7 +85,7 @@ test("npm view . with no package.json", function(t) {
 
 test("npm view . with no published package", function (t) {
   process.chdir(t3dir)
-  mr(common.port, function (s) {
+  mr({port : common.port, plugin : plugin}, function (er, s) {
     common.npm([
       "view"
     , "."
@@ -85,6 +93,7 @@ test("npm view . with no published package", function (t) {
     ], { cwd: t3dir }, function (err, code, stdout, stderr) {
       t.ifError(err, "view command finished successfully")
       t.equal(code, 1, "exit not ok")
+      console.error("foo")
       t.similar(stderr, /version not found/m)
       s.close()
       t.end()
@@ -94,7 +103,7 @@ test("npm view . with no published package", function (t) {
 
 test("npm view .", function (t) {
   process.chdir(t2dir)
-  mr(common.port, function (s) {
+  mr({port : common.port, plugin : plugin}, function (er, s) {
     common.npm([
       "view"
     , "."
@@ -112,7 +121,7 @@ test("npm view .", function (t) {
 
 test("npm view . select fields", function (t) {
   process.chdir(t2dir)
-  mr(common.port, function (s) {
+  mr({port : common.port, plugin : plugin}, function (er, s) {
     common.npm([
       "view"
     , "."
@@ -130,7 +139,7 @@ test("npm view . select fields", function (t) {
 
 test("npm view .@<version>", function (t) {
   process.chdir(t2dir)
-  mr(common.port, function (s) {
+  mr({port : common.port, plugin : plugin}, function (er, s) {
     common.npm([
       "view"
     , ".@0.0.0"
@@ -148,7 +157,7 @@ test("npm view .@<version>", function (t) {
 
 test("npm view .@<version> --json", function (t) {
   process.chdir(t2dir)
-  mr(common.port, function (s) {
+  mr({port : common.port, plugin : plugin}, function (er, s) {
     common.npm([
       "view"
     , ".@0.0.0"
@@ -166,7 +175,7 @@ test("npm view .@<version> --json", function (t) {
 })
 
 test("npm view <package name>", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port, plugin : plugin}, function (er, s) {
     common.npm([
       "view"
     , "underscore"
@@ -183,7 +192,7 @@ test("npm view <package name>", function (t) {
 })
 
 test("npm view <package name> --global", function(t) {
-  mr(common.port, function(s) {
+  mr({port : common.port, plugin : plugin}, function (er, s) {
     common.npm([
       "view"
     , "underscore"
@@ -202,7 +211,7 @@ test("npm view <package name> --global", function(t) {
 
 test("npm view <package name> --json", function(t) {
   t.plan(3)
-  mr(common.port, function (s) {
+  mr({port : common.port, plugin : plugin}, function (er, s) {
     common.npm([
       "view"
     , "underscore"
@@ -226,7 +235,7 @@ test("npm view <package name> --json", function(t) {
 })
 
 test("npm view <package name> <field>", function (t) {
-  mr(common.port, function (s) {
+  mr({port : common.port, plugin : plugin}, function (er, s) {
     common.npm([
       "view"
     , "underscore"


### PR DESCRIPTION
closes npm/npm-registry-mock/issues/25

this is the first part to get npm running with the upcoming npm-registry-mock@1.0.0 which has to get released
