### PR TITLE
add 'npm it' command

### DIFF
--- a/doc/cli/npm-install-test.md
+++ b/doc/cli/npm-install-test.md
@@ -1,0 +1,25 @@
+# npm install-test(1) -- Install package(s) and run tests
+
+## SYNOPSIS
+
+    npm install-test (with no args, in package dir)
+    npm install-test [<@scope>/]<name>
+    npm install-test [<@scope>/]<name>@<tag>
+    npm install-test [<@scope>/]<name>@<version>
+    npm install-test [<@scope>/]<name>@<version range>
+    npm install-test <tarball file>
+    npm install-test <tarball url>
+    npm install-test <folder>
+
+    alias: npm it
+    common options: [--save|--save-dev|--save-optional] [--save-exact] [--dry-run]
+
+## DESCRIPTION
+
+This command runs an `npm install` followed immediately by an `npm test`. It
+takes exactly the same arguments as `npm install`.
+
+## SEE ALSO
+
+- npm-install(1)
+- npm-test(1)

--- a/lib/install-test.js
+++ b/lib/install-test.js
@@ -1,0 +1,23 @@
+'use strict'
+
+// npm install-test
+// Runs `npm install` and then runs `npm test`
+
+module.exports = installTest
+var install = require('./install.js')
+var test = require('./test.js')
+
+installTest.usage = '\nnpm install-test [args]' +
+                    '\nSame args as `npm install`' +
+                    '\n\nalias: npm it'
+
+installTest.completion = install.completion
+
+function installTest (args, cb) {
+  install(args, function (er) {
+    if (er) {
+      return cb(er)
+    }
+    test([], cb)
+  })
+}

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -70,6 +70,7 @@
     'ln': 'link',
     'i': 'install',
     'isntall': 'install',
+    'it': 'install-test',
     'up': 'update',
     'upgrade': 'update',
     'c': 'config',
@@ -99,6 +100,7 @@
   // these are filenames in .
   var cmdList = [
     'install',
+    'install-test',
     'uninstall',
     'cache',
     'config',

--- a/test/tap/it.js
+++ b/test/tap/it.js
@@ -1,0 +1,77 @@
+var join = require('path').join
+var statSync = require('graceful-fs').statSync
+var writeFileSync = require('graceful-fs').writeFileSync
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap')
+
+var pkg = join(__dirname, 'run-script')
+var installed = join(pkg, 'node_modules', 'underscore', 'package.json')
+
+var json = {
+  name: 'npm-it-test',
+  dependencies: {
+    underscore: '1.5.1'
+  },
+  scripts: {
+    test: 'echo hax'
+  }
+}
+
+var server
+
+test('run up the mock registry', function (t) {
+  mr({ port: common.port }, function (err, s) {
+    if (err) throw err
+    server = s
+    t.end()
+  })
+})
+
+test('npm install-test', function (t) {
+  setup()
+  common.npm('install-test', { cwd: pkg }, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.equal(code, 0, 'command ran without error')
+    t.ok(statSync(installed), 'package was installed')
+    t.equal(require(installed).version, '1.5.1', 'underscore got installed as expected')
+    t.match(stdout, /hax/, 'found expected test output')
+    t.notOk(stderr, 'stderr should be empty')
+    t.end()
+  })
+})
+
+test('npm it (the form most people will use)', function (t) {
+  setup()
+  common.npm('it', { cwd: pkg }, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.equal(code, 0, 'command ran without error')
+    t.ok(statSync(installed), 'package was installed')
+    t.equal(require(installed).version, '1.5.1', 'underscore got installed as expected')
+    t.match(stdout, /hax/, 'found expected test output')
+    t.notOk(stderr, 'stderr should be empty')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  process.chdir(osenv.tmpdir())
+  server.close()
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  rimraf.sync(pkg)
+}
+
+function setup () {
+  cleanup()
+  mkdirp.sync(pkg)
+  writeFileSync(join(pkg, 'package.json'), JSON.stringify(json, null, 2))
+}


### PR DESCRIPTION
I keep wanting a command for `npm i && npm t` so I could do `npm it`.

Needs tests and docs, but leaving this here for my fellow CLI peops to weigh in on whether this is a good thing or an excessive thing.
