### PR TITLE
Update npm-start.md

### DIFF
--- a/doc/cli/npm-start.md
+++ b/doc/cli/npm-start.md
@@ -7,7 +7,9 @@ npm-start(1) -- Start a package
 
 ## DESCRIPTION
 
-This runs a package's "start" script, if one was provided.
+This runs an arbitrary command specified in the package's "start" property of its "scripts" object. If no "start" property is specified on the "scripts" object, it will run `node server.js`.
+
+As of npm@2.0.0, you can use custom arguments when executing scripts. Refer to npm-run-script(1) for more details.
 
 ## SEE ALSO
 


### PR DESCRIPTION
@ashleygwilliams 

Addresses #9460, specifying the default command run by "npm start" and the fact that you can pass it arguments.
