### PR TITLE
run `prepublish` for git url packages

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -15,6 +15,7 @@ var addLocal = require('./add-local.js')
 var realizePackageSpecifier = require('realize-package-specifier')
 var normalizeGitUrl = require('normalize-git-url')
 var randomBytes = require('crypto').pseudoRandomBytes // only need uniqueness
+var readJson = require('read-package-json')
 
 var remotes = path.resolve(npm.config.get('cache'), '_git-remotes')
 var templates = path.join(remotes, '_templates')
@@ -257,6 +258,16 @@ module.exports = function addRemoteGit (uri, silent, cb) {
     )
   }
 
+  // install dependencies and run prepublish script to get dist files
+  // https://github.com/npm/npm/issues/3055
+  function buildPackage (cb) {
+    readJson(path.join(tmpdir, 'package.json'), false, function (er, data) {
+      if (er) return cb(er)
+      if (!data.scripts.prepublish) return cb()
+      npm.commands.install(tmpdir, [], cb)
+    })
+  }
+
   // there is no safe way to do a one-step clone to a treeish that isn't
   // guaranteed to be a branch, so explicitly check out the treeish once it's
   // cloned
@@ -273,32 +284,36 @@ module.exports = function addRemoteGit (uri, silent, cb) {
         }
         log.verbose('addRemoteGit', 'checkout', stdout)
 
-        // convince addLocal that the checkout is a local dependency
-        realizePackageSpecifier(tmpdir, function (er, spec) {
-          if (er) {
-            log.error('addRemoteGit', 'Failed to map', tmpdir, 'to a package specifier')
-            return cb(er)
-          }
+        buildPackage(function (er) {
+          if (er) return cb(er)
 
-          // ensure pack logic is applied
-          // https://github.com/npm/npm/issues/6400
-          addLocal(spec, null, function (er, data) {
-            if (data) {
-              log.verbose('addRemoteGit', 'data._resolved:', resolvedURL)
-              data._resolved = resolvedURL
-
-              // the spec passed to addLocal is not what the user originally requested,
-              // so remap
-              // https://github.com/npm/npm/issues/7121
-              if (!data._fromGitHub) {
-                log.silly('addRemoteGit', 'data._from:', originalURL)
-                data._from = originalURL
-              } else {
-                log.silly('addRemoteGit', 'data._from:', data._from, '(GitHub)')
-              }
+          // convince addLocal that the checkout is a local dependency
+          realizePackageSpecifier(tmpdir, function (er, spec) {
+            if (er) {
+              log.error('addRemoteGit', 'Failed to map', tmpdir, 'to a package specifier')
+              return cb(er)
             }
 
-            cb(er, data)
+            // ensure pack logic is applied
+            // https://github.com/npm/npm/issues/6400
+            addLocal(spec, null, function (er, data) {
+              if (data) {
+                log.verbose('addRemoteGit', 'data._resolved:', resolvedURL)
+                data._resolved = resolvedURL
+
+                // the spec passed to addLocal is not what the user originally requested,
+                // so remap
+                // https://github.com/npm/npm/issues/7121
+                if (!data._fromGitHub) {
+                  log.silly('addRemoteGit', 'data._from:', originalURL)
+                  data._from = originalURL
+                } else {
+                  log.silly('addRemoteGit', 'data._from:', data._from, '(GitHub)')
+                }
+              }
+
+              cb(er, data)
+            })
           })
         })
       }


### PR DESCRIPTION
> When there is a `prepublish` script, the `install` command is run to fetch all dependencies (including development ones) and run the `prepublish` script.
> 
> Fixes #3055

I'd really like feedback on this, I never worked with npm core before and I'm not sure of what I'm doing. But at least it works for the package I tried:

``` json
{
  "dependencies": {
    "es6-denodeify": "valeriangalliat/es6-denodeify"
  }
}
```

Without the fix, I get a `node_modules/es6-denodeify` without `index.js` because it was not compiled (and thus it's not usable), but with this PR, the `index.js` is properly compiled with the `prepublish` script. However it takes longer to install since it fetches all the dependencies (including development ones) in order to run the `prepublish` script (basically it's doing a `npm install` in the cloned directory before packaging it).

Also this step is skipped if there is no `prepublish` script (because it would otherwise uselessly fetch dependencies).

Here's a `diff -w` (much less lines than the GitHub diff):

``` diff
diff --git a/lib/cache/add-remote-git.js b/lib/cache/add-remote-git.js
index 9eaf6b1..0435797 100644
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -15,6 +15,7 @@ var addLocal = require('./add-local.js')
 var realizePackageSpecifier = require('realize-package-specifier')
 var normalizeGitUrl = require('normalize-git-url')
 var randomBytes = require('crypto').pseudoRandomBytes // only need uniqueness
+var readJson = require('read-package-json')

 var remotes = path.resolve(npm.config.get('cache'), '_git-remotes')
 var templates = path.join(remotes, '_templates')
@@ -257,6 +258,16 @@ module.exports = function addRemoteGit (uri, silent, cb) {
     )
   }

+  // install dependencies and run prepublish script to get dist files
+  // https://github.com/npm/npm/issues/3055
+  function buildPackage (cb) {
+    readJson(path.join(tmpdir, 'package.json'), false, function (er, data) {
+      if (er) return cb(er)
+      if (!data.scripts.prepublish) return cb()
+      npm.commands.install(tmpdir, [], cb)
+    })
+  }
+
   // there is no safe way to do a one-step clone to a treeish that isn't
   // guaranteed to be a branch, so explicitly check out the treeish once it's
   // cloned
@@ -273,6 +284,9 @@ module.exports = function addRemoteGit (uri, silent, cb) {
         }
         log.verbose('addRemoteGit', 'checkout', stdout)

+        buildPackage(function (er) {
+          if (er) return cb(er)
+
           // convince addLocal that the checkout is a local dependency
           realizePackageSpecifier(tmpdir, function (er, spec) {
             if (er) {
@@ -301,6 +315,7 @@ module.exports = function addRemoteGit (uri, silent, cb) {
               cb(er, data)
             })
           })
+        })
       }
     )
   }
```
