### PR TITLE
Fixes default values on comment in cache.js correctly

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -10,9 +10,9 @@
 fetching a URL:
 1. Check for URL in inflight URLs.  If present, add cb, and return.
 2. Acquire lock at {cache}/{sha(url)}.lock
-   retries = {cache-lock-retries, def=3}
-   stale = {cache-lock-stale, def=30000}
-   wait = {cache-lock-wait, def=100}
+   retries = {cache-lock-retries, def=10}
+   stale = {cache-lock-stale, def=60000}
+   wait = {cache-lock-wait, def=10000}
 3. if lock can't be acquired, then fail
 4. fetch url, clear lock, call cbs
 


### PR DESCRIPTION
It was different in the default value [written in js comment](https://github.com/npm/npm/blob/064d62c2f251cb5e9328f63228f711844b7a1787/lib/cache.js#L13-L15) and the actual [real default value](https://github.com/npm/npm/blob/064d62c2f251cb5e9328f63228f711844b7a1787/lib/config/defaults.js#L119-L121).
