### PR TITLE
Fix branch pruning bugs in move/remove actions

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -624,14 +624,19 @@ Installer.prototype.loadShrinkwrap = function (cb) {
 Installer.prototype.normalizeTree = function (log, cb) {
   validate('OF', arguments)
   log.silly('install', 'normalizeTree')
-  recalculateMetadata(this.currentTree, log, iferr(cb, function (tree) {
-    tree.children.forEach(function (child) {
-      if (child.package._requiredBy.length === 0) {
-        child.package._requiredBy.push('#EXISTING')
-      }
-    })
-    cb(null, tree)
-  }))
+  // Modules installed by npm@3, but not saved to package.json get #USER in
+  // their _requiredBy.
+  // Modules installed by npm@3, that ARE in the package.json get the list
+  // of things that required them in their _requiredBy.
+  // Modules installed by npm@2 don't get a _requiredBy, but should be
+  // flagged so they don't get pruned the minute the user installs something
+  // with npm@3.
+  this.currentTree.children.forEach(function (child) {
+    if (child.package && !child.package._requiredBy) {
+      child.package._requiredBy = ['#EXISTING']
+    }
+  })
+  recalculateMetadata(this.currentTree, log, cb)
 }
 
 Installer.prototype.getInstalledModules = function () {

--- a/lib/install.js
+++ b/lib/install.js
@@ -470,12 +470,6 @@ Installer.prototype.executeActions = function (cb) {
     [doParallelActions, 'extract', staging, todo, cg.newGroup('extract', 10)],
     [doParallelActions, 'preinstall', staging, todo, trackLifecycle.newGroup('preinstall')],
     [doReverseSerialActions, 'remove', staging, todo, cg.newGroup('remove')],
-    // FIXME: We do this here to commit the removes prior to trying to move
-    // anything into place. Once we can rollback removes we should find
-    // a better solution for this.
-    // This is to protect against cruft in the node_modules folder (like dot files)
-    // that stop it from being removed.
-    [this, this.commit, staging, this.todo],
     [doSerialActions, 'move', staging, todo, cg.newGroup('move')],
     [doSerialActions, 'finalize', staging, todo, cg.newGroup('finalize')],
     [doSerialActions, 'build', staging, todo, trackLifecycle.newGroup('build')],

--- a/lib/install/action/extract.js
+++ b/lib/install/action/extract.js
@@ -3,6 +3,7 @@ var path = require('path')
 var iferr = require('iferr')
 var asyncMap = require('slide').asyncMap
 var fs = require('graceful-fs')
+var rename = require('../../utils/rename.js')
 var gentlyRm = require('../../utils/gently-rm.js')
 var updatePackageJson = require('../update-package-json')
 var npm = require('../../npm.js')
@@ -62,7 +63,7 @@ function stageBundledModule (bundler, child, staging, parentPath, next) {
 
   function moveModule () {
     if (child.fromBundle) {
-      return fs.rename(stageFrom, stageTo, iferr(next, updateMovedPackageJson))
+      return rename(stageFrom, stageTo, iferr(next, updateMovedPackageJson))
     } else {
       return fs.stat(stageFrom, function (notExists, exists) {
         if (exists) {

--- a/lib/install/action/finalize.js
+++ b/lib/install/action/finalize.js
@@ -4,6 +4,7 @@ var rimraf = require('rimraf')
 var fs = require('graceful-fs')
 var mkdirp = require('mkdirp')
 var asyncMap = require('slide').asyncMap
+var rename = require('../../utils/rename.js')
 
 module.exports = function (top, buildpath, pkg, log, next) {
   log.silly('finalize', pkg.path)
@@ -21,7 +22,7 @@ module.exports = function (top, buildpath, pkg, log, next) {
 
   function destStated (doesNotExist) {
     if (doesNotExist) {
-      fs.rename(buildpath, pkg.path, whenMoved)
+      rename(buildpath, pkg.path, whenMoved)
     } else {
       moveAway()
     }
@@ -34,18 +35,18 @@ module.exports = function (top, buildpath, pkg, log, next) {
   }
 
   function moveAway () {
-    fs.rename(pkg.path, delpath, whenOldMovedAway)
+    rename(pkg.path, delpath, whenOldMovedAway)
   }
 
   function whenOldMovedAway (renameEr) {
     if (renameEr) return next(renameEr)
-    fs.rename(buildpath, pkg.path, whenConflictMoved)
+    rename(buildpath, pkg.path, whenConflictMoved)
   }
 
   function whenConflictMoved (renameEr) {
     // if we got an error we'll try to put back the original module back,
     // succeed or fail though we want the original error that caused this
-    if (renameEr) return fs.rename(delpath, pkg.path, function () { next(renameEr) })
+    if (renameEr) return rename(delpath, pkg.path, function () { next(renameEr) })
     fs.readdir(path.join(delpath, 'node_modules'), makeTarget)
   }
 
@@ -60,7 +61,7 @@ module.exports = function (top, buildpath, pkg, log, next) {
     asyncMap(files, function (file, done) {
       var from = path.join(delpath, 'node_modules', file)
       var to = path.join(pkg.path, 'node_modules', file)
-      fs.rename(from, to, done)
+      rename(from, to, done)
     }, cleanup)
   }
 

--- a/lib/install/action/finalize.js
+++ b/lib/install/action/finalize.js
@@ -17,10 +17,10 @@ module.exports = function (top, buildpath, pkg, log, next) {
     if (mkdirEr) return next(mkdirEr)
     // We stat first, because we can't rely on ENOTEMPTY from Windows.
     // Windows, by contrast, gives the generic EPERM of a folder already exists.
-    fs.lstat(pkg.path, destStated)
+    fs.lstat(pkg.path, destStatted)
   }
 
-  function destStated (doesNotExist) {
+  function destStatted (doesNotExist) {
     if (doesNotExist) {
       rename(buildpath, pkg.path, whenMoved)
     } else {

--- a/lib/install/action/move.js
+++ b/lib/install/action/move.js
@@ -32,8 +32,8 @@ function removeEmptyParents (pkgdir, next) {
 }
 
 function moveModuleOnly (from, to, log, done) {
-  var from_modules = path.join(from, 'node_modules')
-  var temp_modules = from + '.node_modules'
+  var fromModules = path.join(from, 'node_modules')
+  var tempModules = from + '.node_modules'
 
   log.silly('move', 'remove existing destination', to)
   rimraf(to, iferr(done, makeDestination(done)))
@@ -47,8 +47,8 @@ function moveModuleOnly (from, to, log, done) {
 
   function moveNodeModules (next) {
     return function () {
-      log.silly('move', 'move source node_modules away', from_modules)
-      fs.rename(from_modules, temp_modules, iferr(doMove(next), doMove(moveNodeModulesBack(next))))
+      log.silly('move', 'move source node_modules away', fromModules)
+      fs.rename(fromModules, tempModules, iferr(doMove(next), doMove(moveNodeModulesBack(next))))
     }
   }
 
@@ -62,8 +62,8 @@ function moveModuleOnly (from, to, log, done) {
   function moveNodeModulesBack (next) {
     return function () {
       mkdirp(from, iferr(done, function () {
-        log.silly('move', 'put source node_modules back', from_modules)
-        fs.rename(temp_modules, from_modules, iferr(done, next))
+        log.silly('move', 'put source node_modules back', fromModules)
+        fs.rename(tempModules, fromModules, iferr(done, next))
       }))
     }
   }

--- a/lib/install/action/move.js
+++ b/lib/install/action/move.js
@@ -36,29 +36,35 @@ function moveModuleOnly (from, to, log, done) {
   var temp_modules = from + '.node_modules'
 
   log.silly('move', 'remove existing destination', to)
-  rimraf(to, iferr(done, makeDestination))
+  rimraf(to, iferr(done, makeDestination(done)))
 
-  function makeDestination () {
-    log.silly('move', 'make sure destination parent exists', path.resolve(to, '..'))
-    mkdirp(path.resolve(to, '..'), iferr(done, moveNodeModules))
+  function makeDestination (next) {
+    return function () {
+      log.silly('move', 'make sure destination parent exists', path.resolve(to, '..'))
+      mkdirp(path.resolve(to, '..'), iferr(done, moveNodeModules(next)))
+    }
   }
 
-  function moveNodeModules () {
-    log.silly('move', 'move source node_modules away', from_modules)
-    fs.rename(from_modules, temp_modules, function (er) {
-      doMove(er ? done : moveNodeModulesBack)
-    })
+  function moveNodeModules (next) {
+    return function () {
+      log.silly('move', 'move source node_modules away', from_modules)
+      fs.rename(from_modules, temp_modules, iferr(doMove(next), doMove(moveNodeModulesBack(next))))
+    }
   }
 
   function doMove (next) {
-    log.silly('move', 'move module dir to final dest', from, to)
-    fs.rename(from, to, iferr(done, next))
+    return function () {
+      log.silly('move', 'move module dir to final dest', from, to)
+      fs.rename(from, to, iferr(done, next))
+    }
   }
 
-  function moveNodeModulesBack () {
-    mkdirp(from, iferr(done, function () {
-      log.silly('move', 'put source node_modules back', from_modules)
-      fs.rename(temp_modules, from_modules, done)
-    }))
+  function moveNodeModulesBack (next) {
+    return function () {
+      mkdirp(from, iferr(done, function () {
+        log.silly('move', 'put source node_modules back', from_modules)
+        fs.rename(temp_modules, from_modules, iferr(done, next))
+      }))
+    }
   }
 }

--- a/lib/install/action/move.js
+++ b/lib/install/action/move.js
@@ -7,7 +7,8 @@ var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
 var rmStuff = require('../../unbuild.js').rmStuff
 var lifecycle = require('../../utils/lifecycle.js')
-var updatePackageJson = require('../update-package-json')
+var updatePackageJson = require('../update-package-json.js')
+var rename = require('../../utils/rename.js')
 
 /*
   Move a module from one point in the node_modules tree to another.
@@ -45,7 +46,7 @@ function moveModuleOnly (from, to, log, done) {
 
   log.silly('move', 'move existing destination node_modules away', toModules)
 
-  fs.rename(toModules, tempToModules, removeDestination(done))
+  rename(toModules, tempToModules, removeDestination(done))
 
   function removeDestination (next) {
     return function (er) {
@@ -61,7 +62,7 @@ function moveModuleOnly (from, to, log, done) {
   function moveToModulesBack (next) {
     return function () {
       log.silly('move', 'move existing destination node_modules back', toModules)
-      fs.rename(tempToModules, toModules, iferr(done, next))
+      rename(tempToModules, toModules, iferr(done, next))
     }
   }
 
@@ -75,14 +76,14 @@ function moveModuleOnly (from, to, log, done) {
   function moveNodeModules (next) {
     return function () {
       log.silly('move', 'move source node_modules away', fromModules)
-      fs.rename(fromModules, tempFromModules, iferr(doMove(next), doMove(moveNodeModulesBack(next))))
+      rename(fromModules, tempFromModules, iferr(doMove(next), doMove(moveNodeModulesBack(next))))
     }
   }
 
   function doMove (next) {
     return function () {
       log.silly('move', 'move module dir to final dest', from, to)
-      fs.rename(from, to, iferr(done, next))
+      rename(from, to, iferr(done, next))
     }
   }
 
@@ -90,7 +91,7 @@ function moveModuleOnly (from, to, log, done) {
     return function () {
       mkdirp(from, iferr(done, function () {
         log.silly('move', 'put source node_modules back', fromModules)
-        fs.rename(tempFromModules, fromModules, iferr(done, next))
+        rename(tempFromModules, fromModules, iferr(done, next))
       }))
     }
   }

--- a/lib/install/action/move.js
+++ b/lib/install/action/move.js
@@ -16,7 +16,7 @@ module.exports = function (top, buildpath, pkg, log, next) {
     [lifecycle, pkg.package, 'uninstall', pkg.fromPath, false, true],
     [rmStuff, pkg.package, pkg.fromPath],
     [lifecycle, pkg.package, 'postuninstall', pkg.fromPath, false, true],
-    [moveModuleOnly, pkg.fromPath, pkg.path],
+    [moveModuleOnly, pkg.fromPath, pkg.path, log],
     [lifecycle, pkg.package, 'preinstall', pkg.path, false, true],
     [removeEmptyParents, path.resolve(pkg.fromPath, '..')],
     [updatePackageJson, pkg, pkg.path]
@@ -31,28 +31,33 @@ function removeEmptyParents (pkgdir, next) {
   })
 }
 
-function moveModuleOnly (from, to, done) {
+function moveModuleOnly (from, to, log, done) {
   var from_modules = path.join(from, 'node_modules')
   var temp_modules = from + '.node_modules'
 
+  log.silly('move', 'remove existing destination', to)
   rimraf(to, iferr(done, makeDestination))
 
   function makeDestination () {
+    log.silly('move', 'make sure destination parent exists', path.resolve(to, '..'))
     mkdirp(path.resolve(to, '..'), iferr(done, moveNodeModules))
   }
 
   function moveNodeModules () {
+    log.silly('move', 'move source node_modules away', from_modules)
     fs.rename(from_modules, temp_modules, function (er) {
       doMove(er ? done : moveNodeModulesBack)
     })
   }
 
   function doMove (next) {
+    log.silly('move', 'move module dir to final dest', from, to)
     fs.rename(from, to, iferr(done, next))
   }
 
   function moveNodeModulesBack () {
     mkdirp(from, iferr(done, function () {
+      log.silly('move', 'put source node_modules back', from_modules)
       fs.rename(temp_modules, from_modules, done)
     }))
   }

--- a/lib/install/action/move.js
+++ b/lib/install/action/move.js
@@ -9,6 +9,12 @@ var rmStuff = require('../../unbuild.js').rmStuff
 var lifecycle = require('../../utils/lifecycle.js')
 var updatePackageJson = require('../update-package-json')
 
+/*
+  Move a module from one point in the node_modules tree to another.
+  Do not disturb either the source or target location's node_modules
+  folders.
+*/
+
 module.exports = function (top, buildpath, pkg, log, next) {
   log.silly('move', pkg.fromPath, pkg.path)
   chain([
@@ -33,10 +39,31 @@ function removeEmptyParents (pkgdir, next) {
 
 function moveModuleOnly (from, to, log, done) {
   var fromModules = path.join(from, 'node_modules')
-  var tempModules = from + '.node_modules'
+  var tempFromModules = from + '.node_modules'
+  var toModules = path.join(to, 'node_modules')
+  var tempToModules = to + '.node_modules'
 
-  log.silly('move', 'remove existing destination', to)
-  rimraf(to, iferr(done, makeDestination(done)))
+  log.silly('move', 'move existing destination node_modules away', toModules)
+
+  fs.rename(toModules, tempToModules, removeDestination(done))
+
+  function removeDestination (next) {
+    return function (er) {
+      log.silly('move', 'remove existing destination', to)
+      if (er) {
+        rimraf(to, iferr(next, makeDestination(next)))
+      } else {
+        rimraf(to, iferr(next, makeDestination(iferr(next, moveToModulesBack(next)))))
+      }
+    }
+  }
+
+  function moveToModulesBack (next) {
+    return function () {
+      log.silly('move', 'move existing destination node_modules back', toModules)
+      fs.rename(tempToModules, toModules, iferr(done, next))
+    }
+  }
 
   function makeDestination (next) {
     return function () {
@@ -48,7 +75,7 @@ function moveModuleOnly (from, to, log, done) {
   function moveNodeModules (next) {
     return function () {
       log.silly('move', 'move source node_modules away', fromModules)
-      fs.rename(fromModules, tempModules, iferr(doMove(next), doMove(moveNodeModulesBack(next))))
+      fs.rename(fromModules, tempFromModules, iferr(doMove(next), doMove(moveNodeModulesBack(next))))
     }
   }
 
@@ -63,7 +90,7 @@ function moveModuleOnly (from, to, log, done) {
     return function () {
       mkdirp(from, iferr(done, function () {
         log.silly('move', 'put source node_modules back', fromModules)
-        fs.rename(tempModules, fromModules, iferr(done, next))
+        fs.rename(tempFromModules, fromModules, iferr(done, next))
       }))
     }
   }

--- a/lib/install/action/remove.js
+++ b/lib/install/action/remove.js
@@ -6,6 +6,7 @@ var asyncMap = require('slide').asyncMap
 var mkdirp = require('mkdirp')
 var npm = require('../../npm.js')
 var andIgnoreErrors = require('../and-ignore-errors.js')
+var rename = require('../../utils/rename.js')
 
 // This is weird because we want to remove the module but not it's node_modules folder
 // allowing for this allows us to not worry about the order of operations
@@ -25,7 +26,7 @@ function removeLink (pkg, next) {
 function removeDir (pkg, log, next) {
   var modpath = path.join(path.dirname(pkg.path), '.' + path.basename(pkg.path) + '.MODULES')
 
-  fs.rename(path.join(pkg.path, 'node_modules'), modpath, unbuildPackage)
+  rename(path.join(pkg.path, 'node_modules'), modpath, unbuildPackage)
 
   function unbuildPackage (renameEr) {
     npm.commands.unbuild(pkg.path, true, renameEr ? andRemoveEmptyParents(pkg.path) : moveModulesBack)
@@ -55,7 +56,7 @@ function removeDir (pkg, log, next) {
       var to = path.join(pkg.path, 'node_modules', file)
       // we ignore errors here, because they can legitimately happen, for instance,
       // bundled modules will be in both node_modules folders
-      fs.rename(from, to, andIgnoreErrors(done))
+      rename(from, to, andIgnoreErrors(done))
     }, cleanup)
   }
 

--- a/lib/install/action/remove.js
+++ b/lib/install/action/remove.js
@@ -67,7 +67,7 @@ function removeDir (pkg, log, next) {
   }
 
   function afterCleanup (rimrafEr) {
-    if (rimrafEr) log.warn('finalize', rimrafEr)
+    if (rimrafEr) log.warn('remove', rimrafEr)
     removeEmptyParents(path.resolve(pkg.path, '..'))
   }
 

--- a/lib/install/action/remove.js
+++ b/lib/install/action/remove.js
@@ -29,7 +29,9 @@ function removeDir (pkg, log, next) {
   rename(path.join(pkg.path, 'node_modules'), modpath, unbuildPackage)
 
   function unbuildPackage (renameEr) {
-    npm.commands.unbuild(pkg.path, true, renameEr ? andRemoveEmptyParents(pkg.path) : moveModulesBack)
+    npm.commands.unbuild(pkg.path, true, function () {
+      rimraf(pkg.path, renameEr ? andRemoveEmptyParents(pkg.path) : moveModulesBack)
+    })
   }
 
   function andRemoveEmptyParents (path) {
@@ -76,8 +78,4 @@ function removeDir (pkg, log, next) {
       removeEmptyParents(path.resolve(pkgdir, '..'))
     })
   }
-}
-
-module.exports.commit = function (staging, pkg, next) {
-  rimraf(pkg.path, next)
 }

--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -62,7 +62,7 @@ function requiredByAllLinked (node) {
 function isNotReqByTop (req) {
   return req !== '/' &&     // '/' is the top level itself
          req !== '#USER' && // #USER
-         req !== '#EXTRANEOUS'
+         req !== '#EXISTING'
 }
 
 var sortActions = module.exports.sortActions = function (differences) {

--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -107,7 +107,7 @@ var sortActions = module.exports.sortActions = function (differences) {
   return sorted
 }
 
-function diffTrees (oldTree, newTree) {
+var diffTrees = module.exports._diffTrees = function (oldTree, newTree) {
   validate('OO', arguments)
   var differences = []
   var flatOldTree = flattenTree(oldTree)
@@ -138,7 +138,9 @@ function diffTrees (oldTree, newTree) {
       }
     } else {
       var vername = getNameAndVersion(pkg.package)
-      if (toRemoveByNameAndVer[vername] && toRemoveByNameAndVer[vername].length) {
+      var removing = toRemoveByNameAndVer[vername] && toRemoveByNameAndVer[vername].length
+      var bundlesOrFromBundle = pkg.fromBundle || pkg.package.bundleDependencies
+      if (removing && !bundlesOrFromBundle) {
         var flatname = toRemoveByNameAndVer[vername].shift()
         pkg.fromPath = toRemove[flatname].path
         differences.push(['move', pkg])

--- a/lib/utils/rename.js
+++ b/lib/utils/rename.js
@@ -1,0 +1,16 @@
+'use strict'
+var fs = require('graceful-fs')
+var SaveStack = require('./save-stack.js')
+
+module.exports = rename
+
+function rename (from, to, cb) {
+  var saved = new SaveStack(rename)
+  fs.rename(from, to, function (er) {
+    if (er) {
+      return cb(saved.completeWith(er))
+    } else {
+      return cb()
+    }
+  })
+}

--- a/lib/utils/save-stack.js
+++ b/lib/utils/save-stack.js
@@ -1,0 +1,16 @@
+'use strict'
+var inherits = require('inherits')
+
+module.exports = SaveStack
+
+function SaveStack (fn) {
+  Error.call(this)
+  Error.captureStackTrace(this, fn || SaveStack)
+}
+inherits(SaveStack, Error)
+
+SaveStack.prototype.completeWith = function (er) {
+  this['__' + 'proto' + '__'] = er
+  this.stack = this.stack + '\n\n' + er.stack
+  return this
+}

--- a/test/tap/bundled-no-add-to-move.js
+++ b/test/tap/bundled-no-add-to-move.js
@@ -1,0 +1,41 @@
+'use strict'
+var test = require('tap').test
+var Node = require('../../lib/install/node.js').create
+var diffTrees = require('../../lib/install/diff-trees.js')._diffTrees
+var sortActions = require('../../lib/install/diff-trees.js').sortActions
+
+var oldTree = Node({
+  path: '/',
+  children: [
+    Node({
+      package: {name: 'one', version: '1.0.0', _location: '/one'},
+      path:'/one'
+    })
+  ]
+})
+oldTree.children[0].requiredBy.push(oldTree)
+
+var newTree = Node({
+  path: '/',
+  children: [
+    Node({
+      package: {name: 'abc', version: '1.0.0', _location: '/abc'},
+      path: '/abc',
+      children: [
+        Node({
+          package: {name: 'one', version: '1.0.0', _location: '/abc/one'},
+          fromBundle: true,
+          path: '/one'
+        })
+      ]
+    })
+  ]
+})
+newTree.children[0].requiredBy.push(newTree)
+newTree.children[0].children[0].requiredBy.push(newTree.children[0])
+
+test('test', function (t) {
+  var differences = sortActions(diffTrees(oldTree, newTree)).map(function (diff) { return diff[0] + diff[1].path })
+  t.isDeeply(differences, ['add/abc', 'add/one', 'remove/one'], 'bundled add/remove stays add/remove')
+  t.end()
+})

--- a/test/tap/move-no-clobber-dest-node-modules.js
+++ b/test/tap/move-no-clobber-dest-node-modules.js
@@ -1,0 +1,135 @@
+'use strict'
+var path = require('path')
+var test = require('tap').test
+var fs = require('graceful-fs')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var base = path.join(__dirname, path.basename(__filename, '.js'))
+var common = require('../common-tap.js')
+
+function fixturepath () {
+  return path.join(base, path.join.apply(path, arguments))
+}
+
+function File (contents) {
+  return {
+    type: 'file',
+    contents: typeof contents === 'object' ? JSON.stringify(contents) : contents,
+  }
+}
+
+function Dir (contents) {
+  return {
+    type: 'dir',
+    contents: contents || {}
+  }
+}
+
+function createFixtures (filename, fixture) {
+  if (fixture.type === 'dir') {
+    mkdirp.sync(filename)
+    Object.keys(fixture.contents).forEach(function (content) {
+      createFixtures(path.resolve(filename, content), fixture.contents[content])
+    })
+  } else if (fixture.type === 'file') {
+    fs.writeFileSync(filename, fixture.contents)
+  } else {
+    throw new Error("Unknown fixture type: " + fixture.type)
+  }
+}
+
+var fixtures = Dir({
+// The fixture modules
+  'moda@1.0.1': Dir({
+    'package.json': File({
+      name: 'moda',
+      version: '1.0.1'
+    })
+  }),
+  'modb@1.0.0': Dir({
+    'package.json': File({
+      name: 'modb',
+      version: '1.0.0',
+      bundleDependencies: ['modc'],
+      dependencies: {
+        modc: fixturepath('modc@1.0.0')
+      }
+    })
+  }),
+  'modc@1.0.0': Dir({
+    'package.json': File({
+      name: 'modc',
+      version: '1.0.0'
+    })
+  }),
+// The local config
+  'package.json': File({
+    dependencies: {
+      moda: fixturepath('moda@1.0.1'),
+      modb: fixturepath('modb@1.0.0')
+    }
+  }),
+  'node_modules': Dir({
+    'moda': Dir({
+      'package.json': File({
+        name: 'moda',
+        version: '1.0.0',
+        _requested: { rawSpec: fixturepath('moda@1.0.0') },
+        dependencies: {
+          modb: fixturepath("modb@1.0.0")
+        },
+        bundleDependencies: [ 'modb' ]
+      })
+    })
+  })
+})
+
+function setup () {
+  cleanup()
+  createFixtures(base, fixtures)
+}
+
+function cleanup () {
+  rimraf.sync(base)
+}
+
+function exists (t, filepath, msg) {
+  try {
+    fs.statSync(filepath)
+    t.pass(msg)
+    return true
+  } catch (ex) {
+    t.fail(msg, {found: null, wanted: 'exists', compare: 'fs.stat(' + filepath + ')'})
+    return false
+  }
+}
+
+test('setup', function (t) {
+  setup()
+  common.npm('install', {cwd: fixturepath('modb@1.0.0')}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'modb')
+    common.npm('install', {cwd: fixturepath('node_modules','moda')}, function (err, code, stdout, stderr) {
+      if (err) throw err
+      t.is(code, 0, 'installed moda')
+      t.done()
+    })
+  })
+})
+
+test('no-clobber', function (t) {
+  common.npm('install', {cwd: base}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'installed ok')
+    exists(t, fixturepath('node_modules','moda'), 'moda')
+    exists(t, fixturepath('node_modules', 'modb'), 'modb')
+    exists(t, fixturepath('node_modules', 'modb', 'node_modules', 'modc'), 'modc')
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.pass()
+  t.done()
+})


### PR DESCRIPTION
This is prooooobably the rest of the ENOENT / missing module / etc errors in 3.x:

So npm@3 generates a list of actions to take against the tree on disk. With the exception of lifecycle scripts, it expects these all to be able to act independently without interfering with each other.

This means, for instance, that one should be able to upgrade `b` in `a→b→c` without reinstalling `c`.

That works fine btw.

But it also means that the move action should be able to move `b` in `a→b→c@1.0.1` to `a→d→b→c@1.0.2` without moving or removing `c@1.0.1` and while leaving `c@1.0.2` in place if it was already installed.

That is, the `move` action moves an individual node, replacing itself with an empty spot if it had children. It's not a graft operation.

So, we already took care to leave `c@1.0.1` in place, but were stomping on the destination and so `c@1.0.2` was being removed.

There was also a bug w/ `remove` where it was pruning the entire tree at the remove point, prior to running moves and adds.

This was fine most of the time, but if we were moving one of the deps out from inside it, kaboom.

Really, there was no need for this. I suspect this dates to a point where move was not able to handle its targets already existing.

The reason we didn't see any of these bugs before in Travis was that all of these actions were applying to deps bundled with npm. Previously bundled deps didn't go through the normal installer actions.

Really though, we shouldn't be using moves to try to optimize away bundled deps 'cause we're going to have to extract those regardless so it just adds complexity without any benefit.
