### PR TITLE
Add missing etc/ to $PREFIX-path in npmrc.md

### DIFF
--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -17,7 +17,7 @@ The four relevant files are:
 
 * per-project config file (/path/to/my/project/.npmrc)
 * per-user config file (~/.npmrc)
-* global config file ($PREFIX/npmrc)
+* global config file ($PREFIX/etc/npmrc)
 * npm builtin config file (/path/to/npm/npmrc)
 
 All npm config files are an ini-formatted list of `key = value`


### PR DESCRIPTION
Added missing etc/ to the $PREFIX line at the top of the file.
