### PR TITLE
Fix path used to run the install relative to

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -43,15 +43,14 @@ function update (args, cb) {
     log.info('outdated', 'updating', wanted)
     var toInstall = {}
     wanted.forEach(function (ww) {
-      if (ww.current === ww.wanted) return
-
       // use the initial installation method (repo, tar, git) for updating
       if (url.parse(ww.req).protocol) ww.what = ww.req
 
-      if (toInstall[ww.dep.path]) {
-        toInstall[ww.dep.path].push(ww.what)
+      var where = ww.dep.parent && ww.dep.parent.path || ww.dep.path
+      if (toInstall[where]) {
+        toInstall[where].push(ww.what)
       } else {
-        toInstall[ww.dep.path] = [ww.what]
+        toInstall[where] = [ww.what]
       }
     })
     chain(Object.keys(toInstall).map(function (where) {

--- a/test/tap/update-path.js
+++ b/test/tap/update-path.js
@@ -1,0 +1,35 @@
+'use strict'
+var test = require('tap').test
+var requireInject = require('require-inject')
+
+var mockNpm = {
+  config: {
+    get: function (key) {
+      return false
+    }
+  },
+  commands: {
+    outdated: function (args, silent, cb) {
+      cb(null, [
+        [{path: '/incorrect', parent: {path: '/correct'}}, 'abc', '1.0.0', '1.1.0', '1.1.0', '^1.1.0']
+      ])
+    }
+  }
+}
+
+// What we're testing here is that updates use the parent module's path to
+// install from.
+test('update', function (t) {
+  var update = requireInject('../../lib/update.js', {
+    '../../lib/npm.js': mockNpm,
+    '../../lib/install.js': {
+      'Installer': function (where, dryrun, args) {
+        t.is(where, '/correct', 'We should be installing to the parent of the modules being updated')
+        this.run = function (cb) { cb() }
+      }
+    }
+  })
+  update(['abc'], function () {
+    t.end()
+  })
+})


### PR DESCRIPTION
Previously I was using the path of the module to be updated.  But no, silly, we want the path that CONTAINS it. Not having this results in updates failing with "we can't install that module in itself".

This'll fix #9095
