### PR TITLE
rebuild bundles via npm3 mechanisms

### DIFF
--- a/lib/install/action/build.js
+++ b/lib/install/action/build.js
@@ -6,7 +6,7 @@ var npm = require('../../npm.js')
 module.exports = function (top, buildpath, pkg, log, next) {
   log.silly('build', pkg.package.name)
   chain([
-    [build.linkStuff, pkg.package, pkg.path, npm.config.get('global'), false],
+    [build.linkStuff, pkg.package, pkg.path, npm.config.get('global'), true],
     [build.writeBuiltinConf, pkg.package, pkg.path]
   ], next)
 }

--- a/lib/install/decompose-actions.js
+++ b/lib/install/decompose-actions.js
@@ -10,10 +10,13 @@ module.exports = function (differences, decomposed, next) {
     switch (cmd) {
       case 'add':
       case 'update':
-          addSteps(decomposed, pkg, done)
+        addSteps(decomposed, pkg, done)
         break
       case 'move':
         moveSteps(decomposed, pkg, done)
+        break
+      case 'rebuild':
+        rebuildSteps(decomposed, pkg, done)
         break
       case 'remove':
       case 'update-linked':
@@ -41,6 +44,14 @@ function moveSteps (decomposed, pkg, done) {
   decomposed.push(['install', pkg])
   decomposed.push(['postinstall', pkg])
   decomposed.push(['test', pkg])
+  done()
+}
+
+function rebuildSteps (decomposed, pkg, done) {
+  decomposed.push(['preinstall', pkg])
+  decomposed.push(['build', pkg])
+  decomposed.push(['install', pkg])
+  decomposed.push(['postinstall', pkg])
   done()
 }
 

--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -1,6 +1,7 @@
 'use strict'
 var validate = require('aproba')
 var npa = require('npm-package-arg')
+var npm = require('../npm.js')
 var flattenTree = require('./flatten-tree.js')
 
 function nonRegistrySource (pkg) {
@@ -129,8 +130,9 @@ function diffTrees (oldTree, newTree) {
     pkg.isInLink = (pkg.oldPkg && isLink(pkg.oldPkg.parent)) ||
                    (pkg.parent && isLink(pkg.parent)) ||
                    requiredByAllLinked(pkg)
-    if (pkg.fromBundle) return
-    if (pkg.oldPkg) {
+    if (pkg.fromBundle) {
+      if (npm.config.get('rebuild-bundle')) differences.push(['rebuild', pkg])
+    } else if (pkg.oldPkg) {
       if (!pkg.directlyRequested && pkgAreEquiv(pkg.oldPkg.package, pkg.package)) return
       if (!pkg.isInLink && (isLink(pkg.oldPkg) || isLink(pkg))) {
         differences.push(['update-linked', pkg])


### PR DESCRIPTION
Previously this was being done implicitly via `build.linkStuff`– we're now avoiding that.

Not doing this meant that failures of optional deps during those rebuilds wasn't catchable as an optional failure and would kill the entire install.  My test case for this was `npm install -g karma`. For reasons I'm not super clear on, it didn't do this for non-global installs.  Regardless the new way of rebuilding is the right way.

Similarly, I'm pretty sure that this was responsible for needless rebuilds when running `npm install` on already installed trees that have bundled deps.
