### PR TITLE
error-message: Tell users to open an issue

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -187,8 +187,10 @@ function errorHandler (er) {
               ,"not with npm itself."
               ,"Tell the author that this fails on your system:"
               ,"    "+er.script
-              ,"You can get their info via:"
-              ,"    npm owner ls "+er.pkgname
+              ,'You can get information on how to open an issue for this project with:'
+              ,'    npm bugs ' + er.pkgname
+              ,'Or if that isn\'t available, you can get their info via:',
+              ,'    npm owner ls ' + er.pkgname
               ,"There is likely additional logging output above."
               ].join("\n"))
     break


### PR DESCRIPTION
Same as https://github.com/npm/npm/pull/10496 but for 2.x.

Urge users to open an issue when an error occurs on a package instead of
telling them to contact the author by default.

See #9948 for more info.
