### PR TITLE
Fix spelling error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ npm, Inc. or the Node.js project.
 
 Data published to the npm registry is not part of npm itself, and is
 the sole property of the publisher.  While every effort is made to
-ensure accountability, there is absolutely no guarantee, warrantee, or
+ensure accountability, there is absolutely no guarantee, warranty, or
 assertion expressed or implied as to the quality, fitness for a
 specific purpose, or lack of malice in any given npm package.
 


### PR DESCRIPTION
Line 176 uses the word "warrantee" where the word "warranty" should be used instead. 

According to http://grammarist.com/, "A warrantee is someone to whom a warranty is given. A warranty is a guarantee given by a company to a purchaser stating that a product will meet certain requirements during a given time."

It may seem like I am nitpicking, but I believe this is worth attention considering this word misuse is occurring in the legal section of the README, which can potentially open this open source project up to legal loop holes in the future is someone were so inclined.
