### PR TITLE
deps: remove unused foo.js & bar.js from lru-cache

### DIFF
--- a/node_modules/lru-cache/bar.js
+++ b/node_modules/lru-cache/bar.js
@@ -1,1 +1,0 @@
-console.log("bar");module.exports = "bar"; require("./foo.js")

--- a/node_modules/lru-cache/foo.js
+++ b/node_modules/lru-cache/foo.js
@@ -1,1 +1,0 @@
-console.log(require("."))


### PR DESCRIPTION
These files are not found in https://github.com/isaacs/node-lru-cache and appear to have been erroneously committed in https://github.com/npm/npm/commit/530a2e369128270f3e098f0e9be061533003b0eb.

(see also: https://github.com/iojs/io.js/pull/1658#discussion_r29950685)
