### PR TITLE
cache: fix error messages for private registries

### DIFF
--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -17,6 +17,17 @@ var path = require("path")
 module.exports = addNamed
 
 function getOnceFromRegistry (name, from, next, done) {
+  function fixName(err, data, json, resp) {
+    if (err && err.pkgid && err.pkgid !== name) {
+      err.message = err.message.replace(
+        new RegExp(": " + err.pkgid.replace(/(\W)/g, "\\$1") + "$"),
+        ": " + name
+      )
+      err.pkgid = name
+    }
+    next(err, data, json, resp)
+  }
+
   mapToRegistry(name, npm.config, function (er, uri, auth) {
     if (er) return done(er)
 
@@ -25,7 +36,7 @@ function getOnceFromRegistry (name, from, next, done) {
     if (!next) return log.verbose(from, key, "already in flight; waiting")
     else log.verbose(from, key, "not in flight; fetching")
 
-    npm.registry.get(uri, { auth : auth }, next)
+    npm.registry.get(uri, { auth : auth }, fixName)
   })
 }
 

--- a/test/tap/404-private-registry.js
+++ b/test/tap/404-private-registry.js
@@ -1,0 +1,22 @@
+var nock = require("nock")
+var test = require("tap").test
+var npm = require("../../")
+var addNamed = require("../../lib/cache/add-named")
+
+test("should error", function test404(t) {
+  nock("http://localhost:1337")
+    .get("/registry/foo")
+    .reply(404, {
+      error: "not_found",
+      reason: "document not found"
+    })
+
+  npm.load({registry: "http://localhost:1337/registry", global: true}, function () {
+    addNamed("foo", "*", null, function checkError(err) {
+      t.ok(err, "should error")
+      t.equal(err.message, "404 Not Found: foo", "should have package name in error")
+      t.equal(err.pkgid, "foo", "err.pkgid should match package name")
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
When trying to install a package from a registry that is not hosted at the domain root (eg: `http://localhost:1337/registry`) 404s will result in an error that says module registry was not found rather than the actual module name, this is due to registry-client not knowing how to determine the package name from a request, and falling back to grabbing the first segment.  see https://github.com/npm/npm-registry-client/issues/80 
