### PR TITLE
Hooking into exec code for git, logging error if fails

### DIFF
--- a/lib/utils/git.js
+++ b/lib/utils/git.js
@@ -19,7 +19,13 @@ function prefixGitArgs () {
 
 function execGit (args, options, cb) {
   log.info("git", args)
-  return exec(git, prefixGitArgs().concat(args || []), options, cb)
+  var fullArgs = prefixGitArgs().concat(args || []);
+  return exec(git, fullArgs, options, function (err) {
+    if (err) {
+      log.error("git ", fullArgs.join(' '));
+    }
+    cb.apply(this, arguments);
+  });
 }
 
 function spawnGit (args, options) {


### PR DESCRIPTION
Printing out the actual arguments git was called with if it fails.

Tests are 'ok'.
![2015-02-25-203652_1920x1080_scrot](https://cloud.githubusercontent.com/assets/768913/6388583/ccf77086-bd9b-11e4-8bc7-8be5fd161e51.png)

fixes #7392
