### PR TITLE
lifecycle: keep private values out of child procs

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -313,7 +313,9 @@ function makeEnv (data, prefix, env) {
     , verPref = data.name + "@" + data.version + ":"
 
   keys.forEach(function (i) {
-    if (i.charAt(0) === "_" && i.indexOf("_"+namePref) !== 0) {
+    // in some rare cases (e.g. working with nerf darts), there are segmented
+    // "private" (underscore-prefixed) config names -- don't export
+    if (i.charAt(0) === '_' && i.indexOf('_' + namePref) !== 0 || i.match(/:_/)) {
       return
     }
     var value = npm.config.get(i)

--- a/test/tap/run-script-filter-private.js
+++ b/test/tap/run-script-filter-private.js
@@ -1,0 +1,52 @@
+var fs = require('graceful-fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap')
+
+var pkg = path.resolve(__dirname, 'run-script-filter-private')
+
+var opts = { cwd: pkg }
+
+var json = {
+  name: 'run-script-filter-private',
+  version: '1.2.3'
+}
+
+var npmrc = '//blah.com:_harsh=realms\n'
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.resolve(pkg, 'package.json'),
+    JSON.stringify(json, null, 2) + '\n'
+  )
+  fs.writeFileSync(
+    path.resolve(pkg, '.npmrc'),
+    npmrc
+  )
+  t.end()
+})
+
+test('npm run-script env', function (t) {
+  common.npm(['run-script', 'env'], opts, function (er, code, stdout, stderr) {
+    t.ifError(er, 'using default env script')
+    t.notOk(stderr, 'should not generate errors')
+    t.ok(stdout.indexOf('npm_config_init_version') > 0, 'expected values in var list')
+    t.notMatch(stdout, /harsh/, 'unexpected config not there')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  rimraf.sync(pkg)
+}

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')

--- a/test/tap/tag-version-prefix.js
+++ b/test/tap/tag-version-prefix.js
@@ -19,70 +19,75 @@ var json = { name: 'blah', version: '0.1.2' }
 var configContents = 'sign-git-tag=false\nmessage=":bookmark: %s"\n'
 
 test('npm version <semver> with message config', function (t) {
-    setup()
+  setup()
 
-    npm.load({ prefix: pkg, userconfig: npmrc }, function () {
-        var git = require('../../lib/utils/git.js')
+  npm.load({ prefix: pkg, userconfig: npmrc }, function () {
+    var git = require('../../lib/utils/git.js')
 
-        common.makeGitRepo({ path: pkg }, function (er) {
-            t.ifErr(er, 'git bootstrap ran without error')
+    common.makeGitRepo({ path: pkg }, function (er) {
+        t.ifErr(er, 'git bootstrap ran without error')
 
-            common.npm([
-                'config',
-                'set',
-                'tag-version-prefix',
-                'q'
-            ], { cwd: pkg, env: { PATH: process.env.PATH } },
-            function (err, code, stdout, stderr) {
-                t.ifError(err, 'npm config ran without issue')
+        common.npm(
+          [
+            '--userconfig', npmrc,
+            'config',
+            'set',
+            'tag-version-prefix',
+            'q'
+          ],
+          { cwd: pkg, env: { PATH: process.env.PATH } },
+          function (err, code, stdout, stderr) {
+            t.ifError(err, 'npm config ran without issue')
+            t.notOk(code, 'exited with a non-error code')
+            t.notOk(stderr, 'no error output')
+
+            common.npm(
+              [
+                'version',
+                'patch',
+                '--loglevel', 'silent'
+                // package config is picked up from env
+              ],
+              { cwd: pkg, env: { PATH: process.env.PATH } },
+              function (err, code, stdout, stderr) {
+                t.ifError(err, 'npm version ran without issue')
                 t.notOk(code, 'exited with a non-error code')
                 t.notOk(stderr, 'no error output')
 
-                common.npm(
-                    [
-                        'version',
-                        'patch',
-                        '--loglevel', 'silent'
-                        // package config is picked up from env
-                    ],
-                    { cwd: pkg, env: { PATH: process.env.PATH } },
-                    function (err, code, stdout, stderr) {
-                        t.ifError(err, 'npm version ran without issue')
-                        t.notOk(code, 'exited with a non-error code')
-                        t.notOk(stderr, 'no error output')
-
-                        git.whichAndExec(
-                            ['tag'],
-                            { cwd: pkg, env: process.env },
-                            function (er, tags, stderr) {
-                                t.ok(tags.match(/q0\.1\.3/g), 'tag was created by version' + tags)
-                                t.end()
-                            }
-                        )
-                    }
+                git.whichAndExec(
+                  ['tag'],
+                  { cwd: pkg, env: process.env },
+                  function (er, tags, stderr) {
+                    t.ok(tags.match(/q0\.1\.3/g), 'tag was created by version' + tags)
+                    t.end()
+                  }
                 )
-            })
-        })
-    })
+              }
+            )
+          }
+        )
+      }
+    )
+  })
 })
 
 test('cleanup', function (t) {
-    cleanup()
-    t.end()
+  cleanup()
+  t.end()
 })
 
 function cleanup () {
-    // windows fix for locked files
-    process.chdir(osenv.tmpdir())
+  // windows fix for locked files
+  process.chdir(osenv.tmpdir())
 
-    rimraf.sync(pkg)
+  rimraf.sync(pkg)
 }
 
 function setup () {
-    cleanup()
-    mkdirp.sync(cache)
-    process.chdir(pkg)
+  cleanup()
+  mkdirp.sync(cache)
+  process.chdir(pkg)
 
-    fs.writeFileSync(packagePath, JSON.stringify(json), 'utf8')
-    fs.writeFileSync(npmrc, configContents, 'ascii')
+  fs.writeFileSync(packagePath, JSON.stringify(json), 'utf8')
+  fs.writeFileSync(npmrc, configContents, 'ascii')
 }


### PR DESCRIPTION
`npm@1` didn't include configuration values with names prefixed with an underscore in the environment passed to child processes. `npm@2` includes the notion of scoped configuration, where a nerfed URL can be used to prefix configuration, some of which might be underscore-prefixed without the scope. Add that behavior to npm@2 and close this regression.

**r**: @iarna 
**r**: @isaacs (when he returns)
