### PR TITLE
Don't break global COMP_WORDBREAKS in bash_completion

### DIFF
--- a/lib/utils/completion.sh
+++ b/lib/utils/completion.sh
@@ -7,17 +7,21 @@
 # Or, maybe: npm completion > /usr/local/etc/bash_completion.d/npm
 #
 
-COMP_WORDBREAKS=${COMP_WORDBREAKS/=/}
-COMP_WORDBREAKS=${COMP_WORDBREAKS/@/}
-export COMP_WORDBREAKS
-
 if type complete &>/dev/null; then
   _npm_completion () {
+    local words cword
+    if type _get_comp_words_by_ref &>/dev/null; then
+      _get_comp_words_by_ref -n = -n @ -w words -i cword
+    else
+      cword="$COMP_CWORD"
+      words=("${COMP_WORDS[@]}")
+    fi
+
     local si="$IFS"
-    IFS=$'\n' COMPREPLY=($(COMP_CWORD="$COMP_CWORD" \
+    IFS=$'\n' COMPREPLY=($(COMP_CWORD="$cword" \
                            COMP_LINE="$COMP_LINE" \
                            COMP_POINT="$COMP_POINT" \
-                           npm completion -- "${COMP_WORDS[@]}" \
+                           npm completion -- "${words[@]}" \
                            2>/dev/null)) || return $?
     IFS="$si"
   }


### PR DESCRIPTION
This is a candidate fix for #4530 - works for me, and confirmed by another user.  The problem causes global breakage of all bash completion on a system and thus is a big issue for those affected.

As discussed on #4530 - there is no regression test to update, and no-one on the defect knows what the use-case is that required special handling of "=" and "@".  If anyone can suggest a test-case, please do.

---

As described in #4530, #5820 modification of global variable
COMP_WORDBREAKS causes global breakage of completion:

```
dd if=/dev/ze<tab>
->
dd /dev/zero
```
