### PR TITLE
Allow partial and full disabling of flat trees

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -257,6 +257,16 @@ local copy exists on disk.
 The `-g` or `--global` argument will cause npm to install the package globally
 rather than locally.  See `npm-folders(5)`.
 
+The `--global-style` argument will cause npm to install the package into
+your local `node_modules` folder with the same layout it uses with the
+global `node_modules` folder. Only your direct dependencies will show in
+`node_modules` and everything they depend on will be flattened in their
+`node_modules` folders. This obviously will elminate some deduping.
+
+The `--legacy-bundling` argument will cause npm to install the package such
+that versions of npm prior to 1.4, such as the one included with node 0.8,
+can install the package. This eliminates all automatic deduping.
+
 The `--link` argument will cause npm to link global installs into the
 local space in some cases.
 

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -145,6 +145,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
 
     global: false,
     globalconfig: path.resolve(globalPrefix, 'etc', 'npmrc'),
+    'global-style': false,
     group: process.platform === 'win32' ? 0
             : process.env.SUDO_GID || (process.getgid && process.getgid()),
     heading: 'npm',
@@ -158,6 +159,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'init-license': 'ISC',
     json: false,
     key: null,
+    'legacy-bundling': false,
     link: false,
     'local-address': undefined,
     loglevel: 'warn',
@@ -251,6 +253,7 @@ exports.types = {
   'git-tag-version': Boolean,
   global: Boolean,
   globalconfig: path,
+  'global-bundling': Boolean,
   group: [Number, String],
   'https-proxy': [null, url],
   'user-agent': String,
@@ -265,6 +268,7 @@ exports.types = {
   'init-version': semver,
   json: Boolean,
   key: [null, String],
+  'legacy-bundling': Boolean,
   link: Boolean,
   // local-address must be listed as an IP for a local network interface
   // must be IPv4 due to node bug

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -577,5 +577,8 @@ var earliestInstallable = exports.earliestInstallable = function (requiredBy, tr
   if (!tree.parent) return tree
   if (tree.isGlobal) return tree
 
+  if (npm.config.get('global-style') && !tree.parent.parent) return tree
+  if (npm.config.get('legacy-bundling')) return tree
+
   return (earliestInstallable(requiredBy, tree.parent, pkg) || tree)
 }

--- a/test/tap/tree-style.js
+++ b/test/tap/tree-style.js
@@ -1,0 +1,116 @@
+'use strict'
+var test = require('tap').test
+var path = require('path')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var fs = require('graceful-fs')
+var common = require('../common-tap')
+
+var base = path.resolve(__dirname, path.basename(__filename, '.js'))
+var modA = path.resolve(base, 'modA')
+var modB = path.resolve(base, 'modB')
+var modC = path.resolve(base, 'modC')
+var testNormal = path.resolve(base, 'testNormal')
+var testGlobal = path.resolve(base, 'testGlobal')
+var testLegacy = path.resolve(base, 'testLegacy')
+
+var json = {
+  'name': 'test-tree-style',
+  'version': '1.0.0',
+  'dependencies': {
+    'modA': modA
+  }
+}
+
+var modAJson = {
+  'name': 'modA',
+  'version': '1.0.0',
+  'dependencies': {
+    'modB': modB
+  }
+}
+
+var modBJson = {
+  'name': 'modB',
+  'version': '1.0.0',
+  'dependencies': {
+    'modC': modC
+  }
+}
+
+var modCJson = {
+  'name': 'modC',
+  'version': '1.0.0'
+}
+
+function modJoin () {
+  var modules = Array.prototype.slice.call(arguments)
+  return modules.reduce(function (a, b) {
+    return path.resolve(a, 'node_modules', b)
+  })
+}
+
+function writeJson (mod, data) {
+  fs.writeFileSync(path.resolve(mod, 'package.json'), JSON.stringify(data))
+}
+
+function setup () {
+  cleanup()
+  ;[modA, modB, modC, testNormal, testGlobal, testLegacy].forEach(function (mod) {
+    mkdirp.sync(mod)
+  })
+  writeJson(modA, modAJson)
+  writeJson(modB, modBJson)
+  writeJson(modC, modCJson)
+  ;[testNormal, testGlobal, testLegacy].forEach(function (mod) { writeJson(mod, json) })
+}
+
+function cleanup () {
+  rimraf.sync(base)
+}
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+function exists (t, filepath, msg) {
+  try {
+    fs.statSync(filepath)
+    t.pass(msg)
+    return true
+  } catch (ex) {
+    t.fail(msg, {found: null, wanted: 'exists', compare: 'fs.stat(' + filepath + ')'})
+    return false
+  }
+}
+
+test('tree-style', function (t) {
+  t.plan(12)
+  common.npm(['install'], {cwd: testNormal}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'normal install; result code')
+    t.is(stderr, '', 'normal install; no errors')
+    exists(t, modJoin(testNormal, 'modA'), 'normal install; module A')
+    exists(t, modJoin(testNormal, 'modB'), 'normal install; module B')
+    exists(t, modJoin(testNormal, 'modC'), 'normal install; module C')
+  })
+  common.npm(['install', '--global-style'], {cwd: testGlobal}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'global-style install; result code')
+    t.is(stderr, '', 'global-style install; no errors')
+    exists(t, modJoin(testGlobal, 'modA', 'modB'), 'global-style install; module B')
+    exists(t, modJoin(testGlobal, 'modA', 'modC'), 'global-style install; module C')
+  })
+  common.npm(['install', '--legacy-bundling'], {cwd: testLegacy}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'legacy-bundling install; result code')
+    t.is(stderr, '', 'legacy-bundling install; no errors')
+    exists(t, modJoin(testLegacy, 'modA', 'modB', 'modC'), 'legacy-bundling install; module C')
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
Rename `--no-flat` to `--legacy-bundling`, document it's purpose as making a tree that's compatible with the npm 1.2 that ships with node 0.8.

Rename `--partial-flat` to `--global-style`.

(The secret is that both of these produce 0.8 compatible bundles.)
