### PR TITLE
Make "*" match "latest" if all versions are prerelease

### DIFF
--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -250,7 +250,11 @@ function addNameRange (name, range, data, cb) {
     var versions = Object.keys(data.versions || {})
     var ms = semver.maxSatisfying(versions, range, true)
     if (!ms) {
-      return cb(installTargetsError(range, data))
+      if (range === "*" && versions.length) {
+        return addNameTag(name, "latest", data, cb)
+      } else {
+        return cb(installTargetsError(range, data))
+      }
     }
 
     // if we don't have a registry connection, try to see if

--- a/test/tap/splat-with-only-prerelease-to-latest.js
+++ b/test/tap/splat-with-only-prerelease-to-latest.js
@@ -1,0 +1,81 @@
+'use strict'
+var test = require('tap').test
+var npm = require('../../lib/npm')
+var log = require('npmlog')
+var stream = require('readable-stream')
+
+var moduleName = 'xyzzy-wibble'
+var testModule = {
+  name: moduleName,
+  'dist-tags': {
+    latest: '1.3.0-a'
+  },
+  versions: {
+    '1.0.0-a': {
+      name: moduleName,
+      version: '1.0.0-a',
+      dist: {
+        shasum: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        tarball: 'http://registry.npmjs.org/aproba/-/xyzzy-wibble-1.0.0-a.tgz'
+      }
+    },
+    '1.1.0-a': {
+      name: moduleName,
+      version: '1.1.0-a',
+      dist: {
+        shasum: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        tarball: 'http://registry.npmjs.org/aproba/-/xyzzy-wibble-1.1.0-a.tgz'
+      }
+    },
+    '1.2.0-a': {
+      name: moduleName,
+      version: '1.2.0-a',
+      dist: {
+        shasum: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        tarball: 'http://registry.npmjs.org/aproba/-/xyzzy-wibble-1.2.0-a.tgz'
+      }
+    },
+    '1.3.0-a': {
+      name: moduleName,
+      version: '1.3.0-a',
+      dist: {
+        shasum: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        tarball: 'http://registry.npmjs.org/aproba/-/xyzzy-wibble-1.3.0-a.tgz'
+      }
+    },
+  },
+}
+
+var lastFetched
+test('setup', function (t) {
+  npm.load(function(){
+    npm.config.set('loglevel', 'silly')
+    npm.registry = {
+      get: function (uri, opts, cb) {
+        setImmediate(function () {
+          cb(null, testModule, null, {statusCode: 200})
+        })
+      },
+      fetch: function (u, opts, cb) {
+        lastFetched = u
+        setImmediate(function () {
+          var empty = new stream.Readable()
+          empty.push(null)
+          cb(null, empty)
+        })
+      }
+    }
+    t.end()
+  })
+})
+
+
+test('splat', function (t) {
+  t.plan(3)
+  var addNamed = require('../../lib/cache/add-named.js')
+  addNamed('xyzzy-wibble', '*', testModule, function (err, pkg) {
+    t.error(err, 'Succesfully resolved a splat package')
+    t.is(pkg.name, moduleName)
+    t.is(pkg.version, testModule['dist-tags'].latest)
+  })
+})

--- a/test/tap/version-git-not-clean.js
+++ b/test/tap/version-git-not-clean.js
@@ -56,28 +56,29 @@ test('npm version <semver> with working directory not clean', function (t) {
 })
 
 test('npm version <semver> --force with working directory not clean', function (t) {
-  npm.load({ cache: cache, registry: common.registry, prefix: pkg }, function () {
-    common.npm(
-      [
-        '--force',
-        'version',
-        'patch'
-      ],
-      {cwd: pkg, env: {PATH: process.env.PATH}},
-      function (err, code, stdout, stderr) {
-        t.ifError(err, 'npm version ran without issue')
-        t.notOk(code, 'exited with a non-error code')
-        var errorLines = stderr.trim().split('\n')
-          .map(function (line) {
-            return line.trim()
-          })
-          .filter(function (line) {
-            return !line.indexOf('using --force')
-          })
-        t.notOk(errorLines.length, 'no error output')
-        t.end()
-      })
-  })
+  common.npm(
+    [
+      '--force',
+      '--no-sign-git-tag',
+      '--registry', common.registry,
+      '--prefix', pkg,
+      'version',
+      'patch'
+    ],
+    { cwd: pkg, env: {PATH: process.env.PATH} },
+    function (err, code, stdout, stderr) {
+      t.ifError(err, 'npm version ran without issue')
+      t.notOk(code, 'exited with a non-error code')
+      var errorLines = stderr.trim().split('\n')
+        .map(function (line) {
+          return line.trim()
+        })
+        .filter(function (line) {
+          return !line.indexOf('using --force')
+        })
+      t.notOk(errorLines.length, 'no error output')
+      t.end()
+    })
 })
 
 test('cleanup', function (t) {

--- a/test/tap/version-lifecycle.js
+++ b/test/tap/version-lifecycle.js
@@ -26,7 +26,7 @@ test('npm version <semver> with failing preversion lifecycle script', function (
   }), 'utf8')
   fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', 'utf8')
   fs.chmodSync(path.resolve(pkg, 'fail.sh'), 448)
-  npm.load({cache: cache, registry: common.registry}, function () {
+  npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
     var version = require('../../lib/version')
     version(['patch'], function (err) {
       t.ok(err)
@@ -49,7 +49,7 @@ test('npm version <semver> with failing version lifecycle script', function (t) 
   }), 'utf8')
   fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', 'utf8')
   fs.chmodSync(path.resolve(pkg, 'fail.sh'), 448)
-  npm.load({cache: cache, registry: common.registry}, function () {
+  npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
     var version = require('../../lib/version')
     version(['patch'], function (err) {
       t.ok(err)
@@ -72,7 +72,7 @@ test('npm version <semver> with failing postversion lifecycle script', function 
   }), 'utf8')
   fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', 'utf8')
   fs.chmodSync(path.resolve(pkg, 'fail.sh'), 448)
-  npm.load({cache: cache, registry: common.registry}, function () {
+  npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
     var version = require('../../lib/version')
     version(['patch'], function (err) {
       t.ok(err)
@@ -98,7 +98,7 @@ test('npm version <semver> execution order', function (t) {
   makeScript('preversion')
   makeScript('version')
   makeScript('postversion')
-  npm.load({cache: cache, registry: common.registry}, function () {
+  npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
     common.makeGitRepo({path: pkg}, function (err, git) {
       t.ifError(err, 'git bootstrap ran without error')
 


### PR DESCRIPTION
Fix #8855 to reduce the pain from the change made in 2.11.2 that resulted in depending in `*` no longer working for modules w/o any non-prerelease versions.
