### PR TITLE
Point out that .npmrc needs chmod 600

### DIFF
--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -20,6 +20,8 @@ The four relevant files are:
 * global config file ($PREFIX/etc/npmrc)
 * npm builtin config file (/path/to/npm/npmrc)
 
+**NOTE:** The per-project or per-user config files need to have a **chmod of 600**, otherwise they _will be ignored by npm!_
+
 All npm config files are an ini-formatted list of `key = value`
 parameters.  Environment variables can be replaced using
 `${VARIABLE_NAME}`. For example:


### PR DESCRIPTION
This could save people some troubleshooting, if they are generating the content of an .npmrc file without using _npm adduser_ interactively.
