### PR TITLE
Close stream if possible, otherwise destroy stream. Should fix some TravisCI

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -283,7 +283,8 @@ function untarStream (tarball, cb) {
     } else if (hasTarHeader(c)) {
       doUntar()
     } else {
-      file.close()
+      if (file.close) file.close()
+      if (file.destroy) file.destroy()
       var er = new Error('Non-gzip/tarball ' + tarball)
       er.code = 'ENOTTARBALL'
       return cb(er)


### PR DESCRIPTION
Towards #7842 with Node 0.8.28

Noticed all recent pull requests were failing cryptically on `packages/npm-test-shrinkwrap` (`npm ERR! Object [object Object] has no method 'close'`), because `fetch-package-metadata` was being passed a non-gzip/tarball and Node 0.8.28's file stream does not have a close method, only a destroy method.
