### PR TITLE
doc: use perl in `scripts/update-authors.sh` instead of awk

### DIFF
--- a/scripts/update-authors.sh
+++ b/scripts/update-authors.sh
@@ -1,20 +1,18 @@
 #!/bin/sh
 
-git log --reverse --format='%aN <%aE>' | awk '
+git log --reverse --format='%aN <%aE>' | perl -we '
+
 BEGIN {
-  print "# Authors sorted by whether or not they'\''re me";
+  %seen = (), @authors = ();
 }
 
-{
-  if (all[$NF] != 1) {
-    all[$NF] = 1;
-    ordered[length(all)] = $0;
-  }
+while (<>) {
+  next if $seen{$_};
+  $seen{$_} = push @authors, $_;
 }
 
 END {
-  for (i in ordered) {
-    print ordered[i];
-  }
+  print "# Authors sorted by whether or not they'\''re me\n";
+  print @authors;
 }
 ' > AUTHORS


### PR DESCRIPTION
As a consequence of the [various implementations](https://en.wikipedia.org/wiki/AWK#Versions_and_implementations) of AWK across platforms, the use of AWK in `scripts/update-authors.sh` might result in different sorting behavior on different platforms (i.e. BSD awk on OS X does not maintain the desired sort-by-first-contribution). So, let's use perl instead.
