### PR TITLE
Fix port changing but protocol staying the same

### DIFF
--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -197,6 +197,12 @@ function addNameVersion (name, v, data, cb) {
         var rp = url.parse(ruri)
         if (tb.hostname === rp.hostname && tb.protocol !== rp.protocol) {
           tb.protocol = rp.protocol
+          // If a different port is associated with the other protocol
+          // we need to update that as well
+          if (rp.port !== tb.port) {
+            tb.port = rp.port
+            delete tb.host
+          }
           delete tb.href
         }
         tb = url.format(tb)

--- a/test/tap/add-named-update-protocol-port.js
+++ b/test/tap/add-named-update-protocol-port.js
@@ -1,0 +1,76 @@
+var nock = require('nock')
+var test = require('tap').test
+var npm = require('../../')
+var addNamed = require('../../lib/cache/add-named')
+
+var fooPkg = {
+  name: 'foo',
+  versions: {
+    '0.0.0': {
+      name: 'foo',
+      version: '0.0.0',
+      dist: {
+        tarball: 'https://localhost:1338/registry/foo/-/foo-0.0.0.tgz',
+        shasum: '356a192b7913b04c54574d18c28d46e6395428ab'
+      }
+    }
+  }
+}
+
+var fooiPkg = {
+  name: 'fooi',
+  versions: {
+    '0.0.0': {
+      name: 'fooi',
+      version: '0.0.0',
+      dist: {
+        tarball: 'http://127.0.0.1:1338/registry/fooi/-/fooi-0.0.0.tgz',
+        shasum: '356a192b7913b04c54574d18c28d46e6395428ab'
+      }
+    }
+  }
+}
+
+test('tarball paths should update port if updating protocol', function (t) {
+  nock('http://localhost:1337/registry')
+    .get('/foo')
+    .reply(200, fooPkg)
+
+  nock('http://localhost:1337/registry')
+    .get('/foo/-/foo-0.0.0.tgz')
+    .reply(200, '1')
+
+  nock('http://localhost:1338/registry')
+    .get('/foo/-/foo-0.0.0.tgz')
+    .reply(404)
+
+  npm.load({registry: 'http://localhost:1337/registry', global: true}, function () {
+    addNamed('foo', '0.0.0', null, function checkPath (err, pkg) {
+      t.ifError(err, 'addNamed worked')
+      t.end()
+    })
+  })
+
+})
+
+test('tarball paths should NOT update if different hostname', function (t) {
+  nock('http://localhost:1337/registry')
+    .get('/fooi')
+    .reply(200, fooiPkg)
+
+  nock('http://127.0.0.1:1338/registry')
+    .get('/fooi/-/fooi-0.0.0.tgz')
+    .reply(200, '1')
+
+  nock('http://127.0.0.1:1337/registry')
+    .get('/fooi/-/fooi-0.0.0.tgz')
+    .reply(404)
+
+  npm.load({registry: 'http://localhost:1337/registry', global: true}, function () {
+    addNamed('fooi', '0.0.0', null, function checkPath (err, pkg) {
+      t.ifError(err, 'addNamed worked')
+      t.end()
+    })
+  })
+
+})


### PR DESCRIPTION
If the port is changing the protocol should be allowed to change. I don't think port was intentionally excluded in the `but only if they're the same hostname` comment. Since `fetchit` is checking `hostname` and not `host` it was not accounting for the port possibly changing.
From the Node.js docs:

> `host`: The full lowercased host portion of the URL, including port information.
> Example: 'host.com:8080'
> `hostname`: Just the lowercased hostname portion of the host.
> Example: 'host.com'

Relevant npm-debug.log output:

```
30 silly addNamed @levenlabs/js-lib@0.1.12
31 verbose addNamed "0.1.12" is a plain semver version for @levenlabs/js-lib
32 silly mapToRegistry name @levenlabs/js-lib
33 silly mapToRegistry scope (from package name) @levenlabs
34 silly mapToRegistry registry http://sinopia:4873/
35 silly mapToRegistry uri http://sinopia:4873/@levenlabs%2fjs-lib
36 verbose addRemoteTarball http://sinopia:4874/@levenlabs%2fjs-lib/-/js-lib-0.1.12.tgz not in flight; adding
37 verbose addRemoteTarball [ 'http://sinopia:4874/@levenlabs%2fjs-lib/-/js-lib-0.1.12.tgz',
```

Port 4874 is HTTPS and port 4783 is HTTP. It's fails to download the tarball because its trying to access sinopia with http when it should be using https. It got the other port from the cache where the urls are all `https://sinopia:4874/`.The reason it ever tried http is because the `~/.npmrc` had the registry for `@levenlabs` saved as `http://sinopia:4873`.

Unless we want to clear the cache everywhere and update everyone's npmrc's it would be nice to slowly transition over to https without npm being broken.
