### PR TITLE
doc: Update URLs to https used in defaults.js

### DIFF
--- a/doc/cli/npm-adduser.md
+++ b/doc/cli/npm-adduser.md
@@ -28,7 +28,7 @@ your existing record.
 
 ### registry
 
-Default: http://registry.npmjs.org/
+Default: https://registry.npmjs.org/
 
 The base URL of the npm package registry. If `scope` is also specified,
 this registry will only be used for packages with that scope. See `npm-scope(7)`.

--- a/doc/cli/npm-logout.md
+++ b/doc/cli/npm-logout.md
@@ -22,7 +22,7 @@ connected to that scope, if set.
 
 ### registry
 
-Default: http://registry.npmjs.org/
+Default: https://registry.npmjs.org/
 
 The base URL of the npm package registry. If `scope` is also specified,
 it takes precedence.

--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -130,7 +130,7 @@ easily by doing `npm view npm contributors`.
 If you would like to contribute, but don't know what to work on, check
 the issues list or ask on the mailing list.
 
-* <http://github.com/npm/npm/issues>
+* <https://github.com/npm/npm/issues>
 * <npm-@googlegroups.com>
 
 ## BUGS
@@ -138,7 +138,7 @@ the issues list or ask on the mailing list.
 When you find issues, please report them:
 
 * web:
-  <http://github.com/npm/npm/issues>
+  <https://github.com/npm/npm/issues>
 * email:
   <npm-@googlegroups.com>
 

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -105,10 +105,10 @@ current SPDX license identifier for the license you're using, like this:
 
 You can check [the full list of SPDX license IDs](https://spdx.org/licenses/).
 Ideally you should pick one that is
-[OSI](http://opensource.org/licenses/alphabetical) approved.
+[OSI](https://opensource.org/licenses/alphabetical) approved.
 
 If your package is licensed under multiple common licenses, use an [SPDX license
-expression syntax version 2.0 string](http://npmjs.com/package/spdx), like this:
+expression syntax version 2.0 string](https://npmjs.com/package/spdx), like this:
 
     { "license" : "(ISC OR GPL-3.0)" }
 

--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -104,7 +104,7 @@ create an empty `.npmignore` file to override it. Like `git`, `npm` looks
 for `.npmignore` and `.gitignore` files in all subdirectories of your
 package, not only the root directory.
 
-`.npmignore` files follow the [same pattern rules](http://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#Ignoring-Files)
+`.npmignore` files follow the [same pattern rules](https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#Ignoring-Files)
 as `.gitignore` files:
 
 * Blank lines or lines starting with `#` are ignored.

--- a/doc/misc/npm-faq.md
+++ b/doc/misc/npm-faq.md
@@ -11,7 +11,7 @@ This command will set the npm docs to open in your default web browser rather th
 
 ## It didn't work.
 
-Please provide a little more detail, search for the error via [Google](https://google.com) or [StackOverflow npm](http://stackoverflow.com/search?q=npm) to see if another developer has encountered a similar problem.
+Please provide a little more detail, search for the error via [Google](https://google.com) or [StackOverflow npm](https://stackoverflow.com/search?q=npm) to see if another developer has encountered a similar problem.
 
 ## Why didn't it work?
 
@@ -273,13 +273,13 @@ You don't.  Try one of these node version managers:
 
 Unix:
 
-* <http://github.com/isaacs/nave>
-* <http://github.com/visionmedia/n>
-* <http://github.com/creationix/nvm>
+* <https://github.com/isaacs/nave>
+* <https://github.com/visionmedia/n>
+* <https://github.com/creationix/nvm>
 
 Windows:
 
-* <http://github.com/marcelklehr/nodist>
+* <https://github.com/marcelklehr/nodist>
 * <https://github.com/coreybutler/nvm-windows>
 * <https://github.com/hakobera/nvmw>
 * <https://github.com/nanjingboy/nvmw>
@@ -369,7 +369,7 @@ contributed to it, some of them quite substantially.
 
 The npm open source project, The npm Registry, and [the community
 website](https://www.npmjs.com) are maintained and operated by the
-good folks at [npm, Inc.](http://www.npmjs.com)
+good folks at [npm, Inc.](https://www.npmjs.com)
 
 ## I have a question or request not addressed here. Where should I put it?
 

--- a/doc/misc/npm-registry.md
+++ b/doc/misc/npm-registry.md
@@ -11,10 +11,10 @@ Additionally, npm's package registry implementation supports several
 write APIs as well, to allow for publishing packages and managing user
 account information.
 
-The official public npm registry is at <http://registry.npmjs.org/>.  It
+The official public npm registry is at <https://registry.npmjs.org/>.  It
 is powered by a CouchDB database, of which there is a public mirror at
-<http://skimdb.npmjs.com/registry>.  The code for the couchapp is
-available at <http://github.com/npm/npm-registry-couchapp>.
+<https://skimdb.npmjs.com/registry>.  The code for the couchapp is
+available at <https://github.com/npm/npm-registry-couchapp>.
 
 The registry URL used is determined by the scope of the package (see
 `npm-scope(7)`). If no scope is specified, the default registry is used, which is


### PR DESCRIPTION
Changed the default registry URLs in the docs from http://registry.npmjs.org/ to https://registry.npmjs.org/ to make it consistent with the actual value in lib/config/defaults.js in:
- doc/misc/npm-registry.md
- doc/cli/npm-adduser.md
- doc/cli/npm-logout.md

Also changed several GitHub and npm.js links to https (the http links get redirected to https anyway
but it's better to avoid insecure redirection) and Stack Overflow and OSI links (those don't get redirected so it's even more important for them to use secure URLs) in:
- doc/cli/npm.md
- doc/files/package.json.md
- doc/misc/npm-developers.md
- doc/misc/npm-faq.md
