### PR TITLE
version: set working directory for preversion and postversion scripts

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -48,11 +48,13 @@ function version (args, silent, cb_) {
     if (data.version === newVersion) return cb_(new Error("Version not changed"))
     data.version = newVersion
 
+    var where = path.resolve(npm.dir, "..")
+
     chain([
-          [lifecycle, data, "preversion"]
+          [lifecycle, data, "preversion", where]
         , [version_, data, silent]
         , [lifecycle, data, "version"]
-        , [lifecycle, data, "postversion"] ]
+        , [lifecycle, data, "postversion", where] ]
         , cb_)
   })
 }

--- a/test/tap/version-lifecycle.js
+++ b/test/tap/version-lifecycle.js
@@ -1,0 +1,68 @@
+var common = require("../common-tap.js")
+var test = require("tap").test
+var npm = require("../../")
+var osenv = require("osenv")
+var path = require("path")
+var fs = require("fs")
+var mkdirp = require("mkdirp")
+var rimraf = require("rimraf")
+
+var pkg = path.resolve(__dirname, "version-lifecycle")
+var cache = path.resolve(pkg, "cache")
+
+test("npm version <semver> with failing preversion lifecycle script", function(t) {
+  setup()
+  fs.writeFileSync(path.resolve(pkg, "package.json"), JSON.stringify({
+    author: "Alex Wolfe",
+    name: "version-lifecycle",
+    version: "0.0.0",
+    description: "Test for npm version if preversion script fails",
+    scripts: {
+      preversion: './fail.sh'
+    }
+  }), "utf8")
+  fs.writeFileSync(path.resolve(pkg, "fail.sh"), 'exit 50', {mode: 448})
+  npm.load({cache: cache, registry: common.registry}, function() {
+    var version = require("../../lib/version")
+    version(["patch"], function(err) {
+      t.ok(err)
+      t.ok(err.message.match(/Exit status 50/))
+      t.end()
+    })
+  })
+})
+
+test("npm version <semver> with failing postversion lifecycle script", function(t) {
+  setup()
+  fs.writeFileSync(path.resolve(pkg, "package.json"), JSON.stringify({
+    author: "Alex Wolfe",
+    name: "version-lifecycle",
+    version: "0.0.0",
+    description: "Test for npm version if postversion script fails",
+    scripts: {
+      postversion: './fail.sh'
+    }
+  }), "utf8")
+  fs.writeFileSync(path.resolve(pkg, "fail.sh"), 'exit 50', {mode: 448})
+  npm.load({cache: cache, registry: common.registry}, function() {
+    var version = require("../../lib/version")
+    version(["patch"], function(err) {
+      t.ok(err)
+      t.ok(err.message.match(/Exit status 50/))
+      t.end()
+    })
+  })
+})
+
+test("cleanup", function(t) {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+  t.end()
+})
+
+function setup() {
+  mkdirp.sync(pkg)
+  mkdirp.sync(path.join(pkg, 'node_modules'))
+  mkdirp.sync(cache)
+  process.chdir(pkg)
+}


### PR DESCRIPTION
Explicitly sets the working directory for preversion and postversion scripts. Before this change, the preversion and postversion scripts cannot be found relative to the root directory.

The previous behavior is due to the way that the lifecycle module [resolves a default working directory](https://github.com/npm/npm/blob/f42ba69c82890a9ed872f2800d865f8f205496f9/lib/utils/lifecycle.js#L37). Specifying the working directory solves the problem.
