### PR TITLE
Use HTTP_PROXY and HTTPS_PROXY env vars if available

### DIFF
--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -349,7 +349,8 @@ Conf.prototype.addEnv = function (env) {
   env = env || process.env
   var conf = {}
   Object.keys(env)
-    .filter(function (k) { return k.match(/^npm_config_/i) })
+    .filter(function (k) { return k.match(/^npm_config_/i)
+      || k.toLowerCase().match(/^https?_proxy$/i) })
     .forEach(function (k) {
       if (!env[k])
         return
@@ -358,8 +359,13 @@ Conf.prototype.addEnv = function (env) {
       // it is a "_" - convert all other to "-"
       var p = k.toLowerCase()
                .replace(/^npm_config_/, "")
+               .replace(/^http_proxy$/, "proxy")
                .replace(/(?!^)_/g, "-")
-      conf[p] = env[k]
+              
+      //we don't want http(s)_proxy to overwrite the npm_config_*
+      if(!(k.toLowerCase().match(/^https?_proxy$/i) && p in conf)){
+          conf[p] = env[k]
+      }
     })
   return CC.prototype.addEnv.call(this, "", conf, "env")
 }


### PR DESCRIPTION
- rename `http_proxy` to `proxy` to keep npm vocabulary
- don't overwrite the npm_config_(https)_proxy if set

Fix https://github.com/npm/npm/issues/8011

Also, I had some idea to improve the PR : (I decided to do a minimal commit first)
- add a test
- https_proxy inherit from http_proxy by default
- handle it in a separate function (get_http_proxy)
