### PR TITLE
windows: search for a user-installed npm

### DIFF
--- a/bin/npm
+++ b/bin/npm
@@ -7,8 +7,21 @@ case `uname` in
     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
-if [ -x "$basedir/node.exe" ]; then
-  "$basedir/node.exe" "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
-else
-  node "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
+NODE_EXE="$basedir/node.exe"
+if ! [ -x "$NODE_EXE" ]; then
+  NODE_EXE=node
 fi
+
+NPM_CLI_JS="$basedir/node_modules/npm/bin/npm-cli.js"
+
+case `uname` in
+  *CYGWIN*)
+    NPM_PREFIX=`"$NODE_EXE" "$NPM_CLI_JS" prefix -g`
+    NPM_PREFIX_NPM_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npm-cli.js"
+    if [ -f "$NPM_PREFIX_NPM_CLI_JS" ]; then
+      NPM_CLI_JS="$NPM_PREFIX_NPM_CLI_JS"
+    fi
+    ;;
+esac
+
+"$NODE_EXE" "$NPM_CLI_JS" "$@"

--- a/bin/npm.cmd
+++ b/bin/npm.cmd
@@ -1,6 +1,19 @@
 :: Created by npm, please don't edit manually.
-@IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
-) ELSE (
-  node "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
+@ECHO OFF
+
+SETLOCAL
+
+SET "NODE_EXE=%~dp0\node.exe"
+IF NOT EXIST "%NODE_EXE%" (
+  SET "NODE_EXE=node"
 )
+
+SET "NPM_CLI_JS=%~dp0\node_modules\npm\bin\npm-cli.js"
+FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPM_CLI_JS%" prefix -g') DO (
+  SET "NPM_PREFIX_NPM_CLI_JS=%%F\node_modules\npm\bin\npm-cli.js"
+)
+IF EXIST "%NPM_PREFIX_NPM_CLI_JS%" (
+  SET "NPM_CLI_JS=%NPM_PREFIX_NPM_CLI_JS%"
+)
+
+"%NODE_EXE%" "%NPM_CLI_JS%" %*


### PR DESCRIPTION
This changes npm.cmd and the npm script when running in Cygwin to look for an npm installation in prefix, running it if found. The default npm is used to get the prefix. This implements the changes described in https://github.com/joyent/node/issues/8528 .

Fixes npm/npm#6412
Fixes joyent/node#8528
Refer joyent/node#8554
