### PR TITLE
Correct typo in `bundledDependencies` section

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -571,7 +571,7 @@ this. If you depend on features introduced in 1.5.2, use `">= 1.5.2 < 2"`.
 
 Array of package names that will be bundled when publishing the package.
 
-If this is spelled `"bundleDependencies"`, then that is also honorable.
+If this is spelled `"bundleDependencies"`, then that is also honored.
 
 ## optionalDependencies
 


### PR DESCRIPTION
This corrects a typo in the section on `bundledDependencies` in the `package.json` documentation.
