### PR TITLE
Fix npm.commands.publish when in interactive shell

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -62,7 +62,7 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
     var env = makeEnv(pkg)
     env.npm_lifecycle_event = stage
     env.npm_node_execpath = env.NODE = env.NODE || process.execPath
-    env.npm_execpath = require.main.filename
+    env.npm_execpath = (require.main && require.main.filename) || process.cwd()
 
     // 'nobody' typically doesn't have permission to write to /tmp
     // even if it's never used, sh freaks out.


### PR DESCRIPTION
When running node's interactive shell, require.main is undefined because no specific file is being executed by node.

This pr fixes the issue by falling back on process.cwd() if require.main is undefined, enabling people to test and use npm.commands.publish in node's interactive console.
