### PR TITLE
[npm@3] Use the progress bar only with quiet logging levels

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -358,7 +358,10 @@
 
         log.resume()
 
-        if (config.get('progress')) {
+        if (config.get('progress') &&
+             (log.level == 'warn'  ||
+              log.level == 'error' ||
+              log.level == 'silent')) {
           log.enableProgress()
         } else {
           log.disableProgress()


### PR DESCRIPTION
Adding -d or -ddd to npm invocation
causes a strange mix of the progress bar
along with the verbose output.
