### PR TITLE
cache: fix Windows perms regression

### DIFF
--- a/lib/utils/correct-mkdir.js
+++ b/lib/utils/correct-mkdir.js
@@ -34,15 +34,15 @@ module.exports = function correctMkdir (path, cb) {
 
 function calculateOwner () {
   if (!effectiveOwner) {
-    var uid = +process.getuid()
-    var gid = +process.getgid()
+    effectiveOwner = { uid: 0, gid: 0 }
 
-    if (uid === 0) {
-      if (process.env.SUDO_UID) uid = +process.env.SUDO_UID
-      if (process.env.SUDO_GID) gid = +process.env.SUDO_GID
+    if (process.getuid) effectiveOwner.uid = +process.getuid()
+    if (process.getgid) effectiveOwner.gid = +process.getgid()
+
+    if (effectiveOwner.uid === 0) {
+      if (process.env.SUDO_UID) effectiveOwner.uid = +process.env.SUDO_UID
+      if (process.env.SUDO_GID) effectiveOwner.gid = +process.env.SUDO_GID
     }
-
-    effectiveOwner = { uid: uid, gid: gid }
   }
 
   return effectiveOwner
@@ -56,16 +56,16 @@ function makeDirectory (path, cb) {
     log.verbose('makeDirectory', path, 'creation not in flight; initializing')
   }
 
+  var owner = calculateOwner()
+
   if (!process.getuid) {
     return mkdirp(path, function (er) {
       log.verbose('makeCacheDir', 'UID & GID are irrelevant on', process.platform)
 
-      stats[path] = { uid: 0, gid: 0 }
+      stats[path] = owner
       return cb(er, stats[path])
     })
   }
-
-  var owner = calculateOwner()
 
   if (owner.uid !== 0 || !process.env.HOME) {
     log.silly(


### PR DESCRIPTION
A simple change to make sure that we're never calling `process.getuid()` on platforms that don't have it.

There is no test because of the platform and account restrictions necessary to test it. This _should_ be tested eventually, but just doing it with mocking isn't going to tell us anything useful right now.

**r**: @iarna 
