### PR TITLE
github: fix the ssh fallback for private github modules

### DIFF
--- a/lib/cache/maybe-github.js
+++ b/lib/cache/maybe-github.js
@@ -13,12 +13,12 @@ module.exports = function maybeGithub (p, cb) {
   return addRemoteGit(parsed.git(), true, function (er, data) {
     if (er) {
       log.info("maybeGithub", "Couldn't clone %s", parsed.git())
-      log.info("maybeGithub", "Now attempting %s from %s", p, parsed.ssh())
+      log.info("maybeGithub", "Now attempting %s from %s", p, parsed.sshurl())
 
-      return addRemoteGit(parsed.ssh(), false, function (er, data) {
+      return addRemoteGit(parsed.sshurl(), false, function (er, data) {
         if (er) return cb(er)
 
-        success(parsed.ssh(), data)
+        success(parsed.sshurl(), data)
       })
     }
 

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "nock": "~1.2.0",
     "npm-registry-couchapp": "~2.6.7",
     "npm-registry-mock": "~1.0.0",
-    "require-inject": "~1.1.0",
+    "require-inject": "~1.2.0",
     "sprintf-js": "~1.0.2",
     "tap": "~0.7.1"
   },

--- a/test/tap/github-shortcut.js
+++ b/test/tap/github-shortcut.js
@@ -1,0 +1,32 @@
+'use strict'
+var requireInject = require('require-inject')
+var test = require('tap').test
+
+test('github-shortcut', function (t) {
+  var cloneUrls = [
+    ['git://github.com/foo/private.git', 'github shortcuts try git:// first'],
+    ['ssh://git@github.com/foo/private.git', 'github shortcuts try ssh:// urls second']
+  ]
+  var npm = requireInject.installGlobally('../../lib/npm.js', {
+    'child_process': {
+      'execFile': function (cmd, args, options, cb) {
+        process.nextTick(function () {
+          if (args[0] !== 'clone') return cb(null, '', '')
+          var cloneUrl = cloneUrls.shift()
+          if (cloneUrl) {
+            t.is(args[3], cloneUrl[0], cloneUrl[1])
+          } else {
+            t.fail('too many attempts to clone')
+          }
+          cb(new Error())
+        })
+      }
+    }
+  })
+
+  npm.load({loglevel: 'silent'}, function () {
+    npm.commands.install(['foo/private'], function (er, result) {
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
This only impacts github modules installed via github shortcuts, eg

```
npm install project/module
```

When the module is marked as private.
