### PR TITLE
error-handler: improve EISDIR error message for the most common case

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -366,6 +366,14 @@ function errorHandler (er) {
               ].join("\n"))
     break
 
+  case "EISDIR":
+    log.error("eisdir", [er.message
+              ,"This is most likely not a problem with npm itself"
+              ,"and is related to npm not being able to find a package.json in"
+              ,"a package you are trying to install."
+              ].join("\n"))
+    break
+
   default:
     log.error("", er.message || er)
     log.error("", ["", "If you need help, you may report this error at:"


### PR DESCRIPTION
Reports of `EISDIR` on the issue tracker are almost exclusively caused by users trying to install something that does not have a `package.json`. However, it is clearly difficult for many users to discern this simple problem from the error code alone. So let's expand upon it.

Fixes https://github.com/npm/npm/issues/6590, https://github.com/npm/npm/issues/9297
