### PR TITLE
Fix fetch-package-metadata to have * match latest for modules w/ all prereleases

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -125,6 +125,11 @@ function fetchNamedPackageData (dep, next) {
             return returnAndAddMetadata(pkg.versions[versions[jj]])
           }
         }
+
+        // Failing THAT, if the range was '*' uses latestVersion
+        if (dep.spec === '*') {
+          return returnAndAddMetadata(pkg.versions[latestVersion])
+        }
       }
 
       // And failing that, we error out

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -107,7 +107,7 @@ function fetchNamedPackageData (dep, next) {
         var tagVersion = pkg['dist-tags'][dep.spec]
         if (pkg.versions[tagVersion]) return returnAndAddMetadata(pkg.versions[tagVersion])
       } else {
-        var latestVersion = pkg['dist-tags'].latest || versions[0]
+        var latestVersion = pkg['dist-tags'][npm.config.get('tag')] || versions[0]
 
         // Find the the most recent version less than or equal
         // to latestVersion that satisfies our spec

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -61,6 +61,10 @@ function doesChildVersionMatch (child, requested) {
   // we always consider deps provided by a shrinkwrap as "correct" or else
   // we'll subvert them if they're intentionally "invalid"
   if (child.fromShrinkwrap) return true
+  // ranges of * ALWAYS count as a match, because when downloading we allow
+  // prereleases to match * if there are ONLY prereleases
+  if (requested.spec === '*') return true
+
   var childReq = child.package._requested
   if (childReq) {
     if (childReq.rawSpec === requested.rawSpec) return true

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -58,6 +58,8 @@ function isProdDep (tree, name) {
 var registryTypes = { range: true, version: true }
 
 function doesChildVersionMatch (child, requested) {
+  // we always consider deps provided by a shrinkwrap as "correct" or else
+  // we'll subvert them if they're intentionally "invalid"
   if (child.fromShrinkwrap) return true
   var childReq = child.package._requested
   if (childReq) {


### PR DESCRIPTION
Fixes: #8951 
