### PR TITLE
Make it easier to run just _some_ tests in the same way as the test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,10 +181,11 @@
     "dumpconf": "env | grep npm | sort | uniq",
     "prepublish": "bash scripts/installable.sh && node bin/npm-cli.js prune --prefix=. --no-global && rimraf test/*/*/node_modules && make -j4 doc",
     "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"update AUTHORS\" || true",
-    "tap": "tap --timeout 240 test/tap/*.js",
-    "test": "standard && npm run tap",
-    "test-all": "standard && npm run test-legacy && npm run tap",
-    "test-legacy": "node ./test/run.js"
+    "tap": "tap --timeout 240",
+    "test": "standard && npm run test-tap",
+    "test-all": "standard && npm run test-legacy && npm run test-tap",
+    "test-legacy": "node ./test/run.js",
+    "test-tap": "npm run tap -- test/tap/*.js"
   },
   "license": "Artistic-2.0"
 }


### PR DESCRIPTION
This restructures the test related scripts such that if you want to run ALL the tap tests you now run:

`npm run test-tap`

But if you want to run just a few of the tests:

`npm run tap /path/to/test`

This ensures that environmental differences between running the tests directly, via tap and via `npm run` don't result in tests that succeed when run directly but that fail when run via `npm test-all`.
