### PR TITLE
Added shortcuts to all instances in doc/

### DIFF
--- a/doc/cli/npm-bin.md
+++ b/doc/cli/npm-bin.md
@@ -3,7 +3,7 @@ npm-bin(1) -- Display npm bin folder
 
 ## SYNOPSIS
 
-    npm bin [--global]
+    npm bin [-g|--global]
 
 ## DESCRIPTION
 

--- a/doc/cli/npm-config.md
+++ b/doc/cli/npm-config.md
@@ -3,13 +3,13 @@ npm-config(1) -- Manage the npm configuration files
 
 ## SYNOPSIS
 
-    npm config set <key> <value> [--global]
+    npm config set <key> <value> [-g|--global]
     npm config get <key>
     npm config delete <key>
     npm config list
     npm config edit
     npm get <key>
-    npm set <key> <value> [--global]
+    npm set <key> <value> [-g|--global]
 
 ## DESCRIPTION
 

--- a/doc/cli/npm-init.md
+++ b/doc/cli/npm-init.md
@@ -3,7 +3,7 @@ npm-init(1) -- Interactively create a package.json file
 
 ## SYNOPSIS
 
-    npm init [--force|-f|--yes|-y]
+    npm init [-f|--force|-y|--yes]
 
 ## DESCRIPTION
 

--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -13,7 +13,7 @@ npm-install(1) -- Install a package
     npm install <folder>
 
     alias: npm i
-    common options: [--save|--save-dev|--save-optional] [--save-exact] [--dry-run]
+    common options: [-S|--save|-D|--save-dev|-O|--save-optional] [-E|--save-exact] [--dry-run]
 
 ## DESCRIPTION
 
@@ -73,7 +73,7 @@ after packing it up into a tarball (b).
 
           npm install https://github.com/indexzero/forever/tarball/v0.5.6
 
-* `npm install [<@scope>/]<name> [--save|--save-dev|--save-optional]`:
+* `npm install [<@scope>/]<name> [-S|--save|-D|--save-dev|-O|--save-optional]`:
 
     Do a `<name>@<tag>` install, where `<tag>` is the "tag" config. (See
     `npm-config(7)`.)
@@ -88,16 +88,16 @@ after packing it up into a tarball (b).
     `npm install` takes 3 exclusive, optional flags which save or update
     the package version in your main package.json:
 
-    * `--save`: Package will appear in your `dependencies`.
+    * `-S, --save`: Package will appear in your `dependencies`.
 
-    * `--save-dev`: Package will appear in your `devDependencies`.
+    * `-D, --save-dev`: Package will appear in your `devDependencies`.
 
-    * `--save-optional`: Package will appear in your `optionalDependencies`.
+    * `-O, --save-optional`: Package will appear in your `optionalDependencies`.
 
     When using any of the above options to save dependencies to your
     package.json, there is an additional, optional flag:
 
-    * `--save-exact`: Saved dependencies will be configured with an
+    * `-E, --save-exact`: Saved dependencies will be configured with an
       exact version rather than using npm's default semver range
       operator.
 
@@ -207,7 +207,7 @@ after packing it up into a tarball (b).
 
     Install the package at `https://gist.github.com/gistID` by attempting to
     clone it using `git`. The GitHub username associated with the gist is
-    optional and will not be saved in `package.json` if `--save` is used.
+    optional and will not be saved in `package.json` if `-S` or `--save` is used.
 
     If you don't specify a *commit-ish* then `master` will be used.
 
@@ -249,12 +249,12 @@ versions.
 The `--dry-run` argument will report in the usual way what the install would
 have done without actually installing anything.
 
-The `--force` argument will force npm to fetch remote resources even if a
+The `-f` or `--force` argument will force npm to fetch remote resources even if a
 local copy exists on disk.
 
     npm install sax --force
 
-The `--global` argument will cause npm to install the package globally
+The `-g` or `--global` argument will cause npm to install the package globally
 rather than locally.  See `npm-folders(5)`.
 
 The `--link` argument will cause npm to link global installs into the

