### PR TITLE
update: presence of `npm-shrinkwrap.json` blocks update

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -12,6 +12,8 @@ update.usage = "npm update [pkg]"
 var npm = require("./npm.js")
   , asyncMap = require("slide").asyncMap
   , log = require("npmlog")
+  , fs = require("fs")
+  , path = require("path")
 
   // load these, just so that we know that they'll be available, in case
   // npm itself is getting overwritten.
@@ -24,6 +26,19 @@ function update (args, cb) {
   npm.commands.outdated(args, true, function (er, outdated) {
     log.info("outdated", "updating", outdated)
     if (er) return cb(er)
+
+    // check for existence of shrinkwrap file
+    var shrinkwrapFile = path.resolve(npm.dir, "..", "npm-shrinkwrap.json")
+    log.info("update", "validity-check",
+             "checking for shrinkwrap file " + shrinkwrapFile)
+
+    if (npm.config.get("shrinkwrap") === true &&
+        fs.existsSync(shrinkwrapFile)) {
+        log.error("update", "blocked-by-shrinkwrap",
+                  "Cannot update: `" + shrinkwrapFile + "` exists")
+
+        return cb(null);
+    }
 
     asyncMap(outdated, function (ww, cb) {
       // [[ dir, dep, has, want, req ]]

--- a/test/tap/update-blocked-by-shrinkwrap.js
+++ b/test/tap/update-blocked-by-shrinkwrap.js
@@ -1,0 +1,112 @@
+// the presence of `npm-shrinkwrap.json` should block
+// `npm update`
+var common = require("../common-tap")
+var path = require("path")
+var test = require("tap").test
+var rimraf = require("rimraf")
+var npm = require("../../")
+var npmlog = require("npmlog")
+var mr = require("npm-registry-mock")
+
+var osenv = require("osenv")
+var mkdirp = require("mkdirp")
+var fs = require("fs")
+
+
+var PKG_DIR = path.resolve(__dirname, "update-blocked-by-shrinkwrap")
+var cache = path.resolve(PKG_DIR, "cache")
+
+var pj = JSON.stringify({
+  "name": "silly",
+  "description": "some text",
+  "version": "1.2.3",
+  "main": "index.js",
+  "dependencies": {
+    "underscore": "^1.3.1"
+  },
+  "repository": "git://github.com/luk-/whatever"
+}, null, 2)
+
+var wrap = JSON.stringify({
+  "name": "silly",
+  "version": "1.2.3",
+  "dependencies": {
+    "underscore": {
+      "version": "1.3.1",
+      "from": "underscore@1.3.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.1.tgz"
+    }
+  }
+}, null, 2)
+
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(PKG_DIR)
+}
+
+function setup () {
+  mkdirp.sync(PKG_DIR)
+  process.chdir(PKG_DIR)
+
+  fs.writeFileSync(path.resolve(PKG_DIR, "package.json"), pj);
+  fs.writeFileSync(path.resolve(PKG_DIR, "npm-shrinkwrap.json"), wrap);
+  mkdirp.sync(path.resolve(PKG_DIR, "cache"));
+}
+
+test("setup", function (t) {
+  cleanup()
+  setup()
+
+  t.end()
+})
+
+test("outdated reports underscore is outdated", function (t) {
+  var log = []
+
+  process.chdir(PKG_DIR)
+
+  mr({port: common.port}, function (er, s) {
+    npm.load({
+      cache: cache,
+      loglevel: "silent",
+      regsitry: common.registry,
+      depth: 0
+    }
+    , function () {
+      npmlog.on("log", function (c) {
+        log.push(c.level + " " + c.message);
+      })
+
+      npm.install(".", function (er) {
+        if (er) {
+          throw new Error(er);
+        }
+        npm.outdated(function (err, d) {
+          if (err) {
+            throw new Error(err);
+          }
+          t.equal(d[0][0], PKG_DIR)
+          t.equal(d[0][1], "underscore")
+          t.equal(d[0][2], "1.3.1", "underscore is outdated")
+
+          npm.update(function (e) {
+            t.ok(e === null, "doesn't return error object")
+            t.similar(log[log.length - 1],
+                      /blocked-by-shrinkwrap Cannot update:/, "but logs error")
+            s.close()
+            t.end()
+          })
+        })
+      })
+    })
+  })
+ })
+
+test("cleanup", function (t) {
+  cleanup()
+
+  t.end()
+})
+
+


### PR DESCRIPTION
Candidate fix for issue #6566

Maybe also fix for #6048

This seemed hard: 

> The way @iarna and I want this to work is npm update --save will update both npm-shrinkwrap.json and package.json, but npm update alone in the presence of npm-shrinkwrap.json should be a no-op / WARN that shrinkwrapping is blocking updates and you should use npm update --save.

So I did the simpler thing first; this change just stops `update` from running in the presence of an `npm-shrinkwrap.json` file.  My proposed workflow for updating a shrinkwrap file, after this patch, is:

```
rm -f npm-shrinkwrap.json
npm update --save
npm shrinkwrap
```

This way `npm-shrinkwrap.json` functions as a lock, preventing `npm update` from running.  To remove the lock, you must remove the shrinkwrap file.  To restore the lock, you must run `npm shrinkwrap` again.

In #6566, the proposal was that `npm update --save` would remove the lock and reapply it.  I think it's better for the `npm` commands to run at a more granular level, and allow users to evolve scripts around them as needed, than to have a shrinkwrap-related workflow embedded in `npm update --save`.

Comments/bikeshedding/etc v welcome.
