### PR TITLE
doc: replace `node-waf` with `node-gyp` in default `install` script

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -69,10 +69,10 @@ npm will default some script values based on package contents.
   If there is a `server.js` file in the root of your package, then npm
   will default the `start` command to `node server.js`.
 
-* `"preinstall": "node-waf clean || true; node-waf configure build"`:
+* `"install": "node-gyp rebuild"`:
 
-  If there is a `wscript` file in the root of your package, npm will
-  default the `preinstall` command to compile using node-waf.
+  If there is a `bindings.gyp` file in the root of your package, npm will
+  default the `install` command to compile using node-gyp.
 
 ## USER
 


### PR DESCRIPTION
The behavior described here has been inaccurate for a long time. Not only was the `wscript` bit removed from `read-package-json` over 2 years ago (https://github.com/npm/read-package-json/commit/bb5f88a9809e0382d36fb47db184a0fc6e84fb96), the `install` script is what is set to the default (now `node-gyp rebuild`), not `preinstall`.

Fixes https://github.com/npm/npm/issues/9583
