### PR TITLE
Give better diagnostics for optional dependency failures

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -134,6 +134,7 @@ var doParallelActions = require('./install/actions.js').doParallel
 var doOneAction = require('./install/actions.js').doOne
 var packageId = require('./utils/package-id.js')
 var moduleName = require('./utils/module-name.js')
+var errorMessage = require('./utils/error-message.js')
 
 function unlockCB (lockPath, name, cb) {
   validate('SSF', arguments)
@@ -282,12 +283,19 @@ Installer.prototype.run = function (cb) {
         self.idealTree.warnings.forEach(function (warning) {
           if (warning.code === 'EPACKAGEJSON' && self.global) return
           if (warning.code === 'ENOTDIR') return
-          log.warn(warning.code, warning.message)
+          errorMessage(warning).summary.forEach(function (logline) {
+            log.warn.apply(log, logline)
+          })
         })
       }
       if (installEr && postInstallEr) {
-        log.warn('error', postInstallEr.message)
-        log.verbose('error', postInstallEr.stack)
+        var msg = errorMessage(postInstallEr)
+        msg.summary.forEach(function (logline) {
+          log.warn.apply(log, logline)
+        })
+        msg.detail.forEach(function (logline) {
+          log.verbose.apply(log, logline)
+        })
       }
       cb(installEr || postInstallEr, self.getInstalledModules(), self.idealTree)
     })

