### PR TITLE
Error on install where dep name !== resolved name

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -87,6 +87,9 @@ function fetchOtherPackageData (spec, dep, where, next) {
   validate('SOSF', arguments)
   log.silly('fetchOtherPackageData', spec)
   cache.add(spec, null, where, false, iferr(next, function (pkg) {
+    if (dep.name !== pkg.name) {
+      return next(new Error('Invalid Package: expected ' + dep.name + ' but found ' + pkg.name))
+    }
     var result = clone(pkg)
     result._inCache = true
     next(null, result)


### PR DESCRIPTION
Where the name given for a git url dep doesn't match the name given
in the remote package.json, fail the install and let the user know.

Existing `npm@3.4.0` behaviour is to siltenly prune the dep from the tree.
with no warning.
- Minimal fix for #10401
- Resuses the error message from [tarball verification](https://github.com/npm/npm/blob/65a64c9277184b1a0665d78fce0a9b00f930d9bc/lib/cache/add-local-tarball.js#L124)
