### PR TITLE
shrinkwrap: exclude dependencies of devDependencies and optionalDependencies

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -50,6 +50,14 @@ function isDevDep (tree, name) {
   return npa(name + '@' + reqVer)
 }
 
+// optDeps are a subset of prodDeps
+function isOptDep (tree, name) {
+  var optDeps = tree.package.optionalDependencies || {}
+  var reqVer = optDeps[name]
+  if (reqVer == null) return
+  return npa(name + '@' + reqVer)
+}
+
 function isProdDep (tree, name) {
   var deps = tree.package.dependencies || {}
   var reqVer = deps[name]
@@ -122,9 +130,18 @@ function recalculateMetadata (tree, log, seen, next) {
   })
 }
 
+function determineFlatName (tree, child) {
+  var flatName = flatNameFromTree(tree)
+  if (isProdDep(tree, moduleName(child))) {
+    return isOptDep(tree, moduleName(child)) ? '#OPT:' + flatName : flatName
+  }
+
+  return '#DEV:' + flatName
+}
+
 function addRequiredDep (tree, child) {
   if (!isDep(tree, child)) return false
-  var name = isProdDep(tree, moduleName(child)) ? flatNameFromTree(tree) : '#DEV:' + flatNameFromTree(tree)
+  var name = determineFlatName(tree, child)
   replaceModuleName(child.package, '_requiredBy', name)
   replaceModule(child, 'requiredBy', tree)
   replaceModule(tree, 'requires', child)

--- a/lib/install/is-dev.js
+++ b/lib/install/is-dev.js
@@ -2,6 +2,26 @@
 var isDev = exports.isDev = function (node) {
   return node.package._requiredBy.some(function (req) { return req === '#DEV:/' })
 }
-exports.isOnlyDev = function (node) {
+var isOnlyDev = exports.isOnlyDev = function (node) {
   return node.package._requiredBy.length === 1 && isDev(node)
+}
+var isTreeDev = exports.isTreeDev = function (node, tree) {
+  // If we don't have the node in the tree, assume the node
+  // is not a dev dependency (as we're in a subtree)
+  //
+  // If a node is not required by anything, then we've reached
+  // the top level package.
+  if (!node || (node && node.package && node.package._requiredBy.length === 0)) {
+    return false
+  }
+
+  // A package is only a devDependency if nothing else requires it
+  if (isOnlyDev(node)) {
+    return true
+  }
+
+  // Otherwise, walk up one step.
+  return node.package._requiredBy.every(function (pkg) {
+    return isTreeDev(tree[pkg], tree)
+  })
 }

--- a/lib/install/is-dev.js
+++ b/lib/install/is-dev.js
@@ -2,9 +2,6 @@
 var isDev = exports.isDev = function (node) {
   return node.package._requiredBy.some(function (req) { return req === '#DEV:/' })
 }
-var isOnlyDev = exports.isOnlyDev = function (node) {
-  return node.package._requiredBy.length === 1 && isDev(node)
-}
 var isTreeDev = exports.isTreeDev = function (node, tree) {
   // If we don't have the node in the tree, assume the node
   // is not a dev dependency (as we're in a subtree)
@@ -16,7 +13,7 @@ var isTreeDev = exports.isTreeDev = function (node, tree) {
   }
 
   // A package is only a devDependency if nothing else requires it
-  if (isOnlyDev(node)) {
+  if (node.package._requiredBy.length === 1 && isDev(node)) {
     return true
   }
 

--- a/lib/install/is-extraneous.js
+++ b/lib/install/is-extraneous.js
@@ -1,6 +1,7 @@
 'use strict'
 var path = require('path')
 var isDev = require('./is-dev.js').isDev
+var isOpt = require('./is-opt.js').isOpt
 var npm = require('../npm.js')
 
 module.exports = function (tree) {
@@ -10,5 +11,5 @@ module.exports = function (tree) {
   var isChildOfTop = !isTopLevel && tree.parent.parent == null
   var isTopGlobal = isChildOfTop && tree.parent.path === path.resolve(npm.globalDir, '..')
   var topHasNoPackageJson = isChildOfTop && tree.parent.error
-  return !isTopLevel && (!isChildOfTop || !topHasNoPackageJson) && !isTopGlobal && requiredBy.length === 0 && !isDev(tree)
+  return !isTopLevel && (!isChildOfTop || !topHasNoPackageJson) && !isTopGlobal && requiredBy.length === 0 && !isDev(tree) && !isOpt(tree)
 }

--- a/lib/install/is-opt.js
+++ b/lib/install/is-opt.js
@@ -1,0 +1,24 @@
+'use strict'
+var isOpt = exports.isOpt = function (node) {
+  return node.package._requiredBy.some(function (req) { return req === '#OPT:/' })
+}
+var isTreeOpt = exports.isTreeOpt = function (node, tree) {
+  // If we don't have the node in the tree, assume the node
+  // is not a opt dependency (as we're in a subtree)
+  //
+  // If a node is not required by anything, then we've reached
+  // the top level package.
+  if (!node || (node && node.package && node.package._requiredBy.length === 0)) {
+    return false
+  }
+
+  // A package is only a optional dependency if nothing else requires it
+  if (node.package._requiredBy.length === 1 && isOpt(node)) {
+    return true
+  }
+
+  // Otherwise, walk up one step.
+  return node.package._requiredBy.every(function (pkg) {
+    return isTreeOpt(tree[pkg], tree)
+  })
+}

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -15,6 +15,7 @@ var flattenTree = require('./install/flatten-tree.js')
 var validatePeerDeps = require('./install/deps.js').validatePeerDeps
 var isExtraneous = require('./install/is-extraneous.js')
 var isTreeDev = require('./install/is-dev.js').isTreeDev
+var isTreeOpt = require('./install/is-opt.js').isTreeOpt
 var packageId = require('./utils/package-id.js')
 var moduleName = require('./utils/module-name.js')
 
@@ -79,6 +80,10 @@ function shrinkwrapDeps (dev, problems, deps, tree, seen) {
   tree.children.sort(function (aa, bb) { return moduleName(aa).localeCompare(moduleName(bb)) }).forEach(function (child) {
     if (!dev && isTreeDev(child, flatTree)) {
       log.warn('shrinkwrap', 'Excluding devDependency: %s', packageId(child), child.parent.package.dependencies)
+      return
+    }
+    if (isTreeOpt(child, flatTree)) {
+      log.warn('shrinkwrap', 'Excluding optionalDependency: %s', packageId(child), child.parent.package.dependencies)
       return
     }
     var pkginfo = deps[moduleName(child)] = {}

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -11,9 +11,10 @@ var readPackageTree = require('read-package-tree')
 var validate = require('aproba')
 var npm = require('./npm.js')
 var recalculateMetadata = require('./install/deps.js').recalculateMetadata
+var flattenTree = require('./install/flatten-tree.js')
 var validatePeerDeps = require('./install/deps.js').validatePeerDeps
 var isExtraneous = require('./install/is-extraneous.js')
-var isOnlyDev = require('./install/is-dev.js').isOnlyDev
+var isTreeDev = require('./install/is-dev.js').isTreeDev
 var packageId = require('./utils/package-id.js')
 var moduleName = require('./utils/module-name.js')
 
@@ -74,8 +75,9 @@ function shrinkwrapDeps (dev, problems, deps, tree, seen) {
         (topname ? ', required by ' + topname : ''))
     }
   })
+  var flatTree = flattenTree(tree)
   tree.children.sort(function (aa, bb) { return moduleName(aa).localeCompare(moduleName(bb)) }).forEach(function (child) {
-    if (!dev && isOnlyDev(child)) {
+    if (!dev && isTreeDev(child, flatTree)) {
       log.warn('shrinkwrap', 'Excluding devDependency: %s', packageId(child), child.parent.package.dependencies)
       return
     }

--- a/test/tap/shrinkwrap-prod-no-dev.js
+++ b/test/tap/shrinkwrap-prod-no-dev.js
@@ -1,0 +1,82 @@
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+var npm = npm = require('../../')
+
+var pkg = path.resolve(__dirname, 'shrinkwrap-prod-no-dev')
+
+test('shrinkwrap should not include dev dependency', function (t) {
+  t.plan(1)
+
+  mr({port: common.port}, function (er, s) {
+    setup(function (err) {
+      if (err) return t.fail(err)
+
+      npm.install('.', function (err) {
+        if (err) return t.fail(err)
+
+        npm.commands.shrinkwrap([], true, function (err, results) {
+          if (err) return t.fail(err)
+
+          t.deepEqual(results, desired)
+          s.close()
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+var desired = {
+  name: 'npm-test-shrinkwrap-prod-no-dev',
+  version: '0.0.0',
+  dependencies: {
+    request: {
+      version: '0.9.0',
+      from: 'request@0.9.0',
+      resolved: common.registry + '/request/-/request-0.9.0.tgz'
+    }
+  }
+}
+
+var json = {
+  author: 'Domenic Denicola',
+  name: 'npm-test-shrinkwrap-prod-no-dev',
+  version: '0.0.0',
+  dependencies: {
+    request: '0.9.0'
+  },
+  devDependencies: {
+    underscore: '1.5.1'
+  }
+}
+
+function setup (cb) {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
+  process.chdir(pkg)
+
+  var opts = {
+    cache: path.resolve(pkg, 'cache'),
+    registry: common.registry
+  }
+  npm.load(opts, cb)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}

--- a/test/tap/shrinkwrap-prod-no-opt.js
+++ b/test/tap/shrinkwrap-prod-no-opt.js
@@ -1,0 +1,82 @@
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+var npm = npm = require('../../')
+
+var pkg = path.resolve(__dirname, 'shrinkwrap-prod-no-opt')
+
+test('shrinkwrap should not include opt dependency', function (t) {
+  t.plan(1)
+
+  mr({port: common.port}, function (er, s) {
+    setup(function (err) {
+      if (err) return t.fail(err)
+
+      npm.install('.', function (err) {
+        if (err) return t.fail(err)
+
+        npm.commands.shrinkwrap([], true, function (err, results) {
+          if (err) return t.fail(err)
+
+          t.deepEqual(results, desired)
+          s.close()
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+var desired = {
+  name: 'npm-test-shrinkwrap-prod-no-opt',
+  version: '0.0.0',
+  dependencies: {
+    request: {
+      version: '0.9.0',
+      from: 'request@0.9.0',
+      resolved: common.registry + '/request/-/request-0.9.0.tgz'
+    }
+  }
+}
+
+var json = {
+  author: 'Terin Stock',
+  name: 'npm-test-shrinkwrap-prod-no-opt',
+  version: '0.0.0',
+  dependencies: {
+    request: '0.9.0'
+  },
+  optionalDependencies: {
+    underscore: '1.5.1'
+  }
+}
+
+function setup (cb) {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
+  process.chdir(pkg)
+
+  var opts = {
+    cache: path.resolve(pkg, 'cache'),
+    registry: common.registry
+  }
+  npm.load(opts, cb)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
As the tree is now flattened, dependencies of devDependencies weren't
automatically excluded simply by not recursing into a devDependency's
children.

Instead, now explicitly walk "up" a dependency's tree to the root to
determine if it's a devDependency or solely a dependency of
a devDependency.

Resolve #9727
