### PR TITLE
fix `npm rm [-g] <linkedthing>`

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -542,18 +542,16 @@ Installer.prototype.readGlobalPackageData = function (cb) {
   validate('F', arguments)
   log.silly('install', 'readGlobalPackageData')
   var self = this
-  this.currentTree = new readPackageTree.Node(null, this.where, this.where, null, {})
   this.loadArgMetadata(iferr(cb, function () {
     mkdirp(self.where, iferr(cb, function () {
-      asyncMap(self.args, function (pkg, done) {
-        readPackageTree(path.resolve(self.where, 'node_modules', pkg.name), function (_, subTree) {
-          if (subTree) {
-            subTree.parent = self.currentTree
-            self.currentTree.children.push(subTree)
-          }
-          done()
-        })
-      }, cb)
+      var pkgs = {}
+      self.args.forEach(function (pkg) {
+        pkgs[pkg.name] = true
+      })
+      readPackageTree(self.where, function (ctx, kid) { return ctx.parent || pkgs[kid] }, iferr(cb, function (currentTree) {
+        self.currentTree = currentTree
+        return cb()
+      }))
     }))
   }))
 }

--- a/lib/install/action/finalize.js
+++ b/lib/install/action/finalize.js
@@ -4,6 +4,7 @@ var rimraf = require('rimraf')
 var fs = require('graceful-fs')
 var mkdirp = require('mkdirp')
 var asyncMap = require('slide').asyncMap
+var andIgnoreErrors = require('../and-ignore-errors.js')
 
 module.exports = function (top, buildpath, pkg, log, next) {
   log.silly('finalize', pkg.path)
@@ -62,7 +63,7 @@ module.exports = function (top, buildpath, pkg, log, next) {
       var to = path.join(pkg.path, 'node_modules', file)
       // we ignore errors here, because they can legitimately happen, for instance,
       // bundled modules will be in both node_modules folders
-      fs.rename(from, to, function () { done() })
+      fs.rename(from, to, andIgnoreErrors(done))
     }, cleanup)
   }
 

--- a/lib/install/action/remove.js
+++ b/lib/install/action/remove.js
@@ -5,6 +5,7 @@ var rimraf = require('rimraf')
 var asyncMap = require('slide').asyncMap
 var mkdirp = require('mkdirp')
 var npm = require('../../npm.js')
+var andIgnoreErrors = require('../and-ignore-errors.js')
 
 // This is weird because we want to remove the module but not it's node_modules folder
 // allowing for this allows us to not worry about the order of operations
@@ -54,7 +55,7 @@ function removeDir (pkg, log, next) {
       var to = path.join(pkg.path, 'node_modules', file)
       // we ignore errors here, because they can legitimately happen, for instance,
       // bundled modules will be in both node_modules folders
-      fs.rename(from, to, function () { done() })
+      fs.rename(from, to, andIgnoreErrors(done))
     }, cleanup)
   }
 

--- a/lib/install/and-ignore-errors.js
+++ b/lib/install/and-ignore-errors.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function (cb) {
+  return function () {
+    var args = Array.prototype.slice.call(arguments, 1)
+    if (args.length) args.unshift(null)
+    return cb.apply(null, args)
+  }
+}

--- a/lib/install/check-permissions.js
+++ b/lib/install/check-permissions.js
@@ -6,6 +6,7 @@ var validate = require('aproba')
 var uniq = require('lodash.uniq')
 var asyncMap = require('slide').asyncMap
 var npm = require('../npm.js')
+var andIgnoreErrors = require('./and-ignore-errors.js')
 
 module.exports = function (actions, next) {
   validate('AF', arguments)
@@ -88,7 +89,7 @@ var access = fs.access
       fs.open(tmp, 'w', function (er, fd) {
         if (er) return done(accessError(dir, er))
         fs.close(fd, function () {
-          fs.unlink(tmp, function () { done() })
+          fs.unlink(tmp, andIgnoreErrors(done))
         })
       })
     }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -23,6 +23,7 @@ var npm = require('../npm.js')
 var flatName = require('./flatten-tree.js').flatName
 var createChild = require('./node.js').create
 var resetMetadata = require('./node.js').reset
+var andIgnoreErrors = require('./and-ignore-errors.js')
 
 // The export functions in this module mutate a dependency tree, adding
 // items to them.
@@ -74,7 +75,7 @@ var recalculateMetadata = exports.recalculateMetadata = function (tree, log, nex
       if (er) return done()
       var child = findRequirement(tree, req.name, req)
       if (child) {
-        resolveWithExistingModule(child, tree, log, function () { done() })
+        resolveWithExistingModule(child, tree, log, andIgnoreErrors(done))
       } else if (tree.package.dependencies[req.name] != null) {
         tree.missingDeps[req.name] = req.rawSpec
         done()

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -101,6 +101,7 @@ var recalculateMetadata = exports.recalculateMetadata = function (tree, log, nex
   ], function () {
     tree.userRequired = tree.package._requiredBy.some(function (req) { req === '#USER' })
     tree.existing = tree.package._requiredBy.some(function (req) { req === '#EXISTING' })
+    tree.package._location = flatNameFromTree(tree)
     next(null, tree)
   })
 }
