### PR TITLE
test: update signal string for spawn.kill() in (publish|unpublish)-config

### DIFF
--- a/test/tap/publish-config.js
+++ b/test/tap/publish-config.js
@@ -29,7 +29,7 @@ test(function (t) {
     res.end(JSON.stringify({
       error: "sshhh. naptime nao. \\^O^/ <(YAWWWWN!)"
     }))
-    child.kill()
+    child.kill('SIGHUP')
   }).listen(common.port, function () {
     t.pass("server is listening")
 

--- a/test/tap/unpublish-config.js
+++ b/test/tap/unpublish-config.js
@@ -44,7 +44,7 @@ test('cursory test of unpublishing with config', function (t) {
     res.end(JSON.stringify({
       error: 'shh no tears, only dreams now'
     }))
-    child.kill()
+    child.kill('SIGHUP')
   }).listen(common.port, function () {
     t.pass('server is listening')
 


### PR DESCRIPTION
Currently in test/tap/(publish|unpublish)-config.js with `node@0.8` and `node@0.10`, `not ok npm install exited with code 0` error happened on travis. It's no problem using the version of node after v0.11, but using before that version 143 kill signal has come when exec spawn.kill() so I just putted a `SIGHUP` signal string as argument for spawn.kill(). Thanks.
