### PR TITLE
test: Use correct path for devDependency in --production test

### DIFF
--- a/test/tap/install-cli-production.js
+++ b/test/tap/install-cli-production.js
@@ -47,9 +47,9 @@ test('setup', function (t) {
     JSON.stringify(dependency, null, 2)
   )
 
-  mkdirp.sync(path.join(pkg, 'devDependency'))
+  mkdirp.sync(path.join(pkg, 'dev-dependency'))
   fs.writeFileSync(
-    path.join(pkg, 'devDependency', 'package.json'),
+    path.join(pkg, 'dev-dependency', 'package.json'),
     JSON.stringify(devDependency, null, 2)
   )
 


### PR DESCRIPTION
In messing around a bit with `--production` I noticed this one.

The test case here was creating a package that wasn't expected (`devDependency` versus `dev-dependency`). As a result, if the test was forced to fail (for example, get rid of the `--production` argument), it was failing with incorrect and not-as-helpful errors.

Now, with this commit, if you remove the `--production` argument, you get the following output from the test:

```
test/tap/install-cli-production.js .................... 4/6
  'npm install --production' should only install dependencies
  not ok npm install did not raise error code
    +++ found
    --- wanted
    -0
    +1
    compare: ===
    at:
      file: test/tap/install-cli-production.js
      line: 69
      column: 7
    stack: |
      test/tap/install-cli-production.js:69:7
      f (node_modules/once/once.js:17:25)
      ChildProcess.<anonymous> (test/common-tap.js:56:5)
      maybeClose (child_process.js:1015:16)
      Socket.<anonymous> (child_process.js:1183:11)
      Pipe.close (net.js:485:12)

  'npm install --production' should only install dependencies
  not ok devDependency was NOT installed
    at:
      file: test/tap/install-cli-production.js
      line: 76
      column: 7
    stack: |
      test/tap/install-cli-production.js:76:7
      f (node_modules/once/once.js:17:25)
      ChildProcess.<anonymous> (test/common-tap.js:56:5)
      maybeClose (child_process.js:1015:16)
      Socket.<anonymous> (child_process.js:1183:11)
      Pipe.close (net.js:485:12)

total ................................................. 4/6
```
