### PR TITLE
Optional dependencies name included in warning

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -307,7 +307,7 @@ function andHandleOptionalErrors (log, tree, name, done) {
     var isFatal = failedDependency(tree, name)
     if (er && !isFatal) {
       tree.children = tree.children.filter(noModuleNameMatches(name))
-      log.warn('install', "Couldn't install optional dependency:", er.message)
+      log.warn('install', "Couldn't install optional dependency '" + name + "':", er.message)
       log.verbose('install', er.stack)
       return done()
     } else {


### PR DESCRIPTION
When warning about being unable to install an optional dependency, include the name of the failed dependency in the warning message.
