### PR TITLE
Fix ls depth when outputting json

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -139,13 +139,14 @@ function isCruft (data) {
   return data.extraneous && data.error && data.error.code === 'ENOTDIR'
 }
 
-function getLite (data, noname) {
+function getLite (data, noname, depth) {
   var lite = {}
 
   if (isCruft(data)) return lite
 
   var maxDepth = npm.config.get('depth')
 
+  if (typeof depth === 'undefined') depth = 0
   if (!noname && data.name) lite.name = data.name
   if (data.version) lite.version = data.version
   if (data.extraneous) {
@@ -213,6 +214,9 @@ function getLite (data, noname) {
           lite.problems.push(pdm)
         })
         return [d, { required: dep, peerMissing: true }]
+      } else if (npm.config.get('json')) {
+        if (depth === maxDepth) delete dep.dependencies
+        return [d, getLite(dep, true, depth + 1)]
       }
       return [d, getLite(dep, true)]
     }).reduce(function (deps, d) {

--- a/test/tap/ls-depth-cli.js
+++ b/test/tap/ls-depth-cli.js
@@ -113,6 +113,52 @@ test('npm ls --depth=Infinity', function (t) {
   )
 })
 
+test('npm ls --depth=0 --json', function (t) {
+  common.npm(
+    ['ls', '--depth=0', '--json'],
+    EXEC_OPTS,
+    function (er, c, out) {
+      t.ifError(er, 'npm ls ran without issue')
+      t.equal(c, 0, 'ls ran without raising error code')
+      t.has(
+        out,
+        /test-package-with-one-dep@0\.0\.0/,
+        'output contains test-package-with-one-dep@0.0.0'
+      )
+      t.doesNotHave(
+        out,
+        /test-package@0\.0\.0/,
+        'output not contains test-package@0.0.0'
+      )
+      t.end()
+    }
+  )
+})
+
+test('npm ls --depth=Infinity --json', function (t) {
+  // travis has a preconfigured depth=0, in general we can not depend
+  // on the default value in all environments, so explictly set it here
+  common.npm(
+    ['ls', '--depth=Infinity', '--json'],
+    EXEC_OPTS,
+    function (er, c, out) {
+      t.ifError(er, 'npm ls ran without issue')
+      t.equal(c, 0, 'ls ran without raising error code')
+      t.has(
+        out,
+        /test-package-with-one-dep@0\.0\.0/,
+        'output contains test-package-with-one-dep@0.0.0'
+      )
+      t.has(
+        out,
+        /test-package@0\.0\.0/,
+        'output contains test-package@0.0.0'
+      )
+      t.end()
+    }
+  )
+})
+
 test('cleanup', function (t) {
   cleanup()
   t.end()


### PR DESCRIPTION
This fixes the `depth` option when used in combination with the `json` option.

As an example, prior to this diff:

`npm ls -depth=0`

```
r-dom@2.1.0 /root/temp/r-dom
├── classnames@1.2.2
├── for-each@0.3.2
...
```

`npm ls -depth=0 --json`

```
{
  "name": "r-dom",
  "version": "2.1.0",
  "dependencies": {
    "classnames": {
      "version": "1.2.2",
      "from": "classnames@^1.1.4",
      "resolved": "https://registry.npmjs.org/classnames/-/classnames-1.2.2.tgz"
    },
    "for-each": {
      "version": "0.3.2",
      "from": "for-each@^0.3.2",
      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
      "dependencies": {
        "is-function": {
          "version": "1.0.1",
          "from": "is-function@~1.0.0",
          "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz"
        }
      }
    },
...
```

and after this change:

`npm ls -depth=0`

```
r-dom@2.1.0 /root/temp/r-dom
├── classnames@1.2.2
├── for-each@0.3.2
...
```

`npm ls -depth=0 --json`

```
{
  "name": "r-dom",
  "version": "2.1.0",
  "dependencies": {
    "classnames": {
      "version": "1.2.2",
      "from": "classnames@^1.1.4",
      "resolved": "https://registry.npmjs.org/classnames/-/classnames-1.2.2.tgz"
    },
    "for-each": {
      "version": "0.3.2",
      "from": "for-each@^0.3.2",
      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz"
    },
...
```

Note that the dependencies of `for-each` are incorrectly included prior and correctly excluded after.
