### PR TITLE
Improve npm verbose message to output correct runtime engine name, eg. iojs or node

### DIFF
--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -28,11 +28,19 @@ var path = require("path")
   , shorthands = configDefs.shorthands
   , types = configDefs.types
   , nopt = require("nopt")
+  , engine
 
 // if npm is called as "npmg" or "npm_g", then
 // run in global mode.
 if (path.basename(process.argv[1]).slice(-1)  === "g") {
   process.argv.splice(1, 1, "npm", "-g")
+}
+
+// figure out runtime
+if (process.platform === "win32") {
+  engine = path.basename(process.execPath).replace(/\.exe$/i,"").toLowerCase()
+} else {
+  engine = path.basename(process.execPath).toLowerCase()
 }
 
 log.verbose("cli", process.argv)
@@ -55,7 +63,7 @@ if (conf.versions) {
 }
 
 log.info("using", "npm@%s", npm.version)
-log.info("using", "node@%s", process.version)
+log.info("using", "%s@%s", engine, process.version.replace("v", ""))
 
 process.on("uncaughtException", errorHandler)
 


### PR DESCRIPTION
Now that installing iojs or node bundle will replace each other, we should make it easier to figure out which engine npm is using under the hood.

```
// with iojs installed

$ node cli --verbose
npm info it worked if it ends with ok
npm verb cli [ 'node', '/Users/df/git/code/npm/cli', '--verbose' ]
npm info using npm@2.5.1
npm info using iojs@1.1.0
npm verb node symlink /usr/local/bin/node
```
