### PR TITLE
view: Remove extra newline

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -254,7 +254,11 @@ function printData (data, name, cb) {
     })
   })
 
-  console.log(msg)
+  if (/^\s*\n/.test(msg)) {
+    msg += "\n"
+  }
+
+  process.stdout.write(msg)
   cb(null, data)
 }
 function cleanup (data) {


### PR DESCRIPTION
`npm view` always prints extra newline at the end which in certain cases prevents its output from being easily recognized by other CLI tools.

None of these work:

```
curl $(npm v express dist.tarball) |tar xz
open $(npm v express bugs.url)
git log $(npm v express gitHead)
```

I have to manually remove the newline to make it work which is annoying:

```
curl $(npm v express dist.tarball |head -1) |tar xz
open $(npm v express bugs.url |head -1)
git log $(npm v express gitHead |head -1)
```

This patch makes `npm view` output more suitable for automatic consumption by removing extra newline at the end if there's no obvious reason for it.

As a special case it preserves extra newline if output starts with an empty line (for aesthetic reasons):

```
$ npm v express keywords

[ 'express',
  'framework',
  'sinatra',
  'web',
  'rest',
  'restful',
  'router',
  'app',
  'api' ]

```
