### PR TITLE
Nested scripts

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -6,6 +6,7 @@ var path = require('path')
 var readJson = require('read-package-json')
 var log = require('npmlog')
 var chain = require('slide').chain
+var getobject = require('getobject')
 
 runScript.usage = 'npm run-script <command> [-- <args>...]' +
                   '\n\nalias: npm run'
@@ -131,7 +132,7 @@ function run (pkg, wd, cmd, args, cb) {
       'prestart', 'start', 'poststart'
     ]
   } else {
-    if (!pkg.scripts[cmd]) {
+    if (!getobject.exists(pkg.scripts, cmd)) {
       if (cmd === 'test') {
         pkg.scripts.test = 'echo \'Error: no test specified\''
       } else if (cmd === 'env') {
@@ -151,6 +152,10 @@ function run (pkg, wd, cmd, args, cb) {
     cmds = [cmd]
   }
 
+  // todo:
+  // - how does this apply to nested scripts?
+  // - pre/post at every level or only the deepest?
+  // - recurse/iterate over all nested scripts?
   if (!cmd.match(/^(pre|post)/)) {
     cmds = ['pre' + cmd].concat(cmds).concat('post' + cmd)
   }
@@ -158,8 +163,8 @@ function run (pkg, wd, cmd, args, cb) {
   log.verbose('run-script', cmds)
   chain(cmds.map(function (c) {
     // pass cli arguments after -- to script.
-    if (pkg.scripts[c] && c === cmd) {
-      pkg.scripts[c] = pkg.scripts[c] + joinArgs(args)
+    if (getobject.exists(pkg.scripts, c) && c === cmd) {
+      getobject.set(pkg.scripts, c, getobject.get(pkg.scripts, c) + joinArgs(args))
     }
 
     // when running scripts explicitly, assume that they're trusted.

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -12,6 +12,7 @@ var Stream = require('stream').Stream
 var PATH = 'PATH'
 var uidNumber = require('uid-number')
 var umask = require('./umask')
+var getobject = require('getobject')
 
 // windows calls it's path 'Path' usually, but this is not guaranteed.
 if (process.platform === 'win32') {
@@ -54,9 +55,9 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
 
     if ((wd.indexOf(npm.dir) !== 0 ||
           wd.indexOf(pkg.name) !== wd.length - pkg.name.length) &&
-        !unsafe && pkg.scripts[stage]) {
+        !unsafe && getobject.exists(pkg.scripts, stage)) {
       log.warn('lifecycle', logid(pkg, stage), 'cannot run in wd',
-        '%s %s (wd=%s)', pkg._id, pkg.scripts[stage], wd
+        '%s %s (wd=%s)', pkg._id, getobject.get(pkg.scripts, stage), wd
       )
       return cb()
     }
@@ -93,11 +94,11 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
   if (env[PATH]) pathArr.push(env[PATH])
   env[PATH] = pathArr.join(process.platform === 'win32' ? ';' : ':')
 
-  var packageLifecycle = pkg.scripts && pkg.scripts.hasOwnProperty(stage)
+  var packageLifecycle = getobject.exists(pkg.scripts, stage)
 
   if (packageLifecycle) {
     // define this here so it's available to all scripts.
-    env.npm_lifecycle_script = pkg.scripts[stage]
+    env.npm_lifecycle_script = getobject.get(pkg.scripts, stage)
   } else {
     log.silly('lifecycle', logid(pkg, stage), 'no script for ' + stage + ', continuing')
   }

--- a/node_modules/normalize-package-data/lib/fixer.js
+++ b/node_modules/normalize-package-data/lib/fixer.js
@@ -54,9 +54,9 @@ var fixer = module.exports = {
     }
     Object.keys(data.scripts).forEach(function (k) {
       if (typeof data.scripts[k] !== "string") {
-        this.warn("nonStringScript")
-        delete data.scripts[k]
-      } else if (typos.script[k] && !data.scripts[typos.script[k]]) {
+        // todo: recurse
+      } else
+      if (typos.script[k] && !data.scripts[typos.script[k]]) {
         this.warn("typo", k, typos.script[k], "scripts")
       }
     }, this)

--- a/node_modules/read-package-json/read-json.js
+++ b/node_modules/read-package-json/read-json.js
@@ -123,8 +123,7 @@ function scriptpath (file, data, cb) {
 
 function scriptpath_ (key) {
   var s = this[key]
-  // This is never allowed, and only causes problems
-  if (typeof s !== 'string') return delete this[key]
+  if (typeof s !== 'string') return // todo: recurse
 
   var spre = /^(\.[\/\\])?node_modules[\/\\].bin[\\\/]/
   if (s.match(spre)) {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "fs-write-stream-atomic": "~1.0.4",
     "fstream": "~1.0.8",
     "fstream-npm": "~1.0.5",
+    "getobject": "~0.1.0",
     "glob": "~5.0.15",
     "graceful-fs": "~4.1.2",
     "has-unicode": "~1.0.0",

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -62,6 +62,18 @@ var preversionOnly = {
   }
 }
 
+var nested = {
+  name: 'scripted',
+  version: '1.2.3',
+  scripts: {
+    whoa: 'echo whoa',
+    deep: {
+      one: 'echo one',
+      two: 'echo two'
+    }
+  }
+}
+
 function testOutput (t, command, er, code, stdout, stderr) {
   var lines
 
@@ -258,6 +270,10 @@ test('npm run-script no-params (direct only)', function (t) {
     t.equal(stdout, expected, 'got expected output')
     t.end()
   })
+
+test('npm run-script nested', function (t) {
+  writeMetadata(nested)
+  common.npm(['run-script', 'deep.one'], opts, testOutput.bind(null, t, 'one'))
 })
 
 test('cleanup', function (t) {


### PR DESCRIPTION
Request for feedback. This is a proof of concept for https://github.com/npm/npm/issues/9935

The goal is to eliminate pseudo-nesting of scripts by repeating a prefix. JSON supports nesting, might as well use it.
##### Example

``` json
{ "scripts": {
  "test": "npm run test-lint && npm run test-js",
  "test-lint": "standard",
  "test-js": "mocha"
} }
```

becomes

``` json
{ "scripts": {
  "test": {
    "lint": "standard",
    "js": "mocha"
  }
} }
```

Where `npm run test` recurses into `test` and iterates over `lint` and `js`.

Dot notation to run sub-tasks: `npm run test.lint`. Currently uses [getobject](https://www.npmjs.com/package/getobject) but alternatively [JSONPath](https://www.npmjs.com/package/JSONPath) or [lodash.get](https://lodash.com/docs#get).
##### Concerns

:question: How to handle arrays vs maps? Does order matter?
:question: What about `pre`/`post` hooks? Do they apply only to the deepest property? Or also to all higher level properties?
:exclamation: Did not yet implement recursion or any data sanitisation for this simple proof of concept. Wanted to get some feedback. Afraid it will get shut down hard by core contributors. :cold_sweat:

:poop: Hacks were made to two dependencies: `read-package-json` and `normalize-package-data`. This is to support non-string properties inside `scripts`. Separate pull requests would, of course, need to be made for those packages.
