### PR TITLE
outdated/update: support for private local modules

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -301,7 +301,7 @@ function shouldUpdate (args, dir, dep, has, req, depth, cb, type) {
   }
 
   if (args.length && args.indexOf(dep) === -1) return skip()
-  var parsed = npa(req)
+  var parsed = npa(dep + '@' + req)
   if (parsed.type === "git" || (parsed.hosted && parsed.hosted.type === "github")) {
     return doIt("git", "git")
   }
@@ -313,8 +313,34 @@ function shouldUpdate (args, dir, dep, has, req, depth, cb, type) {
     npm.registry.get(uri, { auth : auth }, updateDeps)
   })
 
+  function updateLocalDeps (latestRegistryVersion) {
+    readJson(path.resolve(parsed.spec, "package.json"), function(er, localD){
+      if(er) return cb()
+      var wanted = localD.version;
+      var latest = localD.version;
+
+      if (latestRegistryVersion) {
+        latest = latestRegistryVersion;
+        if (semver.lt(wanted, latestRegistryVersion)) {
+          wanted = latestRegistryVersion;
+          req = dep + '@' + latest;
+        }
+      }
+
+      if(curr.version !== wanted){
+        doIt(wanted, latest);
+      } else {
+        skip()
+      };
+    });
+  }
+
   function updateDeps (er, d) {
-    if (er) return cb()
+    if (er) {
+      if(parsed.type !== "local") return cb()
+      return updateLocalDeps();
+    }
+
     if (!d || !d["dist-tags"] || !d.versions) return cb()
     var l = d.versions[d["dist-tags"].latest]
     if (!l) return cb()
@@ -355,6 +381,9 @@ function shouldUpdate (args, dir, dep, has, req, depth, cb, type) {
       if (!curr || dFromUrl && cFromUrl && d._from !== curr.from
           || d.version !== curr.version
           || d.version !== l.version) {
+        if (parsed.type === "local") {
+          return updateLocalDeps(l.version);
+        }
         doIt(d.version, l.version)
       }
       else {

--- a/test/tap/outdated-local.js
+++ b/test/tap/outdated-local.js
@@ -1,0 +1,167 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var npm = require("../../")
+var rimraf = require("rimraf")
+var path = require("path")
+var mr = require("npm-registry-mock")
+var osenv = require("osenv")
+var mkdirp = require("mkdirp")
+var fs = require("graceful-fs")
+
+var pkg = path.resolve(__dirname, "outdated-local")
+var pkgLocal = path.resolve(pkg, "local-module")
+var pkgScopedLocal = path.resolve(pkg, "another-local-module")
+var pkgLocalUnderscore = path.resolve(pkg, "underscore")
+var pkgLocalOptimist = path.resolve(pkg, "optimist")
+
+function mocks (server) {
+  server.get("/local-module")
+    .reply(404)
+  server.get("/@scoped%2fanother-local-module")
+    .reply(404)
+}
+
+test("setup", function (t) {
+  bootstrap()
+  t.end()
+})
+
+test("outdated support local modules", function (t) {
+  t.plan(3)
+  process.chdir(pkg)
+  mr({ port : common.port, plugin: mocks }, function (err, s) {
+    npm.load(
+      {
+        loglevel  : "silent",
+        parseable : true,
+        registry  : common.registry
+      },
+      function () {
+        npm.install(".", function (err) {
+          t.ifError(err, "install success")
+          bumpLocalModules()
+          npm.outdated(function (er, d) {
+            t.ifError(er, "outdated success")
+            t.deepEqual(d, [
+              [
+                path.resolve(__dirname, "outdated-local"),
+                "local-module",
+                "1.0.0",
+                "1.1.0",
+                "1.1.0",
+                "file:local-module"
+              ], [
+                path.resolve(__dirname, "outdated-local"),
+                "@scoped/another-local-module",
+                "1.0.0",
+                "1.2.0",
+                "1.2.0",
+                "file:another-local-module"
+              ], [
+              path.resolve(__dirname, "outdated-local"),
+                "underscore",
+                "1.3.1",
+                "1.6.1",
+                "1.5.1",
+                "file:underscore"
+              ], [
+              path.resolve(__dirname, "outdated-local"),
+                "optimist",
+                "0.4.0",
+                "0.6.0",
+                "0.6.0",
+                "optimist@0.6.0"
+              ]
+            ])
+            s.close()
+          })
+        })
+      }
+    )
+  })
+})
+
+test("cleanup", function (t) {
+  cleanup()
+  t.end()
+})
+
+var pjParent = JSON.stringify({
+  name         : "outdated-local",
+  version      : "1.0.0",
+  dependencies : {
+    "local-module" : "file:local-module", // updated locally, not on repo
+    "@scoped/another-local-module" : "file:another-local-module", // updated locally, scoped, not on repo
+    "underscore" : "file:underscore", // updated locally, updated but lesser version on repo
+    "optimist" : "file:optimist" // updated locally, updated and greater version on repo
+  }
+}, null, 2) + "\n"
+
+var pjLocal = JSON.stringify({
+  name         : "local-module",
+  version      : "1.0.0"
+}, null, 2) + "\n"
+
+var pjLocalBumped = JSON.stringify({
+  name         : "local-module",
+  version      : "1.1.0"
+}, null, 2) + "\n"
+
+var pjScopedLocal = JSON.stringify({
+  name         : "@scoped/another-local-module",
+  version      : "1.0.0"
+}, null, 2) + "\n"
+
+var pjScopedLocalBumped = JSON.stringify({
+  name         : "@scoped/another-local-module",
+  version      : "1.2.0"
+}, null, 2) + "\n"
+
+var pjLocalUnderscore = JSON.stringify({
+  name         : "underscore",
+  version      : "1.3.1"
+}, null, 2) + "\n"
+
+var pjLocalUnderscoreBumped = JSON.stringify({
+  name         : "underscore",
+  version      : "1.6.1"
+}, null, 2) + "\n"
+
+var pjLocalOptimist = JSON.stringify({
+  name         : "optimist",
+  version      : "0.4.0"
+}, null, 2) + "\n"
+
+var pjLocalOptimistBumped = JSON.stringify({
+  name         : "optimist",
+  version      : "0.5.0"
+}, null, 2) + "\n"
+
+function bootstrap () {
+  mkdirp.sync(pkg)
+  fs.writeFileSync(path.resolve(pkg, "package.json"), pjParent)
+
+  mkdirp.sync(pkgLocal)
+  fs.writeFileSync(path.resolve(pkgLocal, "package.json"), pjLocal)
+
+  mkdirp.sync(pkgScopedLocal)
+  fs.writeFileSync(path.resolve(pkgScopedLocal, "package.json"), pjScopedLocal)
+
+  mkdirp.sync(pkgLocalUnderscore)
+  fs.writeFileSync(path.resolve(pkgLocalUnderscore, "package.json"), pjLocalUnderscore)
+
+  mkdirp.sync(pkgLocalOptimist)
+  fs.writeFileSync(path.resolve(pkgLocalOptimist, "package.json"), pjLocalOptimist)
+}
+
+function bumpLocalModules () {
+  fs.writeFileSync(path.resolve(pkgLocal, "package.json"), pjLocalBumped)
+  fs.writeFileSync(path.resolve(pkgScopedLocal, "package.json"), pjScopedLocalBumped)
+  fs.writeFileSync(path.resolve(pkgLocalUnderscore, "package.json"), pjLocalUnderscoreBumped)
+  fs.writeFileSync(path.resolve(pkgLocalOptimist, "package.json"), pjLocalOptimistBumped)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}

--- a/test/tap/outdated-private.js
+++ b/test/tap/outdated-private.js
@@ -31,15 +31,16 @@ test("outdated ignores private modules", function (t) {
       function () {
         npm.install(".", function (err) {
           t.ifError(err, "install success")
+          bumpLocalPrivate()
           npm.outdated(function (er, d) {
             t.ifError(er, "outdated success")
             t.deepEqual(d, [[
               path.resolve(__dirname, "outdated-private"),
               "underscore",
               "1.3.1",
-              "1.3.1",
               "1.5.1",
-              "file:underscore"
+              "1.5.1",
+              "underscore@1.5.1"
             ]])
             s.close()
           })
@@ -70,6 +71,12 @@ var pjLocalPrivate = JSON.stringify({
   private      : true
 }, null, 2) + "\n"
 
+var pjLocalPrivateBumped = JSON.stringify({
+  name         : "local-private",
+  version      : "1.1.0",
+  private      : true
+}, null, 2) + "\n"
+
 var pjScopedLocalPrivate = JSON.stringify({
   name         : "@scoped/another-local-private",
   version      : "1.0.0",
@@ -93,6 +100,10 @@ function bootstrap () {
 
   mkdirp.sync(pkgLocalUnderscore)
   fs.writeFileSync(path.resolve(pkgLocalUnderscore, "package.json"), pjLocalUnderscore)
+}
+
+function bumpLocalPrivate () {
+  fs.writeFileSync(path.resolve(pkgLocalPrivate, "package.json"), pjLocalPrivateBumped)
 }
 
 function cleanup () {


### PR DESCRIPTION
Do not ignore them and read the `wanted`+`latest` version from their local `package.json`

This fixes #7426
