### PR TITLE
Fix linking from global for installing when link=true

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -410,7 +410,7 @@ Installer.prototype.computeLinked = function (cb) {
     var isReqByTop = pkg.package._requiredBy.filter(function (name) { return name === '/' }).length
     var isReqByUser = pkg.package._requiredBy.filter(function (name) { return name === '#USER' }).length
     var isExtraneous = pkg.package._requiredBy.length === 0
-    if (!isReqByTop && !isReqByUser && !isExtraneous) return next()
+    if (!self.link && !isReqByTop && !isReqByUser && !isExtraneous) return next()
     isLinkable(pkg, function (install, link) {
       if (install) linkTodoList.push(['global-install', pkg])
       if (link) linkTodoList.push(['global-link', pkg])


### PR DESCRIPTION
A la #10348 

So this may be super naive, since I couldn't exactly decipher why you would only want to link if requiredBy was a top level package or by `"#USER"`, but at the _very_ least this allows modules to get through to `isLinkable()` where before they would never get passed  `if (!isReqByTop && !isReqByUser && !isExtraneous) return next()` condition under what appeared to be any circumstances. It may be entirely possibly to remove that entirely, since aggressive symlinking is what we want anyways, right?

Anyways, this makes symlinking work pretty well again. Would like some feedback on a better way to go about this since I've now identified the cause.
