### PR TITLE
Added npm-dist-tag.md

### DIFF
--- a/doc/cli/npm-dist-tag.md
+++ b/doc/cli/npm-dist-tag.md
@@ -22,6 +22,8 @@ Add, remove, and enumerate distribution tags on a package:
   Show all of the dist-tags for a package, defaulting to the package in
   the current prefix.
 
+Note: If `<pkg>` is not unique, use `@<user>/<pkg>@<version>`.
+
 A tag can be used when installing packages as a reference to a version instead
 of using a specific version number:
 


### PR DESCRIPTION
Using `npm dist-tag` with a non-unique package name fails without providing adequate [feedback](https://gist.github.com/zachfedor/38b66191647c49d5420b). Added a note to provide info for those failures by encouraging use of `@<user>/<pkg>` naming convention.
