### PR TITLE
run-script: include `version` in lifecycle output

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -62,7 +62,7 @@ function runScript (args, cb) {
 function list(cb) {
   var json = path.join(npm.localPrefix, "package.json")
   var cmdList = [ "publish", "install", "uninstall"
-                , "test", "stop", "start", "restart"
+                , "test", "stop", "start", "restart", "version"
                 ].reduce(function (l, p) {
                   return l.concat(["pre" + p, p, "post" + p])
                 }, [])

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -54,6 +54,14 @@ var both = {
   }
 }
 
+var preversionOnly = {
+  name: 'scripted',
+  version: '1.2.3',
+  scripts: {
+    'preversion': 'echo preversion'
+  }
+}
+
 
 function testOutput (t, command, er, code, stdout, stderr) {
   var lines
@@ -182,6 +190,25 @@ test('npm run-script no-params (lifecycle only)', function (t) {
   ].join('\n')
 
   writeMetadata(lifecycleOnly)
+
+  common.npm(['run-script'], opts, function (err, code, stdout, stderr) {
+    t.ifError(err, 'ran run-script without parameters without crashing')
+    t.notOk(code, 'npm exited without error code')
+    t.notOk(stderr, 'npm printed nothing to stderr')
+    t.equal(stdout, expected, 'got expected output')
+    t.end()
+  })
+})
+
+test('npm run-script no-params (preversion only)', function (t) {
+  var expected = [
+    'Lifecycle scripts included in scripted:',
+    '  preversion',
+    '    echo preversion',
+    ''
+  ].join('\n')
+
+  writeMetadata(preversionOnly)
 
   common.npm(['run-script'], opts, function (err, code, stdout, stderr) {
     t.ifError(err, 'ran run-script without parameters without crashing')


### PR DESCRIPTION
`preversion`, `version`, and `postversion` lifecycle scripts were getting included in the generic run-script section instead of being listed as lifecycle events when running `npm run-script` with no arguments.

Fixes #9146.

**r**: @zkat 
