### PR TITLE
build: use npm being released during release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,7 @@ set -e
 
 rm -rf release *.tgz || true
 mkdir release
-npm pack --loglevel error >/dev/null
+node ./cli.js pack --loglevel error >/dev/null
 mv *.tgz release
 cd release
 tar xzf *.tgz
@@ -18,12 +18,12 @@ mv package node_modules/npm
 
 # make the zip for windows users
 cp node_modules/npm/bin/*.cmd .
-zipname=npm-$(npm -v).zip
+zipname=npm-$(node ../cli.js -v).zip
 zip -q -9 -r -X "$zipname" *.cmd node_modules
 
 # make the tar for node's deps
 cd node_modules
-tarname=npm-$(npm -v).tgz
+tarname=npm-$(node ../../cli.js -v).tgz
 tar czf "$tarname" npm
 
 cd ..


### PR DESCRIPTION
There was some weirdness going on where, depending on your
local setup during release, you could get unexpected results
during build (specifically, the version on the tarball and zip
corresponded to your global npm's version)

I went ahead and also made it so the npm pack is also done
by the version getting released, to avoid any possible
issues with 2.x vs 3.x
