### PR TITLE
.git is not required to be a directory.

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -142,7 +142,7 @@ function dump (data, cb) {
 
 function checkGit (localData, cb) {
   fs.stat(path.join(npm.localPrefix, '.git'), function (er, s) {
-    var doGit = !er && s.isDirectory() && npm.config.get('git-tag-version')
+    var doGit = !er && npm.config.get('git-tag-version')
     if (!doGit) {
       if (er) log.verbose('version', 'error checking for .git', er)
       log.verbose('version', 'not tagging in git')


### PR DESCRIPTION
In a submodule it is actually a file with a line in it that tells GIT where to find the actual .git directory.
