### PR TITLE
Fix the progress-config test when run from travis or other CI

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -172,7 +172,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     parseable: false,
     prefix: globalPrefix,
     production: process.env.NODE_ENV === 'production',
-    'progress': process.env.TRAVIS !== 'true' && process.env.CI !== 'true',
+    'progress': !process.env.TRAVIS && !process.env.CI,
     'proprietary-attribs': true,
     proxy: null,
     'https-proxy': null,

--- a/test/tap/progress-config.js
+++ b/test/tap/progress-config.js
@@ -8,6 +8,9 @@ var log = require('npmlog')
 // these various tests.
 var requireInject = require('require-inject')
 
+// Make sure existing environment vars don't muck up the test
+process.env = {}
+
 test('disabled', function (t) {
   t.plan(1)
   var npm = requireInject('../../lib/npm.js', {})
@@ -29,5 +32,25 @@ test('default', function (t) {
   var npm = requireInject('../../lib/npm.js', {})
   npm.load({}, function () {
     t.is(log.progressEnabled, true, 'should be enabled')
+  })
+})
+
+test('default-travis', function (t) {
+  t.plan(1)
+  global.process.env.TRAVIS = 'true'
+  var npm = requireInject('../../lib/npm.js', {})
+  npm.load({}, function () {
+    t.is(log.progressEnabled, false, 'should be disabled')
+    delete global.process.env.TRAVIS
+  })
+})
+
+test('default-ci', function (t) {
+  t.plan(1)
+  global.process.env.CI = 'true'
+  var npm = requireInject('../../lib/npm.js', {})
+  npm.load({}, function () {
+    t.is(log.progressEnabled, false, 'should be disabled')
+    delete global.process.env.CI
   })
 })


### PR DESCRIPTION
We have special code to disable the progress bar on travis (and other CI) to
save ourselves and our users a lot of unhelpful output. Unfortunately as
this test didn't take that into account, it immediately exploded in this
envs.

So we fix that up, PLUS we add tests for the various env options for
suppressing progress bars.
