### PR TITLE
Catch missing tmpdir exception

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -86,7 +86,13 @@ else stableFamily = stableFamily.major + "." + stableFamily.minor
 
 var defaults
 
-var temp = osenv.tmpdir()
+try {
+  var temp = osenv.tmpdir()
+} catch (e) {
+  console.log("You need node v0.8 or higher to run this program.")
+  process.exit(1)
+}
+
 var home = osenv.home()
 
 var uidOrPid = process.getuid ? process.getuid() : process.pid


### PR DESCRIPTION
When running npm with a node version below 0.8 os.tmpDir() is not defined and raises an exception. The then occurring error message is meaningless and leads to a time-consuming Google session. With this patch npm dies with error code 1 and tells that a newer version is required.
