### PR TITLE
Fix failing umask-lifecycle tests under Node.js v0.8

### DIFF
--- a/test/tap/umask-lifecycle.js
+++ b/test/tap/umask-lifecycle.js
@@ -10,14 +10,14 @@ var pkg = path.resolve(__dirname, "umask-lifecycle")
 var pj = JSON.stringify({
   name:"x",
   version: "1.2.3",
-  scripts: { umask: "$npm_execpath config get umask && echo \"$npm_config_umask\" && node -p 'process.umask()'" }
+  scripts: { umask: "$npm_execpath config get umask && echo \"$npm_config_umask\" && node -pe 'process.umask()'" }
 }, null, 2) + "\n"
 
 var umask = process.umask()
 var expected = [
   "",
   "> x@1.2.3 umask "+path.join(__dirname, "umask-lifecycle"),
-  "> $npm_execpath config get umask && echo \"$npm_config_umask\" && node -p 'process.umask()'",
+  "> $npm_execpath config get umask && echo \"$npm_config_umask\" && node -pe 'process.umask()'",
   "",
   sprintf("%04o", umask),
   sprintf("%04o", umask),


### PR DESCRIPTION
Under Node.js v0.8, [`node -p` alone does nothing](https://github.com/joyent/node/issues/3938), so I have added `-e`.

This checks off one item on #7842.
