### PR TITLE
add "-offline" shorthand for "--cache-min 999999"

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -53,6 +53,7 @@ The following shorthands are parsed on the command-line:
 * `-C`: `--prefix`
 * `-l`: `--long`
 * `-m`: `--message`
+* `-offline`: `--cache-min 999999`
 * `-p`, `--porcelain`: `--parseable`
 * `-reg`: `--registry`
 * `-f`: `--force`

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -371,6 +371,7 @@ exports.shorthands = {
   'local': ['--no-global'],
   l: ['--long'],
   m: ['--message'],
+  offline: ['--cache-min', '999999'],
   p: ['--parseable'],
   porcelain: ['--parseable'],
   g: ['--global'],


### PR DESCRIPTION
I was going through @ashleygwilliams's [slides](http://ashleygwilliams.github.io/you-dont-know-npm) and came across [slide 15](http://ashleygwilliams.github.io/you-dont-know-npm/#15) where I discovered how to install a package from the cache, which is super helpful.

She suggested adding an alias of `--offline`, so I thought I'd explore the possibility that this PR would solve that problem. Although it does appear that it will actually shorthand to `-offline` which isn't quite what was suggested. Maybe there's another way of doing this to maintain the double dash syntax for full words that'd be better in this case, and if so, please let me know whether I can do this inside this PR.

Happy to close this if there's a totally different way of doing it, and I'm more than happy to add tests, but I couldn't find any other tests to test whether the shorthands expanded to the intended arguments, so I figured it's not seen as a useful unit test, which is reasonable.
