### PR TITLE
install: Update fs.access to allow io.js versions w/ fixed windows ver

### DIFF
--- a/lib/install/exists.js
+++ b/lib/install/exists.js
@@ -2,17 +2,9 @@
 var fs = require('fs')
 var inflight = require('inflight')
 var accessError = require('./access-error.js')
+var isFsAccessAvailable = require('./is-fs-access-available.js')
 
-// The Windows implementation of `fs.access` has a bug where it will
-// sometimes return access errors all the time for directories, even
-// when access is available. As all we actually test ARE directories, this
-// is a bit of a problem.
-// FIXME: When this is corrected in Node/iojs, update this check to be
-// a bit more specific
-var isWindows = process.platform === 'win32'
-
-// fs.access first introduced in node 0.12 / io.js
-if (fs.access && !isWindows) {
+if (isFsAccessAvailable) {
   module.exports = fsAccessImplementation
 } else {
   module.exports = fsStatImplementation

--- a/lib/install/is-fs-access-available.js
+++ b/lib/install/is-fs-access-available.js
@@ -1,0 +1,24 @@
+'use strict'
+var fs = require('fs')
+var process = require('process')
+var semver = require('semver')
+
+var isWindows = process.platform === 'win32'
+
+// fs.access first introduced in node 0.12 / io.js
+if (!fs.access) {
+  module.exports = false
+} else if (!isWindows) {
+  // fs.access always works on non-Windows OSes
+  module.exports = true
+} else {
+  // The Windows implementation of `fs.access` has a bug where it will
+  // sometimes return access errors all the time for directories, even
+  // when access is available. As all we actually test ARE directories, this
+  // is a bit of a problem.
+  // This was fixed in io.js version 1.5.0
+  // As of 2015-07-20, it is still unfixed in node:
+  // https://github.com/joyent/node/issues/25657
+
+  module.exports = semver.gte(process.version, '1.5.0')
+}

--- a/lib/install/writable.js
+++ b/lib/install/writable.js
@@ -4,17 +4,9 @@ var fs = require('fs')
 var inflight = require('inflight')
 var accessError = require('./access-error.js')
 var andIgnoreErrors = require('./and-ignore-errors.js')
+var isFsAccessAvailable = require('./is-fs-access-available.js')
 
-// The Windows implementation of `fs.access` has a bug where it will
-// sometimes return access errors all the time for directories, even
-// when access is available. As all we actually test ARE directories, this
-// is a bit of a problem.
-// FIXME: When this is corrected in Node/iojs, update this check to be
-// a bit more specific
-var isWindows = process.platform === 'win32'
-
-// fs.access first introduced in node 0.12 / io.js
-if (fs.access && !isWindows) {
+if (isFsAccessAvailable) {
   module.exports = fsAccessImplementation
 } else {
   module.exports = fsOpenImplementation

--- a/test/tap/is-fs-access-available.js
+++ b/test/tap/is-fs-access-available.js
@@ -1,0 +1,47 @@
+'use strict'
+var test = require('tap').test
+var requireInject = require('require-inject')
+
+test('mac + !fs.access', function (t) {
+  var isFsAccessAvailable = requireInject('../../lib/install/is-fs-access-available.js', {
+    fs: {},
+    process: {platform: 'darwin'}
+  })
+  t.is(isFsAccessAvailable, false, 'not available')
+  t.end()
+})
+test('mac + fs.access', function (t) {
+  var isFsAccessAvailable = requireInject('../../lib/install/is-fs-access-available.js', {
+    process: {platform: 'darwin'}
+  })
+  t.is(isFsAccessAvailable, true, 'available')
+  t.end()
+})
+test('windows + !fs.access', function (t) {
+  var isFsAccessAvailable = requireInject('../../lib/install/is-fs-access-available.js', {
+    fs: {},
+    process: {platform: 'win32'}
+  })
+  t.is(isFsAccessAvailable, false, 'not available')
+  t.end()
+})
+test('windows + fs.access + node 0.10.40', function (t) {
+  var isFsAccessAvailable = requireInject('../../lib/install/is-fs-access-available.js', {
+    process: {
+      platform: 'win32',
+      version: '0.10.40'
+    }
+  })
+  t.is(isFsAccessAvailable, false, 'not available')
+  t.end()
+})
+test('windows + fs.access + node 2.4.0', function (t) {
+  var isFsAccessAvailable = requireInject('../../lib/install/is-fs-access-available.js', {
+    process: {
+      platform: 'win32',
+      version: '2.4.0'
+    }
+  })
+  t.is(isFsAccessAvailable, true, 'available')
+  t.end()
+})


### PR DESCRIPTION
This also pushes them off to their own file, so we can stop doing
the copy-pasta dance. It also makes explaining the rational of the
check cleaner I think.
