### PR TITLE
Dedupe modules from git/http/file

### DIFF
--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -240,6 +240,13 @@ function findVersions (npm, summary, cb) {
     var versions = data.versions
 
     var ranges = data.ranges
+
+    // If there is a module from git/http/file, use the first one.
+    var uriMatch = hasFromUri(ranges);
+    if (uriMatch !== undefined) {
+      return cb(null, [[name, has, loc, data.versions[0], uriMatch, locs]])
+    }
+
     mapToRegistry(name, npm.config, function (er, uri, auth) {
       if (er) return cb(er)
 
@@ -262,6 +269,14 @@ function findVersions (npm, summary, cb) {
       cb(null, [[name, has, loc, locMatch, regMatch, locs]])
     }
   }, cb)
+}
+
+function hasFromUri (ranges) {
+  return ranges.filter(function (r) {
+    return ['http', 'git', 'file'].some(function (uriPrefix) {
+      return (r.slice(0, uriPrefix.length) === uriPrefix);
+    });
+  }).pop();
 }
 
 function matches (version, ranges) {


### PR DESCRIPTION
At this time, if there are modules from GitHub repositories or local directories, they won't be de-duplicated. It's required for testing and some of situations.

So, I made this patch and it use the first one if there are many duplicated modules from URIs.
