### PR TITLE
install: Update --only option to install only the argument env regardless of the NODE_ENV

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -273,7 +273,7 @@ The `--nodedir=/path/to/node/source` argument will allow npm to find the
 node source code so that npm can compile native modules.
 
 The `--only={prod[uction]|dev[elopment]}` argument will cause either only
-`devDependencies` or only non-`devDependencies` to be installed.
+`devDependencies` or only non-`devDependencies` to be installed regardless of the `NODE_ENV`.
 
 See `npm-config(7)`.  Many of the configuration params have some
 effect on installation, since that's most of what npm does.

--- a/lib/install.js
+++ b/lib/install.js
@@ -201,7 +201,7 @@ function Installer (where, dryrun, args) {
   this.noPackageJsonOk = !!args.length
   this.topLevelLifecycles = !args.length
   this.npat = npm.config.get('npat')
-  this.dev = npm.config.get('dev') || (!/^prod(uction)?$/.test(npm.config.get('only')) && !npm.config.get('production'))
+  this.dev = npm.config.get('dev') || (!/^prod(uction)?$/.test(npm.config.get('only')) && !npm.config.get('production')) || /^dev(elopment)?$/.test(npm.config.get('only'))
   this.prod = !/^dev(elopment)?$/.test(npm.config.get('only'))
   this.rollback = npm.config.get('rollback')
   this.link = npm.config.get('link')

--- a/test/tap/install-cli-only-development.js
+++ b/test/tap/install-cli-only-development.js
@@ -38,25 +38,8 @@ var devDependency = {
 }
 
 test('setup', function (t) {
-  mkdirp.sync(path.join(pkg, 'dependency'))
-  fs.writeFileSync(
-    path.join(pkg, 'dependency', 'package.json'),
-    JSON.stringify(dependency, null, 2)
-  )
-
-  mkdirp.sync(path.join(pkg, 'dev-dependency'))
-  fs.writeFileSync(
-    path.join(pkg, 'dev-dependency', 'package.json'),
-    JSON.stringify(devDependency, null, 2)
-  )
-
-  mkdirp.sync(path.join(pkg, 'node_modules'))
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-
-  process.chdir(pkg)
+  setup()
+  t.pass('setup ran')
   t.end()
 })
 
@@ -78,8 +61,56 @@ test('\'npm install --only=development\' should only install devDependencies', f
   })
 })
 
+test('\'npm install --only=development\' should only install devDependencies regardless of npm.config.get(\'production\')', function (t) {
+
+  cleanup()
+  setup()
+
+  common.npm(['install', '--only=development', '--production'], EXEC_OPTS, function (err, code) {
+    t.ifError(err, 'install development successful')
+    t.equal(code, 0, 'npm install did not raise error code')
+    t.ok(
+      JSON.parse(fs.readFileSync(
+        path.resolve(pkg, 'node_modules/dev-dependency/package.json'), 'utf8')
+      ),
+      'devDependency was installed'
+    )
+    t.notOk(
+      existsSync(path.resolve(pkg, 'node_modules/dependency/package.json')),
+      'dependency was NOT installed'
+    )
+    t.end()
+  })
+})
+
 test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
+  cleanup()
+  t.pass('cleaned up')
   t.end()
 })
+
+function setup () {
+  mkdirp.sync(path.join(pkg, 'dependency'))
+  fs.writeFileSync(
+    path.join(pkg, 'dependency', 'package.json'),
+    JSON.stringify(dependency, null, 2)
+  )
+
+  mkdirp.sync(path.join(pkg, 'dev-dependency'))
+  fs.writeFileSync(
+    path.join(pkg, 'dev-dependency', 'package.json'),
+    JSON.stringify(devDependency, null, 2)
+  )
+
+  mkdirp.sync(path.join(pkg, 'node_modules'))
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
Hello! I just try to fix #9463. Here is the condition of setting the value of the development / production option.
## npm install
- dev: true
- prod: true
## --only=dev
- dev: true
- prod: false
## --only=prod || NODE_ENV=production
- dev: false
- prod: true

Thanks.
