### PR TITLE
fixes broken http auth install

### DIFF
--- a/lib/utils/map-to-registry.js
+++ b/lib/utils/map-to-registry.js
@@ -46,7 +46,10 @@ function mapToRegistry(name, config, cb) {
   log.silly("mapToRegistry", "registry", registry)
 
   var auth = config.getCredentialsByURI(registry)
-
+  //get auth data from uri for remote type
+  if (data.type === "remote") {
+    auth = config.getCredentialsByURI(data.spec)
+  }
   // normalize registry URL so resolution doesn't drop a piece of registry URL
   var normalized = registry.slice(-1) !== "/" ? registry+"/" : registry
   var uri = url.resolve(normalized, name)

--- a/lib/utils/map-to-registry.js
+++ b/lib/utils/map-to-registry.js
@@ -47,7 +47,7 @@ function mapToRegistry(name, config, cb) {
 
   var auth = config.getCredentialsByURI(registry)
   //get auth data from uri for remote type
-  if (data.type === "remote") {
+  if (data.type === "remote" && !data.scope) {
     auth = config.getCredentialsByURI(data.spec)
   }
   // normalize registry URL so resolution doesn't drop a piece of registry URL


### PR DESCRIPTION
http auth install for dependencies like:
"package": "http://user:password@server/npmrepo/package-0.1.2.tgz" 
 is broken since 2.1.17 or 6b7c5eca6b65e1247d0e51f6400cf

I'm not sure if maptoregistry should be used at all for packages of type remote, but if so, the auth data should be pulled from the uri and not from the registry