--- a/lib/install/actions.js
+++ b/lib/install/actions.js
@@ -63,7 +63,7 @@ function andHandleOptionalDepErrors (pkg, next) {
   return function (er) {
     if (!er) return next.apply(null, arguments)
     markAsFailed(pkg)
-    var anyFatal = pkg.directlyRequested || !pkg.parent
+    var anyFatal = pkg.userRequired || !pkg.parent
     for (var ii = 0; ii < pkg.requiredBy.length; ++ii) {
       var parent = pkg.requiredBy[ii]
       var isFatal = failedDependency(parent, pkg)

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -297,6 +297,18 @@ var failedDependency = exports.failedDependency = function (tree, name_pkg) {
   return false
 }
 
+function top (tree) {
+  if (tree.parent) return top(tree.parent)
+  return tree
+}
+
+function treeWarn (tree, what, error) {
+  var topTree = top(tree)
+  if (!topTree.warnings) topTree.warnings = []
+  error.optional = flatNameFromTree(tree) + '/' + what
+  topTree.warnings.push(error)
+}
+
 function andHandleOptionalErrors (log, tree, name, done) {
   validate('OOSF', arguments)
   return function (er, child, childLog) {
@@ -305,8 +317,7 @@ function andHandleOptionalErrors (log, tree, name, done) {
     var isFatal = failedDependency(tree, name)
     if (er && !isFatal) {
       tree.children = tree.children.filter(noModuleNameMatches(name))
-      log.warn('install', "Couldn't install optional dependency:", er.message)
-      log.verbose('install', er.stack)
+      treeWarn(tree, name, er)
       return done()
     } else {
       return done(er, child, childLog)

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -288,6 +288,8 @@ var failedDependency = exports.failedDependency = function (tree, name_pkg) {
 
   if (!tree.parent) return true
 
+  if (tree.userRequired) return true
+
   for (var ii = 0; ii < tree.requiredBy.length; ++ii) {
     var requireParent = tree.requiredBy[ii]
     if (failedDependency(requireParent, tree.package)) {

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -201,7 +201,7 @@ exports.loadRequestedDeps = function (args, tree, saveToDependencies, log, next)
         tree.package.dependencies[childName] =
           child.package._requested.rawSpec || child.package._requested.spec
       }
-      child.directlyRequested = true
+      child.userRequired = true
       child.save = saveToDependencies
 
       // For things the user asked to install, that aren't a dependency (or
@@ -209,7 +209,6 @@ exports.loadRequestedDeps = function (args, tree, saveToDependencies, log, next)
       // themselves, so we don't remove it as a dep that no longer exists
       if (!addRequiredDep(tree, child)) {
         replaceModuleName(child.package, '_requiredBy', '#USER')
-        child.directlyRequested = true
       }
       depLoaded(null, child, tracker)
     }))

--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -134,7 +134,7 @@ function diffTrees (oldTree, newTree) {
       if (npm.config.get('rebuild-bundle')) differences.push(['rebuild', pkg])
       if (pkg.oldPkg) differences.push(['remove', pkg])
     } else if (pkg.oldPkg) {
-      if (!pkg.directlyRequested && pkgAreEquiv(pkg.oldPkg.package, pkg.package)) return
+      if (!pkg.userRequired && pkgAreEquiv(pkg.oldPkg.package, pkg.package)) return
       if (!pkg.isInLink && (isLink(pkg.oldPkg) || isLink(pkg))) {
         differences.push(['update-linked', pkg])
       } else {

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -2,6 +2,7 @@
 module.exports = errorHandler
 
 var cbCalled = false
+var util = require('util')
 var log = require('npmlog')
 var npm = require('../npm.js')
 var rm = require('rimraf')
@@ -13,6 +14,7 @@ var rollbacks = npm.rollbacks
 var chain = require('slide').chain
 var writeStream = require('fs-write-stream-atomic')
 var nameValidator = require('validate-npm-package-name')
+var errorMessage = require('./error-message.js')
 
 process.on('exit', function (code) {
   log.disableProgress()
@@ -97,6 +99,7 @@ function exit (code, noLog) {
   }
 }
 
+
 function errorHandler (er) {
   log.disableProgress()
   // console.error('errorHandler', er)
@@ -170,319 +173,10 @@ function errorHandler (er) {
   // just a line break
   if (log.levels[log.level] <= log.levels.error) console.error('')
 
-  switch (er.code) {
-    case 'ECONNREFUSED':
-      log.error('', er)
-      log.error(
-        '',
-        [
-          '\nIf you are behind a proxy, please make sure that the',
-          "'proxy' config is set properly.  See: 'npm help config'"
-        ].join('\n')
-      )
-      break
-
-    case 'EACCES':
-    case 'EPERM':
-      log.error('', er)
-      log.error('', ['\nPlease try running this command again as root/Administrator.'
-                ].join('\n'))
-      break
-
-    case 'ELIFECYCLE':
-      log.error('', er.message)
-      log.error(
-        '',
-        [
-          '',
-          'Failed at the ' + er.pkgid + ' ' + er.stage + " script '" + er.script + "'.",
-          'Make sure you have the latest version of node.js and npm installed.',
-          'If you do, this is most likely a problem with the ' + er.pkgname + ' package,',
-          'not with npm itself.',
-          'Tell the author that this fails on your system:',
-          '    ' + er.script,
-          'You can get their info via:',
-          '    npm owner ls ' + er.pkgname,
-          'There is likely additional logging output above.'
-        ].join('\n')
-      )
-      break
-
-    case 'ENOGIT':
-      log.error('', er.message)
-      log.error(
-        '',
-        [
-          '',
-          'Failed using git.',
-          'This is most likely not a problem with npm itself.',
-          'Please check if you have git installed and in your PATH.'
-        ].join('\n')
-      )
-      break
-
-    case 'EJSONPARSE':
-      log.error('', er.message)
-      log.error('', 'File: ' + er.file)
-      log.error(
-        '',
-        [
-          'Failed to parse package.json data.',
-          'package.json must be actual JSON, not just JavaScript.',
-          '',
-          'This is not a bug in npm.',
-          'Tell the package author to fix their package.json file.'
-        ].join('\n'),
-        'JSON.parse'
-      )
-      break
-
-    // TODO(isaacs)
-    // Add a special case here for E401 and E403 explaining auth issues?
-
-    case 'E404':
-      var msg = [er.message]
-      if (er.pkgid && er.pkgid !== '-') {
-        msg.push('', "'" + er.pkgid + "' is not in the npm registry.")
-
-        var valResult = nameValidator(er.pkgid)
-
-        if (valResult.validForNewPackages) {
-          msg.push('You should bug the author to publish it (or use the name yourself!)')
-        } else {
-          msg.push('Your package name is not valid, because', '')
-
-          var errorsArray = (valResult.errors || []).concat(valResult.warnings || [])
-          errorsArray.forEach(function (item, idx) {
-            msg.push(' ' + (idx + 1) + '. ' + item)
-          })
-        }
-
-        if (er.parent) {
-          msg.push("It was specified as a dependency of '" + er.parent + "'")
-        }
-        msg.push(
-          '\nNote that you can also install from a',
-          'tarball, folder, http url, or git url.'
-        )
-      }
-      // There's no need to have 404 in the message as well.
-      msg[0] = msg[0].replace(/^404\s+/, '')
-      log.error('404', msg.join('\n'))
-      break
-
-    case 'EPUBLISHCONFLICT':
-      log.error(
-        'publish fail',
-        [
-          'Cannot publish over existing version.',
-          "Update the 'version' field in package.json and try again.",
-          '',
-          'To automatically increment version numbers, see:',
-          '    npm help version'
-        ].join('\n')
-      )
-      break
-
-    case 'EISGIT':
-      log.error(
-        'git',
-        [
-          er.message,
-          '    ' + er.path,
-          'Refusing to remove it. Update manually,',
-          'or move it out of the way first.'
-        ].join('\n')
-      )
-      break
-
-    case 'ECYCLE':
-      log.error(
-        'cycle',
-        [
-          er.message,
-          'While installing: ' + er.pkgid,
-          'Found a pathological dependency case that npm cannot solve.',
-          'Please report this to the package author.'
-        ].join('\n')
-      )
-      break
-
-    case 'EBADPLATFORM':
-      log.error(
-        'notsup',
-        [
-          er.message,
-          'Not compatible with your operating system or architecture: ' + er.pkgid,
-          'Valid OS:    ' + er.os.join(','),
-          'Valid Arch:  ' + er.cpu.join(','),
-          'Actual OS:   ' + process.platform,
-          'Actual Arch: ' + process.arch
-        ].join('\n')
-      )
-      break
-
-    case 'EEXIST':
-      log.error(
-        [
-          er.message,
-          'File exists: ' + er.path,
-          'Move it away, and try again.'
-        ].join('\n')
-      )
-      break
-
-    case 'ENEEDAUTH':
-      log.error(
-        'need auth',
-        [
-          er.message,
-          'You need to authorize this machine using `npm adduser`'
-        ].join('\n')
-      )
-      break
-
-    case 'EPEERINVALID':
-      var peerErrors = Object.keys(er.peersDepending).map(function (peer) {
-        return 'Peer ' + peer + ' wants ' +
-          er.packageName + '@' + er.peersDepending[peer]
-      })
-      log.error('peerinvalid', [er.message].concat(peerErrors).join('\n'))
-      break
-
-    case 'ECONNRESET':
-    case 'ENOTFOUND':
-    case 'ETIMEDOUT':
-    case 'EAI_FAIL':
-      log.error(
-        'network',
-        [
-          er.message,
-          'This is most likely not a problem with npm itself',
-          'and is related to network connectivity.',
-          'In most cases you are behind a proxy or have bad network settings.',
-          '\nIf you are behind a proxy, please make sure that the',
-          "'proxy' config is set properly.  See: 'npm help config'"
-        ].join('\n')
-      )
-      break
-
-    case 'ENOPACKAGEJSON':
-      log.error(
-        'package.json',
-        [
-          er.message,
-          'This is most likely not a problem with npm itself.',
-          "npm can't find a package.json file in your current directory."
-        ].join('\n')
-      )
-      break
-
-    case 'ETARGET':
-      msg = [
-        er.message,
-        'This is most likely not a problem with npm itself.',
-        'In most cases you or one of your dependencies are requesting',
-        "a package version that doesn't exist."
-      ]
-      if (er.parent) {
-        msg.push("\nIt was specified as a dependency of '" + er.parent + "'\n")
-      }
-      log.error('notarget', msg.join('\n'))
-      break
-
-    case 'ENOTSUP':
-      if (er.required) {
-        log.error(
-          'notsup',
-          [
-            er.message,
-            'Not compatible with your version of node/npm: ' + er.pkgid,
-            'Required: ' + JSON.stringify(er.required),
-            'Actual:   ' + JSON.stringify({
-              npm: npm.version,
-              node: npm.config.get('node-version')
-            })
-          ].join('\n')
-        )
-        break
-      } // else passthrough
-      /*eslint no-fallthrough:0*/
-
-    case 'ENOSPC':
-      log.error(
-        'nospc',
-        [
-          er.message,
-          'This is most likely not a problem with npm itself',
-          'and is related to insufficient space on your system.'
-        ].join('\n')
-      )
-      break
-
-    case 'EROFS':
-      log.error(
-        'rofs',
-        [
-          er.message,
-          'This is most likely not a problem with npm itself',
-          'and is related to the file system being read-only.',
-          '\nOften virtualized file systems, or other file systems',
-          "that don't support symlinks, give this error."
-        ].join('\n')
-      )
-      break
-
-    case 'ENOENT':
-      log.error(
-        'enoent',
-        [
-          er.message,
-          'This is most likely not a problem with npm itself',
-          'and is related to npm not being able to find a file.',
-          er.file ? "\nCheck if the file '" + er.file + "' is present." : ''
-        ].join('\n')
-      )
-      break
-
-    case 'EMISSINGARG':
-    case 'EUNKNOWNTYPE':
-    case 'EINVALIDTYPE':
-    case 'ETOOMANYARGS':
-      log.error(
-        'typeerror',
-        [
-          er.stack,
-          'This is an error with npm itself. Please report this error at:',
-          '    <http://github.com/npm/npm/issues>'
-        ].join('\n')
-      )
-      break
-
-    case 'EISDIR':
-      log.error(
-        'eisdir',
-        [
-          er.message,
-          'This is most likely not a problem with npm itself',
-          'and is related to npm not being able to find a package.json in',
-          'a package you are trying to install.'
-        ].join('\n')
-      )
-      break
-
-    default:
-      log.error('', er.message || er)
-      log.error(
-        '',
-        [
-          '',
-          'If you need help, you may report this error at:',
-          '    <https://github.com/npm/npm/issues>'
-        ].join('\n')
-      )
-      break
-  }
+  var msg = errorMessage(er)
+  msg.summary.concat(msg.detail).forEach(function (errline) {
+    log.error.apply(log, errline)
+  })
 
   exit(typeof er.errno === 'number' ? er.errno : 1)
 }

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -1,0 +1,311 @@
+'use strict'
+module.exports = errorMessage
+
+function errorMessage (er) {
+  var short = []
+  var detail = []
+  if (er.optional) {
+    short.push(['optional', 'Skipping failed optional dependency ' + er.optional + ':'])
+  }
+  switch (er.code) {
+    case 'ECONNREFUSED':
+      short.push(['', er])
+      detail.push([
+        '',
+        [
+          '\nIf you are behind a proxy, please make sure that the',
+          "'proxy' config is set properly.  See: 'npm help config'"
+        ].join('\n')
+      ])
+      break
+
+    case 'EACCES':
+    case 'EPERM':
+      short.push(['', er])
+      detail.push(['', ['\nPlease try running this command again as root/Administrator.'
+                ].join('\n')])
+      break
+
+    case 'ELIFECYCLE':
+      short.push(['', er.message])
+      detail.push([
+        '',
+        [
+          '',
+          'Failed at the ' + er.pkgid + ' ' + er.stage + " script '" + er.script + "'.",
+          'Make sure you have the latest version of node.js and npm installed.',
+          'If you do, this is most likely a problem with the ' + er.pkgname + ' package,',
+          'not with npm itself.',
+          'Tell the author that this fails on your system:',
+          '    ' + er.script,
+          'You can get their info via:',
+          '    npm owner ls ' + er.pkgname,
+          'There is likely additional logging output above.'
+        ].join('\n')]
+      )
+      break
+
+    case 'ENOGIT':
+      short.push(['', er.message])
+      detail.push([
+        '',
+        [
+          '',
+          'Failed using git.',
+          'This is most likely not a problem with npm itself.',
+          'Please check if you have git installed and in your PATH.'
+        ].join('\n')
+      ])
+      break
+
+    case 'EJSONPARSE':
+      short.push(['', er.message])
+      short.push(['', 'File: ' + er.file])
+      detail.push([
+        '',
+        [
+          'Failed to parse package.json data.',
+          'package.json must be actual JSON, not just JavaScript.',
+          '',
+          'This is not a bug in npm.',
+          'Tell the package author to fix their package.json file.'
+        ].join('\n'),
+        'JSON.parse'
+      ])
+      break
+
+    // TODO(isaacs)
+    // Add a special case here for E401 and E403 explaining auth issues?
+
+    case 'E404':
+      // There's no need to have 404 in the message as well.
+      var msg = er.message.replace(/^404\s+/, '')
+      short.push(['404', msg])
+      if (er.pkgid && er.pkgid !== '-') {
+        detail.push(['404', ''])
+        detail.push(['404', '', "'" + er.pkgid + "' is not in the npm registry."])
+
+        var valResult = nameValidator(er.pkgid)
+
+        if (valResult.validForNewPackages) {
+          detail.push(['404', 'You should bug the author to publish it (or use the name yourself!)'])
+        } else {
+          detail.push(['404', 'Your package name is not valid, because', ''])
+
+          var errorsArray = (valResult.errors || []).concat(valResult.warnings || [])
+          errorsArray.forEach(function (item, idx) {
+            detail.push(['404', ' ' + (idx + 1) + '. ' + item])
+          })
+        }
+
+        if (er.parent) {
+          detail.push(['404', "It was specified as a dependency of '" + er.parent + "'"])
+        }
+        detail.push(['404', '\nNote that you can also install from a'])
+        detail.push(['404', 'tarball, folder, http url, or git url.'])
+      }
+      break
+
+    case 'EPUBLISHCONFLICT':
+      short.push(['publish fail', 'Cannot publish over existing version.'])
+      detail.push(['publish fail', "Update the 'version' field in package.json and try again."])
+      detail.push(['publish fail', ''])
+      detail.push(['publish fail', 'To automatically increment version numbers, see:'])
+      detail.push(['publish fail', '    npm help version'])
+      break
+
+    case 'EISGIT':
+      short.push(['git', er.message])
+      short.push(['git', '    ' + er.path])
+      detail.push([
+        'git',
+        [
+          'Refusing to remove it. Update manually,',
+          'or move it out of the way first.'
+        ].join('\n')
+      ])
+      break
+
+    case 'ECYCLE':
+      short.push([
+        'cycle',
+        [
+          er.message,
+          'While installing: ' + er.pkgid
+        ].join('\n')
+      ])
+      detail.push([
+        'cycle',
+        [
+          'Found a pathological dependency case that npm cannot solve.',
+          'Please report this to the package author.'
+        ].join('\n')
+      ])
+      break
+
+    case 'EBADPLATFORM':
+      short.push([
+        'notsup',
+        [
+          'Not compatible with your operating system or architecture: ' + er.pkgid
+        ].join('\n')
+      ])
+      detail.push([
+        'notsup',
+        [
+          'Valid OS:    ' + (er.os.join ? er.os.join(',') : util.inspect(er.os)),
+          'Valid Arch:  ' + (er.cpu.join ? er.cpu.join(',') : util.inspect(er.cpu)),
+          'Actual OS:   ' + process.platform,
+          'Actual Arch: ' + process.arch
+        ].join('\n')
+      ])
+      break
+
+    case 'EEXIST':
+      short.push(['', er.message])
+      short.push(['', 'File exists: ' + er.path])
+      detail.push(['', 'Move it away, and try again.'])
+      break
+
+    case 'ENEEDAUTH':
+      short.push(['need auth', er.message])
+      detail.push(['need auth', 'You need to authorize this machine using `npm adduser`'])
+      break
+
+    case 'ECONNRESET':
+    case 'ENOTFOUND':
+    case 'ETIMEDOUT':
+    case 'EAI_FAIL':
+      short.push(['network', er.message])
+      detail.push([
+        'network',
+        [
+          'This is most likely not a problem with npm itself',
+          'and is related to network connectivity.',
+          'In most cases you are behind a proxy or have bad network settings.',
+          '\nIf you are behind a proxy, please make sure that the',
+          "'proxy' config is set properly.  See: 'npm help config'"
+        ].join('\n')
+      ])
+      break
+
+    case 'ENOPACKAGEJSON':
+      short.push(['package.json', er.message])
+      detail.push([
+        'package.json',
+        [
+          'This is most likely not a problem with npm itself.',
+          "npm can't find a package.json file in your current directory."
+        ].join('\n')
+      ])
+      break
+
+    case 'ETARGET':
+      short.push(['notarget', er.message])
+      msg = [
+        'This is most likely not a problem with npm itself.',
+        'In most cases you or one of your dependencies are requesting',
+        "a package version that doesn't exist."
+      ]
+      if (er.parent) {
+        msg.push("\nIt was specified as a dependency of '" + er.parent + "'\n")
+      }
+      detail.push(['notarget', msg.join('\n')])
+      break
+
+    case 'ENOTSUP':
+      if (er.required) {
+        short.push(['notsup', er.message])
+        short.push(['notsup', 'Not compatible with your version of node/npm: ' + er.pkgid])
+        detail.push([
+          'notsup',
+          [
+            'Not compatible with your version of node/npm: ' + er.pkgid,
+            'Required: ' + JSON.stringify(er.required),
+            'Actual:   ' + JSON.stringify({
+              npm: npm.version,
+              node: npm.config.get('node-version')
+            })
+          ].join('\n')
+        ])
+        break
+      } // else passthrough
+      /*eslint no-fallthrough:0*/
+
+    case 'ENOSPC':
+      short.push(['nospc', er.message])
+      detail.push([
+        'nospc',
+        [
+          'This is most likely not a problem with npm itself',
+          'and is related to insufficient space on your system.'
+        ].join('\n')
+      ])
+      break
+
+    case 'EROFS':
+      short.push(['rofs', er.message])
+      detail.push([
+        'rofs',
+        [
+          'This is most likely not a problem with npm itself',
+          'and is related to the file system being read-only.',
+          '\nOften virtualized file systems, or other file systems',
+          "that don't support symlinks, give this error."
+        ].join('\n')
+      ])
+      break
+
+    case 'ENOENT':
+      short.push(['enoent', er.message])
+      detail.push([
+        'enoent',
+        [
+          er.message,
+          'This is most likely not a problem with npm itself',
+          'and is related to npm not being able to find a file.',
+          er.file ? "\nCheck if the file '" + er.file + "' is present." : ''
+        ].join('\n')
+      ])
+      break
+
+    case 'EMISSINGARG':
+    case 'EUNKNOWNTYPE':
+    case 'EINVALIDTYPE':
+    case 'ETOOMANYARGS':
+      short.push(['typeerror', er.stack])
+      detail.push([
+        'typeerror',
+        [
+          'This is an error with npm itself. Please report this error at:',
+          '    <http://github.com/npm/npm/issues>'
+        ].join('\n')
+      ])
+      break
+
+    case 'EISDIR':
+      short.push(['eisdir', er.message])
+      detail.push([
+        'eisdir',
+        [
+          'This is most likely not a problem with npm itself',
+          'and is related to npm not being able to find a package.json in',
+          'a package you are trying to install.'
+        ].join('\n')
+      ])
+      break
+
+    default:
+      short.push(['', er.message || er])
+      detail.push([
+        '',
+        [
+          '',
+          'If you need help, you may report this error at:',
+          '    <https://github.com/npm/npm/issues>'
+        ].join('\n')
+      ])
+      break
+  }
+  return {summary: short, detail: detail}
+}

--- a/test/tap/full-warning-messages.js
+++ b/test/tap/full-warning-messages.js
@@ -1,0 +1,108 @@
+'use strict'
+var test = require('tap').test
+var path = require('path')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var fs = require('graceful-fs')
+var common = require('../common-tap')
+
+var base = path.resolve(__dirname, path.basename(__filename, '.js'))
+var modA = path.resolve(base, 'modA')
+var modB = path.resolve(base, 'modB')
+
+var json = {
+  'name': 'test-full-warning-messages',
+  'version': '1.0.0',
+  'description': 'abc',
+  'repository': 'git://abc/',
+  'license': 'ISC',
+  'dependencies': {
+    'modA': modA
+  }
+}
+
+var modAJson = {
+  'name': 'modA',
+  'version': '1.0.0',
+  'optionalDependencies': {
+    'modB': modB
+  }
+}
+
+var modBJson = {
+  'name': 'modB',
+  'version': '1.0.0',
+  'os': ['nope'],
+  'cpu': 'invalid'
+}
+
+function modJoin () {
+  var modules = Array.prototype.slice.call(arguments)
+  return modules.reduce(function (a, b) {
+    return path.resolve(a, 'node_modules', b)
+  })
+}
+
+function writeJson (mod, data) {
+  fs.writeFileSync(path.resolve(mod, 'package.json'), JSON.stringify(data))
+}
+
+function setup () {
+  cleanup()
+  ;[modA, modB].forEach(function (mod) { mkdirp.sync(mod) })
+  writeJson(base, json)
+  writeJson(modA, modAJson)
+  writeJson(modB, modBJson)
+}
+
+function cleanup () {
+  rimraf.sync(base)
+}
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+function exists (t, filepath, msg) {
+  try {
+    fs.statSync(filepath)
+    t.pass(msg)
+    return true
+  } catch (ex) {
+    t.fail(msg, {found: null, wanted: 'exists', compare: 'fs.stat(' + filepath + ')'})
+    return false
+  }
+}
+
+function notExists (t, filepath, msg) {
+  try {
+    fs.statSync(filepath)
+    t.fail(msg, {found: 'exists', wanted: null, compare: 'fs.stat(' + filepath + ')'})
+    return true
+  } catch (ex) {
+    t.pass(msg)
+    return false
+  }
+}
+
+test('tree-style', function (t) {
+  common.npm(['install', '--loglevel=warn'], {cwd: base}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'result code')
+    t.match(stdout, /modA@1.0.0/, 'modA got installed')
+    t.notMatch(stdout, /modB/, 'modB not installed')
+    var stderrlines = stderr.trim().split(/\n/)
+    t.is(stderrlines.length, 2, 'two lines of warnings')
+    t.match(stderr, /Skipping failed optional dependency/, 'expected optional failure warning')
+    t.match(stderr, /Not compatible with your operating system or architecture/, 'reason for optional failure')
+    exists(t, modJoin(base, 'modA'), 'module A')
+    notExists(t, modJoin(base, 'modB'), 'module B')
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
Optional dependency errors were printing out the error object alone, which often lacked context. This updates the output to use the same code as error-handler

Fixes: #9204
