### PR TITLE
Refactor upgrades

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -133,6 +133,16 @@ function addRequiredDep (tree, child) {
   return true
 }
 
+function removeObsoleteDep (child) {
+  if (child.removed) return
+  child.removed = true
+  var requires = child.requires || []
+  requires.forEach(function (requirement) {
+    requirement.requiredBy = requirement.requiredBy.filter(function (reqBy) { reqBy !== child })
+    if (requirement.requiredBy.length === 0) removeObsoleteDep(requirement)
+  })
+}
+
 function matchingDep (tree, name) {
   if (tree.package.dependencies && tree.package.dependencies[name]) return tree.package.dependencies[name]
   if (tree.package.devDependencies && tree.package.devDependencies[name]) return tree.package.devDependencies[name]
@@ -178,10 +188,6 @@ exports.loadRequestedDeps = function (args, tree, saveToDependencies, log, next)
   validate('AOOF', [args, tree, log, next])
   asyncMap(args, function (pkg, done) {
     var depLoaded = andAddParentToErrors(tree, done)
-    var pkgName = moduleName(pkg)
-    tree.children = tree.children.filter(function (child) {
-      return moduleName(child) !== pkgName
-    })
     resolveWithNewModule(pkg, tree, log.newGroup('loadRequestedDeps'), iferr(depLoaded, function (child, tracker) {
       validate('OO', arguments)
       if (npm.config.get('global')) {
@@ -464,7 +470,8 @@ function resolveWithNewModule (pkg, tree, log, next) {
         isLink: tree.isLink
       })
 
-      replaceModule(parent, 'children', child)
+      var replaced = replaceModule(parent, 'children', child)
+      if (replaced) removeObsoleteDep(replaced)
       addRequiredDep(tree, child)
       pkg._location = flatNameFromTree(child)
 
@@ -511,7 +518,7 @@ function validateAllPeerDeps (tree, onInvalid, seen) {
 var findRequirement = exports.findRequirement = function (tree, name, requested) {
   validate('OSO', arguments)
   var nameMatch = function (child) {
-    return moduleName(child) === name && child.parent
+    return moduleName(child) === name && child.parent && !child.removed
   }
   var versionMatch = function (child) {
     return doesChildVersionMatch(child, requested)
@@ -539,15 +546,16 @@ var findRequirement = exports.findRequirement = function (tree, name, requested)
 // If it is, then it's the level below where its installed.
 var earliestInstallable = exports.earliestInstallable = function (requiredBy, tree, pkg) {
   validate('OOO', arguments)
-  var nameMatch = function (child) {
-    return moduleName(child) === pkg.name
-  }
 
-  if (tree.children.some(nameMatch)) return null
+  function undeletedModuleMatches (child) {
+    return !child.removed && moduleName(child) === pkg.name
+  }
+  if (tree.children.some(undeletedModuleMatches)) return null
 
   // If any of the children of this tree have conflicting
   // binaries then we need to decline to install this package here.
   var binaryMatches = tree.children.some(function (child) {
+    if (child.removed) return false
     return Object.keys(child.package.bin || {}).some(function (bin) {
       return pkg.bin && pkg.bin[bin]
     })
@@ -557,7 +565,8 @@ var earliestInstallable = exports.earliestInstallable = function (requiredBy, tr
   // if this tree location requested the same module then we KNOW it
   // isn't compatible because if it were findRequirement would have
   // found that version.
-  if (requiredBy !== tree && tree.package.dependencies && tree.package.dependencies[pkg.name]) {
+  var deps = tree.package.dependencies || {}
+  if (!tree.removed && requiredBy !== tree && deps[pkg.name]) {
     return null
   }
 

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -127,9 +127,9 @@ function recalculateMetadata (tree, log, seen, next) {
 function addRequiredDep (tree, child) {
   if (!isDep(tree, child)) return false
   var name = isProdDep(tree, moduleName(child)) ? flatNameFromTree(tree) : '#DEV:' + flatNameFromTree(tree)
-  child.requiredBy = union(child.requiredBy || [], [tree])
-  tree.requires = union(tree.requires || [], [child])
   replaceModuleName(child.package, '_requiredBy', name)
+  replaceModule(child, 'requiredBy', tree)
+  replaceModule(tree, 'requires', child)
   return true
 }
 
@@ -211,6 +211,10 @@ exports.loadRequestedDeps = function (args, tree, saveToDependencies, log, next)
   }, andForEachChild(loadDeps, andFinishTracker(log, next)))
 }
 
+function moduleNameMatches (name) {
+  return function (child) { return moduleName(child) === name }
+}
+
 function noModuleNameMatches (name) {
   return function (child) { return moduleName(child) !== name }
 }
@@ -222,8 +226,8 @@ exports.removeDeps = function (args, tree, saveToDependencies, log, next) {
   args.forEach(function (pkg) {
     var pkgName = moduleName(pkg)
     if (saveToDependencies) {
-      var toRemove = tree.children.filter(function (child) { return moduleName(child) === pkgName })
-      tree.removed = union(tree.removed || [], toRemove)
+      var toRemove = tree.children.filter(moduleNameMatches(pkgName))
+      replaceModule(tree, 'removed', toRemove[0])
       toRemove.forEach(function (parent) {
         parent.save = saveToDependencies
       })
@@ -412,6 +416,23 @@ function replaceModuleName (obj, key, name) {
   obj[key] = union(obj[key] || [], [name])
 }
 
+exports.test.replaceModule = replaceModule
+function replaceModule (obj, key, child) {
+  validate('OSO', arguments)
+  if (!obj[key]) obj[key] = []
+  // we replace children with a new array object instead of mutating it
+  // because mutating it results in weird failure states.
+  // I would very much like to know _why_ this is. =/
+  var children = [].concat(obj[key])
+  var childName = moduleName(child)
+  for (var replaceAt = 0; replaceAt < children.length; ++replaceAt) {
+    if (moduleName(children[replaceAt]) === childName) break
+  }
+  var replacing = children.splice(replaceAt, 1, child)
+  obj[key] = children
+  return replacing[0]
+}
+
 function resolveWithNewModule (pkg, tree, log, next) {
   validate('OOOF', arguments)
   if (pkg.type) {
@@ -428,8 +449,6 @@ function resolveWithNewModule (pkg, tree, log, next) {
     }))
   }
 
-  var pkgName = moduleName(pkg)
-
   if (!pkg._from) {
     pkg._from = pkg._requested.name + '@' + pkg._requested.spec
   }
@@ -445,8 +464,7 @@ function resolveWithNewModule (pkg, tree, log, next) {
         isLink: tree.isLink
       })
 
-      parent.children = parent.children.filter(function (pkg) { return pkgName !== moduleName(pkg) })
-      parent.children.push(child)
+      replaceModule(parent, 'children', child)
       addRequiredDep(tree, child)
       pkg._location = flatNameFromTree(child)
 

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -209,6 +209,10 @@ exports.loadRequestedDeps = function (args, tree, saveToDependencies, log, next)
   }, andForEachChild(loadDeps, andFinishTracker(log, next)))
 }
 
+function noModuleNameMatches (name) {
+  return function (child) { return moduleName(child) !== name }
+}
+
 // while this implementation does not require async calling, doing so
 // gives this a consistent interface with loadDeps et al
 exports.removeDeps = function (args, tree, saveToDependencies, log, next) {
@@ -222,7 +226,7 @@ exports.removeDeps = function (args, tree, saveToDependencies, log, next) {
         parent.save = saveToDependencies
       })
     }
-    tree.children = tree.children.filter(function (child) { return moduleName(child) !== pkgName })
+    tree.children = tree.children.filter(noModuleNameMatches(pkgName))
   })
   log.finish()
   next()
@@ -264,7 +268,7 @@ var failedDependency = exports.failedDependency = function (tree, name_pkg) {
     name = moduleName(pkg)
   }
 
-  tree.children = tree.children.filter(function (child) { return moduleName(child) !== name })
+  tree.children = tree.children.filter(noModuleNameMatches(name))
 
   if (isDepOptional(tree, name)) {
     return false
@@ -290,7 +294,7 @@ function andHandleOptionalErrors (log, tree, name, done) {
     if (!er) return done(er, child, childLog)
     var isFatal = failedDependency(tree, name)
     if (er && !isFatal) {
-      tree.children = tree.children.filter(function (child) { return moduleName(child) !== name })
+      tree.children = tree.children.filter(noModuleNameMatches(name))
       log.warn('install', "Couldn't install optional dependency:", er.message)
       log.verbose('install', er.stack)
       return done()

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -28,6 +28,8 @@ var isInstallable = require('./validate-args.js').isInstallable
 var packageId = require('../utils/package-id.js')
 var moduleName = require('../utils/module-name.js')
 
+exports.test = {} // used to hold functions for testing by unit tests
+
 // The export functions in this module mutate a dependency tree, adding
 // items to them.
 
@@ -125,9 +127,9 @@ function recalculateMetadata (tree, log, seen, next) {
 function addRequiredDep (tree, child) {
   if (!isDep(tree, child)) return false
   var name = isProdDep(tree, moduleName(child)) ? flatNameFromTree(tree) : '#DEV:' + flatNameFromTree(tree)
-  child.package._requiredBy = union(child.package._requiredBy || [], [name])
   child.requiredBy = union(child.requiredBy || [], [tree])
   tree.requires = union(tree.requires || [], [child])
+  replaceModuleName(child.package, '_requiredBy', name)
   return true
 }
 
@@ -201,7 +203,7 @@ exports.loadRequestedDeps = function (args, tree, saveToDependencies, log, next)
       // won't be when we're done), flag it as "depending" on the user
       // themselves, so we don't remove it as a dep that no longer exists
       if (!addRequiredDep(tree, child)) {
-        child.package._requiredBy = union(child.package._requiredBy, ['#USER'])
+        replaceModuleName(child.package, '_requiredBy', '#USER')
         child.directlyRequested = true
       }
       depLoaded(null, child, tracker)
@@ -402,6 +404,12 @@ function flatNameFromTree (tree) {
   var path = flatNameFromTree(tree.parent)
   if (path !== '/') path += '/'
   return flatName(path, tree)
+}
+
+exports.test.replaceModuleName = replaceModuleName
+function replaceModuleName (obj, key, name) {
+  validate('OSS', arguments)
+  obj[key] = union(obj[key] || [], [name])
 }
 
 function resolveWithNewModule (pkg, tree, log, next) {

--- a/test/tap/unit-deps-replaceModule.js
+++ b/test/tap/unit-deps-replaceModule.js
@@ -1,0 +1,50 @@
+'use strict'
+var test = require('tap').test
+var npm = require('../../lib/npm')
+
+test('setup', function (t) {
+  npm.load({}, t.done)
+})
+
+test('replaceModule', function (t) {
+  var replaceModule = require('../../lib/install/deps').test.replaceModule
+  var mods = []
+  for (var ii = 0; ii < 10; ++ii) {
+    mods.push({package: {name: ii}})
+  }
+
+  var test = {}
+  test.A = mods.slice(0, 4)
+  replaceModule(test, 'A', mods[2])
+  t.isDeeply(test.A, mods.slice(0, 4), 'replacing an existing module leaves the order alone')
+  replaceModule(test, 'A', mods[7])
+  t.isDeeply(test.A, mods.slice(0, 4).concat(mods[7]), 'replacing a new module appends')
+
+  test.B = mods.slice(0, 4)
+  var replacement = {package: {name: 1}, isReplacement: true}
+  replaceModule(test, 'B', replacement)
+  t.isDeeply(test.B, [mods[0], replacement, mods[2], mods[3]], 'replacing existing module swaps out for the new version')
+
+  replaceModule(test, 'C', mods[7])
+  t.isDeeply(test.C, [mods[7]], 'replacing when the key does not exist yet, causes its creation')
+  t.end()
+})
+
+test('replaceModuleName', function (t) {
+  var replaceModuleName = require('../../lib/install/deps').test.replaceModuleName
+  var mods = []
+  for (var ii = 0; ii < 10; ++ii) {
+    mods.push('pkg' + ii)
+  }
+
+  var test = {}
+  test.A = mods.slice(0, 4)
+  replaceModuleName(test, 'A', mods[2])
+  t.isDeeply(test.A, mods.slice(0, 4), 'replacing an existing module leaves the order alone')
+  replaceModuleName(test, 'A', mods[7])
+  t.isDeeply(test.A, mods.slice(0, 4).concat(mods[7]), 'replacing a new module appends')
+
+  replaceModuleName(test, 'C', mods[7])
+  t.isDeeply(test.C, [mods[7]], 'replacing when the key does not exist yet, causes its creation')
+  t.end()
+})


### PR DESCRIPTION
By which I mean, when npm decides it needs to upgrade an existing module, this changes how it does that. This applies to both `npm install foo@newversion` and updating a package.json and running `npm install`. In either case, it does a better job of cleaning out the older deps, which means that the resulting tree is flatter!

Fixes: #9520 
