### PR TITLE
Closes GH-8685 npm hangs when installing some packages, temporary dir…

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -298,7 +298,7 @@ function resolveHead (from, cloneURL, treeish, cachedRemote, cb) {
       log.verbose('resolveHead', from, 'resolved Git URL:', resolvedURL)
 
       // generate a unique filename
-      var tmpdir = path.join(npm.tmp, tempFilename('git-cache'), resolvedTreeish)
+      var tmpdir = path.join( tempFilename('git-cache'), resolvedTreeish)
       log.silly('resolveHead', 'Git working directory:', tmpdir)
 
       mkdir(tmpdir, function (er) {


### PR DESCRIPTION
The temporary directory was being doubled , when you clone the workspace , the file already /lib/utils/temp-filename.js add npm.tmp , there is no need to join again to invoke the function .

Closes GH-8685
