### PR TITLE
Added nvm-windows link to npm-faq

### DIFF
--- a/doc/misc/npm-faq.md
+++ b/doc/misc/npm-faq.md
@@ -279,6 +279,7 @@ Unix:
 Windows:
 
 * <http://github.com/marcelklehr/nodist>
+* <https://github.com/coreybutler/nvm-windows>
 * <https://github.com/hakobera/nvmw>
 * <https://github.com/nanjingboy/nvmw>
 


### PR DESCRIPTION
Added a link to [corey-butler/nvm-windows](https://github.com/coreybutler/nvm-windows).

Based on github stars, this is the most popular windows nvm utility of the ones listed.
