### PR TITLE
install: check-permissions: disable access checks on win32

### DIFF
--- a/lib/install/check-permissions.js
+++ b/lib/install/check-permissions.js
@@ -74,6 +74,16 @@ var exists = fs.access
 var access = fs.access
   ? function (dir, done) { fs.access(dir, fs.W_OK, done) }
   : function (dir, done) {
+      // FIXME: So it turns out that for larger installations on windows
+      // this sometimes fails.  We need to make this work better.  Options
+      // include:
+      //   caching results
+      //   inflighting results
+      //   limiting concurrency
+      // Maybe all three.
+      // That this is going through asyncMap and then running ALL THIS
+      // makes this failure completely unsurprising. 😕
+      if (process.platform === 'win32') return done()
       var tmp = path.join(dir, '.npm.check.permissions')
       fs.open(tmp, 'w', function (er, fd) {
         if (er) return done(accessError(dir, er))


### PR DESCRIPTION
The way this was written was sometimes (always in large installs) resulting
in errors.

This is a temporary work around to make win32 work better until we have time to fix the problem more permanently.
