### PR TITLE
shrinkwrap: handle devDeps separately

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -24,6 +24,8 @@ function inflateShrinkwrap (topPath, tree, swdeps, finishInflating) {
   var onDisk = {}
   tree.children.forEach(function (child) { onDisk[moduleName(child)] = child })
   tree.children = []
+  var dev = npm.config.get('dev') || (!/^prod(uction)?$/.test(npm.config.get('only')) && !npm.config.get('production')) || /^dev(elopment)?$/.test(npm.config.get('only'))
+  var prod = !/^dev(elopment)?$/.test(npm.config.get('only'))
   return asyncMap(Object.keys(swdeps), doRealizeAndInflate, finishInflating)
 
   function doRealizeAndInflate (name, next) {
@@ -34,6 +36,7 @@ function inflateShrinkwrap (topPath, tree, swdeps, finishInflating) {
     return function (requested) {
       var sw = swdeps[name]
       var dependencies = sw.dependencies || {}
+      if ((!prod && !sw.dev) || (!dev && sw.dev)) return next()
       var child = onDisk[name]
       if (child && (child.fromShrinkwrap ||
                     (sw.resolved && child.package._resolved === sw.resolved) ||

--- a/lib/install/is-dev.js
+++ b/lib/install/is-dev.js
@@ -21,7 +21,7 @@ function andIsOnlyDev (name) {
   }
 }
 
-exports.isOnlyDev = function (node) {
+var isOnlyDev = exports.isOnlyDev = function (node) {
   return node.requiredBy.every(andIsOnlyDev(moduleName(node)))
 }
 var isTreeDev = exports.isTreeDev = function (node, tree) {
@@ -30,7 +30,7 @@ var isTreeDev = exports.isTreeDev = function (node, tree) {
   //
   // If a node is not required by anything, then we've reached
   // the top level package.
-  if (!node || (node && node.package && node.package._requiredBy.length === 0)) {
+  if (!node || (node && node.requiredBy && node.requiredBy.length === 0)) {
     return false
   }
 
@@ -40,7 +40,7 @@ var isTreeDev = exports.isTreeDev = function (node, tree) {
   }
 
   // Otherwise, walk up one step.
-  return node.package._requiredBy.every(function (pkg) {
+  return node.requiredBy.every(function (pkg) {
     return isTreeDev(tree[pkg], tree)
   })
 }
@@ -48,11 +48,11 @@ var isTreeDev = exports.isTreeDev = function (node, tree) {
 var isTreeOptional = exports.isTreeOptional = function (node, tree) {
   // If a node is not required by anything, then we've reached
   // the top level package.
-  if (!node || (node && node.package && node.package._requiredBy.length === 0)) {
+  if (!node || (node && node.requiredBy && node.requiredBy.length === 0)) {
     return false
   }
 
-  return node.package._requiredBy.every(function (pkg) {
-    return tree[pkg] && tree[pkg].package.optionalDependencies[node.package.name] || isTreeOptional(tree[pkg], tree)
+  return node.requiredBy.every(function (pkg) {
+    return pkg && pkg.package.optionalDependencies[node.package.name] || isTreeOptional(pkg, tree)
   })
 }

--- a/lib/install/is-dev.js
+++ b/lib/install/is-dev.js
@@ -24,3 +24,23 @@ function andIsOnlyDev (name) {
 exports.isOnlyDev = function (node) {
   return node.requiredBy.every(andIsOnlyDev(moduleName(node)))
 }
+var isTreeDev = exports.isTreeDev = function (node, tree) {
+  // If we don't have the node in the tree, assume the node
+  // is not a dev dependency (as we're in a subtree)
+  //
+  // If a node is not required by anything, then we've reached
+  // the top level package.
+  if (!node || (node && node.package && node.package._requiredBy.length === 0)) {
+    return false
+  }
+
+  // A package is only a devDependency if nothing else requires it
+  if (isOnlyDev(node)) {
+    return true
+  }
+
+  // Otherwise, walk up one step.
+  return node.package._requiredBy.every(function (pkg) {
+    return isTreeDev(tree[pkg], tree)
+  })
+}

--- a/lib/install/is-dev.js
+++ b/lib/install/is-dev.js
@@ -44,3 +44,15 @@ var isTreeDev = exports.isTreeDev = function (node, tree) {
     return isTreeDev(tree[pkg], tree)
   })
 }
+
+var isTreeOptional = exports.isTreeOptional = function (node, tree) {
+  // If a node is not required by anything, then we've reached
+  // the top level package.
+  if (!node || (node && node.package && node.package._requiredBy.length === 0)) {
+    return false
+  }
+
+  return node.package._requiredBy.every(function (pkg) {
+    return tree[pkg] && tree[pkg].package.optionalDependencies[node.package.name] || isTreeOptional(tree[pkg], tree)
+  })
+}

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -17,6 +17,7 @@ var flattenTree = require('./install/flatten-tree.js')
 var validatePeerDeps = require('./install/deps.js').validatePeerDeps
 var isExtraneous = require('./install/is-extraneous.js')
 var isTreeDev = require('./install/is-dev.js').isTreeDev
+var isTreeOptional = require('./install/is-dev.js').isTreeOptional
 var packageId = require('./utils/package-id.js')
 var moduleName = require('./utils/module-name.js')
 var output = require('./utils/output.js')
@@ -104,6 +105,7 @@ function shrinkwrapDeps (dev, problems, deps, tree, seen) {
     pkginfo.from = child.package._from
     pkginfo.resolved = child.package._resolved
     if (dev && childIsTreeDev) pkginfo.dev = true
+    if (isTreeOptional(child, flatTree)) pkginfo.optional = true
     if (isExtraneous(child)) {
       problems.push('extraneous: ' + child.package._id + ' ' + child.path)
     }

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -94,7 +94,8 @@ function shrinkwrapDeps (dev, problems, deps, tree, seen) {
   })
   var flatTree = flattenTree(tree)
   tree.children.sort(function (aa, bb) { return moduleName(aa).localeCompare(moduleName(bb)) }).forEach(function (child) {
-    if (!dev && isTreeDev(child, flatTree)) {
+    var childIsTreeDev = isTreeDev(child, flatTree)
+    if (!dev && childIsTreeDev) {
       log.warn('shrinkwrap', 'Excluding devDependency: %s', packageId(child), child.parent.package.dependencies)
       return
     }
@@ -102,6 +103,7 @@ function shrinkwrapDeps (dev, problems, deps, tree, seen) {
     pkginfo.version = child.package.version
     pkginfo.from = child.package._from
     pkginfo.resolved = child.package._resolved
+    if (dev && childIsTreeDev) pkginfo.dev = true
     if (isExtraneous(child)) {
       problems.push('extraneous: ' + child.package._id + ' ' + child.path)
     }

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -13,9 +13,10 @@ var validate = require('aproba')
 var chain = require('slide').chain
 var npm = require('./npm.js')
 var recalculateMetadata = require('./install/deps.js').recalculateMetadata
+var flattenTree = require('./install/flatten-tree.js')
 var validatePeerDeps = require('./install/deps.js').validatePeerDeps
 var isExtraneous = require('./install/is-extraneous.js')
-var isOnlyDev = require('./install/is-dev.js').isOnlyDev
+var isTreeDev = require('./install/is-dev.js').isTreeDev
 var packageId = require('./utils/package-id.js')
 var moduleName = require('./utils/module-name.js')
 var output = require('./utils/output.js')
@@ -91,8 +92,9 @@ function shrinkwrapDeps (dev, problems, deps, tree, seen) {
         (topname ? ', required by ' + topname : ''))
     }
   })
+  var flatTree = flattenTree(tree)
   tree.children.sort(function (aa, bb) { return moduleName(aa).localeCompare(moduleName(bb)) }).forEach(function (child) {
-    if (!dev && isOnlyDev(child)) {
+    if (!dev && isTreeDev(child, flatTree)) {
       log.warn('shrinkwrap', 'Excluding devDependency: %s', packageId(child), child.parent.package.dependencies)
       return
     }

--- a/test/tap/install-cli-only-shrinkwrap.js
+++ b/test/tap/install-cli-only-shrinkwrap.js
@@ -1,0 +1,135 @@
+var fs = require('graceful-fs')
+var path = require('path')
+var existsSync = fs.existsSync || path.existsSync
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+
+var pkg = path.join(__dirname, 'install-cli-development')
+
+var EXEC_OPTS = { cwd: pkg }
+
+var json = {
+  name: 'install-cli-only-shrinkwrap',
+  description: 'fixture',
+  version: '0.0.0',
+  dependencies: {
+    dependency: 'file:./dependency'
+  },
+  devDependencies: {
+    'dev-dependency': 'file:./dev-dependency'
+  }
+}
+
+var shrinkwrap = {
+  name: 'install-cli-only-shrinkwrap',
+  description: 'fixture',
+  version: '0.0.0',
+  dependencies: {
+    dependency: {
+      version: '0.0.0',
+      from: 'file:./dependency'
+    },
+    'dev-dependency': {
+      version: '0.0.0',
+      from: 'file:./dev-dependency',
+      dev: true
+    }
+  }
+}
+
+var dependency = {
+  name: 'dependency',
+  description: 'fixture',
+  version: '0.0.0'
+}
+
+var devDependency = {
+  name: 'dev-dependency',
+  description: 'fixture',
+  version: '0.0.0'
+}
+
+test('setup', function (t) {
+  setup()
+  t.pass('setup ran')
+  t.end()
+})
+
+test('\'npm install --only=development\' should only install devDependencies', function (t) {
+  common.npm(['install', '--only=development'], EXEC_OPTS, function (err, code) {
+    t.ifError(err, 'install development successful')
+    t.equal(code, 0, 'npm install did not raise error code')
+    t.ok(
+      JSON.parse(fs.readFileSync(
+        path.resolve(pkg, 'node_modules/dev-dependency/package.json'), 'utf8')
+      ),
+      'devDependency was installed'
+    )
+    t.notOk(
+      existsSync(path.resolve(pkg, 'node_modules/dependency/package.json')),
+      'dependency was NOT installed'
+    )
+    t.end()
+  })
+})
+
+test('\'npm install --only=production\' should only install dependencies', function (t) {
+  cleanup()
+  setup()
+  common.npm(['install', '--only=production'], EXEC_OPTS, function (err, code) {
+    t.ifError(err, 'install production successful')
+    t.equal(code, 0, 'npm install did not raise error code')
+    t.ok(
+      JSON.parse(fs.readFileSync(
+        path.resolve(pkg, 'node_modules/dependency/package.json'), 'utf8')
+      ),
+      'dependency was installed'
+    )
+    t.notOk(
+      existsSync(path.resolve(pkg, 'node_modules/dev-dependency/package.json')),
+      'devDependency was NOT installed'
+    )
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.pass('cleaned up')
+  t.end()
+})
+
+function setup () {
+  mkdirp.sync(path.join(pkg, 'dependency'))
+  fs.writeFileSync(
+    path.join(pkg, 'dependency', 'package.json'),
+    JSON.stringify(dependency, null, 2)
+  )
+
+  mkdirp.sync(path.join(pkg, 'dev-dependency'))
+  fs.writeFileSync(
+    path.join(pkg, 'dev-dependency', 'package.json'),
+    JSON.stringify(devDependency, null, 2)
+  )
+
+  mkdirp.sync(path.join(pkg, 'node_modules'))
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  fs.writeFileSync(
+    path.join(pkg, 'npm-shrinkwrap.json'),
+    JSON.stringify(shrinkwrap, null, 2)
+  )
+  process.chdir(pkg)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}

--- a/test/tap/shrinkwrap-optional-property.js
+++ b/test/tap/shrinkwrap-optional-property.js
@@ -1,0 +1,100 @@
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+var npm = npm = require('../../')
+
+var pkg = path.resolve(__dirname, 'shrinkwrap-optional-dependency')
+
+test('shrinkwrap adds optional property when optional dependency', function (t) {
+  t.plan(1)
+
+  mr({port: common.port}, function (er, s) {
+    function fail (err) {
+      s.close() // Close on failure to allow node to exit
+      t.fail(err)
+    }
+
+    setup(function (err) {
+      if (err) return fail(err)
+
+      // Install with the optional dependency
+      npm.install('.', function (err) {
+        if (err) return fail(err)
+
+        writePackage()
+
+        npm.commands.shrinkwrap([], true, function (err, results) {
+          if (err) return fail(err)
+
+          t.deepEqual(results, desired)
+          s.close()
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+var desired = {
+  name: 'npm-test-shrinkwrap-optional-dependency',
+  version: '0.0.0',
+  dependencies: {
+    'test-package': {
+      version: '0.0.0',
+      from: 'test-package@0.0.0',
+      resolved: common.registry + '/test-package/-/test-package-0.0.0.tgz'
+    },
+    'underscore': {
+      version: '1.3.3',
+      from: 'underscore@1.3.3',
+      resolved: 'http://localhost:1337/underscore/-/underscore-1.3.3.tgz',
+      optional: true
+    }
+  }
+}
+
+var json = {
+  author: 'Maximilian Antoni',
+  name: 'npm-test-shrinkwrap-optional-dependency',
+  version: '0.0.0',
+  dependencies: {
+    'test-package': '0.0.0'
+  },
+  optionalDependencies: {
+    'underscore': '1.3.3'
+  }
+}
+
+function writePackage () {
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
+}
+
+function setup (cb) {
+  cleanup()
+  mkdirp.sync(pkg)
+  writePackage()
+  process.chdir(pkg)
+
+  var opts = {
+    cache: path.resolve(pkg, 'cache'),
+    registry: common.registry
+  }
+  npm.load(opts, cb)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}

--- a/test/tap/shrinkwrap-prod-dependency-also.js
+++ b/test/tap/shrinkwrap-prod-dependency-also.js
@@ -70,6 +70,7 @@ var desired = {
       resolved: common.registry + '/request/-/request-0.9.0.tgz'
     },
     underscore: {
+      dev: true,
       version: '1.5.1',
       from: 'underscore@1.5.1',
       resolved: common.registry + '/underscore/-/underscore-1.5.1.tgz'

--- a/test/tap/shrinkwrap-prod-dependency.js
+++ b/test/tap/shrinkwrap-prod-dependency.js
@@ -50,6 +50,7 @@ var desired = {
       resolved: common.registry + '/request/-/request-0.9.0.tgz'
     },
     underscore: {
+      dev: true,
       version: '1.5.1',
       from: 'underscore@1.5.1',
       resolved: common.registry + '/underscore/-/underscore-1.5.1.tgz'

--- a/test/tap/shrinkwrap-prod-no-dev.js
+++ b/test/tap/shrinkwrap-prod-no-dev.js
@@ -1,0 +1,82 @@
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+var npm = npm = require('../../')
+
+var pkg = path.resolve(__dirname, 'shrinkwrap-prod-no-dev')
+
+test('shrinkwrap should not include dev dependency', function (t) {
+  t.plan(1)
+
+  mr({port: common.port}, function (er, s) {
+    setup(function (err) {
+      if (err) return t.fail(err)
+
+      npm.install('.', function (err) {
+        if (err) return t.fail(err)
+
+        npm.commands.shrinkwrap([], true, function (err, results) {
+          if (err) return t.fail(err)
+
+          t.deepEqual(results, desired)
+          s.close()
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+var desired = {
+  name: 'npm-test-shrinkwrap-prod-no-dev',
+  version: '0.0.0',
+  dependencies: {
+    request: {
+      version: '0.9.0',
+      from: 'request@0.9.0',
+      resolved: common.registry + '/request/-/request-0.9.0.tgz'
+    }
+  }
+}
+
+var json = {
+  author: 'Domenic Denicola',
+  name: 'npm-test-shrinkwrap-prod-no-dev',
+  version: '0.0.0',
+  dependencies: {
+    request: '0.9.0'
+  },
+  devDependencies: {
+    underscore: '1.5.1'
+  }
+}
+
+function setup (cb) {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
+  process.chdir(pkg)
+
+  var opts = {
+    cache: path.resolve(pkg, 'cache'),
+    registry: common.registry
+  }
+  npm.load(opts, cb)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
We've been running into issues caused by #5403, so this a PR to implement it. 

As a result of this PR, the following things happen:
- `devDependency`-only items in the shrinkwrap are marked with `dev: true`.
- `npm i --only=prod` will not install anything in the shrinkwrap marked `dev: true`.
- `npm i --only=dev` will only install things in the shrinkwrap marked with `dev: true`.
