### PR TITLE
mark our installable flag as internal

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -408,10 +408,10 @@ function resolveWithNewModule (pkg, tree, log, next) {
     }))
   }
 
-  if (!pkg.installable) {
+  if (!pkg._installable) {
     log.silly('resolveWithNewModule', packageId(pkg), 'checking installable status')
     return isInstallable(pkg, iferr(next, function () {
-      pkg.installable = true
+      pkg._installable = true
       resolveWithNewModule(pkg, tree, log, next)
     }))
   }


### PR DESCRIPTION
This is just a dumb little flag I had in the package.json that should have been polluting the main namespace of package.json files.
