### PR TITLE
Adds function call to gitEnv in checkGitDir

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -94,7 +94,7 @@ function checkGitDir (p, u, co, origUrl, silent, cb) {
 
     git.whichAndExec(
       [ "config", "--get", "remote.origin.url" ],
-      { cwd : p, env : gitEnv },
+      { cwd : p, env : gitEnv() },
       function (er, stdout, stderr) {
         var stdoutTrimmed = (stdout + "\n" + stderr).trim()
         if (er || u !== stdout.trim()) {


### PR DESCRIPTION
In checkGitDir when executing `git config --get remote.origin.url` the gitEnv function is passed to git.whichAndExec instead of the result of that function.

The typo was introduced with this commit: https://github.com/npm/npm/commit/00ecb6101422984696929f602e14da186f9f669c#diff-949ff1cc9c69a73d643a809580064773R84 
