### PR TITLE
Document git+ssh true URLs with absolute path

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -419,8 +419,9 @@ install time.
 Git urls can be of the form:
 
     git://github.com/user/project.git#commit-ish
-    git+ssh://user@hostname:project.git#commit-ish
+    git+ssh://user@hostname/absolute/path.git#commit-ish
     git+ssh://user@hostname/project.git#commit-ish
+    git+ssh://user@hostname:project.git#commit-ish
     git+http://user@hostname/project/blah.git#commit-ish
     git+https://user@hostname/project/blah.git#commit-ish
 

--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -37,6 +37,7 @@ after packing it up into a tarball (b).
 Git urls can be of the form:
 
     git://github.com/user/project.git#commit-ish
+    git+ssh://user@hostname/absolute/path.git#commit-ish
     git+ssh://user@hostname:project.git#commit-ish
     git+http://user@hostname/project/blah.git#commit-ish
     git+https://user@hostname/project/blah.git#commit-ish

--- a/doc/misc/npm-faq.md
+++ b/doc/misc/npm-faq.md
@@ -169,6 +169,7 @@ after packing it up into a tarball (b).
 Git urls can be of the form:
 
     git://github.com/user/project.git#commit-ish
+    git+ssh://user@hostname/absolute/path.git#commit-ish
     git+ssh://user@hostname:project.git#commit-ish
     git+http://user@hostname/project/blah.git#commit-ish
     git+https://user@hostname/project/blah.git#commit-ish


### PR DESCRIPTION
that work with all versions of NPM

this is the minimal fix for #8031
