### PR TITLE
fix for 'npm: command not found'

### DIFF
--- a/bin/npm
+++ b/bin/npm
@@ -10,5 +10,5 @@ esac
 if [ -x "$basedir/node.exe" ]; then
   "$basedir/node.exe" "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
 else
-  node "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
+  node "$basedir/npm-cli.js" "$@"
 fi


### PR DESCRIPTION
npm and npm-cli.js are in the same directory
