### PR TITLE
don't use $HOME/.npm as cache directory when running as root

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -95,7 +95,11 @@ if (home) process.env.HOME = home
 else home = path.resolve(temp, "npm-" + uidOrPid)
 
 var cacheExtra = process.platform === "win32" ? "npm-cache" : ".npm"
-var cacheRoot = process.platform === "win32" && process.env.APPDATA || home
+var cacheRoot = process.platform === "win32" && process.env.APPDATA ||
+  // if packages are installed globally with root, we can't use the local .npm
+  // directory, otherwise the next local install may fail due to folders
+  // in our local cache directory being owned by root.
+  (uidOrPid === 0 ? temp : home)
 var cache = path.resolve(cacheRoot, cacheExtra)
 
 


### PR DESCRIPTION
When installing packages globally using root we can't use $HOME/.npm as
$HOME is most often not changed by sudo and so it's still the user's own
home dir.  Now, if a local npm install is run it may fail since folders in
the cache dir are owned by root. In particular when the local npm install
tries to grab newer package versions. Instead we install to the temp
dir when run as root.
