### PR TITLE
Fix git url parsing for non-hosted repos

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -425,25 +425,19 @@ function getResolved (uri, treeish) {
 
   var parsed = url.parse(uri)
 
-  // non-hosted SSH strings that are not URLs (git@whatever.com:foo.git) are
-  // no bueno
-  // https://github.com/npm/npm/issues/7961
-  if (!parsed.protocol) return
-
-  parsed.hash = treeish
-  if (!/^git[+:]/.test(parsed.protocol)) {
-    parsed.protocol = 'git+' + parsed.protocol
+  // Checks for known protocols:
+  // http:, https:, ssh:, and git:, with optional git+ prefix.
+  if (!parsed.protocol ||
+      !parsed.protocol.match(/^(((git\+)?(https?|ssh))|git|file):$/)) {
+    uri = 'git+ssh://' + uri
   }
 
-  // node incorrectly sticks a / at the start of the path We know that the host
-  // won't change, so split and detect this
-  // https://github.com/npm/npm/issues/3224
-  var spo = uri.split(parsed.host)
-  var spr = url.format(parsed).split(parsed.host)
-  if (spo[1] && spo[1].charAt(0) === ':' && spr[1] && spr[1].charAt(0) === '/') {
-    spr[1] = spr[1].slice(1)
+  if (!/^git[+:]/.test(uri)) {
+    uri = 'git+' + uri
   }
-  return spr.join(parsed.host)
+
+  // Not all URIs are actually URIs, so use regex for the treeish.
+  return uri.replace(/(?:#.*)?$/, '#' + treeish)
 }
 
 // similar to chmodr except it add permissions rather than overwriting them

--- a/node_modules/normalize-git-url/normalize-git-url.js
+++ b/node_modules/normalize-git-url/normalize-git-url.js
@@ -1,4 +1,4 @@
-var url = require("url")
+var url = require('url')
 
 module.exports = function normalize (u) {
   var parsed = url.parse(u, true)
@@ -9,19 +9,22 @@ module.exports = function normalize (u) {
   // If the path is like ssh://foo:some/path then it works, but
   // only if you remove the ssh://
   if (parsed.protocol) {
-    parsed.protocol = parsed.protocol.replace(/^git\+/, "")
-
-    // ssh paths that are scp-style urls don't need the ssh://
-    parsed.pathname = parsed.pathname.replace(/^\/?:/, "/")
+    parsed.protocol = parsed.protocol.replace(/^git\+/, '')
   }
 
   // figure out what we should check out.
-  var checkout = parsed.hash && parsed.hash.substr(1) || "master"
-  parsed.hash = ""
+  var checkout = parsed.hash && parsed.hash.substr(1) || 'master'
+  parsed.hash = ''
 
-  u = url.format(parsed)
+  var returnedUrl
+  if (parsed.pathname.match(/\/?:/)) {
+    returnedUrl = u.replace(/^(?:git\+)?ssh:\/\//, '').replace(/#[^#]*$/, '')
+  } else {
+    returnedUrl = url.format(parsed)
+  }
+
   return {
-    url : u,
-    branch : checkout
+    url: returnedUrl,
+    branch: checkout
   }
 }

--- a/node_modules/normalize-git-url/package.json
+++ b/node_modules/normalize-git-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalize-git-url",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Normalizes Git URLs. For npm, but you can use it too.",
   "main": "normalize-git-url.js",
   "directories": {
@@ -33,10 +33,29 @@
     "url": "https://github.com/npm/normalize-git-url/issues"
   },
   "homepage": "https://github.com/npm/normalize-git-url",
-  "readme": "# normalize-git-url\n\nYou have a bunch of Git URLs. You want to convert them to a canonical\nrepresentation, probably for use inside npm so that it doesn't end up creating\na bunch of superfluous cached origins. You use this package.\n\n## Usage\n\n```javascript\nvar ngu = require('normalize-git-url');\nvar normalized = ngu(\"git+ssh://git@github.com:organization/repo.git#hashbrowns\")\n// get back:\n// {\n//   url : \"ssh://git@github.com/organization/repo.git\",\n//   branch : \"hashbrowns\" // did u know hashbrowns are delicious?\n// }\n```\n\n## API\n\nThere's just the one function, and all it takes is a single parameter, a non-normalized Git URL.\n\n### normalizeGitUrl(url)\n\n* `url` {String} The Git URL (very loosely speaking) to be normalized.\n\nReturns an object with the following format:\n\n* `url` {String} The normalized URL.\n* `branch` {String} The treeish to be checked out once the repo at `url` is\n  cloned. It doesn't have to be a branch, but it's a lot easier to intuit what\n  the output is for with that name.\n\n## Limitations\n\nRight now this doesn't try to special-case GitHub too much -- it doesn't ensure\nthat `.git` is added to the end of URLs, it doesn't prefer `https:` over\n`http:` or `ssh:`, it doesn't deal with redirects, and it doesn't try to\nresolve symbolic names to treeish hashcodes. For now, it just tries to account\nfor minor differences in representation.\n",
-  "readmeFilename": "README.md",
-  "gitHead": "d87bf42e845ed664e4a8bab3490052fb44c90433",
-  "_id": "normalize-git-url@1.0.1",
-  "_shasum": "1b561345d66e3a3bc5513a5ace85f155ca42613e",
-  "_from": "normalize-git-url@>=1.0.1 <1.1.0"
+  "gitHead": "cf9fb245bc25d2a8914b71e8989ec426e7819e00",
+  "_id": "normalize-git-url@2.0.0",
+  "_shasum": "2cf92aeda24dd2bccf076edef83f4feaf925e436",
+  "_from": "normalize-git-url@latest",
+  "_npmVersion": "2.11.3",
+  "_nodeVersion": "2.3.1",
+  "_npmUser": {
+    "name": "iarna",
+    "email": "me@re-becca.org"
+  },
+  "dist": {
+    "shasum": "2cf92aeda24dd2bccf076edef83f4feaf925e436",
+    "tarball": "http://registry.npmjs.org/normalize-git-url/-/normalize-git-url-2.0.0.tgz"
+  },
+  "maintainers": [
+    {
+      "name": "othiym23",
+      "email": "ogd@aoaioxxysz.net"
+    },
+    {
+      "name": "iarna",
+      "email": "me@re-becca.org"
+    }
+  ],
+  "_resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-2.0.0.tgz"
 }

--- a/node_modules/normalize-git-url/test/basic.js
+++ b/node_modules/normalize-git-url/test/basic.js
@@ -1,55 +1,55 @@
-var test = require("tap").test
+var test = require('tap').test
 
-var normalize = require("../normalize-git-url.js")
+var normalize = require('../normalize-git-url.js')
 
-test("basic normalization tests", function (t) {
+test('basic normalization tests', function (t) {
   t.same(
-    normalize("git+ssh://user@hostname:project.git#commit-ish"),
-    { url : "ssh://user@hostname/project.git", branch : "commit-ish" }
+    normalize('git+ssh://user@hostname:project.git#commit-ish'),
+    { url: 'user@hostname:project.git', branch: 'commit-ish' }
   )
   t.same(
-    normalize("git+http://user@hostname/project/blah.git#commit-ish"),
-    { url : "http://user@hostname/project/blah.git", branch : "commit-ish" }
+    normalize('git+http://user@hostname/project/blah.git#commit-ish'),
+    { url: 'http://user@hostname/project/blah.git', branch: 'commit-ish' }
   )
   t.same(
-    normalize("git+https://user@hostname/project/blah.git#commit-ish"),
-    { url : "https://user@hostname/project/blah.git", branch : "commit-ish" }
+    normalize('git+https://user@hostname/project/blah.git#commit-ish'),
+    { url: 'https://user@hostname/project/blah.git', branch: 'commit-ish' }
   )
   t.same(
-    normalize("git+ssh://git@github.com:npm/npm.git#v1.0.27"),
-    { url : "ssh://git@github.com/npm/npm.git", branch : "v1.0.27" }
+    normalize('git+ssh://git@github.com:npm/npm.git#v1.0.27'),
+    { url: 'git@github.com:npm/npm.git', branch: 'v1.0.27' }
   )
   t.same(
-    normalize("git+ssh://git@github.com:org/repo#dev"),
-    { url : "ssh://git@github.com/org/repo", branch : "dev" }
+    normalize('git+ssh://git@github.com:org/repo#dev'),
+    { url: 'git@github.com:org/repo', branch: 'dev' }
   )
   t.same(
-    normalize("git+ssh://git@github.com/org/repo#dev"),
-    { url : "ssh://git@github.com/org/repo", branch : "dev" }
+    normalize('git+ssh://git@github.com/org/repo#dev'),
+    { url: 'ssh://git@github.com/org/repo', branch: 'dev' }
   )
   t.same(
-    normalize("git+ssh://foo:22/some/path"),
-    { url : "ssh://foo:22/some/path", branch : "master" }
+    normalize('git+ssh://foo:22/some/path'),
+    { url: 'ssh://foo:22/some/path', branch: 'master' }
   )
   t.same(
-    normalize("git@github.com:org/repo#dev"),
-    { url : "git@github.com:org/repo", branch : "dev" }
+    normalize('git@github.com:org/repo#dev'),
+    { url: 'git@github.com:org/repo', branch: 'dev' }
   )
   t.same(
-    normalize("git+https://github.com/KenanY/node-uuid"),
-    { url : "https://github.com/KenanY/node-uuid", branch : "master" }
+    normalize('git+https://github.com/KenanY/node-uuid'),
+    { url: 'https://github.com/KenanY/node-uuid', branch: 'master' }
   )
   t.same(
-    normalize("git+https://github.com/KenanY/node-uuid#7a018f2d075b03a73409e8356f9b29c9ad4ea2c5"),
-    { url : "https://github.com/KenanY/node-uuid", branch : "7a018f2d075b03a73409e8356f9b29c9ad4ea2c5" }
+    normalize('git+https://github.com/KenanY/node-uuid#7a018f2d075b03a73409e8356f9b29c9ad4ea2c5'),
+    { url: 'https://github.com/KenanY/node-uuid', branch: '7a018f2d075b03a73409e8356f9b29c9ad4ea2c5' }
   )
   t.same(
-    normalize("git+ssh://git@git.example.com:b/b.git#v1.0.0"),
-    { url : "ssh://git@git.example.com/b/b.git", branch : "v1.0.0" }
+    normalize('git+ssh://git@git.example.com:b/b.git#v1.0.0'),
+    { url: 'git@git.example.com:b/b.git', branch: 'v1.0.0' }
   )
   t.same(
-    normalize("git+ssh://git@github.com:npm/npm-proto.git#othiym23/organized"),
-    { url : "ssh://git@github.com/npm/npm-proto.git", branch : "othiym23/organized" }
+    normalize('git+ssh://git@github.com:npm/npm-proto.git#othiym23/organized'),
+    { url: 'git@github.com:npm/npm-proto.git', branch: 'othiym23/organized' }
   )
 
   t.end()

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mkdirp": "~0.5.1",
     "node-gyp": "~2.0.1",
     "nopt": "~3.0.2",
-    "normalize-git-url": "~1.0.1",
+    "normalize-git-url": "~2.0.1",
     "normalize-package-data": "~2.3.0",
     "npm-cache-filename": "~1.0.1",
     "npm-install-checks": "~1.0.5",

--- a/test/tap/add-remote-git-get-resolved.js
+++ b/test/tap/add-remote-git-get-resolved.js
@@ -74,9 +74,16 @@ test('add-remote-git#get-resolved HTTPS', function (t) {
 test('add-remote-git#get-resolved edge cases', function (t) {
   var getResolved = require('../../lib/cache/add-remote-git.js').getResolved
 
-  t.notOk(
-    getResolved('git@bananaboat.com:galbi.git', 'decadacefadabade'),
-    'non-hosted Git SSH non-URI strings are invalid'
+  t.equal(
+    getResolved('git+ssh://user@bananaboat.com:galbi/blah.git', 'decadacefadabade'),
+    'git+ssh://user@bananaboat.com:galbi/blah.git#decadacefadabade',
+    'don\'t break non-hosted scp-style locations'
+  )
+
+  t.equal(
+    getResolved('git+ssh://bananaboat:galbi/blah', 'decadacefadabade'),
+    'git+ssh://bananaboat:galbi/blah#decadacefadabade',
+    'don\'t break non-hosted scp-style locations'
   )
 
   t.equal(
@@ -86,16 +93,16 @@ test('add-remote-git#get-resolved edge cases', function (t) {
   )
 
   t.equal(
+    getResolved('git+ssh://git.bananaboat.net:/foo', 'decadacefadabade'),
+    'git+ssh://git.bananaboat.net:/foo#decadacefadabade',
+    'don\'t break non-hosted SSH URLs'
+  )
+
+  t.equal(
     getResolved('git://gitbub.com/foo/bar.git', 'decadacefadabade'),
     'git://gitbub.com/foo/bar.git#decadacefadabade',
     'don\'t break non-hosted git: URLs'
   )
 
-  t.comment('test for https://github.com/npm/npm/issues/3224')
-  t.equal(
-    getResolved('git+ssh://git@git.example.com:my-repo.git#9abe82cb339a70065e75300f62b742622774693c', 'decadacefadabade'),
-    'git+ssh://git@git.example.com:my-repo.git#decadacefadabade',
-    'preserve weird colon in semi-standard ssh:// URLs'
-  )
   t.end()
 })


### PR DESCRIPTION
Fixes #8031 

This patch fixes normalization issues for `git+ssh` non-URLs (which are just scp-style identifiers with a special `git+ssh://` prefix), and makes sure to leave them as intact as possible. The issue was present for non-hosted git servers, which we can't normalize very aggressively because we have no guarantee that our normalizations will still point to the same resource.
