### PR TITLE
npm: define properties of commands as configurable

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -224,7 +224,7 @@ Object.keys(abbrevs).concat(plumbing).forEach(function addCommand (c) {
     })
 
     return commandCache[a]
-  }, enumerable: fullList.indexOf(c) !== -1 })
+  }, enumerable: fullList.indexOf(c) !== -1, configurable: true })
 
   // make css-case commands callable via camelCase as well
   if (c.match(/\-([a-z])/)) {


### PR DESCRIPTION
make npm commands configurable: true by default
allows npm.commands.foo to be replaced by mock fn in testing
