### PR TITLE
Remove broken (and duplicate!) link

### DIFF
--- a/doc/cli/npm-dist-tag.md
+++ b/doc/cli/npm-dist-tag.md
@@ -69,5 +69,4 @@ begin with a number or the letter `v`.
 * npm-registry(7)
 * npm-config(1)
 * npm-config(7)
-* npm-tag(3)
 * npmrc(5)


### PR DESCRIPTION
There was a duplicate link to `npm-tag` which was erroneously pointing to https://docs.npmjs.com/undefined/tag
