### PR TITLE
git: resolved git URLs can be 'git' *or* 'hosted'

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -293,8 +293,9 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
 
   // add giturl to name@version
   if (data._resolved) {
-    if (npa(data._resolved).type === "git")
-      out.label += " (" + data._resolved + ")"
+    var type = npa(data._resolved).type
+      , isGit = (type === "git" || type === "hosted")
+    if (isGit) out.label += " (" + data._resolved + ")"
   }
 
   if (long) {


### PR DESCRIPTION
The command `npm ls` was not displaying the resolved git URL for hosted URLs.

Here's a quick before and after:

```
~/Desktop ⚡ npm install -g https://github.com/npm/npm.git
/usr/local/bin/npm -> /usr/local/lib/node_modules/npm/bin/npm-cli.js
npm@2.9.1 /usr/local/lib/node_modules/npm
~/Desktop ⚡ npm ls -g npm
/usr/local/lib
└── npm@2.9.1 

~/Desktop ⚡ npm install -g git://github.com/zornme/npm.git
/usr/local/bin/npm -> /usr/local/lib/node_modules/npm/bin/npm-cli.js
npm@2.9.1 /usr/local/lib/node_modules/npm
~/Desktop ⚡ npm ls -g npm
/usr/local/lib
└── npm@2.9.1  (git://github.com/zornme/npm.git#45c2b1aaa051733fa352074994ae6e569fd51e8b)
```
