### PR TITLE
pack: always ignore .npmrc

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -84,7 +84,8 @@ BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
       entry.match(/^\..*\.swp$/) ||
       entry === '.DS_Store' ||
       entry.match(/^\._/) ||
-      entry === 'npm-debug.log'
+      entry === 'npm-debug.log' ||
+      entry === '.npmrc'
     ) {
     return false
   }


### PR DESCRIPTION
npm should ignore it's own dotfiles when running `npm pack`. This patch adds `.npmrc` to the internal ignore list.

Background story: I must have published packages with my credentials. I use `.npmrc` at work for my open source projects. I'm ignoring them with a global git ignore, so I tend to forget that they're there. Your bot suggests to add .npmrc to .npmignore, which would work of cause, but I'd rather have it in npm itself instead of adding new .npmignore files to other peoples projects.

@zkat @iarna I'm on npm@3, but maybe this should go to both branches. I tried finding a test case to build on. Could find one, sorry.
