### PR TITLE
Remove dead code around npm.ROLLBACK global

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -237,7 +237,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
 
   function procError (er) {
     if (progressEnabled) log.enableProgress()
-    if (er && !npm.ROLLBACK) {
+    if (er) {
       log.info('lifecycle', logid(pkg, stage), 'Failed to exec ' + stage + ' script')
       er.message = pkg._id + ' ' + stage + ': `' + cmd + '`\n' +
                    er.message
@@ -248,13 +248,8 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
       er.stage = stage
       er.script = cmd
       er.pkgname = pkg.name
-      return cb(er)
-    } else if (er) {
-      log.error('lifecycle', logid(pkg, stage), er)
-      log.error('lifecycle', logid(pkg, stage), 'continuing anyway')
-      return cb()
     }
-    cb(er)
+    return cb(er)
   }
 }
 


### PR DESCRIPTION
`npm.ROLLBACK` was used in npm@2, but is no longer used at all in npm@3.
