### PR TITLE
npmconf: don't open a deleted cafile

### DIFF
--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -76,6 +76,7 @@ function load () {
   cb = once(function (er, conf) {
     if (!er)
       exports.loaded = conf
+      loading = false
     loadCbs.forEach(function (fn) {
       fn(er, conf)
     })

--- a/lib/config/load-cafile.js
+++ b/lib/config/load-cafile.js
@@ -9,8 +9,14 @@ function loadCAFile(cafilePath, cb) {
   fs.readFile(cafilePath, "utf8", afterCARead.bind(this))
 
   function afterCARead(er, cadata) {
-    if (er)
+
+    // Previous cafile no longer exists, so just continue on gracefully
+    if (er && er.code === 'ENOENT') {
+      return cb()
+    }
+    if (er) {
       return cb(er)
+    }
 
     var delim = "-----END CERTIFICATE-----"
     var output

--- a/test/tap/config-new-cafile.js
+++ b/test/tap/config-new-cafile.js
@@ -1,0 +1,56 @@
+require('./00-config-setup.js')
+
+var path = require('path')
+var fs = require('graceful-fs')
+var test = require('tap').test
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var osenv = require('osenv')
+var npmconf = require('../../lib/config/core.js')
+
+var dir = path.resolve(__dirname, 'config-new-cafile')
+var beep = path.resolve(dir, 'beep.pem')
+
+test('setup', function (t) {
+  bootstrap()
+  t.end()
+})
+
+test('can set new cafile when old is gone', function (t) {
+  t.plan(5)
+  npmconf.load(function (error, conf) {
+    npmconf.loaded = false
+    t.ifError(error)
+    conf.set('cafile', beep, 'user')
+    conf.save('user', function (error) {
+      t.ifError(error)
+      t.equal(conf.get('cafile'), beep)
+      rimraf.sync(beep)
+      npmconf.load(function (error, conf) {
+        if (error) {
+          throw error
+        }
+        t.equal(conf.get('cafile'), beep)
+        conf.del('cafile')
+        conf.save('user', function (error) {
+          t.ifError(error)
+        })
+      })
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function bootstrap () {
+  mkdirp.sync(dir)
+  fs.writeFileSync(beep, '')
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(dir)
+}


### PR DESCRIPTION
On `npmconf.load`, the current `cafile` is read and if an `ENOENT` is given then `npmconf` just gives up. Since the config is loaded every time one runs `npm`, this can render `npm` completely unusuable:

``` bash
$ npm config set cafile beep.pem
$ rm beep.pem
$ npm
Error: ENOENT: no such file or directory, open '/home/kenan/Code/npm-7656/beep.pem'
    at Error (native)
```

At this point, one would have to manually remove the `cafile` from their `.npmrc`.

This patch fixes this issue by having `npmconf` not just pack up its bags and go home whenever the `cafile` does not exist anymore.

Fixes https://github.com/npm/npm/issues/7656
