### PR TITLE
Add lifecycle script that actually runs before (and only before) prepublish

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -71,6 +71,7 @@ function cacheAddPublish (dir, didPre, isRetry, cb) {
     var cachedir = path.resolve(cachedPackageRoot(data), 'package')
     chain(
       [
+        [lifecycle, data, 'actuallyprepublish', cachedir],
         !didPre && [lifecycle, data, 'prepublish', cachedir],
         [publish_, dir, data, isRetry, cachedir],
         [lifecycle, data, 'publish', didPre ? dir : cachedir],


### PR DESCRIPTION
This PR adds a lifecycle script that runs before (and only before) publish.
This PR closes https://github.com/npm/npm/issues/8402
This PR does not break legacy behavior of `prepublish` script.
If merged, users who need a lifecycle script that actually runs before prepublish may opt into this change
by installing the latest npm and adding an `"actuallyprepublish"` script to their `package.json`.

If there is a better way to implement this change, please advise.
If you would merge this please let me know and I'll add documentation.

This PR supercedes this feature request https://github.com/npm/npm/issues/9721

There is a bit of a bikeshed about what this script should be called, I settled on `actuallyprepublish` but I considered `prepublishliterally` and `pregoddamnpublish`. Any other suggestions are welcome.
