### PR TITLE
Label and clear progress bar on publish

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -133,6 +133,7 @@ function publish_ (arg, data, isRetry, cachedir, cb) {
       params.access = config.get('access')
     }
 
+    log.showProgress('publish:' + data._id)
     registry.publish(registryBase, params, function (er) {
       if (er && er.code === 'EPUBLISHCONFLICT' &&
           npm.config.get('force') && !isRetry) {
@@ -146,6 +147,7 @@ function publish_ (arg, data, isRetry, cachedir, cb) {
       // report the unpublish error if this was a retry and unpublish failed
       if (er && isRetry && isRetry !== true) return cb(isRetry)
       if (er) return cb(er)
+      log.clearProgress()
       console.log('+ ' + data._id)
       cb()
     })


### PR DESCRIPTION
Progress bar was not labeled in any way on publish nor was it cleared after successful publishing.

This now labels the progress bar with `publish:<publish-id>` and clears the progress bar after successful publishing showing `+ <publish-id>` like npm@2 does.
