### PR TITLE
Handle scoped packages in the dedupe command

### DIFF
--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -314,11 +314,28 @@ function readInstalled (dir, counter, parent, cb) {
   })
 
   fs.readdir(path.resolve(dir, "node_modules"), function (er, c) {
-    children = c || [] // error is ok, just means no children.
-    children = children.filter(function (p) {
-      return !p.match(/^[\._-]/)
-    })
-    next()
+    children = children || [] // error is ok, just means no children.
+    // check if there are scoped packages.
+    asyncMap(c || [], function (child, cb) {
+      if (child.indexOf('@') === 0) {
+        fs.readdir(path.resolve(dir, "node_modules", child), function (er, scopedChildren) {
+          // error is ok, just means no children.
+          ;(scopedChildren || []).forEach(function (sc) {
+            children.push(child + "/" + sc)
+          })
+          cb()
+        })
+      } else {
+        children.push(child)
+        cb()
+      }
+    }, function (er) {
+      if (er) return cb(er)
+      children = children.filter(function (p) {
+        return !p.match(/^[\._-]/)
+      })
+      next();
+    });
   })
 
   function next () {

--- a/test/tap/dedupe-scoped.js
+++ b/test/tap/dedupe-scoped.js
@@ -1,0 +1,71 @@
+var test = require("tap").test
+  , fs = require("fs")
+  , path = require("path")
+  , existsSync = fs.existsSync || path.existsSync
+  , rimraf = require("rimraf")
+  , mr = require("npm-registry-mock")
+  , common = require("../common-tap.js")
+
+var EXEC_OPTS = {}
+
+test("dedupe finds the common scoped modules and moves it up one level", function (t) {
+  setup(function (s) {
+    common.npm(
+    [
+      "install", ".",
+      "--registry", common.registry
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      scopePackages(function () {
+        t.ifError(err, "successfully installed directory")
+        t.equal(code, 0, "npm install exited with code")
+        common.npm(["dedupe"], {}, function (err, code) {
+          t.ifError(err, "successfully deduped against previous install")
+          t.notOk(code, "npm dedupe exited with code")
+          t.ok(existsSync(path.join(__dirname, "dedupe-scoped", "node_modules", "minimist")))
+          t.ok(!existsSync(path.join(__dirname, "dedupe-scoped", "node_modules", "checker")))
+          s.close() // shutdown mock registry.
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+function setup (cb) {
+  process.chdir(path.join(__dirname, "dedupe-scoped"))
+  mr({port : common.port}, function (er, s) { // create mock registry.
+    rimraf.sync(path.join(__dirname, "dedupe-scoped", "node_modules"))
+    fs.mkdirSync(path.join(__dirname, "dedupe-scoped", "node_modules"))
+    cb(s)
+  })
+}
+
+function scopePackages (cb) {
+  scopeAt("minimist", path.join(__dirname, "dedupe-scoped", "node_modules", "optimist"));
+  scopeAt("minimist", path.join(__dirname, "dedupe-scoped", "node_modules", "clean"));
+  cb();
+}
+
+function scopeAt(pkgName, targetPath) {
+  var pkg, p, p2;
+
+  p = path.join(targetPath, "package.json")
+  pkg = JSON.parse(fs.readFileSync(p).toString())
+  pkg.dependencies["@scoped/" + pkgName] = pkg.dependencies[pkgName]
+  delete pkg.dependencies[pkgName]
+  fs.writeFileSync(p, JSON.stringify(pkg, null, 2))
+
+  p = path.join(targetPath, "node_modules", pkgName, "package.json")
+  pkg = JSON.parse(fs.readFileSync(p).toString())
+  pkg.name = "@scoped/" + pkgName
+  fs.writeFileSync(p, JSON.stringify(pkg, null, 2))
+
+  p = path.join(targetPath, "node_modules", "@scoped")
+  fs.mkdirSync(p)
+
+  p = path.join(targetPath, "node_modules", pkgName)
+  p2 = path.join(targetPath, "node_modules", "@scoped", pkgName)
+  fs.renameSync(p, p2)
+}

--- a/test/tap/dedupe-scoped/package.json
+++ b/test/tap/dedupe-scoped/package.json
@@ -1,0 +1,9 @@
+{
+  "author": "Dedupe tester",
+  "name": "dedupe",
+  "version": "0.0.0",
+  "dependencies": {
+    "optimist": "0.6.0",
+    "clean": "2.1.6"
+  }
+}


### PR DESCRIPTION
WIP.

Scoped packages now get deduped just like unscoped packages.
The fix is in the logic that scans node_modules looking for child packages.

I'm struggling to get a test going for this. As you can see in the PR, I was trying to reuse the `dedupe` and scope the `minimist` package to be `@scoped/minimist` in the setup. However, I think this won't work since dedupe is running `npm install` behind the scenes https://github.com/npm/npm/blob/448efd0eaa6f97af0889bf47efc543a1ea2f8d7e/lib/dedupe.js#L197. So the test is currently failing.
