### PR TITLE
Document that the project npmrc is not read in global mode

### DIFF
--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -52,6 +52,9 @@ running npm in.  It has no effect when your module is published.  For
 example, you can't publish a module that forces itself to install
 globally, or in a different location.
 
+Additionally, this file is not read in global mode, such as when running
+`npm install -g`.
+
 ### Per-user config file
 
 `$HOME/.npmrc` (or the `userconfig` param, if set in the environment


### PR DESCRIPTION
For instance, when performing a global install.

Fixes #8036.

Motivated by https://github.com/npm/npm/pull/8848#issuecomment-120103424.
