### PR TITLE
When replacing an existing module with a bundled one, remove it first

### DIFF
--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -132,6 +132,7 @@ function diffTrees (oldTree, newTree) {
                    requiredByAllLinked(pkg)
     if (pkg.fromBundle) {
       if (npm.config.get('rebuild-bundle')) differences.push(['rebuild', pkg])
+      if (pkg.oldPkg) differences.push(['remove', pkg])
     } else if (pkg.oldPkg) {
       if (!pkg.directlyRequested && pkgAreEquiv(pkg.oldPkg.package, pkg.package)) return
       if (!pkg.isInLink && (isLink(pkg.oldPkg) || isLink(pkg))) {


### PR DESCRIPTION
If a bundled module is going to be replacing a module that's currently on disk (for instance, when you upgrade a module that includes bundled dependencies) we want to select the version from the bundle in preference over the one that was there previously.

We achieve this by removing the obsoleted module before extracting the bundled dependency.

This fixes the problems npm is currently seeing in Travis, where it has trouble upgrading to 3.3.11 from a 2.x branch.
