### PR TITLE
run `build` not `prepublish` script before `npm install <noargs>`

### DIFF
--- a/lib/cache/add-local.js
+++ b/lib/cache/add-local.js
@@ -5,6 +5,7 @@ var chownr = require('chownr')
 var pathIsInside = require('path-is-inside')
 var readJson = require('read-package-json')
 var log = require('npmlog')
+var chain = require('slide').chain
 var npm = require('../npm.js')
 var tar = require('../utils/tar.js')
 var deprCheck = require('../utils/depr-check.js')
@@ -94,7 +95,10 @@ function addLocalDirectory (p, pkgData, shasum, cb) {
         if (er) return cb(er)
         var doPrePublish = !pathIsInside(p, npm.tmp)
         if (doPrePublish) {
-          lifecycle(data, 'prepublish', p, iferr(cb, thenPack))
+          chain([
+            [lifecycle, data, 'build', p],
+            [lifecycle, data, 'prepublish', p]
+          ], iferr(cb, thenPack))
         } else {
           thenPack()
         }

--- a/lib/install.js
+++ b/lib/install.js
@@ -535,10 +535,6 @@ Installer.prototype.runTopLevelLifecycles = function (cb) {
     steps.push(
       [doOneAction, 'test', this.idealTree.path, this.idealTree, trackLifecycle.newGroup('npat:.')])
   }
-  if (this.dev) {
-    steps.push(
-      [doOneAction, 'prepublish', this.idealTree.path, this.idealTree, trackLifecycle.newGroup('prepublish')])
-  }
   chain(steps, cb)
 }
 

--- a/lib/install/action/build.js
+++ b/lib/install/action/build.js
@@ -1,12 +1,14 @@
 'use strict'
 var chain = require('slide').chain
 var build = require('../../build.js')
+var lifecycle = require('../../utils/lifecycle.js')
 var npm = require('../../npm.js')
 
 module.exports = function (top, buildpath, pkg, log, next) {
   log.silly('build', pkg.package.name)
   chain([
     [build.linkStuff, pkg.package, pkg.path, npm.config.get('global'), false],
-    [build.writeBuiltinConf, pkg.package, pkg.path]
+    [build.writeBuiltinConf, pkg.package, pkg.path],
+    [lifecycle, pkg.package, 'build', buildpath, false, false, next]
   ], next)
 }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -71,6 +71,7 @@ function cacheAddPublish (dir, didPre, isRetry, cb) {
     var cachedir = path.resolve(cachedPackageRoot(data), 'package')
     chain(
       [
+        !didPre && [lifecycle, data, 'build', cachedir],
         !didPre && [lifecycle, data, 'prepublish', cachedir],
         [publish_, dir, data, isRetry, cachedir],
         [lifecycle, data, 'publish', didPre ? dir : cachedir],


### PR DESCRIPTION
hey. o/

[everyone knows](https://terrytao.wordpress.com/2011/04/07/the-blue-eyed-islanders-puzzle-repost/) that [`prepublish` before `npm install <noargs>` is a misfeature](https://github.com/npm/npm/issues/3059#issuecomment-58283393), we honestly should [fix it in some upcoming release](https://github.com/npm/npm/issues/8402) (4.0.0?).

here's a strawman for a particular implementation based on:

[[0](https://github.com/npm/npm/issues/3059#issuecomment-12273443)]

> @dfellis: I use `prepublish` to actually take care of chores that need to be done
> prior to publishing, such as generating a minified version for
> browsers, building documentation from the source code, making the
> commit for these things and tagging that commit with the new version
> number.

[[1](https://github.com/npm/npm/issues/3059#issuecomment-60379536)]

> @jussi-kalliokoski: When you think of prepublish as build, things start making sense. For
> example:
> - Travis CI default setup is `npm install && npm test`, so basically the
>   idea is that after install, your package is ready, then you test it.
> - You download the sources of a service, then to get it up and running,
>   you run `npm install && npm start`.
> - You scp the sources of a node module from somewhere, then you go into
>   the directory, you run `npm install` and you expect it to be ready to used
>   from outside.
> 
> So basically, the idea is that `npm install` without arguments gives you
> the same result as installing the package from the npm repositories,
> where it has already been built.
