### PR TITLE
Improve shasum check sanity

### DIFF
--- a/lib/cache/add-remote-tarball.js
+++ b/lib/cache/add-remote-tarball.js
@@ -86,12 +86,10 @@ function fetchAndShaCheck (u, tmp, shasum, auth, cb) {
 
     tarball.on("finish", function () {
       if (!shasum) {
-        // Well, we weren't given a shasum, so at least sha what we have
-        // in case we want to compare it to something else later
-        return sha.get(tmp, function (er, shasum) {
-          log.silly("fetchAndShaCheck", "shasum", shasum)
-          cb(er, response, shasum)
-        })
+        // We weren't given a shasum, so set value as empty.
+        // This will cause the check below to fail while
+        // ensuring that `shasum` is indeed of type string.
+        shasum = ""
       }
 
       // validate that the url we just downloaded matches the expected shasum.


### PR DESCRIPTION
Previously, npm's behavior in case it did not receive a shasum was to:
1. Itself generate a shasum for whatever package is downloaded over HTTP,
2. Cache this arbitrary shasum as a valid, genuine shasum, exactly as if it was sent via TLS from `registry.npmjs.com`.

I would argue that this behavior is not reasonable. Instead, npm should insist on a shasum being delivered and do diligent comparison for any requested packages, without exception.

I am a new contributor to this project, so please excuse me in case I am missing something. I have done some testing, however, and feel this solution is legitimate. I also look forward to investigating in the future the possibility of adding feasible, easy to use code-signing features into npm.
