### PR TITLE
WIP: make npm code conform to `standard`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ npm-debug.log
 /node_modules/marked
 /node_modules/require-inject
 /node_modules/sprintf-js
+/node_modules/standard
 /html/api/
 /html/partial/
 /html/doc/

--- a/package.json
+++ b/package.json
@@ -183,13 +183,14 @@
     "npm-registry-mock": "~1.0.0",
     "require-inject": "~1.1.0",
     "sprintf-js": "~1.0.2",
+    "standard": "~2.7.3",
     "tap": "~0.6.0"
   },
   "scripts": {
     "test-legacy": "node ./test/run.js",
-    "test": "tap --timeout 120 test/tap/*.js",
+    "test": "standard && tap --timeout 120 test/tap/*.js",
     "tap": "tap --timeout 120 test/tap/*.js",
-    "test-all": "node ./test/run.js && tap test/tap/*.js",
+    "test-all": "standard && node ./test/run.js && tap test/tap/*.js",
     "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rm -rf test/*/*/node_modules && make -j8 doc",
     "dumpconf": "env | grep npm | sort | uniq"
   },


### PR DESCRIPTION
This time based against the correct branch.

This is probably too big a diff to effectively review, so once standard is passing (and the tests are passing multi-stage as well), we'll just have to cross our fingers and merge this. So far it's down from ~14,000 warnings to 1,569, most of which are comma-first clauses that need to be reformatted.

It doesn't look _that_ different.

r:@iarna
