### PR TITLE
Make checkGit more reliable

### DIFF
--- a/lib/utils/git.js
+++ b/lib/utils/git.js
@@ -3,6 +3,7 @@
 exports.spawn = spawnGit
 exports.chainableExec = chainableExec
 exports.whichAndExec = whichAndExec
+exports.getGitRoot = getGitRoot
 
 var exec = require('child_process').execFile
 var spawn = require('./spawn')
@@ -47,4 +48,12 @@ function whichAndExec (args, options, cb) {
 
     execGit(args, options, cb)
   })
+}
+
+function getGitRoot (cb) {
+  whichAndExec(
+    [ 'rev-parse', '--show-toplevel' ],
+    { env: process.env  },
+    cb
+  )
 }

--- a/lib/utils/git.js
+++ b/lib/utils/git.js
@@ -53,7 +53,7 @@ function whichAndExec (args, options, cb) {
 function getGitRoot (cb) {
   whichAndExec(
     [ 'rev-parse', '--show-toplevel' ],
-    { env: process.env  },
+    { env: process.env },
     cb
   )
 }

--- a/lib/version.js
+++ b/lib/version.js
@@ -141,8 +141,8 @@ function dump (data, cb) {
 }
 
 function checkGit (localData, cb) {
-  fs.stat(path.join(npm.localPrefix, '.git'), function (er, s) {
-    var doGit = !er && s.isDirectory() && npm.config.get('git-tag-version')
+  git.getGitRoot(function (er) {
+    var doGit = !er && npm.config.get('git-tag-version')
     if (!doGit) {
       if (er) log.verbose('version', 'error checking for .git', er)
       log.verbose('version', 'not tagging in git')

--- a/test/tap/version-update-shrinkwrap.js
+++ b/test/tap/version-update-shrinkwrap.js
@@ -14,7 +14,8 @@ var cache = path.resolve(pkg, 'cache')
 
 test('npm version <semver> updates shrinkwrap - no git', function (t) {
   setup()
-  npm.load({ cache: pkg + '/cache', registry: common.registry }, function () {
+
+  npm.load({ cache: pkg + '/cache', registry: common.registry, 'git-tag-version': false }, function () {
     npm.commands.version(['patch'], function (err) {
       if (err) return t.fail('Error perform version patch')
       var shrinkwrap = require(path.resolve(pkg, 'npm-shrinkwrap.json'))


### PR DESCRIPTION
Check the result of `git rev-parse --show-toplevel` instead of checking whether `${npm.localPrefix}/.git` exists and it's a directory.

This has the effect of making `npm version` to correctly identify a git repository when running inside
a subdirectory (issue #8962)
