### PR TITLE
config: null uri props in nerf-dart

### DIFF
--- a/lib/config/nerf-dart.js
+++ b/lib/config/nerf-dart.js
@@ -13,11 +13,11 @@ module.exports = toNerfDart
  */
 function toNerfDart(uri) {
   var parsed = url.parse(uri)
-  delete parsed.protocol
-  delete parsed.auth
-  delete parsed.query
-  delete parsed.search
-  delete parsed.hash
+  parsed.protocol = null
+  parsed.auth = null
+  parsed.query = null
+  parsed.search = null
+  parsed.hash = null
 
   return url.resolve(url.format(parsed), ".")
 }


### PR DESCRIPTION
Deleting a uri's properties will not work anymore in io.js 2.0.0 as the properties are now getters/setters and deleting them will delete the getters/setters themselves from the instance. Nulling the properties has the same effect, while also bringing a performance gain over `delete`.

Related: https://github.com/iojs/io.js/issues/1591
