### PR TITLE
Make sure user installed modules are attached to root of logical tree

### DIFF
--- a/lib/install/logical-tree.js
+++ b/lib/install/logical-tree.js
@@ -46,6 +46,9 @@ var logicalTree = module.exports = function (tree) {
     requiredBy.forEach(function (parentNode) {
       parentNode.children = union(parentNode.children, [node])
     })
+    if (node.package._requiredBy.some(function (nodename) { return nodename[0] === '#' })) {
+      newTree.children = union(newTree.children, [node])
+    }
   })
   return newTree
 }

--- a/test/tap/extraneous-dep-cycle-ls-ok.js
+++ b/test/tap/extraneous-dep-cycle-ls-ok.js
@@ -1,0 +1,70 @@
+'use strict'
+var fs = require('fs')
+var path = require('path')
+
+var test = require('tap').test
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+
+var common = require('../common-tap')
+
+var pkg = path.resolve(__dirname, path.basename(__filename, '.js'))
+var pathModA = path.join(pkg, 'node_modules', 'moduleA')
+var pathModB = path.join(pkg, 'node_modules', 'moduleB')
+
+var modA = {
+  name: 'moduleA',
+  version: '1.0.0',
+  _requiredBy: [ '#USER', '/moduleB' ],
+  dependencies: {
+    moduleB: '1.0.0'
+  }
+}
+var modB = {
+  name: 'moduleB',
+  version: '1.0.0',
+  _requiredBy: [ '/moduleA' ],
+  dependencies: {
+    moduleA: '1.0.0'
+  }
+}
+
+function setup () {
+  mkdirp.sync(pathModA)
+  fs.writeFileSync(
+    path.join(pathModA, 'package.json'),
+    JSON.stringify(modA, null, 2)
+  )
+  mkdirp.sync(pathModB)
+  fs.writeFileSync(
+    path.join(pathModB, 'package.json'),
+    JSON.stringify(modB, null, 2)
+  )
+}
+
+function cleanup () {
+  rimraf.sync(pkg)
+}
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+  t.end()
+})
+
+var expected = pkg + '\n' +
+               '└─┬ moduleA@1.0.0\n' +
+               '  └── moduleB@1.0.0\n\n'
+
+test('extraneous-dep-cycle', function (t) {
+  common.npm(['ls'], {cwd: pkg}, function (er, code, stdout, stderr) {
+    t.ifErr(er, 'install finished successfully')
+    t.is(stdout, expected, 'ls output shows module')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
If you had a set of modules with a dep cycle that never touched the root of the tree (that is, the top level was extraneous) then it would be entirely invisible to `npm ls`. It got detached from the root and never attached anywhere else.

Ordinarily extraneous modules were explicitly left in place, but it turns out that the way I was determining... er, extraneousness, was to see if anything required the module.

This will half fix #9113 
