### PR TITLE
docs: make a note on files always included/excluded in the package

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -183,6 +183,10 @@ which will keep files from being included, even if they would be picked
 up by the files array.  The ".npmignore" file works just like a
 ".gitignore".
 
+Certain files like `package.json`, `readme` `changes|changelog|history` and
+`license` are always included, while things like `.git`, `.DS_Store`,
+`npm-debug.log` are excluded.
+
 ## main
 
 The main field is a module ID that is the primary entry point to your program.


### PR DESCRIPTION
Not sure how to document it, but I think it should be somehow.
I found [this](https://github.com/npm/npm/blob/master/lib/utils/tar.js#L61) when searching, is that the place these are applied?

Should I list everything? In a table? Make a note about file type not mattering much?
