### PR TITLE
Travis CI test stable and LTS Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "4.1"
-  - "4.0"
+  - "stable"
+  - "4.2"
   - iojs
   - "0.12"
   - "0.10"


### PR DESCRIPTION
Test not all Node.js 4.x and 5.x and so on!
Tests the 4.2 LTS and the latest stable version!
