### PR TITLE
fix: always quote args

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -189,8 +189,7 @@ function run (pkg, wd, cmd, args, cb) {
 function joinArgs (args) {
   var joinedArgs = ""
   args.forEach(function(arg) {
-    if (arg.match(/[ '"]/)) arg = '"' + arg.replace(/"/g, '\\"') + '"'
-    joinedArgs += " " + arg
+    joinedArgs += ' "' + arg.replace(/"/g, '\\"') + '"'
   })
   return joinedArgs
 }

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -111,6 +111,10 @@ test('npm run-script with args that contain double quotes', function (t) {
   common.npm(['run-script', 'start', '--', 'what"s "up"?'], opts, testOutput.bind(null, t, 'what"s "up"?'))
 })
 
+test('npm run-script with args that contain ticks', function (t) {
+  common.npm(['run-script', 'start', '--', 'what\'s \'up\'?'], opts, testOutput.bind(null, t, 'what\'s \'up\'?'))
+})
+
 test('npm run-script with pre script', function (t) {
   common.npm(['run-script', 'with-post'], opts, testOutput.bind(null, t, 'main;post'))
 })


### PR DESCRIPTION
This fixes #7743 by simply always quoting all passed arguments after `--`.

I struggled to write an automated test case, although it's actually quite easy to reproduce.
Put a `package.json` with this content into an empty directory:

```
{
  "name": "test",
  "version": "1.0.0",
  "scripts": {
    "test": "npm run echo -- '*.json'",
    "echo": "echo"
  }
}
```

Without the fix `npm t` will print

```
> test@1.0.0 test /Users/max/projects/npm-test
> npm run echo -- '*.json'

> test@1.0.0 echo /Users/max/projects/npm-test
> echo *.json

package.json
```

With the patch applied, the output is

```
> test@1.0.0 test /Users/max/projects/npm-test
> npm run echo -- '*.json'

> test@1.0.0 echo /Users/max/projects/npm-test
> echo "*.json"

*.json
```

The added test case only asserts that args with `'` get passed on correctly. This already worked without this fix, but it wasn't tested yet.
