### PR TITLE
Add direct support for local modules

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -9,6 +9,7 @@ var tar = require('tar')
 var once = require('once')
 var semver = require('semver')
 var readPackageTree = require('read-package-tree')
+var readPackageJson = require('read-package-json')
 var iferr = require('iferr')
 var rimraf = require('rimraf')
 var clone = require('lodash.clonedeep')
@@ -55,6 +56,8 @@ module.exports = function fetchPackageMetadata (spec, where, tracker, done) {
   }
   if (dep.type === 'version' || dep.type === 'range' || dep.type === 'tag') {
     fetchNamedPackageData(dep, addRequestedAndFinish)
+  } else if (dep.type === 'directory') {
+    fetchDirectoryPackageData(dep, where, addRequestedAndFinish)
   } else {
     fetchOtherPackageData(spec, dep, where, addRequestedAndFinish)
   }
@@ -78,6 +81,12 @@ function fetchOtherPackageData (spec, dep, where, next) {
     result._inCache = true
     next(null, result)
   }))
+}
+
+function fetchDirectoryPackageData(dep, where, next) {
+  validate('OSF', arguments)
+  log.silly('fetchDirectoryPackageData', dep.name || dep.rawSpec)
+  readPackageJson(path.join(dep.spec, 'package.json'), false, next)
 }
 
 var regCache = {}

--- a/test/tap/verify-no-lifecycle-on-repo.js
+++ b/test/tap/verify-no-lifecycle-on-repo.js
@@ -1,0 +1,55 @@
+'use strict'
+var path = require('path')
+var fs = require('graceful-fs')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var test = require('tap').test
+var common = require('../common-tap.js')
+
+var base = path.join(__dirname, path.basename(__filename, '.js'))
+
+var baseJSON = {
+  name: 'base',
+  version: '1.0.0',
+  repository: {
+    type: "git",
+    url: "http://example.com"
+  },
+  scripts: {
+    prepublish: 'false'
+  }
+}
+
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+  t.end()
+})
+
+test('repo', function (t) {
+  common.npm(['repo', '--browser=echo'], {cwd: base}, function (er, code, stdout, stderr) {
+    t.ifError(er, 'npm config ran without issue')
+    t.is(code, 0, 'exited with a non-error code')
+    t.is(stderr, '', 'Ran without errors')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function saveJson(pkgPath, json) {
+  mkdirp.sync(pkgPath)
+  fs.writeFileSync(path.join(pkgPath, 'package.json'), JSON.stringify(json, null, 2))
+}
+
+function setup () {
+  saveJson(base, baseJSON)
+}
+
+function cleanup () {
+  rimraf.sync(base)
+}


### PR DESCRIPTION
So, `fetch-package-metadata` has direct support for fetching metadata from the registry. For anything else it adds the package to the cache and then gets the metadata from there.

This adds support for loading metadata directly from local directories. This turns out to be important for commands like `npm repo` that want metadata about the module in the current directory.

Fixes: #9308
