### PR TITLE
lifecycle: fix safety check to work with scoped packages.

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -48,7 +48,8 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
 
     unsafe = unsafe || npm.config.get('unsafe-perm')
 
-    if ((wd.indexOf(npm.dir) !== 0 || path.basename(wd) !== pkg.name) &&
+    if ((wd.indexOf(npm.dir) !== 0 ||
+          wd.indexOf(pkg.name) !== wd.length - pkg.name.length) &&
         !unsafe &&
         pkg.scripts[stage]) {
       log.warn(


### PR DESCRIPTION
A safety check compares `path.basename(wd)` to `pkg.name`.
In the case of scoped packages (e.g. `@foo/bar`), the two are
never equal. Change it to check if `wd` ends with `pkg.name`.

Fixes: https://github.com/npm/npm/issues/8862