@@ -347,7 +348,6 @@ function addDependency (name, versionSpec, tree, log, done) {
 function resolveWithExistingModule (child, tree, log, next) {
   validate('OOOF', arguments)
   addRequiredDep(tree, child)
-  child.package._location = flatNameFromTree(child)
 
   if (tree.parent && child.parent !== tree) updatePhantomChildren(tree.parent, child)
 

--- a/lib/install/filter-invalid-actions.js
+++ b/lib/install/filter-invalid-actions.js
@@ -8,13 +8,25 @@ module.exports = function (top, differences, next) {
   validate('SAF', arguments)
   var action
   var keep = []
+
+  differences.forEach(function (action) {
+    var cmd = action[0]
+    var pkg = action[1]
+    if (cmd === 'remove') {
+      pkg.removing = true
+    }
+  })
+
   /*eslint no-cond-assign:0*/
   while (action = differences.shift()) {
     var cmd = action[0]
     var pkg = action[1]
-    if (pkg.isInLink || pkg.parent.target) {
-      log.warn('skippingAction', 'Module is inside a symlinked module: not running ' +
-        cmd + ' ' + getPackageId(pkg) + ' ' + path.relative(top, pkg.path))
+    if (pkg.isInLink || pkg.parent.target || pkg.parent.isLink) {
+      // we want to skip warning if this is a child of another module that we're removing
+      if (!pkg.parent.removing) {
+        log.warn('skippingAction', 'Module is inside a symlinked module: not running ' +
+          cmd + ' ' + getPackageId(pkg) + ' ' + path.relative(top, pkg.path))
+      }
     } else {
       keep.push(action)
     }

--- a/node_modules/read-package-tree/README.md
+++ b/node_modules/read-package-tree/README.md
@@ -6,7 +6,13 @@ Read the contents of node_modules.
 
 ```javascript
 var rpt = require ('read-package-tree')
-rpt('/path/to/pkg/root', function (er, data) {
+rpt('/path/to/pkg/root', function (node, kidName) {
+  // optional filter function– if included, each package folder found is passed to
+  // it to see if it should be included in the final tree
+  // node is what we're adding children to
+  // kidName is the directory name of the module we're considering adding
+  // return true -> include, false -> skip
+}, function (er, data) {
   // er means that something didn't work.
   // data is a structure like:
   // {

--- a/node_modules/read-package-tree/package.json
+++ b/node_modules/read-package-tree/package.json
@@ -1,35 +1,35 @@
 {
   "_args": [
     [
-      "read-package-tree@~5.0.0",
+      "read-package-tree@~5.1.0",
       "/Users/rebecca/code/npm"
     ]
   ],
-  "_from": "read-package-tree@>=5.0.0 <5.1.0",
-  "_id": "read-package-tree@5.0.0",
+  "_from": "read-package-tree@>=5.1.0 <5.2.0",
+  "_id": "read-package-tree@5.1.0",
   "_inCache": true,
   "_location": "/read-package-tree",
-  "_nodeVersion": "0.12.4",
+  "_nodeVersion": "0.10.38",
   "_npmUser": {
     "email": "me@re-becca.org",
     "name": "iarna"
   },
-  "_npmVersion": "2.11.2",
+  "_npmVersion": "3.1.2",
   "_phantomChildren": {},
   "_requested": {
     "name": "read-package-tree",
-    "raw": "read-package-tree@~5.0.0",
-    "rawSpec": "~5.0.0",
+    "raw": "read-package-tree@~5.1.0",
+    "rawSpec": "~5.1.0",
     "scope": null,
-    "spec": ">=5.0.0 <5.1.0",
+    "spec": ">=5.1.0 <5.2.0",
     "type": "range"
   },
   "_requiredBy": [
     "/"
   ],
-  "_shasum": "0960bb19bff77ec7e35c1ea7ca8208945ea4bfb2",
+  "_shasum": "63cf2699d5cf8fb227703322e10a700f1208fc13",
   "_shrinkwrap": null,
-  "_spec": "read-package-tree@~5.0.0",
+  "_spec": "read-package-tree@~5.1.0",
   "_where": "/Users/rebecca/code/npm",
   "author": {
     "email": "i@izs.me",
@@ -49,16 +49,16 @@
   "description": "Read the contents of node_modules.",
   "devDependencies": {
     "archy": "0",
-    "tap": "^0.4.12"
+    "tap": "^1.2.0"
   },
   "directories": {
     "test": "test"
   },
   "dist": {
-    "shasum": "0960bb19bff77ec7e35c1ea7ca8208945ea4bfb2",
-    "tarball": "http://registry.npmjs.org/read-package-tree/-/read-package-tree-5.0.0.tgz"
+    "shasum": "63cf2699d5cf8fb227703322e10a700f1208fc13",
+    "tarball": "http://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.0.tgz"
   },
-  "gitHead": "57ab023d0a50214b5ea73887adb874723a4b0232",
+  "gitHead": "9c8baac5c966f4976cfc4de6caafe58299d7a51e",
   "homepage": "https://github.com/npm/read-package-tree",
   "license": "ISC",
   "main": "rpt.js",
@@ -81,5 +81,5 @@
   "scripts": {
     "test": "tap test/*.js"
   },
-  "version": "5.0.0"
+  "version": "5.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "read": "~1.0.6",
     "read-installed": "~4.0.1",
     "read-package-json": "~2.0.0",
-    "read-package-tree": "~5.0.0",
+    "read-package-tree": "~5.1.0",
     "realize-package-specifier": "~3.0.1",
     "retry": "~0.6.1",
     "rimraf": "~2.4.1",

--- a/test/tap/rm-linked.js
+++ b/test/tap/rm-linked.js
@@ -1,0 +1,136 @@
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var path = require('path')
+var rimraf = require('rimraf')
+var test = require('tap').test
+var writeFileSync = require('fs').writeFileSync
+
+var common = require('../common-tap.js')
+
+var link = path.join(__dirname, 'rmlinked')
+var linkDep = path.join(link, 'node_modules', 'baz')
+var linkInstall = path.join(__dirname, 'rmlinked-install')
+var linkRoot = path.join(__dirname, 'rmlinked-root')
+
+var config = 'prefix = ' + linkRoot
+var configPath = path.join(link, '_npmrc')
+
+var OPTS = {
+  env: {
+    'npm_config_userconfig': configPath
+  }
+}
+
+var linkedJSON = {
+  name: 'foo',
+  version: '1.0.0',
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: 'echo \"Error: no test specified\" && exit 1'
+  },
+  dependencies: {
+    'baz': '1.0.0'
+  },
+  author: '',
+  license: 'ISC'
+}
+
+var linkedDepJSON = {
+  name: 'baz',
+  version: '1.0.0',
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: 'echo \"Error: no test specified\" && exit 1'
+  },
+  author: '',
+  license: 'ISC'
+}
+
+var installJSON = {
+  name: 'bar',
+  version: '1.0.0',
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: 'echo \"Error: no test specified\" && exit 1'
+  },
+  dependencies: {
+    'foo': '1.0.0'
+  },
+  author: '',
+  license: 'ISC'
+}
+
+test('setup', function (t) {
+  setup()
+  common.npm(['ls', '-g', '--depth=0'], OPTS, function (err, c, out) {
+    t.ifError(err)
+    t.equal(c, 0, 'set up ok')
+    t.notOk(out.match(/UNMET DEPENDENCY foo@/), "foo isn't in global")
+    t.end()
+  })
+})
+
+test('creates global link', function (t) {
+  process.chdir(link)
+  common.npm(['link'], OPTS, function (err, c, out) {
+    t.ifError(err, 'link has no error')
+    common.npm(['ls', '-g'], OPTS, function (err, c, out, stderr) {
+      t.ifError(err)
+      t.equal(c, 0)
+      t.equal(stderr, '', 'got expected stderr')
+      t.has(out, /foo@1.0.0/, 'creates global link ok')
+      t.end()
+    })
+  })
+})
+
+test('uninstall the global linked package', function (t) {
+  process.chdir(osenv.tmpdir())
+  common.npm(['uninstall', '-g', 'foo'], OPTS, function (err) {
+    t.ifError(err, 'uninstall has no error')
+    process.chdir(link)
+    common.npm(['ls'], OPTS, function (err, c, out) {
+      t.ifError(err)
+      t.equal(c, 0)
+      t.has(out, /baz@1.0.0/, "uninstall didn't remove dep")
+      t.end()
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  try { rimraf.sync(linkRoot) } catch (e) { }
+  try { rimraf.sync(linkDep) } catch (e) { }
+  try { rimraf.sync(link) } catch (e) { }
+  try { rimraf.sync(linkInstall) } catch (e) { }
+}
+
+function setup () {
+  cleanup()
+  mkdirp.sync(linkRoot)
+  mkdirp.sync(link)
+  writeFileSync(
+    path.join(link, 'package.json'),
+    JSON.stringify(linkedJSON, null, 2)
+  )
+  mkdirp.sync(linkDep)
+  writeFileSync(
+    path.join(linkDep, 'package.json'),
+    JSON.stringify(linkedDepJSON, null, 2)
+  )
+  mkdirp.sync(linkInstall)
+  writeFileSync(
+    path.join(linkInstall, 'package.json'),
+    JSON.stringify(installJSON, null, 2)
+  )
+  writeFileSync(configPath, config)
+}


### PR DESCRIPTION
npm@3 was breaking this in a variety of exciting ways.

First, w/ the global install patch from the last release, it was no longer recognizing global symlinks as symlinks.

Second, even when it did, it would try to remove all of their deps, before removing the link to them.

And finally, even if it _didn't_ remove all the subdeps, it would complain about not being able to touch them.

This addresses all three issues.
- [x] This requires a test.
