### PR TITLE
Add deprecation warning for invalid git+http URIs

### DIFF
--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -52,6 +52,9 @@ running npm in.  It has no effect when your module is published.  For
 example, you can't publish a module that forces itself to install
 globally, or in a different location.
 
+Additionally, this file is not read in global mode, such as when running
+`npm install -g`.
+
 ### Per-user config file
 
 `$HOME/.npmrc` (or the `userconfig` param, if set in the environment

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -10,9 +10,9 @@
 fetching a URL:
 1. Check for URL in inflight URLs.  If present, add cb, and return.
 2. Acquire lock at {cache}/{sha(url)}.lock
-   retries = {cache-lock-retries, def=3}
-   stale = {cache-lock-stale, def=30000}
-   wait = {cache-lock-wait, def=100}
+   retries = {cache-lock-retries, def=10}
+   stale = {cache-lock-stale, def=60000}
+   wait = {cache-lock-wait, def=10000}
 3. if lock can't be acquired, then fail
 4. fetch url, clear lock, call cbs
 

--- a/node_modules/normalize-git-url/normalize-git-url.js
+++ b/node_modules/normalize-git-url/normalize-git-url.js
@@ -1,7 +1,10 @@
 var url = require('url')
 
 module.exports = function normalize (u) {
-  var parsed = url.parse(u, true)
+  var parsed = url.parse(u)
+  // If parsing actually alters the URL, it is almost certainly an
+  // scp-style URL, or an invalid one.
+  var altered = u !== url.format(parsed)
 
   // git is so tricky!
   // if the path is like ssh://foo:22/some/path then it works, but
@@ -17,8 +20,13 @@ module.exports = function normalize (u) {
   parsed.hash = ''
 
   var returnedUrl
-  if (parsed.pathname.match(/\/?:/)) {
-    returnedUrl = u.replace(/^(?:git\+)?ssh:\/\//, '').replace(/#[^#]*$/, '')
+  if (altered) {
+    if (u.match(/^git\+https?/) && parsed.pathname.match(/\/?:[^0-9]/)) {
+      returnedUrl = u.replace(/^git\+(.*:[^:]+):(.*)/, '$1/$2')
+    } else {
+      returnedUrl = u.replace(/^(?:git\+)?ssh:\/\//, '')
+    }
+    returnedUrl = returnedUrl.replace(/#[^#]*$/, '')
   } else {
     returnedUrl = url.format(parsed)
   }

--- a/node_modules/normalize-git-url/package.json
+++ b/node_modules/normalize-git-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalize-git-url",
-  "version": "2.0.0",
+  "version": "3.0.1",
   "description": "Normalizes Git URLs. For npm, but you can use it too.",
   "main": "normalize-git-url.js",
   "directories": {
@@ -33,29 +33,10 @@
     "url": "https://github.com/npm/normalize-git-url/issues"
   },
   "homepage": "https://github.com/npm/normalize-git-url",
-  "gitHead": "cf9fb245bc25d2a8914b71e8989ec426e7819e00",
-  "_id": "normalize-git-url@2.0.0",
-  "_shasum": "2cf92aeda24dd2bccf076edef83f4feaf925e436",
-  "_from": "normalize-git-url@latest",
-  "_npmVersion": "2.11.3",
-  "_nodeVersion": "2.3.1",
-  "_npmUser": {
-    "name": "iarna",
-    "email": "me@re-becca.org"
-  },
-  "dist": {
-    "shasum": "2cf92aeda24dd2bccf076edef83f4feaf925e436",
-    "tarball": "http://registry.npmjs.org/normalize-git-url/-/normalize-git-url-2.0.0.tgz"
-  },
-  "maintainers": [
-    {
-      "name": "othiym23",
-      "email": "ogd@aoaioxxysz.net"
-    },
-    {
-      "name": "iarna",
-      "email": "me@re-becca.org"
-    }
-  ],
-  "_resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-2.0.0.tgz"
+  "readme": "# normalize-git-url\n\nYou have a bunch of Git URLs. You want to convert them to a canonical\nrepresentation, probably for use inside npm so that it doesn't end up creating\na bunch of superfluous cached origins. You use this package.\n\n## Usage\n\n```javascript\nvar ngu = require('normalize-git-url');\nvar normalized = ngu(\"git+ssh://git@github.com:organization/repo.git#hashbrowns\")\n// get back:\n// {\n//   url : \"ssh://git@github.com/organization/repo.git\",\n//   branch : \"hashbrowns\" // did u know hashbrowns are delicious?\n// }\n```\n\n## API\n\nThere's just the one function, and all it takes is a single parameter, a non-normalized Git URL.\n\n### normalizeGitUrl(url)\n\n* `url` {String} The Git URL (very loosely speaking) to be normalized.\n\nReturns an object with the following format:\n\n* `url` {String} The normalized URL.\n* `branch` {String} The treeish to be checked out once the repo at `url` is\n  cloned. It doesn't have to be a branch, but it's a lot easier to intuit what\n  the output is for with that name.\n\n## Limitations\n\nRight now this doesn't try to special-case GitHub too much -- it doesn't ensure\nthat `.git` is added to the end of URLs, it doesn't prefer `https:` over\n`http:` or `ssh:`, it doesn't deal with redirects, and it doesn't try to\nresolve symbolic names to treeish hashcodes. For now, it just tries to account\nfor minor differences in representation.\n",
+  "readmeFilename": "README.md",
+  "gitHead": "8393cd4345e404eb6ad2ff6853dcc8287807ca22",
+  "_id": "normalize-git-url@3.0.1",
+  "_shasum": "d40d419d05a15870271e50534dbb7b8ccd9b0a5c",
+  "_from": "normalize-git-url@latest"
 }

--- a/node_modules/normalize-git-url/test/basic.js
+++ b/node_modules/normalize-git-url/test/basic.js
@@ -16,8 +16,16 @@ test('basic normalization tests', function (t) {
     { url: 'https://user@hostname/project/blah.git', branch: 'commit-ish' }
   )
   t.same(
+    normalize('git+https://user@hostname:project/blah.git#commit-ish'),
+    { url: 'https://user@hostname/project/blah.git', branch: 'commit-ish' }
+  )
+  t.same(
     normalize('git+ssh://git@github.com:npm/npm.git#v1.0.27'),
     { url: 'git@github.com:npm/npm.git', branch: 'v1.0.27' }
+  )
+  t.same(
+    normalize('git+ssh://git@github.com:/npm/npm.git#v1.0.28'),
+    { url: 'git@github.com:/npm/npm.git', branch: 'v1.0.28' }
   )
   t.same(
     normalize('git+ssh://git@github.com:org/repo#dev'),

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "mkdirp": "~0.5.1",
     "node-gyp": "~2.0.1",
     "nopt": "~3.0.3",
-    "normalize-git-url": "~2.0.0",
+    "normalize-git-url": "~3.0.1",
     "normalize-package-data": "~2.3.0",
     "npm-cache-filename": "~1.0.2",
     "npm-install-checks": "~1.0.5",

--- a/test/tap/add-remote-git-get-resolved.js
+++ b/test/tap/add-remote-git-get-resolved.js
@@ -65,6 +65,12 @@ test('add-remote-git#get-resolved HTTPS', function (t) {
   verify('https://github.com/foo/repo#master')
   verify('git+https://github.com/foo/repo.git#master')
   verify('git+https://github.com/foo/repo#decadacefadabade')
+  // DEPRECATED
+  // this is an invalid URL but we normalize it
+  // anyway. Users shouldn't use this in the future. See note
+  // below for how this affected non-hosted URLs.
+  // See https://github.com/npm/npm/issues/8881
+  verify('git+https://github.com:foo/repo.git#master')
 
   function verify (uri) {
     t.equal(
@@ -90,6 +96,12 @@ test('add-remote-git#get-resolved edge cases', function (t) {
     'don\'t break non-hosted scp-style locations'
   )
 
+  // DEPRECATED
+  // When we were normalizing all git URIs, git+https: was being
+  // automatically converted to ssh:. Some users were relying
+  // on this funky behavior, so after removing the aggressive
+  // normalization from non-hosted URIs, we brought this back.
+  // See https://github.com/npm/npm/issues/8881
   t.equal(
     tryGetResolved('git+https://bananaboat:galbi/blah', 'decadacefadabade'),
     'git+https://bananaboat/galbi/blah#decadacefadabade',


### PR DESCRIPTION
Fixes #8881 

Main changes were made in npm/normalize-git-url#3 and npm/normalize-git-url#4