--- a/doc/cli/npm-search.md
+++ b/doc/cli/npm-search.md
@@ -3,7 +3,7 @@ npm-search(1) -- Search for packages
 
 ## SYNOPSIS
 
-    npm search [--long] [search terms ...]
+    npm search [-l|--long] [search terms ...]
 
     aliases: s, se
 

--- a/doc/cli/npm-uninstall.md
+++ b/doc/cli/npm-uninstall.md
@@ -3,7 +3,7 @@ npm-rm(1) -- Remove a package
 
 ## SYNOPSIS
 
-    npm uninstall [<@scope>/]<pkg>[@<version>]... [--save|--save-dev|--save-optional]
+    npm uninstall [<@scope>/]<pkg>[@<version>]... [-S|--save|-D|--save-dev|-O|--save-optional]
 
     aliases: remove, rm, r, un, unlink
 
@@ -22,11 +22,11 @@ it uninstalls the current package context as a global package.
 `npm uninstall` takes 3 exclusive, optional flags which save or update
 the package version in your main package.json:
 
-* `--save`: Package will be removed from your `dependencies`.
+* `-S, --save`: Package will be removed from your `dependencies`.
 
-* `--save-dev`: Package will be removed from your `devDependencies`.
+* `-D, --save-dev`: Package will be removed from your `devDependencies`.
 
-* `--save-optional`: Package will be removed from your `optionalDependencies`.
+* `-O, --save-optional`: Package will be removed from your `optionalDependencies`.
 
 Further, if you have an `npm-shrinkwrap.json` then it will be updated as
 well.

--- a/doc/cli/npm-update.md
+++ b/doc/cli/npm-update.md
@@ -114,7 +114,8 @@ version that satisfies `^0.4.0` (`>= 0.4.0 <0.5.0`)
 
 When you want to update a package and save the new version as
 the minimum required dependency in `package.json`, you can use
-`npm update --save`.  For example if `package.json` contains
+`npm update -S` or `npm update --save`.  For example if
+`package.json` contains:
 
 ```
 dependencies: {

--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -5,7 +5,7 @@ npm-version(1) -- Bump a package version
 
     npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease]
 
-    'npm -v' or 'npm --version' to print npm version
+    'npm [-v | --version]' to print npm version
     'npm view <pkg> version' to view a package's published version
     'npm ls' to inspect current package/dependency versions
 
@@ -22,10 +22,10 @@ the existing version will be incremented by 1 in the specified field.
 If run in a git repo, it will also create a version commit and tag.
 This behavior is controlled by `git-tag-version` (see below), and can
 be disabled on the command line by running `npm --no-git-tag-version version`.
-It will fail if the working directory is not clean, unless the `--force`
-flag is set.
+It will fail if the working directory is not clean, unless the `-f` or
+`--force` flag is set.
 
-If supplied with `--message` (shorthand: `-m`) config option, npm will
+If supplied with `-m` or `--message` config option, npm will
 use it as a commit message when creating a version commit.  If the
 `message` config contains `%s` then that will be replaced with the
 resulting version number.  For example:

--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -61,7 +61,7 @@ In particular, npm has two modes of operation:
   defaults to the current working directory.  Packages are installed to
   `./node_modules`, and bins are installed to `./node_modules/.bin`.
 
-Local mode is the default.  Use `--global` or `-g` on any command to
+Local mode is the default.  Use `-g` or `--global` on any command to
 operate in global mode instead.
 
 ## DEVELOPER USAGE

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -468,8 +468,8 @@ included.  For example:
 ## Local Paths
 
 As of version 2.0.0 you can provide a path to a local directory that contains a
-package. Local paths can be saved using `npm install --save`, using any of
-these forms:
+package. Local paths can be saved using `npm install -S` or
+`npm install --save`, using any of these forms:
 
     ../foo/bar
     ~/foo/bar


### PR DESCRIPTION
In response to #7600. I went through and added the shortcuts to all instances in the `doc` folder; however, I still we think we should also farm these out to the console.logs in `lib`, and I'm not sure that this was what @othiym23 was suggesting in #7600. 
