### PR TITLE
Test if entries are directories before mandatorily including them

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -62,17 +62,19 @@ function BundledPacker (props) {
 inherits(BundledPacker, Packer)
 
 BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
-  // package.json files can never be ignored.
-  if (entry === 'package.json') return true
+  if (!entryObj || entryObj.type !== 'Directory') {
+    // package.json files can never be ignored.
+    if (entry === 'package.json') return true
 
-  // readme files should never be ignored.
-  if (entry.match(/^readme(\.[^\.]*)$/i)) return true
+    // readme files should never be ignored.
+    if (entry.match(/^readme(\.[^\.]*)$/i)) return true
 
-  // license files should never be ignored.
-  if (entry.match(/^(license|licence)(\.[^\.]*)?$/i)) return true
+    // license files should never be ignored.
+    if (entry.match(/^(license|licence)(\.[^\.]*)?$/i)) return true
 
-  // changelogs should never be ignored.
-  if (entry.match(/^(changes|changelog|history)(\.[^\.]*)?$/i)) return true
+    // changelogs should never be ignored.
+    if (entry.match(/^(changes|changelog|history)(\.[^\.]*)?$/i)) return true
+  }
 
   // special rules.  see below.
   if (entry === 'node_modules' && this.packageRoot) return true


### PR DESCRIPTION
This matches the behavior in fstream-npm@1.0.6 from d82ff81403e906931fac701775723626dcb443b3.

I was tempted to completely remove the `applyIgnores` method (which is the only thing `BundledPacker` extends from `fstream-npm`), but it seems like there is slightly different logic in how bundled dependencies are packaged in [`npm`](https://github.com/npm/npm/blob/65a64c9277184b1a0665d78fce0a9b00f930d9bc/lib/utils/tar.js#L130-L131) vs [`fstream-npm`](https://github.com/npm/fstream-npm/blob/d57b6b24f91156067f73417dd8785c6312bfc75f/fstream-npm.js#L167-L178). The bundled dependencies logic was the only thing I could find that `npm` does in addition to `fstream-npm`, everything else was additional logic from `fstream-npm`.

Here's a full diff of the two functions: https://gist.github.com/lukekarrys/4bf53ef42ac41d395a32

Ref #9642
