### PR TITLE
`npm link` uses absolute path

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -127,7 +127,7 @@ function linkPkg (folder, cb_) {
       return cb(er)
     }
     var target = path.resolve(npm.globalDir, d.name)
-    symlink(me, target, function (er) {
+    symlink(me, target, false, true, function (er) {
       if (er) return cb(er)
       log.verbose("link", "build target", target)
       // also install missing dependencies.

--- a/lib/utils/link.js
+++ b/lib/utils/link.js
@@ -16,13 +16,14 @@ function linkIfExists (from, to, gently, cb) {
   })
 }
 
-function link (from, to, gently, cb) {
+function link (from, to, gently, abs, cb) {
+  if (typeof cb !== "function") cb = abs, abs = false
   if (typeof cb !== "function") cb = gently, gently = null
   if (npm.config.get("force")) gently = false
 
   to = path.resolve(to)
   var target = from = path.resolve(from)
-  if (process.platform !== "win32") {
+  if (!abs && process.platform !== "win32") {
     // junctions on windows must be absolute
     target = path.relative(path.dirname(to), from)
     // if there is no folder in common, then it will be much


### PR DESCRIPTION
ref: #7713 

`npm link` fails when there is a symlink between path of npm.

procedure for reproducing:

```
# download node.js
$ mkdir working && cd working
$ wget http://nodejs.org/dist/v0.12.1/node-v0.12.1-darwin-x64.tar.gz
$ tar xzf node-v0.12.1-darwin-x64.tar.gz

# symlink node
$ ln -s `pwd`/node-v0.12.1-darwin-x64 ~/node
$ PATH=~/node/bin:$PATH
$ which npm #=> /usr/local/node/bin/npm
$ npm -v #=> 2.5.1

# run init and link
$ mkdir ../mypackage && cd ../mypackage
$ npm init
$ npm link #=> Error!
```

npm-debug.log is here: https://gist.github.com/hokaccha/631f146431675c70aee2

I think this issue is caused by `path.relative` problem which is not resolve symlinks. I tried symlink behavior:

```
# setup
$ mkdir -p foo bar/baz target
$ ln -s ../bar foo/bar
$ echo 'this is target!!!' > target/file
$ tree
.
├── foo
│   └── bar -> ../bar
├── bar
│   └── baz
└── target
    └── file

# symlink
$ ln -s ../../target foo/bar/baz/target
$ cat foo/bar/baz/target/file
this is target!!!
```

It's not `../../../target`, but `../../target`. Because `foo/bar` is linked to `bar`. However, result of `path.relative` is `../../../target`.

``` javascript
var path = require('path');
var target = path.resolve('./target');
var to = path.resolve('./foo/bar/baz');
console.log(path.relative(to, target));
// => ../../../target
```

Symlink to `../../../target` will fail (`ln` will be success but link is created by wrong path).

```
$ ln -s ../../../target foo/bar/baz/target
$ cat foo/bar/baz/target/file
cat: foo/bar/baz/target/file: No such file or directory
```

This is because `path.relative` does not resolve the symlink.

To solve this problem, using absolute path is better than relative path in `npm link`. This patch passes all tests and #7730.
