### PR TITLE
Split scripts list in scripts or run-scripts

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -84,31 +84,52 @@ function runScript (args, cb) {
 
 function list(cb) {
   var json = path.join(npm.localPrefix, "package.json")
+  var cmdList = [ "publish", "install", "uninstall"
+                , "test", "stop", "start", "restart"
+                ].reduce(function (l, p) {
+                  return l.concat(["pre" + p, p, "post" + p])
+                }, [])
   return readJson(json, function(er, d) {
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     if (er) d = {}
-    var scripts = Object.keys(d.scripts || {})
+    var allScripts = Object.keys(d.scripts || {})
+    var scripts = [], runScripts = []
+    allScripts.forEach(function (script) {
+      if (cmdList.indexOf(script) !== -1) scripts.push(script)
+      else runScripts.push(script)
+    })
 
     if (log.level === "silent") {
-      return cb(null, scripts)
+      return cb(null, allScripts)
     }
 
     if (npm.config.get("json")) {
       console.log(JSON.stringify(d.scripts || {}, null, 2))
-      return cb(null, scripts)
+      return cb(null, allScripts)
     }
 
-    var s = ":"
-    var prefix = ""
-    if (!npm.config.get("parseable")) {
-      s = "\n    "
-      prefix = "  "
-      console.log("Available scripts in the %s package:", d.name)
+    if (npm.config.get("parseable")) {
+      allScripts.forEach(function(script) {
+        console.log(script + ":" + d.scripts[script])
+      })
+      return cb(null, allScripts)
     }
+
+    var s = "\n    "
+    var prefix = "  "
+    var header = "Available scripts in the %s package"
+    if (scripts) console.log(header + ":", d.name)
     scripts.forEach(function(script) {
       console.log(prefix + script + s + d.scripts[script])
     })
-    return cb(null, scripts)
+    if (!scripts && runScripts) {
+      console.log(header + " with run-scripts:", d.name)
+    }
+    else if (runScripts) console.log("\nwith run-scripts:")
+    runScripts.forEach(function(script) {
+      console.log(prefix + script + s + d.scripts[script])
+    })
+    return cb(null, allScripts)
   })
 }
 

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -93,7 +93,8 @@ function list(cb) {
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     if (er) d = {}
     var allScripts = Object.keys(d.scripts || {})
-    var scripts = [], runScripts = []
+    var scripts = []
+    var runScripts = []
     allScripts.forEach(function (script) {
       if (cmdList.indexOf(script) !== -1) scripts.push(script)
       else runScripts.push(script)
@@ -118,14 +119,16 @@ function list(cb) {
     var s = "\n    "
     var prefix = "  "
     var header = "Available scripts in the %s package"
-    if (scripts) console.log(header + ":", d.name)
+    if (scripts.length) console.log(header + ":", d.name)
     scripts.forEach(function(script) {
       console.log(prefix + script + s + d.scripts[script])
     })
-    if (!scripts && runScripts) {
+    if (!scripts.length && runScripts.length) {
       console.log(header + " with run-scripts:", d.name)
     }
-    else if (runScripts) console.log("\nwith run-scripts:")
+    else if (runScripts.length) {
+      console.log("\nwith run-scripts:")
+    }
     runScripts.forEach(function(script) {
       console.log(prefix + script + s + d.scripts[script])
     })


### PR DESCRIPTION
I fixed #7463: Improvements in displaying npm run-script list

Run example:

```
$ ./bin/npm-cli.js run
Available scripts in the npm package:
  test
    tap --timeout 120 test/tap/*.js
  prepublish
    node bin/npm-cli.js prune --prefix=. --no-global && rm -rf test/*/*/node_modules && make -j8 doc

with run-scripts:
  test-legacy
    node ./test/run.js
  tap
    tap --timeout 120 test/tap/*.js
  test-all
    node ./test/run.js && tap test/tap/*.js
  dumpconf
    env | grep npm | sort | uniq
```
