### PR TITLE
doc: de-anachronize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and prior, clone the git repo and dig through the old tags and branches.
 
 ## Super Easy Install
 
-npm comes with [node](http://nodejs.org/download/) now.
+npm is bundled with [node](http://nodejs.org/download/).
 
 ### Windows Computers
 


### PR DESCRIPTION
As far as bundling npm with npm is concerned, "now" stopped being now about four years ago.

Replaces: #9279.
