### PR TITLE
lib, doc: new command `npm upgrade`

### DIFF
--- a/doc/cli/npm-upgrade.md
+++ b/doc/cli/npm-upgrade.md
@@ -1,0 +1,37 @@
+npm-upgrade(1) -- Update npm
+============================
+
+## SYNOPSIS
+
+    npm upgrade
+
+## DESCRIPTION
+
+This command updates the currently-running `npm` to the `latest`
+version that has been published on the `npm` registry.
+
+This command is similar to `npm install -g npm@latest` when `npm` is
+installed as one of the global `npm` modules.
+
+When `npm` is not installed in the location specified by `prefix`,
+this command attempts to upgrade the running `npm`; since `npm` may
+not have permission to write to its own installation directory, you
+may need to use `sudo` or a similar command to run with administrative
+permissions.
+
+## WARNINGS
+
+If this command fails, it may leave your `npm` in a broken state.  You
+can fix this on a Unix-like system by installing `npm` from scratch:
+
+```
+curl -L https://npmjs.org/install.sh | sudo sh
+```
+
+On Windows, it may be necessary to reinstall `node`.
+
+## SEE ALSO
+
+* npm-install(1)
+* npm-update(1)
+* npm-install(3)

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -97,6 +97,7 @@ var commandCache = {}
               , "set"
               , "get"
               , "update"
+              , "upgrade"
               , "outdated"
               , "prune"
               , "pack"

--- a/lib/upgrade.js
+++ b/lib/upgrade.js
@@ -1,0 +1,17 @@
+module.exports = upgrade
+
+upgrade.usage = 'npm upgrade'
+
+var npm = require('./npm.js')
+var path = require('path')
+
+function upgrade (args, cb) {
+
+  npm.config.set('global', false)
+  npm.config.set('prefix', path.resolve(__dirname, '..', '..', '..'))
+  if (args.length) return cb(new Error('`npm upgrade` does not take arguments'))
+
+  npm.config.set('depth', 0)
+  npm.config.set('tag', 'latest')
+  npm.commands.update(['npm'], cb)
+}


### PR DESCRIPTION
Ref issue #7510 

I thought about it a bit more and I realized that the desired behavior of `npm upgrade` is distinct from `npm install -g npm@latest`.  The latter only works to upgrade the currently-running `npm` when `npm` is installed under its own prefix (as is normal on OSX).

But on some systems, notably Windows, and with the official Red Hat and Ubuntu packages, `npm` is installed as a local binary (e.g. in /usr/local/bin) but npm's prefix is different (e.g., /usr/local/lib/nodejs).  This causes an `npm install -g npm@latest` to successfully install an updated npm in a different place, leaving the system npm at its existing version.  This leaves the system with two installed `npm` versions, generally causing problems.

So really what `npm upgrade` should want to do is figure out where the **currently running** npm is, and set up an install/update of **that** npm -- whether it's in `prefix` or not -- to `latest`.  If that directory not normally writable by `npm`, then the command will fail with EACCES and the user will be directed to use `sudo` or `Run As Administrator` (if on Windows).

This PR is a first cut at that.  As written the `npm upgrade` command is ugly, using `__dirname` to find the parent directory three levels above `upgrade.js`.  I set `global`, `prefix`, `tag` and `depth` explicitly in case the user manages to get weird stuff in their config file.  Possibly worth setting `registry` too?

No test yet, as this is a proof of concept, and also, I keep blowing away my changes when I try to test them :-P

This will require extensive testing on Windows and with default linux distribution.

However the upsides are:
- no more 'upgrading is a pain on Windows, follow these instructions'
- no more 'upgrading is a pain on Linux, follow these instructions'
- brew/apt-get/etc. users who expect a `foo upgrade` will now be happy
