### PR TITLE
Minor minor tweaks to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
   `glob@4.4.2`: Handle bad symlinks properly.
   ([@isaacs](https://github.com/isaacs))
 
-###E TYPSO & CLARFIICATIONS
+### E TYPSO & CLARFIICATIONS
 
 dId yuo know that submiting fxies for doc tpyos is an exclelent way to get
 strated contriburting to a new open-saurce porject?


### PR DESCRIPTION
GitHub Markdown need space between `###` and title text. See also [v2.7.1 release page](https://github.com/npm/npm/releases/tag/v2.7.1). Thanks.
