### PR TITLE
Fix stack overflow on pack

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -20,6 +20,7 @@ var myUid = process.getuid && process.getuid()
 var myGid = process.getgid && process.getgid()
 var readPackageTree = require('read-package-tree')
 var union = require('lodash.union')
+var flattenTree = require('../install/flatten-tree.js')
 
 if (process.env.SUDO_UID && myUid === 0) {
   if (!isNaN(process.env.SUDO_UID)) myUid = +process.env.SUDO_UID
@@ -35,12 +36,22 @@ function pack (tarball, folder, pkg, cb) {
   log.verbose('tarball', tarball)
   log.verbose('folder', folder)
 
-  var recalculateMetadata = require('../install/deps.js').recalculateMetadata
-  readPackageTree(folder, iferr(cb, function (tree) {
-    recalculateMetadata(tree, log.newGroup('pack:' + pkg), iferr(cb, function () {
-      pack_(tarball, folder, tree, pkg, cb)
-    }))
-  }))
+  readJson(path.join(folder, 'package.json'), function (er, pkg) {
+    if (er || !pkg.bundleDependencies) {
+      pack_(tarball, folder, null, null, pkg, cb)
+    } else {
+      // we require this at runtime due to load-order issues, because recursive
+      // requires fail if you replace the exports object, and we do, not in deps, but
+      // in a dep of it.
+      var recalculateMetadata = require('../install/deps.js').recalculateMetadata
+
+      readPackageTree(folder, iferr(cb, function (tree) {
+        recalculateMetadata(tree, log.newGroup('pack:' + pkg), iferr(cb, function () {
+          pack_(tarball, folder, tree, flattenTree(tree), pkg, cb)
+        }))
+      }))
+    }
+  })
 }
 
 function BundledPacker (props) {
@@ -124,9 +135,7 @@ BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
 
 function nameMatch (name) { return function (other) { return name === other.package.name } }
 
-function pack_ (tarball, folder, tree, pkg, cb) {
-  var flattenTree = require('../install/flatten-tree.js')
-  var flatTree = flattenTree(tree)
+function pack_ (tarball, folder, tree, flatTree, pkg, cb) {
   function InstancePacker (props) {
     BundledPacker.call(this, props)
   }
@@ -139,6 +148,7 @@ function pack_ (tarball, folder, tree, pkg, cb) {
       throw new Error(this.package.name + '\'s `bundledDependencies` should ' +
                       'be an array')
     }
+    if (!tree) return false
 
     if (bd.indexOf(name) !== -1) return true
     var pkg = tree.children.filter(nameMatch(name))[0]

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -45,18 +45,8 @@ function pack (tarball, folder, pkg, cb) {
 
 function BundledPacker (props) {
   Packer.call(this, props)
-  this.tree = props.tree
-  var flattenTree = require('../install/flatten-tree.js')
-  this.flatTree = props.flatTree || flattenTree(props.tree)
 }
 inherits(BundledPacker, Packer)
-
-BundledPacker.prototype.getChildProps = function (stat) {
-  var props = Packer.prototype.getChildProps.call(this, stat)
-  props.tree = this.tree
-  props.flatTree = this.flatTree
-  return props
-}
 
 BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
   // package.json files can never be ignored.
@@ -134,36 +124,42 @@ BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
 
 function nameMatch (name) { return function (other) { return name === other.package.name } }
 
-BundledPacker.prototype.isBundled = function (name) {
-  var bd = this.package && this.package.bundleDependencies
-  if (!bd) return false
-
-  if (!Array.isArray(bd)) {
-    throw new Error(this.package.name + '\'s `bundledDependencies` should ' +
-                    'be an array')
-  }
-
-  if (bd.indexOf(name) !== -1) return true
-  var pkg = this.tree.children.filter(nameMatch(name))[0]
-  if (!pkg) return false
-  var requiredBy = union([], pkg.package._requiredBy)
-  var seen = {}
-  while (requiredBy.length) {
-    var req = requiredBy.shift()
-    if (seen[req]) continue
-    seen[req] = true
-    var reqPkg = this.flatTree[req]
-    if (!reqPkg) continue
-    if (reqPkg.parent === this.tree && bd.indexOf(reqPkg.package.name) !== -1) {
-      return true
-    }
-    requiredBy = union(requiredBy, reqPkg.package._requiredBy)
-  }
-  return false
-}
-
 function pack_ (tarball, folder, tree, pkg, cb) {
-  new BundledPacker({ path: folder, tree: tree, type: 'Directory', isDirectory: true })
+  var flattenTree = require('../install/flatten-tree.js')
+  var flatTree = flattenTree(tree)
+  function InstancePacker (props) {
+    BundledPacker.call(this, props)
+  }
+  inherits(InstancePacker, BundledPacker)
+  InstancePacker.prototype.isBundled = function (name) {
+    var bd = this.package && this.package.bundleDependencies
+    if (!bd) return false
+
+    if (!Array.isArray(bd)) {
+      throw new Error(this.package.name + '\'s `bundledDependencies` should ' +
+                      'be an array')
+    }
+
+    if (bd.indexOf(name) !== -1) return true
+    var pkg = tree.children.filter(nameMatch(name))[0]
+    if (!pkg) return false
+    var requiredBy = union([], pkg.package._requiredBy)
+    var seen = {}
+    while (requiredBy.length) {
+      var req = requiredBy.shift()
+      if (seen[req]) continue
+      seen[req] = true
+      var reqPkg = flatTree[req]
+      if (!reqPkg) continue
+      if (reqPkg.parent === tree && bd.indexOf(reqPkg.package.name) !== -1) {
+        return true
+      }
+      requiredBy = union(requiredBy, reqPkg.package._requiredBy)
+    }
+    return false
+  }
+
+  new InstancePacker({ path: folder, type: 'Directory', isDirectory: true })
     .on('error', function (er) {
       if (er) log.error('tar pack', 'Error reading ' + folder)
       return cb(er)

--- a/test/tap/bundled-dependencies-nonarray.js
+++ b/test/tap/bundled-dependencies-nonarray.js
@@ -1,12 +1,10 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var test = require('tap').test
 
-var npm = require('../../lib/npm.js')
 var common = require('../common-tap.js')
 
 var dir = path.resolve(__dirname, 'bundleddependencies')
@@ -36,24 +34,19 @@ test('setup', function (t) {
 
 test('errors on non-array bundleddependencies', function (t) {
   t.plan(6)
-  process.chdir(pkg)
-  npm.load({},
-    function () {
-      common.npm(['install'], { cwd: pkg }, function (err, code, stdout, stderr) {
-        t.ifError(err, 'npm install ran without issue')
-        t.notOk(code, 'exited with a non-error code')
-        t.notOk(stderr, 'no error output')
+  common.npm(['install'], { cwd: pkg }, function (err, code, stdout, stderr) {
+    t.ifError(err, 'npm install ran without issue')
+    t.is(code, 0, 'exited with a non-error code')
+    t.is(stderr, '', 'no error output')
 
-        common.npm(['install', './pkg-with-bundled'], { cwd: dir },
-          function (err, code, stdout, stderr) {
-            t.ifError(err, 'npm install ran without issue')
-            t.ok(code, 'exited with a error code')
-            t.ok(stderr.indexOf('be an array') > -1, 'nice error output')
-          }
-        )
-      })
-    }
-  )
+    common.npm(['install', './pkg-with-bundled'], { cwd: dir },
+      function (err, code, stdout, stderr) {
+        t.ifError(err, 'npm install ran without issue')
+        t.notEqual(code, 0, 'exited with a error code')
+        t.like(stderr, /be an array/, 'nice error output')
+      }
+    )
+  })
 })
 
 test('cleanup', function (t) {
@@ -62,7 +55,9 @@ test('cleanup', function (t) {
 })
 
 function bootstrap () {
+  cleanup()
   mkdirp.sync(dir)
+  mkdirp.sync(path.join(dir, 'node_modules'))
 
   mkdirp.sync(pkg)
   fs.writeFileSync(path.resolve(pkg, 'package.json'), pj)
@@ -72,6 +67,5 @@ function bootstrap () {
 }
 
 function cleanup () {
-  process.chdir(osenv.tmpdir())
   rimraf.sync(dir)
 }


### PR DESCRIPTION
So... under some circumstances we're seeing stack overflows when people initiate actions that result in a package being created. This can be from installing a directory, running `npm publish` or directly running `npm pack`.

While walking back through the tarball creation code, I realized that the npm@3 bundled dependency support, which needs to check to see if an installed package is a subdep of a bundled dep, was hanging on to its copy of the install tree by sticking it in the `props` attribute. The problem with this is that the `props` attribute gets written to the tarball's headers in a recursive fashion. If there any dependency cycles then this recursion would go on forever and we'd see a stack overflow.

This patch stops storing the tree in the object and instead closes over it with the class we'll be using to feed the tarball. This results in simpler and (I believe) easier to understand code.

While I was working on this, I realized that we were needlessly building out the tree in the first place in the case of modules w/o any bundled dependencies. So this pull request also includes a patch to stop doing that.
