### PR TITLE
Remove arguments from npm-dedupe.md

### DIFF
--- a/doc/cli/npm-dedupe.md
+++ b/doc/cli/npm-dedupe.md
@@ -3,8 +3,8 @@ npm-dedupe(1) -- Reduce duplication
 
 ## SYNOPSIS
 
-    npm dedupe [package names...]
-    npm ddp [package names...]
+    npm dedupe
+    npm ddp
 
 ## DESCRIPTION
 


### PR DESCRIPTION
The example invocations of npm dedupe show arguments provided, but the copy says "Arguments are ignored. Dedupe always acts on the entire tree.", and that appears to be correct.
