### PR TITLE
install: blast linked modules if direct request

### DIFF
--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -135,7 +135,7 @@ function diffTrees (oldTree, newTree) {
       if (pkg.oldPkg) differences.push(['remove', pkg])
     } else if (pkg.oldPkg) {
       if (!pkg.directlyRequested && pkgAreEquiv(pkg.oldPkg.package, pkg.package)) return
-      if (!pkg.isInLink && (isLink(pkg.oldPkg) || isLink(pkg))) {
+      if (!pkg.directlyRequested && !pkg.isInLink && (isLink(pkg.oldPkg) || isLink(pkg))) {
         differences.push(['update-linked', pkg])
       } else {
         differences.push(['update', pkg])

--- a/lib/install/filter-invalid-actions.js
+++ b/lib/install/filter-invalid-actions.js
@@ -21,7 +21,7 @@ module.exports = function (top, differences, next) {
   while (action = differences.shift()) {
     var cmd = action[0]
     var pkg = action[1]
-    if (pkg.isInLink || pkg.parent.target || pkg.parent.isLink) {
+    if (!pkg.directlyRequested && (pkg.isInLink || pkg.parent.target || pkg.parent.isLink)) {
       // we want to skip warning if this is a child of another module that we're removing
       if (!pkg.parent.removing) {
         log.warn('skippingAction', 'Module is inside a symlinked module: not running ' +


### PR DESCRIPTION
- addresses issue #9693
- `npm install foo` will overwrite any existing symlinks to package `foo`

This may not be npm's intended behavior, but it makes sense to me.  Currently (`master` as of this writing):

``` sh
$ cd foo
$ npm link
$ cd ../bar
$ npm link foo
$ npm install ../foo # doesn't seem to do much of anything
```

This PR makes `npm install ../foo` just go ahead and install `../foo`.  

This PR _does not_ address the inherent problems with the `update-linked` wording, which can suggest a package needs to be replaced with itself.  Especially confusing here is that if a package has the same `version` property, but otherwise a slightly (or wildly!) different `package.json`, a user may receive the warning.

So, I wouldn't consider #9693 to be resolved by this PR, but addresses _what I consider to be_ unexpected behavior surrounding it.  I can't recall if npm v2 would simply overwrite the symlinked package?

Questions: 
1.  I didn't see anywhere where the nuances of `install`'s behavior against existing linked packages are documented.  If this is to be written, please let me know where.
2.  My local tests pass, so I imagine there is no coverage here.  If you are interested in this PR, please let me know what you want tested, specifically, and I will create a new test suite.
3.  If this is not acceptable/intended/desired behavior for npm, what is an effective solution to #9693?
4.  If the current behavior is not a "bug", then this is a breaking change.  If it _is_ a bug, then this still might be a breaking change.  :smile:
