### PR TITLE
memoize access checks to eliminate duplicate checks

### DIFF
--- a/lib/install/access-error.js
+++ b/lib/install/access-error.js
@@ -1,0 +1,8 @@
+'use strict'
+module.exports = function (dir, er) {
+  if (!er) return
+  var accessEr = new Error("EACCES, access '" + dir + "'", -13)
+  accessEr.code = 'EACCES'
+  accessEr.path = dir
+  return accessEr
+}

--- a/lib/install/check-permissions.js
+++ b/lib/install/check-permissions.js
@@ -1,11 +1,12 @@
 'use strict'
 var path = require('path')
-var fs = require('graceful-fs')
 var log = require('npmlog')
 var validate = require('aproba')
 var uniq = require('lodash.uniq')
 var asyncMap = require('slide').asyncMap
 var npm = require('../npm.js')
+var exists = require('./exists.js')
+var writable = require('./writable.js')
 
 module.exports = function (actions, next) {
   validate('AF', arguments)
@@ -61,42 +62,8 @@ function hasAnyWriteAccess (dir, errors, done) {
 
 function hasWriteAccess (dir, errors, done) {
   validate('SAF', arguments)
-  access(dir, function (er) {
+  writable(dir, function (er) {
     if (er) errors.push(er)
     done()
   })
-}
-
-var exists = fs.access
-  ? function (dir, done) { fs.access(dir, fs.F_OK, done) }
-  : function (dir, done) { fs.stat(dir, function (er) { done(accessError(dir, er)) }) }
-
-var access = fs.access
-  ? function (dir, done) { fs.access(dir, fs.W_OK, done) }
-  : function (dir, done) {
-      // FIXME: So it turns out that for larger installations on windows
-      // this sometimes fails.  We need to make this work better.  Options
-      // include:
-      //   caching results
-      //   inflighting results
-      //   limiting concurrency
-      // Maybe all three.
-      // That this is going through asyncMap and then running ALL THIS
-      // makes this failure completely unsurprising. 😕
-      if (process.platform === 'win32') return done()
-      var tmp = path.join(dir, '.npm.check.permissions')
-      fs.open(tmp, 'w', function (er, fd) {
-        if (er) return done(accessError(dir, er))
-        fs.close(fd, function () {
-          fs.unlink(tmp, function () { done() })
-        })
-      })
-    }
-
-function accessError (dir, er) {
-  if (!er) return
-  var accessEr = new Error("EACCES, access '" + dir + "'", -13)
-  accessEr.code = 'EACCES'
-  accessEr.path = dir
-  return accessEr
 }

--- a/lib/install/exists.js
+++ b/lib/install/exists.js
@@ -1,0 +1,35 @@
+'use strict'
+var fs = require('fs')
+var inflight = require('inflight')
+var accessError = require('./access-error.js')
+
+// The Windows implementation of `fs.access` has a bug where it will
+// sometimes return access errors all the time for directories, even
+// when access is available. As all we actually test ARE directories, this
+// is a bit of a problem.
+// FIXME: When this is corrected in Node/iojs, update this check to be
+// a bit more specific
+var isWindows = process.platform === 'win32'
+
+// fs.access first introduced in node 0.12 / io.js
+if (fs.access && !isWindows) {
+  module.exports = fsAccessImplementation
+} else {
+  module.exports = fsStatImplementation
+}
+
+// exposed only for testing purposes
+module.exports.fsAccessImplementation = fsAccessImplementation
+module.exports.fsStatImplementation = fsStatImplementation
+
+function fsAccessImplementation (dir, done) {
+  done = inflight('exists:'+dir, done)
+  if (!done) return
+  fs.access(dir, fs.F_OK, done)
+}
+
+function fsStatImplementation (dir, done) {
+  done = inflight('exists:'+dir, done)
+  if (!done) return
+  fs.stat(dir, function (er) { done(accessError(dir, er)) })
+}

--- a/lib/install/writable.js
+++ b/lib/install/writable.js
@@ -1,0 +1,42 @@
+'use strict'
+var path = require('path')
+var fs = require('fs')
+var inflight = require('inflight')
+var accessError = require('./access-error.js')
+
+// The Windows implementation of `fs.access` has a bug where it will
+// sometimes return access errors all the time for directories, even
+// when access is available. As all we actually test ARE directories, this
+// is a bit of a problem.
+// FIXME: When this is corrected in Node/iojs, update this check to be
+// a bit more specific
+var isWindows = process.platform === 'win32'
+
+// fs.access first introduced in node 0.12 / io.js
+if (fs.access && !isWindows) {
+  module.exports = fsAccessImplementation
+} else {
+  module.exports = fsOpenImplementation
+}
+
+// exposed only for testing purposes
+module.exports.fsAccessImplementation = fsAccessImplementation
+module.exports.fsOpenImplementation = fsOpenImplementation
+
+function fsAccessImplementation (dir, done) {
+  done = inflight('writable:'+dir, done)
+  if (!done) return
+  fs.access(dir, fs.W_OK, done)
+}
+
+function fsOpenImplementation (dir, done) {
+  done = inflight('writable:'+dir, done)
+  if (!done) return
+  var tmp = path.join(dir, '.npm.check.permissions')
+  fs.open(tmp, 'w', function (er, fd) {
+    if (er) return done(accessError(dir, er))
+    fs.close(fd, function () {
+      fs.unlink(tmp, function () { done() })
+    })
+  })
+}

--- a/test/tap/check-permissions.js
+++ b/test/tap/check-permissions.js
@@ -1,0 +1,88 @@
+'use strict'
+var fs = require('fs')
+var path = require('path')
+var test = require('tap').test
+var rimraf = require('rimraf')
+var writable = require('../../lib/install/writable.js').fsAccessImplementation
+var writableFallback = require('../../lib/install/writable.js').fsOpenImplementation
+var exists = require('../../lib/install/exists.js').fsAccessImplementation
+var existsFallback = require('../../lib/install/exists.js').fsStatImplementation
+
+var testBase = path.resolve(__dirname, 'check-permissions')
+var existingDir = path.resolve(testBase, 'exists')
+var nonExistingDir = path.resolve(testBase, 'does-not-exist')
+var writableDir = path.resolve(testBase, 'writable')
+var nonWritableDir = path.resolve(testBase, 'non-writable')
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+  t.end()
+})
+
+test('exists', function (t) {
+  t.plan(2)
+  // fs.access first introduced in node 0.12 / io.js
+  if (fs.access) {
+    existsTests(t, exists)
+  } else {
+    t.pass('# skip fs.access not available in this version')
+    t.pass('# skip fs.access not available in this version')
+  }
+})
+
+test('exists-fallback', function (t) {
+  t.plan(2)
+  existsTests(t, existsFallback)
+})
+
+test('writable', function (t) {
+  t.plan(2)
+  // fs.access first introduced in node 0.12 / io.js
+  if (fs.access) {
+    writableTests(t, writable)
+  } else {
+    t.pass('# skip fs.access not available in this version')
+    t.pass('# skip fs.access not available in this version')
+  }
+})
+
+test('writable-fallback', function (t) {
+  t.plan(2)
+  writableTests(t, writableFallback)
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function setup () {
+  fs.mkdirSync(testBase)
+  fs.mkdirSync(existingDir)
+  fs.mkdirSync(writableDir)
+  fs.mkdirSync(nonWritableDir)
+  fs.chmodSync(nonWritableDir, '555')
+}
+
+function existsTests (t, exists) {
+  exists(existingDir, function (er) {
+    t.error(er, 'exists dir is exists')
+  })
+  exists(nonExistingDir, function (er) {
+    t.ok(er, 'non-existing dir resulted in an error')
+  })
+}
+
+function writableTests (t, writable) {
+  writable(writableDir, function (er) {
+    t.error(er, 'writable dir is writable')
+  })
+  writable(nonWritableDir, function (er) {
+    t.ok(er, 'non-writable dir resulted in an error')
+  })
+}
+
+function cleanup () {
+  rimraf.sync(testBase)
+}


### PR DESCRIPTION
This was causing all sorts of problems for windows users. While we're here we refactor this code and add some tests.
