### PR TITLE
lifecycle: add /d and /s to cmd.exe

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -306,3 +306,4 @@ Kyle M. Tarplee <kyle.tarplee@numerica.us>
 Derek Peterson <derekpetey@gmail.com>
 Greg Whiteley <greg.whiteley@atomos.com>
 murgatroid99 <mlumish@google.com>
+Marcin Cieślak <saper@marcincieslak.com>

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -207,7 +207,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
 
   if (process.platform === 'win32') {
     sh = process.env.comspec || 'cmd'
-    shFlag = '/c'
+    shFlag = '/d /s /c'
     conf.windowsVerbatimArguments = true
   }
 


### PR DESCRIPTION
`/d` disables `cmd.exe` AutoRuns feature, where registry entry points to the script that will be executed when cmd.exe starts. Surprisingly a lot of users have `CD \` or similar command there which causes lifecycle scripts to fail, since relative path to the script no longer works (and `package.json` has no way to deduce absolute path)

/s enables handling of quotes, so that you can have "C:\Program Files\Node\node.exe" quoted in your script. Node's `child_process.exec()` is doing the same. We prevent additional quoting by libuv already by setting `uv_spawn()` flag `UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS`.

If those flags are not set there is no way package.json can reliably tell us to run "node" executable with a relative script path:

``` json
    "scripts": {
      "install": "node scripts/install.js"
    }
```

Without /d "node" invocation may end up in a random directory as a result of the AutoRuns command.

Fixes:
    https://github.com/npm/npm/issues/8751
    https://github.com/npm/npm/issues/7333
    https://github.com/sass/node-sass/issues/1027
    https://github.com/sass/node-sass/issues/1012
    https://github.com/sass/node-sass/issues/659
    https://github.com/sass/node-sass/issues/603
