### PR TITLE
Try to ensure string-type `package.bin` don't cause crashers

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -15,6 +15,7 @@ var rimraf = require('rimraf')
 var clone = require('lodash.clonedeep')
 var validate = require('aproba')
 var unpipe = require('unpipe')
+var normalizePackageData = require('normalize-package-data')
 
 var npm = require('./npm.js')
 var mapToRegistry = require('./utils/map-to-registry.js')
@@ -68,6 +69,15 @@ module.exports = function fetchPackageMetadata (spec, where, tracker, done) {
       pkg._where = where
       if (!pkg._args) pkg._args = []
       pkg._args.push([pkg._spec, pkg._where])
+      // non-npm registries can and will return unnormalized data, plus
+      // even the npm registry may have package data normalized with older
+      // normalization rules. This ensures we get package data in a consistent,
+      // stable format.
+      try {
+        normalizePackageData(pkg)
+      } catch (ex) {
+        // don't care
+      }
     }
     logAndFinish(er, pkg)
   }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -554,10 +554,11 @@ var earliestInstallable = exports.earliestInstallable = function (requiredBy, tr
 
   // If any of the children of this tree have conflicting
   // binaries then we need to decline to install this package here.
-  var binaryMatches = tree.children.some(function (child) {
+  var binaryMatches = typeof pkg.bin === 'object' && tree.children.some(function (child) {
     if (child.removed) return false
-    return Object.keys(child.package.bin || {}).some(function (bin) {
-      return pkg.bin && pkg.bin[bin]
+    if (typeof child.package.bin !== 'object') return false
+    return Object.keys(child.package.bin).some(function (bin) {
+      return pkg.bin[bin]
     })
   })
   if (binaryMatches) return null

--- a/test/tap/bugs.js
+++ b/test/tap/bugs.js
@@ -144,7 +144,7 @@ test('npm bugs test-repo-url-https - non-github (https://)', function (t) {
   })
 })
 
-test('npm bugs test-repo-url-ssh - non-github (ssh://)', function (t) {
+test('npm bugs test-repo-url-ssh - gitlab (ssh://)', function (t) {
   mr({ port: common.port }, function (er, s) {
     common.npm(
       [
@@ -160,7 +160,7 @@ test('npm bugs test-repo-url-ssh - non-github (ssh://)', function (t) {
         t.equal(code, 0, 'exit ok')
         var res = fs.readFileSync(outFile, 'ascii')
         s.close()
-        t.equal(res, 'https://www.npmjs.org/package/test-repo-url-ssh\n')
+        t.equal(res, 'https://gitlab.com/evanlucas/test-repo-url-ssh/issues\n')
         rimraf.sync(outFile)
         t.end()
       }


### PR DESCRIPTION
I've not yet been able to reproduce the root cause– my current pet theory is that it's caused by third party registries returning unnormalized package.json data.

So this patch does two things, first it makes sure that whatever route the module is getting to us, `fetch-package-metadata` can only ever return normalized results, and second it insures the proximate cause of the crash can't make a crash happen, even if it slips in through some door I can't see/think of.

Fixes: #9187
