### PR TITLE
doc: remove refs to nonexistent `npm-rm(1)` manpage

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -353,5 +353,5 @@ affects a real use-case, it will be investigated.
 * npmrc(5)
 * npm-registry(7)
 * npm-tag(1)
-* npm-rm(1)
+* npm-uninstall(1)
 * npm-shrinkwrap(1)

--- a/doc/cli/npm-prune.md
+++ b/doc/cli/npm-prune.md
@@ -21,6 +21,6 @@ negate `NODE_ENV` being set to `production`.
 
 ## SEE ALSO
 
-* npm-rm(1)
+* npm-uninstall(1)
 * npm-folders(5)
 * npm-ls(1)

--- a/doc/cli/npm-uninstall.md
+++ b/doc/cli/npm-uninstall.md
@@ -1,4 +1,4 @@
-npm-rm(1) -- Remove a package
+npm-uninstall(1) -- Remove a package
 =============================
 
 ## SYNOPSIS

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -726,4 +726,4 @@ npm will default some values based on package contents.
 * npm-faq(7)
 * npm-install(1)
 * npm-publish(1)
-* npm-rm(1)
+* npm-uninstall(1)

--- a/doc/misc/removing-npm.md
+++ b/doc/misc/removing-npm.md
@@ -50,5 +50,5 @@ modules.  To track those down, you can do the following:
 ## SEE ALSO
 
 * README
-* npm-rm(1)
+* npm-uninstall(1)
 * npm-prune(1)


### PR DESCRIPTION
The correct manpage is `npm-uninstall(1)`, **or** `doc/cli/npm-uninstall.md` should be renamed to `doc/cli/npm-rm.md`.
