### PR TITLE
Create ENOENT error for Node.js v0.8

### DIFF
--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -11,7 +11,18 @@ function spawn (cmd, args, options) {
     er.file = cmd
     cooked.emit("error", er)
   }).on("close", function (code, signal) {
-    cooked.emit("close", code, signal)
+    // Create ENOENT error because Node.js v0.8 will not emit
+    // an `error` event if the command could not be found.
+    if (code === 127) {
+      var er = new Error('spawn ENOENT')
+      er.code = 'ENOENT'
+      er.errno = 'ENOENT'
+      er.syscall = 'spawn'
+      er.file = cmd
+      cooked.emit('error', er)
+    } else {
+      cooked.emit("close", code, signal)
+    }
   })
 
   cooked.stdin = raw.stdin


### PR DESCRIPTION
`test/tap/spawn-enoent-help.js` did not work under Node.js v0.8 because `spawn` doesn’t emit an `error` event if the command could not be found. Instead, [the documentation recommends to check for `execvp`](http://nodejs.org/dist/v0.8.28/docs/api/child_process.html#child_process_child_process_spawn_command_args_options). However, this would require regex-matching `stderr` and wouldn’t work well with `stdio: ignore`.

Thus, I opted for creating an `ENOENT` error if the exit code is 127 as [it is reserved for “command not found”](http://tldp.org/LDP/abs/html/exitcodes.html).

The output from Node.js v0.8.28 and Node.js v0.10.38 now looks almost identical:

```
$ node bin/npm-cli.js help config
execvp(): No such file or directory
npm ERR! Darwin 13.3.0
npm ERR! argv "node" "/…/npm/bin/npm-cli.js" "help" "config"
npm ERR! node v0.8.28
npm ERR! npm  v2.7.6
npm ERR! file man
npm ERR! code ENOENT
npm ERR! errno ENOENT
npm ERR! syscall spawn

npm ERR! enoent spawn ENOENT
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent 
npm ERR! enoent Check if the file 'man' is present.

npm ERR! Please include the following file with any support request:
npm ERR!     /…/npm/npm-debug.log
```

```
$ node bin/npm-cli.js help config 
npm ERR! Darwin 13.3.0
npm ERR! argv "node" "/…/npm/bin/npm-cli.js" "help" "config"
npm ERR! node v0.10.38
npm ERR! npm  v2.7.6
npm ERR! file man
npm ERR! code ENOENT
npm ERR! errno ENOENT
npm ERR! syscall spawn

npm ERR! enoent spawn ENOENT
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent 
npm ERR! enoent Check if the file 'man' is present.

npm ERR! Please include the following file with any support request:
npm ERR!     /…/npm/npm-debug.log
```

Checks off one item on #7842.
