### PR TITLE
run-script: completion only prints local scripts

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -13,7 +13,6 @@ runScript.completion = function (opts, cb) {
 
   // see if there's already a package specified.
   var argv = opts.conf.argv.remain
-    , installedShallow = require("./utils/completion/installed-shallow.js")
 
   if (argv.length >= 4) return cb()
 
@@ -41,33 +40,11 @@ runScript.completion = function (opts, cb) {
     })
   }
 
-  // complete against the installed-shallow, and the pwd's scripts.
-  // but only packages that have scripts
-  var installed
-    , scripts
-  installedShallow(opts, function (d) {
-    return d.scripts
-  }, function (er, inst) {
-    installed = inst
-    next()
-  })
-
-  if (npm.config.get("global")) {
-    scripts = []
-    next()
-  }
-  else readJson(path.join(npm.localPrefix, "package.json"), function (er, d) {
+  readJson(path.join(npm.localPrefix, "package.json"), function (er, d) {
     if (er && er.code !== "ENOENT" && er.code !== "ENOTDIR") return cb(er)
     d = d || {}
-    scripts = Object.keys(d.scripts || {})
-    next()
+    cb(null, Object.keys(d.scripts || {}))
   })
-
-  function next () {
-    if (!installed || !scripts) return
-
-    cb(null, scripts.concat(installed))
-  }
 }
 
 function runScript (args, cb) {


### PR DESCRIPTION
Remove the `installed-shallow` logic so that only scripts of the pwd package.json are considered for completion. This might fix #7973.

I'm not sure if I'm overlooking a use case here. It's also quite a lot of work to bootstrap test cases for completion since there's nothing there yet. This make me feel uncomfortable deleting a whole code branch, but currently the run-script completions produce a lot of garbage on my machine.
