### PR TITLE
Add working npm ls with --production and --dev flags

### DIFF
--- a/doc/cli/npm-ls.md
+++ b/doc/cli/npm-ls.md
@@ -67,6 +67,20 @@ project.
 
 Max display depth of the dependency tree.
 
+### production
+
+* Type: Boolean
+* Default: false
+
+Display only the dependency type is dependency tree.
+
+### dev
+
+* Type: Boolean
+* Default: false
+
+Display only the dependency type is devDependency tree.
+
 ## SEE ALSO
 
 * npm-config(1)

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -39,6 +39,7 @@ function ls (args, silent, cb) {
   var depth = npm.config.get("depth")
   var opt = { depth: depth, log: log.warn, dev: true }
   readInstalled(dir, opt, function (er, data) {
+    filterByEnv(data)
     pruneNestedExtraneous(data)
     var bfs = bfsify(data, args)
       , lite = getLite(bfs)
@@ -86,6 +87,21 @@ function pruneNestedExtraneous (data, visited) {
       pruneNestedExtraneous(data.dependencies[i], visited)
     }
   }
+}
+
+function filterByEnv (data) {
+  var dev = npm.config.get("dev")
+  var production = npm.config.get("production")
+  if (dev === production) return
+  var dependencies = {}
+  var devDependencies = data.devDependencies || []
+  Object.keys(data.dependencies).forEach(function (name) {
+    var keys = Object.keys(devDependencies)
+    if (production && keys.indexOf(name) !== -1) return
+    if (dev && keys.indexOf(name) === -1) return
+    dependencies[name] = data.dependencies[name]
+  })
+  data.dependencies = dependencies
 }
 
 function alphasort (a, b) {

--- a/test/tap/ls-env.js
+++ b/test/tap/ls-env.js
@@ -1,0 +1,57 @@
+var common = require("../common-tap")
+  , test = require("tap").test
+  , path = require("path")
+  , rimraf = require("rimraf")
+  , osenv = require("osenv")
+  , mkdirp = require("mkdirp")
+  , pkg = path.resolve(__dirname, "ls-depth")
+  , mr = require("npm-registry-mock")
+  , opts = {cwd: pkg}
+
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg + "/cache")
+  rimraf.sync(pkg + "/tmp")
+  rimraf.sync(pkg + "/node_modules")
+}
+
+test("setup", function (t) {
+  cleanup()
+  mkdirp.sync(pkg + "/cache")
+  mkdirp.sync(pkg + "/tmp")
+  mr({port : common.port}, function (er, s) {
+    var cmd = ["install", "--registry=" + common.registry]
+    common.npm(cmd, opts, function (er, c) {
+      if (er) throw er
+      t.equal(c, 0)
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test("npm ls --dev", function (t) {
+  common.npm(["ls", "--dev"], opts, function (er, c, out) {
+    if (er) throw er
+    t.equal(c, 0)
+    t.has(out, /(empty)/
+      , "output contains (empty)")
+    t.end()
+  })
+})
+
+test("npm ls --production", function (t) {
+  common.npm(["ls", "--production"], opts, function (er, c, out) {
+    if (er) throw er
+    t.equal(c, 0)
+    t.has(out, /test-package-with-one-dep@0\.0\.0/
+      , "output contains test-package-with-one-dep@0.0.0")
+    t.end()
+  })
+})
+
+test("cleanup", function (t) {
+  cleanup()
+  t.end()
+})

--- a/test/tap/shrinkwrap-dev-dependency.js
+++ b/test/tap/shrinkwrap-dev-dependency.js
@@ -14,7 +14,7 @@ test("shrinkwrap doesn't strip out the dependency", function (t) {
   t.plan(1)
 
   mr({port : common.port}, function (er, s) {
-    setup({ production: true }, function (err) {
+    setup({}, function (err) {
       if (err) return t.fail(err)
 
       npm.install(".", function (err) {


### PR DESCRIPTION
I fixed #2853: Supports `npm ls` works with `--production` and `--dev` flags.

Example:

```
$ ./bin/npm-cli.js ls --depth=0 --dev
npm@2.6.1 /Users/watilde/Development/npm
├── marked@0.3.3
├── marked-man@0.1.4
├── nock@0.59.1
├── npm-registry-couchapp@2.6.6
├── npm-registry-mock@1.0.0
├── require-inject@1.1.1
├── sprintf-js@1.0.2
└── tap@0.6.0
```
