### PR TITLE
brings coverage on access.js from 63% to 95%

### DIFF
--- a/lib/access.js
+++ b/lib/access.js
@@ -119,5 +119,5 @@ function ls (args, cb) {
 }
 
 function edit (args, cb) {
-  return cb(new Error("npm edit ls isn't implemented yet!"))
+  return cb(new Error("npm access edit isn't implemented yet!"))
 }

--- a/test/tap/access.js
+++ b/test/tap/access.js
@@ -83,6 +83,102 @@ test("npm access on named package", function (t) {
   )
 })
 
+test("npm change access on unscoped package", function (t) {
+  common.npm(
+    [
+      "access",
+      "restricted", "yargs",
+      "--registry", common.registry
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ok(code, 'exited with Error')
+      t.ok(stderr.match(/you can't change the access level of unscoped packages/))
+      t.end()
+    }
+  )
+})
+
+test('npm access add', function (t) {
+  common.npm(
+    [
+      "access",
+      "add", "@scoped/another",
+      "--registry", common.registry
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ok(code, 'exited with Error')
+      t.ok(stderr.match(/npm access add isn't implemented yet!/))
+      t.end()
+    }
+  )
+})
+
+test('npm access rm', function (t) {
+  common.npm(
+    [
+      "access",
+      "rm", "@scoped/another",
+      "--registry", common.registry
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ok(code, 'exited with Error')
+      t.ok(stderr.match(/npm access rm isn't implemented yet!/))
+      t.end()
+    }
+  )
+})
+
+test('npm access ls', function (t) {
+  common.npm(
+    [
+      "access",
+      "ls", "@scoped/another",
+      "--registry", common.registry
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ok(code, 'exited with Error')
+      t.ok(stderr.match(/npm access ls isn't implemented yet!/))
+      t.end()
+    }
+  )
+})
+
+test('npm access edit', function (t) {
+  common.npm(
+    [
+      "access",
+      "edit", "@scoped/another",
+      "--registry", common.registry
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ok(code, 'exited with Error')
+      t.ok(stderr.match(/npm access edit isn't implemented yet!/))
+      t.end()
+    }
+  )
+})
+
+test('npm access blerg', function (t) {
+  common.npm(
+    [
+      "access",
+      "blerg", "@scoped/another",
+      "--registry", common.registry
+    ],
+    { cwd : pkg },
+    function (er, code, stdout, stderr) {
+      t.ok(code, 'exited with Error')
+      t.ok(stderr.match(/Usage:/))
+      t.end()
+    }
+  )
+})
+
 test("cleanup", function (t) {
   t.pass("cleaned up")
   rimraf.sync(pkg)


### PR DESCRIPTION
As a test of the validity of the code coverage reports that are now being generated, I brought the test coverage on access.js from 65% to 95%.

https://gist.github.com/bcoe/6ada958113bc755dc3d7

I found a small typo going through this exercise.
