### PR TITLE
'hosted' is Git

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -892,7 +892,7 @@ function targetResolver (where, context, deps, devDeps) {
         return cb(null, [])
       }
 
-      var isGit = npa(what).type === "git"
+      var isGit = (npa(what).type === "git" || npa(what).type === "hosted")
 
       if (!er &&
           data &&
@@ -918,7 +918,7 @@ function installOne (target, where, context, cb) {
   // the --link flag makes this a "link" command if it's at the
   // the top level.
   var isGit = false
-  if (target && target._from) isGit = npa(target._from).type === 'git'
+  if (target && target._from) isGit = (npa(target._from).type === 'git' || npa(target._from).type === 'hosted')
 
   if (where === npm.prefix && npm.config.get("link")
       && !npm.config.get("global") && !isGit) {


### PR DESCRIPTION
I found this error in run npm install.

```
$ npm install --link git://github.com/ysimonson/grunt-jsfmt.git

# ...

npm ERR! 404 Not Found: grunt-jsfmt
npm ERR! 404
npm ERR! 404 'grunt-jsfmt' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
npm verb exit [ 1, true ]
```

`grunt-jsfmt` is not exist in npm registry. But git repo exists.

https://github.com/ysimonson/grunt-jsfmt

In this case, installed when disable `link` option will succeed.

```
$ npm install --no-link git://github.com/ysimonson/grunt-jsfmt

grunt-jsfmt@0.0.2 node_modules/grunt-jsfmt
└── jsfmt@0.4.0 (underscore@1.6.0, tmp@0.0.25, docopt@0.4.1, rc@0.5.5, esformatter-braces@0.1.7, esprima@1.1.0-dev-harmony, escodegen@1.3.3, rocambole@0.3.6, falafel@0.3.1, glob@4.0.6, esformatter@0.4.3)
```

This problem probably not occur if was registered to npm  already.

```
$ npm  install --link https://github.com/request/request.git
```

I saw this error be eventually call `getOnceFromRegistry` if enabled `--link`
https://github.com/npm/npm/blob/c3744baf2e4a140ada61c71fb4725804cec0f7e8/lib/cache/add-named.js#L116

I have an impression that fix this error need change `isGit`.
