### PR TITLE
Creating `lib` directory before installing

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -193,19 +193,8 @@ function Installer (where, dryrun, args) {
 }
 Installer.prototype = {}
 
-Installer.prototype.prepareBaselineConditions = function (cb) {
-  validate('F', arguments)
-  log.silly('install', 'prepareBaselineConditions')
-
-  chain([
-    // Fix for https://github.com/npm/npm/issues/8020
-    [mkdirp, this.where],
-  ], cb)
-}
-
 Installer.prototype.run = function (cb) {
   validate('F', arguments)
-  this.newTracker(log, 'prepareBaselineConditions', 4)
   this.newTracker(log, 'loadCurrentTree', 4)
   this.newTracker(log, 'loadIdealTree', 12)
   this.newTracker(log, 'generateActionsToTake')
@@ -214,9 +203,6 @@ Installer.prototype.run = function (cb) {
 
   var steps = []
   steps.push(
-    [this, this.prepareBaselineConditions],
-    [this, this.finishTracker, 'prepareBaselineConditions'],
-
     [this, this.loadCurrentTree],
     [this, this.finishTracker, 'loadCurrentTree'],
 
@@ -415,26 +401,28 @@ Installer.prototype.readLocalPackageData = function (cb) {
   validate('F', arguments)
   log.silly('install', 'readLocalPackageData')
   var self = this
-  readPackageTree(this.where, iferr(cb, function (currentTree) {
-    self.currentTree = currentTree
-    if (!self.noPackageJsonOk && !currentTree.package) {
-      log.error('install', "Couldn't read dependencies")
-      var er = new Error("ENOENT, open '" + path.join(self.where, 'package.json') + "'")
-      er.code = 'ENOPACKAGEJSON'
-      er.errno = 34
-      return cb(er)
-    }
-    if (!currentTree.package) currentTree.package = {}
-    if (currentTree.package._shrinkwrap) return cb()
-    fs.readFile(path.join(self.where, 'npm-shrinkwrap.json'), {encoding: 'utf8'}, function (er, data) {
-      if (er) return cb()
-      try {
-        currentTree.package._shrinkwrap = JSON.parse(data)
-      } catch (ex) {
-        return cb(ex)
-      }
-      return cb()
-    })
+  mkdirp(this.where, iferr(cb, function() {
+    readPackageTree(self.where, iferr(cb, function (currentTree) {
+        self.currentTree = currentTree
+        if (!self.noPackageJsonOk && !currentTree.package) {
+        log.error('install', "Couldn't read dependencies")
+        var er = new Error("ENOENT, open '" + path.join(self.where, 'package.json') + "'")
+        er.code = 'ENOPACKAGEJSON'
+        er.errno = 34
+        return cb(er)
+        }
+        if (!currentTree.package) currentTree.package = {}
+        if (currentTree.package._shrinkwrap) return cb()
+        fs.readFile(path.join(self.where, 'npm-shrinkwrap.json'), {encoding: 'utf8'}, function (er, data) {
+        if (er) return cb()
+        try {
+            currentTree.package._shrinkwrap = JSON.parse(data)
+        } catch (ex) {
+            return cb(ex)
+        }
+        return cb()
+        })
+    }))
   }))
 
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -193,8 +193,19 @@ function Installer (where, dryrun, args) {
 }
 Installer.prototype = {}
 
+Installer.prototype.prepareBaselineConditions = function (cb) {
+  validate('F', arguments)
+  log.silly('install', 'prepareBaselineConditions')
+
+  chain([
+    // Fix for https://github.com/npm/npm/issues/8020
+    [mkdirp, this.where],
+  ], cb)
+}
+
 Installer.prototype.run = function (cb) {
   validate('F', arguments)
+  this.newTracker(log, 'prepareBaselineConditions', 4)
   this.newTracker(log, 'loadCurrentTree', 4)
   this.newTracker(log, 'loadIdealTree', 12)
   this.newTracker(log, 'generateActionsToTake')
@@ -203,6 +214,9 @@ Installer.prototype.run = function (cb) {
 
   var steps = []
   steps.push(
+    [this, this.prepareBaselineConditions],
+    [this, this.finishTracker, 'prepareBaselineConditions'],
+
     [this, this.loadCurrentTree],
     [this, this.finishTracker, 'loadCurrentTree'],
 


### PR DESCRIPTION
The problem was identified to be the missing `lib` directory when the installation of npm begins. So, we manually create the directory before proceeding with the installation.

This has been introduced as a separate function because, [once we figure out all the baseline conditions](https://github.com/npm/npm/issues/8020#issuecomment-94860080), we can satisfy all the conditions in this function itself.
