### PR TITLE
Incorrect date format in doc-build.sh

### DIFF
--- a/scripts/doc-build.sh
+++ b/scripts/doc-build.sh
@@ -61,7 +61,7 @@ fi
 src=$1
 dest=$2
 name=$(basename ${src%.*})
-date=$(date -u +'%Y-%M-%d %H:%m:%S')
+date=$(date -u +'%Y-%m-%d %H:%M:%S')
 version=$(node cli.js -v)
 
 mkdir -p $(dirname $dest)


### PR DESCRIPTION
In `scripts/doc-build.sh`, the date format simply uses minutes and months at the wrong places.

(credits due to @twillouer for detecting it, I'm just a messenger)
