### PR TITLE
Stop warning about cruft in module directories

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -280,6 +280,7 @@ Installer.prototype.run = function (cb) {
       if (self.idealTree) {
         self.idealTree.warnings.forEach(function (warning) {
           if (warning.code === 'EPACKAGEJSON' && self.global) return
+          if (warning.code === 'ENOTDIR') return
           log.warn(warning.code, warning.message)
         })
       }

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -134,8 +134,15 @@ function alphasort (a, b) {
        : a < b ? -1 : 0
 }
 
+function isCruft (data) {
+  return data.extraneous && data.error && data.error.code === 'ENOTDIR'
+}
+
 function getLite (data, noname) {
   var lite = {}
+
+  if (isCruft(data)) return lite
+
   var maxDepth = npm.config.get('depth')
 
   if (!noname && data.name) lite.name = data.name
@@ -376,7 +383,9 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
   out.nodes = []
   if (depth <= npm.config.get('depth')) {
     out.nodes = Object.keys(data.dependencies || {})
-      .sort(alphasort).map(function (d) {
+      .sort(alphasort).filter(function (d) {
+        return !isCruft(data.dependencies[d])
+      }).map(function (d) {
         return makeArchy_(data.dependencies[d], long, dir, depth + 1, data, d)
       })
   }

--- a/test/tap/cruft-test.js
+++ b/test/tap/cruft-test.js
@@ -1,0 +1,43 @@
+'use strict'
+var fs = require('graceful-fs')
+var path = require('path')
+var mkdirpSync = require('mkdirp').sync
+var rimraf = require('rimraf')
+var test = require('tap').test
+var common = require('../common-tap.js')
+
+var base = path.join(__dirname, path.basename(__filename, '.js'))
+var cruft = path.join(base, 'node_modules', 'cruuuft')
+var pkg = {
+  name: 'example',
+  version: '1.0.0',
+  dependencies: {}
+}
+
+function setup () {
+  mkdirpSync(path.dirname(cruft))
+  fs.writeFileSync(cruft, 'this is some cruft for sure')
+  fs.writeFileSync(path.join(base, 'package.json'), JSON.stringify(pkg))
+}
+
+function cleanup () {
+  rimraf.sync(base)
+}
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+  t.done()
+})
+
+test('cruft', function (t) {
+  common.npm(['ls'], {cwd: base}, function (er, code, stdout, stderr) {
+    t.is(stderr, '', 'no warnings or errors from ls')
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.done()
+})


### PR DESCRIPTION
Currently, npm@3 will report warnings if you have random files in your node_modules folder. npm@2 did not do this, and while this probably isn't desirable per se, there's actually no reason to report this as an error. Suddenly starting to do so is definitely surprising, since previously error free node_modules folders would suddenly start printing all these warnings. Further, the fact that these extra files were flagged as extraneous modules meant that `shrinkwrap` would refuse to run as long as they were there.

This fixes #9285 
