### PR TITLE
Prefer rawSpec over spec when saving

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -171,10 +171,12 @@ exports.loadRequestedDeps = function (args, tree, saveToDependencies, log, next)
         child.isGlobal = true
       }
       if (saveToDependencies) {
-        tree.package[saveToDependencies][child.package.name] = child.package._requested.spec
+        tree.package[saveToDependencies][child.package.name] =
+          child.package._requested.rawSpec || child.package._requested.spec
       }
       if (saveToDependencies && saveToDependencies !== 'devDependencies') {
-        tree.package.dependencies[child.package.name] = child.package._requested.spec
+        tree.package.dependencies[child.package.name] =
+          child.package._requested.rawSpec || child.package._requested.spec
       }
       child.directlyRequested = true
       child.save = saveToDependencies


### PR DESCRIPTION
This is necessary because npa mangles spec in ways that are not compatible npa itself. For reasons. Specifically, `git+ssh` urls have their `git+` stripped from the front, which, for reasons, is then fed BACK into npa, which then explodes.

Fixes: #9077
