### PR TITLE
Two minor issues

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -41,6 +41,7 @@ function outdated (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
   var dir = path.resolve(npm.dir, "..")
   outdated_(args, dir, {}, 0, function (er, list) {
+    if (!list) list = []
     if (er || silent || list.length === 0) return cb(er, list)
     if (npm.config.get("json")) {
       console.log(makeJSON(list))

--- a/test/tap/add-remote-git-fake-windows.js
+++ b/test/tap/add-remote-git-fake-windows.js
@@ -20,7 +20,9 @@ var git
 test("setup", function (t) {
   bootstrap()
   setup(function (er, r) {
-    t.ifError(er, "git started up successfully")
+    if (er) {
+      throw er
+    }
 
     if (!er) {
       daemon = r[r.length - 2]
@@ -66,11 +68,13 @@ var pjChild = JSON.stringify({
 }, null, 2) + "\n"
 
 function bootstrap () {
+  rimraf.sync(pkg)
   mkdirp.sync(pkg)
   fs.writeFileSync(resolve(pkg, "package.json"), pjParent)
 }
 
 function setup (cb) {
+  rimraf.sync(repo)
   mkdirp.sync(repo)
   fs.writeFileSync(resolve(repo, "package.json"), pjChild)
   npm.load({ registry : common.registry, loglevel : "silent" }, function () {


### PR DESCRIPTION
The first cleans up some test folders at the start of the add-remote-git-fake-windows test.

The second handles an edge case where `outdated` returns an empty list.
