### PR TITLE
Fix client certificate options being misread

### DIFF
--- a/lib/cache/caching-client.js
+++ b/lib/cache/caching-client.js
@@ -198,8 +198,8 @@ function adaptConfig (config) {
       localAddress : config.get("local-address")
     },
     ssl : {
-      certificate : config.get("cert"),
-      key         : config.get("key"),
+      cert        : fs.readFileSync(config.get("cert")),
+      key         : fs.readFileSync(config.get("key")),
       ca          : config.get("ca"),
       strict      : config.get("strict-ssl")
     },


### PR DESCRIPTION
This pull request is to be able to use client certificates properly with npm, it is a possible fix for https://github.com/npm/npm/issues/7672.
