### PR TITLE
make tests always use right node + npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,8 @@
     "test": "standard && npm run test-tap",
     "test-all": "standard && npm run test-legacy && npm run test-tap",
     "test-legacy": "node ./test/run.js",
-    "test-tap": "npm run tap -- \"test/tap/*.js\""
+    "test-tap": "npm run tap -- \"test/tap/*.js\"",
+    "test-node": "\"$NODE\" ./test/run.js && \"$NODE\" \"$(which tap)\" --timeout 240 \"test/tap/*.js\""
   },
   "license": "Artistic-2.0"
 }

--- a/test/run.js
+++ b/test/run.js
@@ -49,6 +49,7 @@ env.npm_config_npat = 'false'
 env.PATH = pathEnv.join(pathEnvSplit)
 env.NODE_PATH = path.join(root, 'node_modules')
 env.npm_config_cache = cache
+env.npm_config_user_agent = ''
 
 function cleanup (cb) {
   if (failures !== 0) return

--- a/test/tap/outdated-depth-deep.js
+++ b/test/tap/outdated-depth-deep.js
@@ -59,7 +59,9 @@ test('outdated depth deep (9999)', function (t) {
     function () {
       npm.install('.', function (er) {
         if (er) throw new Error(er)
-        npm.explore('npm-test-peer-deps', 'npm', 'install', 'underscore', function (er) {
+        var nodepath = process.env.npm_node_execpath || process.env.NODE || process.execPath
+        var clibin = path.resolve(__dirname, '../../bin/npm-cli.js')
+        npm.explore('npm-test-peer-deps', nodepath, clibin, 'install', 'underscore', function (er) {
           if (er) throw new Error(er)
           npm.outdated(function (err, d) {
             if (err) throw new Error(err)


### PR DESCRIPTION
Our test lifecycles regularly run npm commands as a part of them– this patch ensures that they're run with the same npm and node that the original was run.
