### PR TITLE
Version prefix should be a config param rather than a magic string

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -804,6 +804,17 @@ it will install the specified tag.
 Also the tag that is added to the package@version specified by the `npm
 tag` command, if no explicit tag is given.
 
+### tag-version-prefix
+
+* Default: `"v"`
+* Type: string
+
+If set, alters the prefix used when tagging a new version when performing a
+version increment using  `npm-version`.
+
+Only use this property if it is absolutely necessary.  Use of this property
+can break unrelated features, and should be avoided if possible.
+
 ### tmp
 
 * Default: TMPDIR environment variable, or "/tmp"

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -196,6 +196,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , spin: true
     , "strict-ssl": true
     , tag : "latest"
+    , "tag-version-prefix" : "v"
     , tmp : temp
     , unicode : true
     , "unsafe-perm" : process.platform === "win32"
@@ -308,6 +309,7 @@ exports.types =
   , userconfig : path
   , umask: Umask
   , version : Boolean
+  , "tag-version-prefix" : String
   , versions : Boolean
   , viewer: String
   , _exit : Boolean

--- a/lib/version.js
+++ b/lib/version.js
@@ -155,7 +155,7 @@ function commit (version, hasShrinkwrap, cb) {
       git.chainableExec([ "add", "package.json" ], options),
       hasShrinkwrap && git.chainableExec([ "add", "npm-shrinkwrap.json" ] , options),
       git.chainableExec([ "commit", "-m", message ], options),
-      git.chainableExec([ "tag", "v" + version, flag, message ], options)
+      git.chainableExec([ "tag", npm.config.get("tag-version-prefix") + version, flag, message ], options)
     ],
     cb
   )

--- a/test/tap/tag-version-prefix.js
+++ b/test/tap/tag-version-prefix.js
@@ -1,0 +1,88 @@
+var common = require('../common-tap.js')
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var npm = require('../../lib/npm.js')
+
+var pkg = path.resolve(__dirname, 'version-message-config')
+var cache = path.resolve(pkg, 'cache')
+var npmrc = path.resolve(pkg, '.npmrc')
+var packagePath = path.resolve(pkg, 'package.json')
+
+var json = { name: 'blah', version: '0.1.2' }
+
+var configContents = 'sign-git-tag=false\nmessage=":bookmark: %s"\n'
+
+test('npm version <semver> with message config', function (t) {
+    setup()
+
+    npm.load({ prefix: pkg, userconfig: npmrc }, function () {
+        var git = require('../../lib/utils/git.js')
+
+        common.makeGitRepo({ path: pkg }, function (er) {
+            t.ifErr(er, 'git bootstrap ran without error')
+
+            common.npm([
+                'config',
+                'set',
+                'tag-version-prefix',
+                'q'
+            ], { cwd: pkg, env: { PATH: process.env.PATH } },
+            function (err, code, stdout, stderr) {
+                t.ifError(err, 'npm config ran without issue')
+                t.notOk(code, 'exited with a non-error code')
+                t.notOk(stderr, 'no error output')
+
+                common.npm(
+                    [
+                        'version',
+                        'patch',
+                        '--loglevel', 'silent'
+                        // package config is picked up from env
+                    ],
+                    { cwd: pkg, env: { PATH: process.env.PATH } },
+                    function (err, code, stdout, stderr) {
+                        t.ifError(err, 'npm version ran without issue')
+                        t.notOk(code, 'exited with a non-error code')
+                        t.notOk(stderr, 'no error output')
+
+                        git.whichAndExec(
+                            ['tag'],
+                            { cwd: pkg, env: process.env },
+                            function (er, tags, stderr) {
+                                t.ok(tags.match(/q0\.1\.3/g), 'tag was created by version' + tags)
+                                t.end()
+                            }
+                        )
+                    }
+                )
+            })
+        })
+    })
+})
+
+test('cleanup', function (t) {
+    cleanup()
+    t.end()
+})
+
+function cleanup () {
+    // windows fix for locked files
+    process.chdir(osenv.tmpdir())
+
+    rimraf.sync(pkg)
+}
+
+function setup () {
+    cleanup()
+    mkdirp.sync(cache)
+    process.chdir(pkg)
+
+    fs.writeFileSync(packagePath, JSON.stringify(json), 'utf8')
+    fs.writeFileSync(npmrc, configContents, 'ascii')
+}


### PR DESCRIPTION
My workplace does not use the "v" prefix for our versioning, which means I cannot use npm version.  While this is ultimately a mere inconvenience, it'd be nice if npm was not opinionated on this subject.
