### PR TITLE
Fix complete brokenness in `npm install blah` in npm@3.1.1

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -574,19 +574,20 @@ Installer.prototype.readLocalPackageData = function (cb) {
         return cb(er)
       }
       if (!currentTree.package) currentTree.package = {}
-      if (currentTree.package._shrinkwrap) return cb()
-      fs.readFile(path.join(self.where, 'npm-shrinkwrap.json'), function (er, data) {
-        if (er) return cb()
-        try {
-          currentTree.package._shrinkwrap = parseJSON(data)
-        } catch (ex) {
-          return cb(ex)
-        }
-        return this.loadArgMetadata(cb)
-      })
+      self.loadArgMetadata(iferr(cb, function () {
+        if (currentTree.package._shrinkwrap) return cb()
+        fs.readFile(path.join(self.where, 'npm-shrinkwrap.json'), function (er, data) {
+          if (er) return cb()
+          try {
+            currentTree.package._shrinkwrap = parseJSON(data)
+          } catch (ex) {
+            return cb(ex)
+          }
+          return cb()
+        })
+      }))
     }))
   }))
-
 }
 
 Installer.prototype.cloneCurrentTreeToIdealTree = function (cb) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -546,7 +546,7 @@ Installer.prototype.readGlobalPackageData = function (cb) {
   this.loadArgMetadata(iferr(cb, function () {
     mkdirp(self.where, iferr(cb, function () {
       asyncMap(self.args, function (pkg, done) {
-        readPackageTree(path.resolve(self.where, 'node_modules', pkg.name), function (err, subTree) {
+        readPackageTree(path.resolve(self.where, 'node_modules', pkg.name), function (_, subTree) {
           if (subTree) {
             subTree.parent = self.currentTree
             self.currentTree.children.push(subTree)

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -130,7 +130,7 @@ function getShrinkwrap (tree, name) {
 }
 
 exports.getAllMetadata = function (args, tree, next) {
-  asyncMap( args, function (spec, done) {
+  asyncMap(args, function (spec, done) {
     if (spec.lastIndexOf('@') <= 0) {
       var sw = getShrinkwrap(tree, spec)
       if (sw) {

--- a/test/tap/bitbucket-https-url-with-creds.js
+++ b/test/tap/bitbucket-https-url-with-creds.js
@@ -38,7 +38,7 @@ test('bitbucket-https-url-with-creds', function (t) {
           } else {
             t.fail('too many attempts to clone')
           }
-          cb(new Error())
+          cb(new Error('execFile mock fails on purpose'))
         })
       }
     }

--- a/test/tap/bitbucket-shortcut.js
+++ b/test/tap/bitbucket-shortcut.js
@@ -39,7 +39,7 @@ test('bitbucket-shortcut', function (t) {
           } else {
             t.fail('too many attempts to clone')
           }
-          cb(new Error())
+          cb(new Error('execFile mock fails on purpose'))
         })
       }
     }

--- a/test/tap/gist-short-shortcut.js
+++ b/test/tap/gist-short-shortcut.js
@@ -39,7 +39,7 @@ test('gist-shortcut', function (t) {
           } else {
             t.fail('too many attempts to clone')
           }
-          cb(new Error())
+          cb(new Error('execFile mock fails on purpose'))
         })
       }
     }

--- a/test/tap/github-shortcut.js
+++ b/test/tap/github-shortcut.js
@@ -39,7 +39,7 @@ test('github-shortcut', function (t) {
           } else {
             t.fail('too many attempts to clone')
           }
-          cb(new Error())
+          cb(new Error('execFile mock fails on purpose'))
         })
       }
     }

--- a/test/tap/github-shortcut.js
+++ b/test/tap/github-shortcut.js
@@ -26,9 +26,7 @@ test('github-shortcut', function (t) {
   var cloneUrls = [
     ['git://github.com/foo/private.git', 'GitHub shortcuts try git URLs first'],
     ['https://github.com/foo/private.git', 'GitHub shortcuts try HTTPS URLs second'],
-    ['git@github.com:foo/private.git', 'GitHub shortcuts try SSH third'],
-    ['https://bitbucket.org/foo/private.git', 'bitbucket shortcuts try HTTPS URLs first'],
-    ['git@bitbucket.org:foo/private.git', 'bitbucket shortcuts try SSH second']
+    ['git@github.com:foo/private.git', 'GitHub shortcuts try SSH third']
   ]
   var npm = requireInject.installGlobally('../../lib/npm.js', {
     'child_process': {
@@ -57,9 +55,7 @@ test('github-shortcut', function (t) {
   npm.load(opts, function (er) {
     t.ifError(er, 'npm loaded without error')
     npm.commands.install(['foo/private'], function (er, result) {
-      npm.commands.install(['bitbucket:foo/private'], function (er, result) {
-        t.end()
-      })
+      t.end()
     })
   })
 })

--- a/test/tap/gitlab-shortcut.js
+++ b/test/tap/gitlab-shortcut.js
@@ -38,7 +38,7 @@ test('gitlab-shortcut', function (t) {
           } else {
             t.fail('too many attempts to clone')
           }
-          cb(new Error())
+          cb(new Error('execFile mock fails on purpose'))
         })
       }
     }

--- a/test/tap/no-scan-full-global-dir.js
+++ b/test/tap/no-scan-full-global-dir.js
@@ -2,7 +2,6 @@
 var test = require('tap').test
 var requireInject = require('require-inject')
 var path = require('path')
-var log = require('npmlog')
 var inherits = require('inherits')
 
 var packages = {
@@ -12,7 +11,7 @@ var packages = {
   jkl: {package: {name: 'jkl'}, path: path.join(__dirname, 'node_modules', 'jkl')}
 }
 var dir = {}
-dir[__dirname] ={ children: [ packages.abc, packages.def, packages.ghi, packages.jkl ] }
+dir[__dirname] = { children: [ packages.abc, packages.def, packages.ghi, packages.jkl ] }
 dir[packages.abc.path] = packages.abc
 dir[packages.def.path] = packages.def
 dir[packages.ghi.path] = packages.ghi


### PR DESCRIPTION
Argh. No more 4am releases. Most (but not ALL) `npm install` use cases were instant crashers. Of course, the use cases I directly tested against were the one's that didn't crash. I THEN apparently went on to run the test suite against the wrong tree. =( =(

Existing test cases already exercise this code– without this patch much explodes. Tests for the patch that this patch fixes were previously merged.

This fixes the bug introduced by #8876
