### PR TITLE
version: put a hook for version to lifecycle

### DIFF
--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -40,6 +40,14 @@ in your git config for this to work properly.  For example:
 
     Enter passphrase:
 
+If "preversion", "version", "postversion" in the "scripts" property of
+the package.json, it will execute by running `npm version`. preversion
+and version ware executed before bump the package version, postversion
+was executed after bump the package version. For example to run `npm version`
+after passed all test:
+
+    "scripts": { "preversion": "npm test" }
+
 ## CONFIGURATION
 
 ### git-tag-version
@@ -52,6 +60,8 @@ Commit and tag the version change.
 ## SEE ALSO
 
 * npm-init(1)
+* npm-run-script(1)
+* npm-scripts(7)
 * package.json(5)
 * semver(7)
 * config(7)

--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -19,6 +19,10 @@ following scripts:
   Run BEFORE the package is uninstalled.
 * postuninstall:
   Run AFTER the package is uninstalled.
+* preversion, version:
+  Run BEFORE bump the package version.
+* postversion:
+  Run AFTER bump the package version.
 * pretest, test, posttest:
   Run by the `npm test` command.
 * prestop, stop, poststop:

--- a/lib/version.js
+++ b/lib/version.js
@@ -11,6 +11,7 @@ var semver = require("semver")
   , npm = require("./npm.js")
   , git = require("./utils/git.js")
   , assert = require("assert")
+  , lifecycle = require("./utils/lifecycle.js")
 
 version.usage = "npm version [<newversion> | major | minor | patch | prerelease | preminor | premajor ]\n"
               + "\n(run in package dir)\n"
@@ -26,11 +27,6 @@ function version (args, silent, cb_) {
 
   var packagePath = path.join(npm.localPrefix, "package.json")
   fs.readFile(packagePath, function (er, data) {
-    function cb (er) {
-      if (!er && !silent) console.log("v" + data.version)
-      cb_(er)
-    }
-
     if (data) data = data.toString()
     try {
       data = JSON.parse(data)
@@ -52,17 +48,30 @@ function version (args, silent, cb_) {
     if (data.version === newVersion) return cb_(new Error("Version not changed"))
     data.version = newVersion
 
-    checkGit(function (er, hasGit) {
-      if (er) return cb_(er)
+    chain([
+          [lifecycle, data, "preversion"]
+        , [version_, data, silent]
+        , [lifecycle, data, "version"]
+        , [lifecycle, data, "postversion"] ]
+        , cb_)
+  })
+}
 
-      write(data, "package.json", function (er) {
-        if (er) return cb_(er)
+function version_ (data, silent, cb_) {
+  function cb (er) {
+    if (!er && !silent) console.log("v" + data.version)
+    cb_(er)
+  }
 
-        updateShrinkwrap(newVersion, function (er, hasShrinkwrap) {
-          if (er || !hasGit) return cb(er)
+  checkGit(function (er, hasGit) {
+    if (er) return cb(new Error(er))
 
-          commit(data.version, hasShrinkwrap, cb)
-        })
+    write(data, "package.json", function (er) {
+      if (er) return cb(new Error(er))
+
+      updateShrinkwrap(data.version, function (er, hasShrinkwrap) {
+        if (er || !hasGit) return cb(new Error(er))
+        commit(data.version, hasShrinkwrap, cb)
       })
     })
   })

--- a/test/tap/ignore-scripts.js
+++ b/test/tap/ignore-scripts.js
@@ -37,7 +37,10 @@ var json = {
     poststart: 'exit 123',
     prerestart: 'exit 123',
     restart: 'exit 123',
-    postrestart: 'exit 123'
+    postrestart: 'exit 123',
+    preversion: 'exit 123',
+    version: 'exit 123',
+    postversion: 'exit 123'
   }
 }
 
@@ -69,7 +72,8 @@ var scripts = [
   'pretest', 'test', 'posttest',
   'prestop', 'stop', 'poststop',
   'prestart', 'start', 'poststart',
-  'prerestart', 'restart', 'postrestart'
+  'prerestart', 'restart', 'postrestart',
+  'preversion', 'version', 'postversion'
 ]
 
 scripts.forEach(function (script) {


### PR DESCRIPTION
I thought including `npm version` in lifecycle sctips is good solution to prevent bump version for the package that has not passed test. Any thoughts on this please? See also: https://github.com/npm/npm/issues/7906
