### PR TITLE
Fix project config not being read with npm i -g

### DIFF
--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -127,8 +127,7 @@ function load_ (builtin, rc, cli, cb) {
     var projectConf = path.resolve(conf.localPrefix, '.npmrc')
     var defaultUserConfig = rc.get('userconfig')
     var resolvedUserConfig = conf.get('userconfig')
-    if (!conf.get('global') &&
-        projectConf !== defaultUserConfig &&
+    if (projectConf !== defaultUserConfig &&
         projectConf !== resolvedUserConfig) {
       conf.addFile(projectConf, 'project')
       conf.once('load', afterPrefix)


### PR DESCRIPTION
Fixes #8036.

[This commit](https://github.com/npm/npm/commit/1707fcedb7503251eb77719aba7ac52931721205#diff-0274417318d45b56e7adc8820b6a76b3R110) ensured that only non-global operations read the project configuration, possibly for performance reasons. However, the project configuration `.npmrc` file can change `prefix`, which modifies where a global operation such as `npm i -g` stores files.

No tests were broken. No tests were added either; it seems inadequate to make a test to check that a piece of code isn't there when it shouldn't have been there.
