### PR TITLE
completion: enable on Windows in git bash

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -45,8 +45,8 @@ completion.completion = function (opts, cb) {
 }
 
 function completion (args, cb) {
-  if (process.platform === 'win32') {
-    var e = new Error('npm completion not supported on windows')
+  if (process.platform === 'win32' && !(/^MINGW(32|64)$/.test(process.env.MSYSTEM))) {
+    var e = new Error('npm completion supported only in MINGW / Git bash on Windows')
     e.code = 'ENOTSUP'
     e.errno = require('constants').ENOTSUP
     return cb(e)


### PR DESCRIPTION
npm completion used to be always blocked on Windows but it works just fine on Git Bash.

(I'm surprised no one submitted a PR for this yet, maybe it was due to instant closing of 
#3420 and  #6998)

---

Tested on Windows 7 with git bash 1.9.5

```
$ git --version
git version 1.9.5.msysgit.1

$ cmd //c ver
Microsoft Windows [Version 6.1.7601]

$ node --version
v0.12.7

$ npm completion >> ~/.bashrc
```

Restarted bash, then quick tests:

```
me@mymachine /d/gh/npm/lib (completion-on-windows-bash)
$ npm [TAB]
Display all 83 possibilities? (y or n)
access       c            dist-tag     find-dupes   init         ln           ping         remove       se           start        un           upgrade
add-user     cache        dist-tags    get          install      login        prefix       repo         search       stop         uninstall    v
adduser      completion   docs         help         issues       logout       prune        restart      set          t            unlink       verison
apihelp      config       edit         help-search  la           ls           publish      rm           show         tag          unpublish    version
author       ddp          explore      home         link         outdated     r            root         shrinkwrap   team         unstar       view
bin          dedupe       faq          i            list         owner        rb           run-script   star         test         up           whoami
bugs         deprecate    find         info         ll           pack         rebuild      s            stars        tst          update
```

```
me@mymachine /d/gh/npm/lib (completion-on-windows-bash)
$ npm run-script [TAB]
dumpconf     prepublish   preversion   tap          test         test-all     test-legacy  test-node    test-tap
```

@othiym23 is npm interested in integrating this patch? what about backporting it to npm2? Do you see any potential issues here or something can be done better? 

Thanks
Jakub
