### PR TITLE
Fix target folders for peerDependencies of scoped packages.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1128,7 +1128,12 @@ function write (target, targetFolder, context, cb_) {
               "in npm 3+. Your application will need to depend on it explicitly."
             ], pd+","+data.name)
         })
-        var pdTargetFolder = path.resolve(targetFolder, "..", "..")
+
+        // Package scopes cause an addditional tree level which needs to be
+        // considered when resolving a peerDependency's target folder.
+        var pdTargetFolder = path.resolve(targetFolder,
+            (target.name[0] === "@" ? "../../.." : "../.."))
+
         var pdContext = context
         if (peerDeps.length > 0) {
           actions.push(

--- a/test/tap/install-scoped-with-peer-dependency.js
+++ b/test/tap/install-scoped-with-peer-dependency.js
@@ -1,0 +1,32 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var path = require("path")
+var fs = require("fs")
+var rimraf = require("rimraf")
+var mkdirp = require("mkdirp")
+var pkg = path.join(__dirname, "install-scoped-with-peer-dependency")
+
+var EXEC_OPTS = { }
+
+test("setup", function (t) {
+  mkdirp.sync(pkg)
+  mkdirp.sync(path.resolve(pkg, "node_modules"))
+  process.chdir(pkg)
+  t.end()
+})
+
+test("it should install peerDependencies in same tree level as the parent package", function(t) {
+  common.npm(["install", "./package"], EXEC_OPTS, function(err, code) {
+    var p = path.resolve(pkg, "node_modules/underscore/package.json")
+    t.ifError(err, "install local package successful")
+    t.equal(code, 0, "npm install exited with code")
+    t.ok(JSON.parse(fs.readFileSync(p, "utf8")))
+    t.end()
+  })
+})
+
+test("cleanup", function(t) {
+  process.chdir(__dirname)
+  rimraf.sync(path.resolve(pkg, "node_modules"))
+  t.end()
+})

--- a/test/tap/install-scoped-with-peer-dependency/package/package.json
+++ b/test/tap/install-scoped-with-peer-dependency/package/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@scope/package",
+  "version": "0.0.0",
+  "peerDependencies": {
+    "underscore": "*"
+  }
+}


### PR DESCRIPTION
Package scopes cause an additional level in the tree structure which
must be considered when resolving the target folders of a package's
peerDependencies.

Fixes #7454.
