### PR TITLE
doc: remove unused --tag for install

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -242,10 +242,6 @@ For example:
 
     npm install sax@">=0.1.0 <0.2.0" bench supervisor
 
-The `--tag` argument will apply to all of the specified install targets. If a
-tag with the given name exists, the tagged version is preferred over newer
-versions.
-
 The `--dry-run` argument will report in the usual way what the install would
 have done without actually installing anything.
 

--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -242,6 +242,10 @@ For example:
 
     npm install sax@">=0.1.0 <0.2.0" bench supervisor
 
+The `--tag` argument will apply to all of the specified install targets. If a
+tag with the given name exists, the tagged version is preferred over newer
+versions.
+
 The `--dry-run` argument will report in the usual way what the install would
 have done without actually installing anything.
 

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -255,8 +255,7 @@ function addNameRange (name, range, data, cb) {
     // if the tagged version satisfies, then use that.
     var tagged = data['dist-tags'][npm.config.get('tag')]
     if (tagged &&
-        data.versions[tagged] &&
-        semver.satisfies(tagged, range, true)) {
+        data.versions[tagged]) {
       return addNamed(name, tagged, data.versions[tagged], cb)
     }
 


### PR DESCRIPTION
Discussed this with Aria over IRC a few days ago. Encountered a snippet in the CLI install documentation that mentioned `--tag` to overrule any semver targets. However the functionality does not seem to be available atm. 

What works: `npm install package@tag`
What doesn't seem to work, but is implied from the docs: `npm install package@semver --tag=something`. Also, if no semver is specified it will still install latest, even if the tag specifies some other available release.

From what I got from checking source code , it feels changing around [the if logic here](https://github.com/npm/npm/blob/master/lib/cache/add-named.js#L57-L66) could make it possible, but also might result in more issues than solving stuff, so for now it might be best to just remove the docs snippet.  
