### PR TITLE
Clarify license metadata guidelines

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -120,23 +120,30 @@ idea to include a LICENSE file at the top level of the package.
 Some old packages used license objects or a "licenses" property containing an
 array of license objects:
 
+    // Not valid metadata
     { "license" :
-      { "type" : "MIT"
-      , "url" : "http://opensource.org/licenses/MIT"
+      { "type" : "ISC"
+      , "url" : "http://opensource.org/licenses/ISC"
       }
-	}
+    }
 
+    // Not valid metadata
     { "licenses" :
       [
-        { "type" : "MIT"
-        , "url" : "http://opensource.org/licenses/MIT"
+        { "type": "MIT"
+        , "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      , { "type": "Apache-2.0"
+        , "url": "http://opensource.org/licenses/apache2.0.php"
         }
       ]
     }
 
-Those styles are now deprecated. Instead, use an SPDX expression, like this:
+Those styles are now deprecated. Instead, use SPDX expressions, like this:
 
-    { "license": "MIT" }
+    { "license": "ISC" }
+
+    { "license": "(MIT OR Apache-2.0)" }
 
 ## people fields: author, contributors
 

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -134,7 +134,9 @@ array of license objects:
       ]
     }
 
-Those styles are now deprecated.
+Those styles are now deprecated. Instead, use an SPDX expression, like this:
+
+    { "license": "MIT" }
 
 ## people fields: author, contributors
 

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -98,9 +98,8 @@ If a url is provided, it will be used by the `npm bugs` command.
 You should specify a license for your package so that people know how they are
 permitted to use it, and any restrictions you're placing on it.
 
-The simplest way, assuming you're using a common license such as BSD-3-Clause
-or MIT, is to just specify the standard SPDX ID of the license you're using,
-like this:
+If you're using a common license such as BSD-2-Clause or MIT, add a
+current SPDX license identifier for the license you're using, like this:
 
     { "license" : "BSD-3-Clause" }
 
@@ -108,8 +107,34 @@ You can check [the full list of SPDX license IDs](https://spdx.org/licenses/).
 Ideally you should pick one that is
 [OSI](http://opensource.org/licenses/alphabetical) approved.
 
-It's also a good idea to include a LICENSE file at the top level in
-your package.
+If your package is licensed under multiple common licenses, use an SPDX license
+expression syntax version 2.0 string, like this:
+
+    { "license" : "(ISC OR GPL-3.0)" }
+
+If you are using a license that hasn't been assigned an SPDX identifier, or if
+you are using an uncommon or custom license, do not include a "license" string
+in package.json. In those cases especially, but also more generally, it's a good
+idea to include a LICENSE file at the top level of the package.
+
+Some old packages used license objects or a "licenses" property containing an
+array of license objects:
+
+    { "license" :
+      { "type" : "MIT"
+      , "url" : "http://opensource.org/licenses/MIT"
+      }
+	}
+
+    { "licenses" :
+      [
+        { "type" : "MIT"
+        , "url" : "http://opensource.org/licenses/MIT"
+        }
+      ]
+    }
+
+Those styles are now deprecated.
 
 ## people fields: author, contributors
 

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -107,8 +107,8 @@ You can check [the full list of SPDX license IDs](https://spdx.org/licenses/).
 Ideally you should pick one that is
 [OSI](http://opensource.org/licenses/alphabetical) approved.
 
-If your package is licensed under multiple common licenses, use an SPDX license
-expression syntax version 2.0 string, like this:
+If your package is licensed under multiple common licenses, use an [SPDX license
+expression syntax version 2.0 string](http://npmjs.com/package/spdx), like this:
 
     { "license" : "(ISC OR GPL-3.0)" }
 

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -113,9 +113,11 @@ expression syntax version 2.0 string](http://npmjs.com/package/spdx), like this:
     { "license" : "(ISC OR GPL-3.0)" }
 
 If you are using a license that hasn't been assigned an SPDX identifier, or if
-you are using an uncommon or custom license, do not include a "license" string
-in package.json. In those cases especially, but also more generally, it's a good
-idea to include a LICENSE file at the top level of the package.
+you are using a custom license, use the following valid SPDX expression:
+
+    { "license" : "LicenseRef-LICENSE" }
+
+Then include a LICENSE file at the top level of the package. 
 
 Some old packages used license objects or a "licenses" property containing an
 array of license objects:


### PR DESCRIPTION
This PR changes the documentation visible with `npm help 7 package.json` to make a few clarifications about license metadata in `package.json`:
1. `"license"` should be a string SPDX license expression. Thus `"GNU Public License"` is not good metadata,  while `"GPL-3.0"` is fine. So is `"(MIT OR GPL-2.0)"` for a "multi-licensed" project.
2. Old-style `{type:..., url:...}` objects and `"licenses"` arrays are deprecated.
3. If you're non-standard enough that SPDX expressions don't do it, leave `"license"` out, and make sure you include a `LICENSE` file in the package.

There are a couple of open issues on point, both of which would benefit by an official word: #6241 and #4473.

I have also opened PRs to make SPDX expression validation part of `npm init` and metadata normalization: npm/init-package-json#42 and npm/normalize-package-data#61.

There are several ways to to specify machine-readable license metadata that would seem "right". Past affirmatively requiring a valid SPDX identifier, it's a bikeshed, since so few projects are multi-licensed. Some important ones are, but they are few.

I only bring this up early because so many of the most-used npm packages are older, and haven't had their metadata updated since the `licenses: [{...}]` days. Normalizing those packages would help spread the word, and give us a shot at making machine-readable licensing the norm on npm.
