### PR TITLE
Fix linking of scoped modules

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -50,6 +50,14 @@ function link (args, cb) {
   linkPkg(npm.prefix, cb)
 }
 
+function parentFolder (id, folder) {
+  if (id[0] === '@') {
+    return path.resolve(folder, '..', '..')
+  } else {
+    return path.resolve(folder, '..')
+  }
+}
+
 function linkInstall (pkgs, cb) {
   asyncMap(pkgs, function (pkg, cb) {
     var t = path.resolve(npm.globalDir, '..')
@@ -61,8 +69,9 @@ function linkInstall (pkgs, cb) {
       if (er) return cb(er, data)
       // we want the ONE thing that was installed into the global dir
       var installed = data.filter(function (info) {
+        var id = info[0]
         var folder = info[1]
-        return path.resolve(folder, '..') === npm.globalDir
+        return parentFolder(id, folder) === npm.globalDir
       })
       var id = installed[0][0]
       pp = installed[0][1]

--- a/test/tap/link.js
+++ b/test/tap/link.js
@@ -8,6 +8,7 @@ var writeFileSync = require('fs').writeFileSync
 var common = require('../common-tap.js')
 
 var link = path.join(__dirname, 'link')
+var linkScoped = path.join(__dirname, 'link-scoped')
 var linkInstall = path.join(__dirname, 'link-install')
 var linkRoot = path.join(__dirname, 'link-root')
 
@@ -22,6 +23,18 @@ var OPTS = {
 
 var readJSON = {
   name: 'foo',
+  version: '1.0.0',
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: 'echo \"Error: no test specified\" && exit 1'
+  },
+  author: '',
+  license: 'ISC'
+}
+
+var readScopedJSON = {
+  name: '@scope/foo',
   version: '1.0.0',
   description: '',
   main: 'index.js',
@@ -54,7 +67,7 @@ test('setup', function (t) {
   })
 })
 
-test('creates global link', function (t) {
+test('create global link', function (t) {
   process.chdir(link)
   common.npm(['link'], OPTS, function (err, c, out) {
     t.ifError(err, 'link has no error')
@@ -68,6 +81,20 @@ test('creates global link', function (t) {
   })
 })
 
+test('create scoped global link', function (t) {
+  process.chdir(linkScoped)
+  common.npm(['link'], OPTS, function (err, c, out) {
+    t.ifError(err, 'link has no error')
+    common.npm(['ls', '-g'], OPTS, function (err, c, out, stderr) {
+      t.ifError(err)
+      t.equal(c, 0)
+      t.equal(stderr, '', 'got expected stderr')
+      t.has(out, /@scope[/]foo@1.0.0/, 'creates global link ok')
+      t.end()
+    })
+  })
+})
+
 test('link-install the package', function (t) {
   process.chdir(linkInstall)
   common.npm(['link', 'foo'], OPTS, function (err) {
@@ -76,6 +103,19 @@ test('link-install the package', function (t) {
       t.ifError(err)
       t.equal(c, 1)
       t.has(out, /foo@1.0.0/, 'link-install ok')
+      t.end()
+    })
+  })
+})
+
+test('link-install the scoped package', function (t) {
+  process.chdir(linkInstall)
+  common.npm(['link', linkScoped], OPTS, function (err) {
+    t.ifError(err, 'link-install has no error')
+    common.npm(['ls'], OPTS, function (err, c, out) {
+      t.ifError(err)
+      t.equal(c, 1)
+      t.has(out, /@scope[/]foo@1.0.0/, 'link-install ok')
       t.end()
     })
   })
@@ -99,6 +139,7 @@ test('cleanup', function (t) {
 function cleanup () {
   rimraf.sync(linkRoot)
   rimraf.sync(link)
+  rimraf.sync(linkScoped)
   rimraf.sync(linkInstall)
 }
 
@@ -109,6 +150,11 @@ function setup () {
   writeFileSync(
     path.join(link, 'package.json'),
     JSON.stringify(readJSON, null, 2)
+  )
+  mkdirp.sync(linkScoped)
+  writeFileSync(
+    path.join(linkScoped, 'package.json'),
+    JSON.stringify(readScopedJSON, null, 2)
   )
   mkdirp.sync(linkInstall)
   writeFileSync(


### PR DESCRIPTION
Linking scoped modules was failing due to a check intended to see if the module was installed in the global directory. This did the classic `path.resolve(blah, '..')` which always, ALWAYS fails for scoped modules. Alas. Adds a test for this scenario too.
