### PR TITLE
doc: fix minor typo in npm-team.md

### DIFF
--- a/doc/cli/npm-team.md
+++ b/doc/cli/npm-team.md
@@ -52,4 +52,4 @@ use the `npm access` command to grant or revoke the appropriate permissions.
 ## SEE ALSO
 
 * npm-access(1)
-* npm-registr(7)
+* npm-registry(7)


### PR DESCRIPTION
Missing a `y` in the `npm team` docs
