### PR TITLE
Clarify documentation wrt `.{npm,git}ignore` behaviour

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -178,10 +178,10 @@ The "files" field is an array of files to include in your project.  If
 you name a folder in the array, then it will also include the files
 inside that folder. (Unless they would be ignored by another rule.)
 
-You can also provide a ".npmignore" file in the root of your package,
-which will keep files from being included, even if they would be picked
-up by the files array.  The ".npmignore" file works just like a
-".gitignore".
+You can also provide a ".npmignore" file in the root of your package or
+in subdirectories, which will keep files from being included, even
+if they would be picked up by the files array.  The `.npmignore` file
+works just like a `.gitignore`.
 
 Certain files are always included, regardless of settings:
 

--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -100,7 +100,9 @@ Use a `.npmignore` file to keep stuff out of your package.  If there's
 no `.npmignore` file, but there *is* a `.gitignore` file, then npm will
 ignore the stuff matched by the `.gitignore` file.  If you *want* to
 include something that is excluded by your `.gitignore` file, you can
-create an empty `.npmignore` file to override it.
+create an empty `.npmignore` file to override it. Like `git`, `npm` looks
+for `.npmignore` and `.gitignore` files in all subdirectories of your
+package, not only the root directory.
 
 `.npmignore` files follow the [same pattern rules](http://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#Ignoring-Files)
 as `.gitignore` files:


### PR DESCRIPTION
I was a bit confused when I found out that `.gitignore` files are treated as replacements for `.npmignore` files even in subdirectories, given that the documentation basically only talks about `.npmignore` in the root directory.
I hope this clears things up a little for other users.
