### PR TITLE
error-message: Tell users to open an issue

### DIFF
--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -42,7 +42,9 @@ function errorMessage (er) {
           'not with npm itself.',
           'Tell the author that this fails on your system:',
           '    ' + er.script,
-          'You can get their info via:',
+          'You can get information on how to open an issue for this project with:',
+          '    npm bugs ' + er.pkgname,
+          'Or if that isn\'t available, you can get their info via:',
           '    npm owner ls ' + er.pkgname,
           'There is likely additional logging output above.'
         ].join('\n')]


### PR DESCRIPTION
Urge users to open an issue when an error occurs on a package instead of
telling them to contact the author by default.

See #9948
