### PR TITLE
Resolve peer deps from the perspective of the parent module

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -430,9 +430,10 @@ function resolveWithNewModule (pkg, tree, log, next) {
 
 var validatePeerDeps = exports.validatePeerDeps = function (tree, onInvalid) {
   if (!tree.package.peerDependencies) return
+  if (!tree.parent) return
   Object.keys(tree.package.peerDependencies).forEach(function (pkgname) {
     var version = tree.package.peerDependencies[pkgname]
-    var match = findRequirement(tree, pkgname, npa(pkgname + '@' + version))
+    var match = findRequirement(tree.parent, pkgname, npa(pkgname + '@' + version))
     if (!match) onInvalid(tree, pkgname, version)
   })
 }

--- a/lib/install/logical-tree.js
+++ b/lib/install/logical-tree.js
@@ -6,6 +6,7 @@ var validate = require('aproba')
 var flattenTree = require('./flatten-tree.js')
 var isExtraneous = require('./is-extraneous.js')
 var validateAllPeerDeps = require('./deps.js').validateAllPeerDeps
+var getPackageId = require('./get-package-id.js')
 
 var logicalTree = module.exports = function (tree) {
   validate('O', arguments)
@@ -74,17 +75,27 @@ function translateTree (tree) {
       }
     }
   })
-  if (tree.missingPeers) {
-    Object.keys(tree.missingPeers).forEach(function (pkgname) {
-      var version = tree.missingPeers[pkgname]
-      pkg.dependencies[pkgname] = {
-        _id: pkgname + '@' + version,
-        name: pkgname,
-        version: version,
-        peerMissing: true
-      }
-    })
-  }
+  tree.children.forEach(function (child) {
+    var childPkg = pkg.dependencies[child.package.name]
+    if (child.missingPeers) {
+      Object.keys(child.missingPeers).forEach(function (pkgname) {
+        var version = child.missingPeers[pkgname]
+        var peerPkg = pkg.dependencies[pkgname]
+        if (!peerPkg) {
+          peerPkg = pkg.dependencies[pkgname] = {
+            _id: pkgname + '@' + version,
+            name: pkgname,
+            version: version
+          }
+        }
+        if (!peerPkg.peerMissing) peerPkg.peerMissing = []
+        peerPkg.peerMissing.push({
+          requiredBy: getPackageId(child),
+          requires: pkgname + '@' + version
+        })
+      })
+    }
+  })
   pkg.path = tree.path
 
   pkg.error = tree.error

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -196,11 +196,13 @@ function getLite (data, noname) {
         return [d, { required: dep.requiredBy, missing: true }]
       } else if (dep.peerMissing) {
         lite.problems = lite.problems || []
-        var pdm = 'peer dep missing: ' +
-            d + '@' + dep.version +
-            ', required by ' +
-            getPackageId(data)
-        lite.problems.push(pdm)
+        dep.peerMissing.forEach(function (missing) {
+          var pdm = 'peer dep missing: ' +
+              missing.requires +
+              ', required by ' +
+              missing.requiredBy
+          lite.problems.push(pdm)
+        })
         return [d, { required: dep, peerMissing: true }]
       }
       return [d, getLite(dep, true)]


### PR DESCRIPTION
This stops it from considering a direct dependency to be acceptable. The exception to this is if you're operating with the module with the peer deps as your top level. This means you're developing that module and having its peer deps installed inside it is appropriate.

This also updates `ls` to display this new perspective correctly.

Fixes: #9050
