### PR TITLE
document `git-tag-version` in the manpage of `npm version`

### DIFF
--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -38,6 +38,14 @@ in your git config for this to work properly.  For example:
 
     Enter passphrase:
 
+## CONFIGURATION
+
+### git-tag-version
+
+* Default: true
+* Type: Boolean
+
+Commit and tag the version change.
 
 ## SEE ALSO
 


### PR DESCRIPTION
Since [`git-tag-version`](https://docs.npmjs.com/misc/config#git-tag-version) affects the behavior of `npm version`, it should be documented as a configuration option in the documentation of `npm version`.

Fixes https://github.com/npm/npm/issues/6711
