### PR TITLE
Update Developer Guide .npmignore Section to Match package.json Spec

### DIFF
--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -132,7 +132,9 @@ The following paths and files are never ignored, so adding them to
 `.npmignore` is pointless:
 
 * `package.json`
-* `README.*`
+* `README` (and its variants)
+* `CHANGELOG` (and its variants)
+* `LICENSE` / `LICENCE`
 
 ## Link Packages
 


### PR DESCRIPTION
[Developer Guide](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package):

```
The following paths and files are never ignored, so adding them to .npmignore is pointless:

package.json
README.*
```

[package.json Spec](https://docs.npmjs.com/files/package.json#files):

```
Certain files are always included, regardless of settings:

package.json
README (and its variants)
CHANGELOG (and its variants)
LICENSE / LICENCE
```
