### PR TITLE
Elminate warnings about missing package.json at top level

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -146,7 +146,8 @@ function getLite (data, noname) {
     lite.problems.push('extraneous: ' + getPackageId(data) + ' ' + (data.path || ''))
   }
 
-  if (data.error && data.path !== path.resolve(npm.globalDir, '..')) {
+  if (data.error && data.path !== path.resolve(npm.globalDir, '..') &&
+      (data.error.code !== 'ENOENT' || noname)) {
     lite.invalid = true
     lite.problems = lite.problems || []
     var message = data.error.message

--- a/test/tap/ls-l-depth-0.js
+++ b/test/tap/ls-l-depth-0.js
@@ -77,7 +77,7 @@ test('#6311: npm ll --depth=0 duplicates listing', function (t) {
         EXEC_OPTS,
         function (err, code, stdout, stderr) {
           t.ifError(err, 'npm ll ran without error')
-          t.is(code, 1, 'npm ll complained about there being no package.json')
+          t.is(code, 0, 'npm ll exited cleanly')
           t.notOk(stderr, 'npm ll ran silently')
           t.equal(
             stdout,

--- a/test/tap/ls-top-errors.js
+++ b/test/tap/ls-top-errors.js
@@ -1,0 +1,71 @@
+'use strict'
+var fs = require('fs')
+var path = require('path')
+
+var test = require('tap').test
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+
+var common = require('../common-tap')
+
+var pkg = path.resolve(__dirname, path.basename(__filename, '.js'))
+var pathModA = path.join(pkg, 'node_modules', 'moduleA')
+var pathModB = path.join(pkg, 'node_modules', 'moduleB')
+
+var modA = {
+  name: 'moduleA',
+  version: '1.0.0',
+  _requiredBy: [ '#USER', '/moduleB' ],
+  dependencies: {
+    moduleB: '1.0.0'
+  }
+}
+var modB = {
+  name: 'moduleB',
+  version: '1.0.0',
+  _requiredBy: [ '/moduleA' ],
+  dependencies: {
+    moduleA: '1.0.0'
+  }
+}
+
+function setup () {
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    '{broken json'
+  )
+  mkdirp.sync(pathModA)
+  fs.writeFileSync(
+    path.join(pathModA, 'package.json'),
+    JSON.stringify(modA, null, 2)
+  )
+  mkdirp.sync(pathModB)
+  fs.writeFileSync(
+    path.join(pathModB, 'package.json'),
+    JSON.stringify(modB, null, 2)
+  )
+}
+
+function cleanup () {
+  rimraf.sync(pkg)
+}
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+  t.end()
+})
+
+test('ls-top-errors', function (t) {
+  common.npm(['ls'], {cwd: pkg}, function (er, code, stdout, stderr) {
+    t.ifErr(er, 'install finished successfully')
+    t.match(stderr, /Failed to parse json/)
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
npm@2 didn't emit these and to be honest, it's not that interesting. The test change actually just reverts a previous test change when these warnings were introduced.

This will half fix #9113 
