### PR TITLE
Make npm init text a little more friendly

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -17,7 +17,7 @@ function init (args, cb) {
   if (!initJson.yes(npm.config)) {
     console.log(
       ["This utility will walk you through creating a package.json file."
-      ,"It only covers the most common items, and tries to guess sane defaults."
+      ,"It only covers the most common items, and tries to guess sensible defaults."
       ,""
       ,"See `npm help json` for definitive documentation on these fields"
       ,"and exactly what they do."


### PR DESCRIPTION
I'm not sure we should use the word "sane" to refer settings etc, it seems a little ableist and there are nicer and more accurate words we could use instead.

_Personally it gets me a little down every time I make a new package._
