### PR TITLE
Add node 4.0 and 4.1 to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "4.1"
+  - "4.0"
   - iojs
   - "0.12"
   - "0.10"


### PR DESCRIPTION
There are a few other PRs like this, and I apologize for duplicating - let's count them as +1s

I also have one question for discussion: should `iojs` be removed from the versions tested against? If my understanding's correct, it's no longer supported and folks should move to 4.x?
