### PR TITLE
Encourage users to update node & npm before contacting package maintainers

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -196,7 +196,8 @@ function errorHandler (er) {
       [
         '',
         'Failed at the ' + er.pkgid + ' ' + er.stage + " script '" + er.script + "'.",
-        'This is most likely a problem with the ' + er.pkgname + ' package,',
+        'Make sure you have the latest version of node.js and npm installed.',
+        'If you do, this is most likely a problem with the ' + er.pkgname + ' package,',
         'not with npm itself.',
         'Tell the author that this fails on your system:',
         '    ' + er.script,


### PR DESCRIPTION
This could vastly reduce the e-mail volume to package maintainers.
