### PR TITLE
Don't warn on prefer global for devDependencies

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -137,7 +137,9 @@ function shouldWarn (pkg, folder, global, cb) {
       if (!topPkg.dependencies) return cb()
 
       // don't generate a warning if it's listed in dependencies
-      if (Object.keys(topPkg.dependencies).indexOf(currentPkg) === -1) {
+      if (Object.keys(topPkg.dependencies)
+          .concat(Object.keys(topPkg.devDependencies || {}))
+          .indexOf(currentPkg) === -1) {
 
         if (top && pkg.preferGlobal && !global) {
           log.warn('prefer global', getPackageId(pkg) + ' should be installed with -g')


### PR DESCRIPTION
Windows Powershell assumes the command has failed
whenever something is written to stderr.

Followup-To: #1648
Fixes: #8517
