### PR TITLE
Minor tweaks for node v0.8 in test/tap/version-lifecycle.js

### DIFF
--- a/test/tap/version-lifecycle.js
+++ b/test/tap/version-lifecycle.js
@@ -22,7 +22,8 @@ test('npm version <semver> with failing preversion lifecycle script', function (
       preversion: './fail.sh'
     }
   }), 'utf8')
-  fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', {mode: 448})
+  fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', 'utf8')
+  fs.chmodSync(path.resolve(pkg, 'fail.sh'), 448)
   npm.load({cache: cache, registry: common.registry}, function () {
     var version = require('../../lib/version')
     version(['patch'], function (err) {
@@ -44,7 +45,8 @@ test('npm version <semver> with failing postversion lifecycle script', function 
       postversion: './fail.sh'
     }
   }), 'utf8')
-  fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', {mode: 448})
+  fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', 'utf8')
+  fs.chmodSync(path.resolve(pkg, 'fail.sh'), 448)
   npm.load({cache: cache, registry: common.registry}, function () {
     var version = require('../../lib/version')
     version(['patch'], function (err) {


### PR DESCRIPTION
In node v0.8, there is no mode option in `fs.writeFileSync`([docs](https://nodejs.org/docs/v0.8.28/api/fs.html#fs_fs_writefilesync_filename_data_encoding)). I minor tweaked to separate fs.chmodSync from fs.WriteSync using mode option. Thanks.
