### PR TITLE
Tweaks to npm test-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "test-legacy": "node ./test/run.js",
     "test": "tap --timeout 240 test/tap/*.js",
     "tap": "tap --timeout 240 test/tap/*.js",
-    "test-all": "node ./test/run.js && tap --timeout 240 test/tap/*.js",
+    "test-all": "npm run test-legacy && npm test",
     "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rimraf test/*/*/node_modules && make -j8 doc",
     "dumpconf": "env | grep npm | sort | uniq"
   },

--- a/package.json
+++ b/package.json
@@ -182,8 +182,8 @@
   },
   "scripts": {
     "test-legacy": "node ./test/run.js",
-    "test": "tap --timeout 120 test/tap/*.js",
-    "tap": "tap --timeout 120 test/tap/*.js",
+    "test": "tap --timeout 240 test/tap/*.js",
+    "tap": "tap --timeout 240 test/tap/*.js",
     "test-all": "node ./test/run.js && tap --timeout 240 test/tap/*.js",
     "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rimraf test/*/*/node_modules && make -j8 doc",
     "dumpconf": "env | grep npm | sort | uniq"


### PR DESCRIPTION
Updates:
- Sync timeout time of test-all to test and tap in scripts.
- Use an alias of `scripts` and `run-scripts` in `test-all`.

Thanks.
