### PR TITLE
doc: Convert typewriter apostrophes to typographic apostrophes

### DIFF
--- a/doc/cli/npm-access.md
+++ b/doc/cli/npm-access.md
@@ -31,7 +31,7 @@ subcommand.
 * ls-packages:
 
   Show all of the packages a user or a team is able to access, along with the
-  access level, except for read-only public packages (it won't print the whole
+  access level, except for read-only public packages (it won’t print the whole
   registry listing)
 
 * ls-collaborators:

--- a/doc/cli/npm-bugs.md
+++ b/doc/cli/npm-bugs.md
@@ -7,7 +7,7 @@ npm-bugs(1) -- Bugs for a package in a web browser maybe
 
 ## DESCRIPTION
 
-This command tries to guess at the likely location of a package's
+This command tries to guess at the likely location of a package’s
 bug tracker URL, and then tries to open it using the `--browser`
 config param. If no package name is provided, it will search for
 a `package.json` in the current folder and use the `name` property.

--- a/doc/cli/npm-completion.md
+++ b/doc/cli/npm-completion.md
@@ -11,7 +11,7 @@ Enables tab-completion in all npm commands.
 
 The synopsis above
 loads the completions into your current shell.  Adding it to
-your ~/.bashrc or ~/.zshrc will make the completions available
+your `~/.bashrc` or `~/.zshrc` will make the completions available
 everywhere:
 
     npm completion >> ~/.bashrc

--- a/doc/cli/npm-config.md
+++ b/doc/cli/npm-config.md
@@ -16,7 +16,7 @@ npm-config(1) -- Manage the npm configuration files
 npm gets its config settings from the command line, environment
 variables, `npmrc` files, and in some cases, the `package.json` file.
 
-See npmrc(5) for more information about the npmrc files.
+See `npmrc(5)` for more information about the npmrc files.
 
 See `npm-config(7)` for a more thorough discussion of the mechanisms
 involved.

--- a/doc/cli/npm-dedupe.md
+++ b/doc/cli/npm-dedupe.md
@@ -27,7 +27,7 @@ In this case, `npm-dedupe(1)` will transform the tree to:
     +-- d
     `-- c@1.0.10
 
-Because of the hierarchical nature of node’s module lookup, b and d
+Because of the hierarchical nature of Node’s module lookup, b and d
 will both get their dependency met by the single c package at the root
 level of the tree.
 

--- a/doc/cli/npm-dedupe.md
+++ b/doc/cli/npm-dedupe.md
@@ -27,7 +27,7 @@ In this case, `npm-dedupe(1)` will transform the tree to:
     +-- d
     `-- c@1.0.10
 
-Because of the hierarchical nature of node's module lookup, b and d
+Because of the hierarchical nature of node’s module lookup, b and d
 will both get their dependency met by the single c package at the root
 level of the tree.
 

--- a/doc/cli/npm-docs.md
+++ b/doc/cli/npm-docs.md
@@ -10,7 +10,7 @@ npm-docs(1) -- Docs for a package in a web browser maybe
 
 ## DESCRIPTION
 
-This command tries to guess at the likely location of a package's
+This command tries to guess at the likely location of a package’s
 documentation URL, and then tries to open it using the `--browser`
 config param. You can pass multiple package names at once. If no
 package name is provided, it will search for a `package.json` in

--- a/doc/cli/npm-edit.md
+++ b/doc/cli/npm-edit.md
@@ -7,7 +7,7 @@ npm-edit(1) -- Edit an installed package
 
 ## DESCRIPTION
 
-Opens the package folder in the default editor (or whatever you've
+Opens the package folder in the default editor (or whatever you’ve
 configured as the npm `editor` config -- see `npm-config(7)`.)
 
 After it has been edited, the package is rebuilt so as to pick up any

--- a/doc/cli/npm-init.md
+++ b/doc/cli/npm-init.md
@@ -10,9 +10,9 @@ npm-init(1) -- Interactively create a package.json file
 This will ask you a bunch of questions, and then write a package.json for you.
 
 It attempts to make reasonable guesses about what you want things to be set to,
-and then writes a package.json file with the options you've selected.
+and then writes a package.json file with the options you’ve selected.
 
-If you already have a package.json file, it'll read that first, and default to
+If you already have a package.json file, it’ll read that first, and default to
 the options in there.
 
 It is strictly additive, so it does not delete options from your package.json

--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -47,7 +47,7 @@ after packing it up into a tarball (b).
 
     By default, `npm install` will install all modules listed as dependencies
     in `package.json(5)`.
-    
+
     With the `--production` flag (or when the `NODE_ENV` environment variable
     is set to `production`), npm will not install modules listed in
     `devDependencies`.
@@ -100,7 +100,7 @@ after packing it up into a tarball (b).
     package.json, there is an additional, optional flag:
 
     * `-E, --save-exact`: Saved dependencies will be configured with an
-      exact version rather than using npm's default semver range
+      exact version rather than using npm’s default semver range
       operator.
 
     Further, if you have an `npm-shrinkwrap.json` then it will be updated as
@@ -198,7 +198,7 @@ after packing it up into a tarball (b).
     Install the package at `https://github.com/githubname/githubrepo` by
     attempting to clone it using `git`.
 
-    If you don't specify a *commit-ish* then `master` will be used.
+    If you don’t specify a *commit-ish* then `master` will be used.
 
     Examples:
 
@@ -211,7 +211,7 @@ after packing it up into a tarball (b).
     clone it using `git`. The GitHub username associated with the gist is
     optional and will not be saved in `package.json` if `-S` or `--save` is used.
 
-    If you don't specify a *commit-ish* then `master` will be used.
+    If you don’t specify a *commit-ish* then `master` will be used.
 
     Example:
 
@@ -222,7 +222,7 @@ after packing it up into a tarball (b).
     Install the package at `https://bitbucket.org/bitbucketname/bitbucketrepo`
     by attempting to clone it using `git`.
 
-    If you don't specify a *commit-ish* then `master` will be used.
+    If you don’t specify a *commit-ish* then `master` will be used.
 
     Example:
 
@@ -233,7 +233,7 @@ after packing it up into a tarball (b).
     Install the package at `https://gitlab.com/gitlabname/gitlabrepo`
     by attempting to clone it using `git`.
 
-    If you don't specify a *commit-ish* then `master` will be used.
+    If you don’t specify a *commit-ish* then `master` will be used.
 
     Example:
 
@@ -288,7 +288,7 @@ The `--only={prod[uction]|dev[elopment]}` argument will cause either only
 `devDependencies` or only non-`devDependencies` to be installed regardless of the `NODE_ENV`.
 
 See `npm-config(7)`.  Many of the configuration params have some
-effect on installation, since that's most of what npm does.
+effect on installation, since that’s most of what npm does.
 
 ## ALGORITHM
 
@@ -331,7 +331,7 @@ privately for itself.
 See npm-folders(5) for a more detailed description of the specific
 folder structures that npm creates.
 
-### Limitations of npm's Install Algorithm
+### Limitations of npm’s Install Algorithm
 
 There are some very rare and pathological edge-cases where a cycle can
 cause npm to try to install a never-ending tree of packages.  Here is

--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -19,7 +19,7 @@ npm-install(1) -- Install a package
 
 This command installs a package, and any packages that it depends on. If the
 package has a shrinkwrap file, the installation of dependencies will be driven
-by that. See npm-shrinkwrap(1).
+by that. See `npm-shrinkwrap(1)`.
 
 A `package` is:
 
@@ -328,7 +328,7 @@ For `A{B,C}, B{C,D@1}, C{D@2}`, this algorithm produces:
 Because B's D@1 will be installed in the top level, C now has to install D@2
 privately for itself.
 
-See npm-folders(5) for a more detailed description of the specific
+See `npm-folders(5)` for a more detailed description of the specific
 folder structures that npm creates.
 
 ### Limitations of npm’s Install Algorithm

--- a/doc/cli/npm-link.md
+++ b/doc/cli/npm-link.md
@@ -54,7 +54,7 @@ The second line is the equivalent of doing:
     npm link node-redis
 
 That is, it first creates a global link, and then links the global
-installation target into your project's `node_modules` folder.
+installation target into your project’s `node_modules` folder.
 
 If your linked package is scoped (see `npm-scope(7)`) your link command must
 include that scope, e.g.

--- a/doc/cli/npm-logout.md
+++ b/doc/cli/npm-logout.md
@@ -8,8 +8,8 @@ npm-logout(1) -- Log out of the registry
 ## DESCRIPTION
 
 When logged into a registry that supports token-based authentication, tell the
-server to end this token's session. This will invalidate the token everywhere
-you're using it, not just for the current environment.
+server to end this token’s session. This will invalidate the token everywhere
+you’re using it, not just for the current environment.
 
 When logged into a legacy registry that uses username and password authentication, this will
 clear the credentials in your user configuration. In this case, it will _only_ affect

--- a/doc/cli/npm-ls.md
+++ b/doc/cli/npm-ls.md
@@ -15,7 +15,7 @@ installed, as well as their dependencies, in a tree-structure.
 Positional arguments are `name@version-range` identifiers, which will
 limit the results to only the paths to the packages named.  Note that
 nested packages will *also* show the paths to the specified packages.
-For example, running `npm ls promzard` in npm's source tree will show:
+For example, running `npm ls promzard` in npm’s source tree will show:
 
     npm@@VERSION@ /path/to/npm
     └─┬ init-package-json@0.0.4

--- a/doc/cli/npm-owner.md
+++ b/doc/cli/npm-owner.md
@@ -22,7 +22,7 @@ Manage ownership of published packages.
   privileges.
 
 Note that there is only one level of access.  Either you can modify a package,
-or you can't.  Future versions may contain more fine-grained access levels, but
+or you can’t.  Future versions may contain more fine-grained access levels, but
 that is not implemented at this time.
 
 ## SEE ALSO

--- a/doc/cli/npm-pack.md
+++ b/doc/cli/npm-pack.md
@@ -7,7 +7,7 @@ npm-pack(1) -- Create a tarball from a package
 
 ## DESCRIPTION
 
-For anything that's installable (that is, a package folder, tarball,
+For anything that’s installable (that is, a package folder, tarball,
 tarball url, name@tag, name@version, name, or scoped name), this
 command will fetch it to the cache, and then copy the tarball to the
 current working directory as `<name>-<version>.tgz`, and then write

--- a/doc/cli/npm-prune.md
+++ b/doc/cli/npm-prune.md
@@ -12,7 +12,7 @@ provided, then only packages matching one of the supplied names are
 removed.
 
 Extraneous packages are packages that are not listed on the parent
-package's dependencies list.
+package’s dependencies list.
 
 If the `--production` flag is specified or the `NODE_ENV` environment
 variable is set to `production`, this command will remove the packages

--- a/doc/cli/npm-publish.md
+++ b/doc/cli/npm-publish.md
@@ -12,7 +12,7 @@ npm-publish(1) -- Publish a package
 ## DESCRIPTION
 
 Publishes a package to the registry so that it can be installed by name. See
-`npm-developers(7)` for details on what's included in the published package, as
+`npm-developers(7)` for details on what’s included in the published package, as
 well as details on how the package is built.
 
 By default npm will publish to the public registry. This can be overridden by
@@ -34,7 +34,7 @@ specifying a different default registry or using a `npm-scope(7)` in the name
 * `[--access <public|restricted>]`
   Tells the registry whether this package should be published as public or
   restricted. Only applies to scoped packages, which default to `restricted`.
-  If you don't have a paid account, you must publish with `--access public`
+  If you don’t have a paid account, you must publish with `--access public`
   to publish scoped packages.
 
 Fails if the package name and version combination already exists in

--- a/doc/cli/npm-repo.md
+++ b/doc/cli/npm-repo.md
@@ -7,7 +7,7 @@ npm-repo(1) -- Open package repository page in the browser
 
 ## DESCRIPTION
 
-This command tries to guess at the likely location of a package's
+This command tries to guess at the likely location of a package’s
 repository URL, and then tries to open it using the `--browser`
 config param. If no package name is provided, it will search for
 a `package.json` in the current folder and use the `name` property.

--- a/doc/cli/npm-restart.md
+++ b/doc/cli/npm-restart.md
@@ -9,7 +9,7 @@ npm-restart(1) -- Restart a package
 
 This restarts a package.
 
-This runs a package's "stop", "restart", and "start" scripts, and associated
+This runs a package’s "stop", "restart", and "start" scripts, and associated
 pre- and post- scripts, in the order given below:
 
 1. prerestart

--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -9,10 +9,10 @@ npm-run-script(1) -- Run arbitrary package scripts
 
 ## DESCRIPTION
 
-This runs an arbitrary command from a package's `"scripts"` object.  If no
+This runs an arbitrary command from a package’s `"scripts"` object.  If no
 `"command"` is provided, it will list the available scripts.  `run[-script]` is
 used by the test, start, restart, and stop commands, but can be called
-directly, as well. When the scripts in the package are printed out, they're
+directly, as well. When the scripts in the package are printed out, they’re
 separated into lifecycle (test, start, restart) and directly-run scripts.
 
 As of [`npm@2.0.0`](http://blog.npmjs.org/post/98131109725/npm-2-0-0), you can
@@ -30,7 +30,7 @@ environment variables that will be available to the script at runtime. If an
 "env" command is defined in your package it will take precedence over the
 built-in.
 
-In addition to the shell's pre-existing `PATH`, `npm run` adds
+In addition to the shell’s pre-existing `PATH`, `npm run` adds
 `node_modules/.bin` to the `PATH` provided to scripts. Any binaries provided by
 locally-installed dependencies can be used without the `node_modules/.bin`
 prefix. For example, if there is a `devDependency` on `tap` in your package,

--- a/doc/cli/npm-search.md
+++ b/doc/cli/npm-search.md
@@ -11,7 +11,7 @@ npm-search(1) -- Search for packages
 
 Search the registry for packages matching the search terms.
 
-If a term starts with `/`, then it's interpreted as a regular expression.
+If a term starts with `/`, then it’s interpreted as a regular expression.
 A trailing `/` will be ignored in this case.  (Note that many regular
 expression characters must be escaped or quoted in most shells.)
 

--- a/doc/cli/npm-shrinkwrap.md
+++ b/doc/cli/npm-shrinkwrap.md
@@ -7,22 +7,22 @@ npm-shrinkwrap(1) -- Lock down dependency versions
 
 ## DESCRIPTION
 
-This command locks down the versions of a package's dependencies so
+This command locks down the versions of a package’s dependencies so
 that you can control exactly which versions of each dependency will be
 used when your package is installed. The `package.json` file is still
 required if you want to use `npm install`.
 
-By default, `npm install` recursively installs the target's
+By default, `npm install` recursively installs the target’s
 dependencies (as specified in `package.json`), choosing the latest
-available version that satisfies the dependency's semver pattern. In
+available version that satisfies the dependency’s semver pattern. In
 some situations, particularly when shipping software where each change
-is tightly managed, it's desirable to fully specify each version of
+is tightly managed, it’s desirable to fully specify each version of
 each dependency recursively so that subsequent builds and deploys do
 not inadvertently pick up newer versions of a dependency that satisfy
 the semver pattern. Specifying specific semver patterns in each
-dependency's `package.json` would facilitate this, but that's not always
+dependency’s `package.json` would facilitate this, but that’s not always
 possible or desirable, as when another author owns the npm package.
-It's also possible to check dependencies directly into source control,
+It’s also possible to check dependencies directly into source control,
 but that may be undesirable for other reasons.
 
 As an example, consider package A:
@@ -66,15 +66,15 @@ install:
     `-- B@0.0.2
         `-- C@0.0.1
 
-assuming the new version did not modify B's dependencies. Of course,
+assuming the new version did not modify B’s dependencies. Of course,
 the new version of B could include a new version of C and any number
 of new dependencies. If such changes are undesirable, the author of A
-could specify a dependency on B@0.0.1. However, if A's author and B's
-author are not the same person, there's no way for A's author to say
+could specify a dependency on B@0.0.1. However, if A’s author and B’s
+author are not the same person, there’s no way for A’s author to say
 that he or she does not want to pull in newly published versions of C
-when B hasn't changed at all.
+when B hasn’t changed at all.
 
-In this case, A's author can run
+In this case, A’s author can run
 
     npm shrinkwrap
 
@@ -99,13 +99,13 @@ This generates `npm-shrinkwrap.json`, which will look something like this:
       }
     }
 
-The shrinkwrap command has locked down the dependencies based on what's
+The shrinkwrap command has locked down the dependencies based on what’s
 currently installed in `node_modules`.  The installation behavior is changed to:
 
 1. The module tree described by the shrinkwrap is reproduced. This means
 reproducing the structure described in the file, using the specific files
 referenced in "resolved" if available, falling back to normal package
-resolution using "version" if one isn't.
+resolution using "version" if one isn’t.
 
 2. The tree is walked and any missing dependencies are installed in the usual fashion.
 
@@ -143,10 +143,10 @@ available.
 
 ### Other Notes
 
-A shrinkwrap file must be consistent with the package's `package.json`
+A shrinkwrap file must be consistent with the package’s `package.json`
 file. `npm shrinkwrap` will fail if required dependencies are not
 already installed, since that would result in a shrinkwrap that
-wouldn't actually work. Similarly, the command will fail if there are
+wouldn’t actually work. Similarly, the command will fail if there are
 extraneous packages (not referenced by `package.json`), since that would
 indicate that `package.json` is not correct.
 
@@ -157,11 +157,11 @@ installed `devDependencies` are excluded, then npm will print a
 warning.  If you want them to be installed with your module by
 default, please consider adding them to `dependencies` instead.
 
-If shrinkwrapped package A depends on shrinkwrapped package B, B's
+If shrinkwrapped package A depends on shrinkwrapped package B, B’s
 shrinkwrap will not be used as part of the installation of A. However,
-because A's shrinkwrap is constructed from a valid installation of B
-and recursively specifies all dependencies, the contents of B's
-shrinkwrap will implicitly be included in A's shrinkwrap.
+because A’s shrinkwrap is constructed from a valid installation of B
+and recursively specifies all dependencies, the contents of B’s
+shrinkwrap will implicitly be included in A’s shrinkwrap.
 
 ### Caveats
 

--- a/doc/cli/npm-star.md
+++ b/doc/cli/npm-star.md
@@ -8,12 +8,12 @@ npm-star(1) -- Mark your favorite packages
 
 ## DESCRIPTION
 
-"Starring" a package means that you have some interest in it.  It's
+"Starring" a package means that you have some interest in it.  It’s
 a vaguely positive way to show that you care.
 
 "Unstarring" is the same thing, but in reverse.
 
-It's a boolean thing.  Starring repeatedly has no additional effect.
+It’s a boolean thing.  Starring repeatedly has no additional effect.
 
 ## SEE ALSO
 

--- a/doc/cli/npm-stars.md
+++ b/doc/cli/npm-stars.md
@@ -10,7 +10,7 @@ npm-stars(1) -- View packages marked as favorites
 If you have starred a lot of neat things and want to find them again
 quickly this command lets you do just that.
 
-You may also want to see your friend's favorite packages, in this case
+You may also want to see your friend’s favorite packages, in this case
 you will most certainly enjoy this command.
 
 ## SEE ALSO

--- a/doc/cli/npm-start.md
+++ b/doc/cli/npm-start.md
@@ -7,7 +7,7 @@ npm-start(1) -- Start a package
 
 ## DESCRIPTION
 
-This runs an arbitrary command specified in the package's `"start"` property of
+This runs an arbitrary command specified in the package’s `"start"` property of
 its `"scripts"` object. If no `"start"` property is specified on the
 `"scripts"` object, it will run `node server.js`.
 

--- a/doc/cli/npm-stop.md
+++ b/doc/cli/npm-stop.md
@@ -7,7 +7,7 @@ npm-stop(1) -- Stop a package
 
 ## DESCRIPTION
 
-This runs a package's "stop" script, if one was provided.
+This runs a package’s "stop" script, if one was provided.
 
 ## SEE ALSO
 

--- a/doc/cli/npm-tag.md
+++ b/doc/cli/npm-tag.md
@@ -8,7 +8,7 @@ npm-tag(1) -- Tag a published version
 
 ## DESCRIPTION
 
-THIS COMMAND IS DEPRECATED. See npm-dist-tag(1) for details.
+THIS COMMAND IS DEPRECATED. See `npm-dist-tag(1)` for details.
 
 Tags the specified version of the package with the specified tag, or the
 `--tag` config if not specified.

--- a/doc/cli/npm-test.md
+++ b/doc/cli/npm-test.md
@@ -8,7 +8,7 @@ npm-test(1) -- Test a package
 
 ## DESCRIPTION
 
-This runs a package's "test" script, if one was provided.
+This runs a package’s "test" script, if one was provided.
 
 To run tests as a condition of installation, set the `npat` config to
 true.

--- a/doc/cli/npm-update.md
+++ b/doc/cli/npm-update.md
@@ -60,7 +60,7 @@ on dependencies, `dep1` (`dep2`, .. etc.).  The published versions of `dep1` are
 
 ### Caret Dependencies
 
-If `app`'s `package.json` contains:
+If `app`’s `package.json` contains:
 
 ```
 dependencies: {
@@ -73,7 +73,7 @@ Then `npm update` will install `dep1@1.2.2`, because `1.2.2` is `latest` and
 
 ### Tilde Dependencies
 
-However, if `app`'s `package.json` contains:
+However, if `app`’s `package.json` contains:
 
 ```
 dependencies: {

--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -6,7 +6,7 @@ npm-version(1) -- Bump a package version
     npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease]
 
     'npm [-v | --version]' to print npm version
-    'npm view <pkg> version' to view a package's published version
+    'npm view <pkg> version' to view a package’s published version
     'npm ls' to inspect current package/dependency versions
 
 ## DESCRIPTION

--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -28,8 +28,8 @@ You probably got npm because you want to install stuff.
 Use `npm install blerg` to install the latest version of "blerg".  Check out
 `npm-install(1)` for more info.  It can do a lot of stuff.
 
-Use the `npm search` command to show everything that's available.
-Use `npm ls` to show everything you've installed.
+Use the `npm search` command to show everything that’s available.
+Use `npm ls` to show everything you’ve installed.
 
 ## DEPENDENCIES
 
@@ -66,17 +66,17 @@ operate in global mode instead.
 
 ## DEVELOPER USAGE
 
-If you're using npm to develop and publish your code, check out the
+If you’re using npm to develop and publish your code, check out the
 following help topics:
 
 * json:
   Make a package.json file.  See `package.json(5)`.
 * link:
-  For linking your current working code into Node's path, so that you
-  don't have to reinstall every time you make a change.  Use
+  For linking your current working code into Node’s path, so that you
+  don’t have to reinstall every time you make a change.  Use
   `npm link` to do this.
 * install:
-  It's a good idea to install things if you don't need the symbolic link.
+  It’s a good idea to install things if you don’t need the symbolic link.
   Especially, installing other peoples code from the registry is done via
   `npm install`
 * adduser:
@@ -92,7 +92,7 @@ npm is extremely configurable.  It reads its configuration options from
 
 * Command line switches:  
   Set a config with `--key val`.  All keys take a value, even if they
-  are booleans (the config parser doesn't know what the options are at
+  are booleans (the config parser doesn’t know what the options are at
   the time of parsing.)  If no value is provided, then the option is set
   to boolean `true`.
 * Environment Variables:  
@@ -108,7 +108,7 @@ npm is extremely configurable.  It reads its configuration options from
   If the `globalconfig` option is set in the cli, env, or user config,
   then that file is parsed instead.
 * Defaults:  
-  npm's default configuration options are defined in
+  npm’s default configuration options are defined in
   lib/utils/config-defs.js.  These must not be changed.
 
 See `npm-config(7)` for much much more information.
@@ -119,15 +119,15 @@ Patches welcome!
 
 * code:
   Read through `npm-coding-style(7)` if you plan to submit code.
-  You don't have to agree with it, but you do have to follow it.
+  You don’t have to agree with it, but you do have to follow it.
 * docs:
   If you find an error in the documentation, edit the appropriate markdown
-  file in the "doc" folder.  (Don't worry about generating the man page.)
+  file in the "doc" folder.  (Don’t worry about generating the man page.)
 
-Contributors are listed in npm's `package.json` file.  You can view them
+Contributors are listed in npm’s `package.json` file.  You can view them
 easily by doing `npm view npm contributors`.
 
-If you would like to contribute, but don't know what to work on, check
+If you would like to contribute, but don’t know what to work on, check
 the issues list or ask on the mailing list.
 
 * <https://github.com/npm/npm/issues>
@@ -142,7 +142,7 @@ When you find issues, please report them:
 * email:
   <npm-@googlegroups.com>
 
-Be sure to include *all* of the output from the npm command that didn't work
+Be sure to include *all* of the output from the npm command that didn’t work
 as expected.  The `npm-debug.log` file is also helpful to provide.
 
 You can also look for isaacs in #node.js on irc://irc.freenode.net.  He

--- a/doc/files/npm-folders.md
+++ b/doc/files/npm-folders.md
@@ -21,7 +21,7 @@ This document will tell you what it puts where.
 
 The `prefix` config defaults to the location where node is installed.
 On most systems, this is `/usr/local`, and most of the time is the same
-as node’s `process.installPrefix`.
+as Node’s `process.installPrefix`.
 
 On windows, this is the exact location of the node.exe binary.  On Unix
 systems, it’s one level up, since node is typically installed at
@@ -118,7 +118,7 @@ but using the folders described above.
 
 ### Cycles, Conflicts, and Folder Parsimony
 
-Cycles are handled using the property of node’s module system that it
+Cycles are handled using the property of Node’s module system that it
 walks up the directories looking for `node_modules` folders.  So, at every
 stage, if a package is already installed in an ancestor `node_modules`
 folder, then it is not installed at the current location.

--- a/doc/files/npm-folders.md
+++ b/doc/files/npm-folders.md
@@ -3,7 +3,7 @@ npm-folders(5) -- Folder Structures Used by npm
 
 ## DESCRIPTION
 
-npm puts various things on your computer.  That's its job.
+npm puts various things on your computer.  That’s its job.
 
 This document will tell you what it puts where.
 
@@ -13,18 +13,18 @@ This document will tell you what it puts where.
   package root.
 * Global install (with `-g`): puts stuff in /usr/local or wherever node
   is installed.
-* Install it **locally** if you're going to `require()` it.
-* Install it **globally** if you're going to run it on the command line.
+* Install it **locally** if you’re going to `require()` it.
+* Install it **globally** if you’re going to run it on the command line.
 * If you need both, then install it in both places, or use `npm link`.
 
 ### prefix Configuration
 
 The `prefix` config defaults to the location where node is installed.
 On most systems, this is `/usr/local`, and most of the time is the same
-as node's `process.installPrefix`.
+as node’s `process.installPrefix`.
 
 On windows, this is the exact location of the node.exe binary.  On Unix
-systems, it's one level up, since node is typically installed at
+systems, it’s one level up, since node is typically installed at
 `{prefix}/bin/node` rather than `{prefix}/node.exe`.
 
 When the `global` flag is set, npm installs things into this prefix.
@@ -95,14 +95,14 @@ Starting at the $PWD, npm will walk up the folder tree checking for a
 folder that contains either a `package.json` file, or a `node_modules`
 folder.  If such a thing is found, then that is treated as the effective
 "current directory" for the purpose of running npm commands.  (This
-behavior is inspired by and similar to git's .git-folder seeking
+behavior is inspired by and similar to git’s .git-folder seeking
 logic when running git commands in a working dir.)
 
 If no package root is found, then the current folder is used.
 
 When you run `npm install foo@1.2.3`, then the package is loaded into
 the cache, and then unpacked into `./node_modules/foo`.  Then, any of
-foo's dependencies are similarly unpacked into
+foo’s dependencies are similarly unpacked into
 `./node_modules/foo/node_modules/...`.
 
 Any bin files are symlinked to `./node_modules/.bin/`, so that they may
@@ -118,15 +118,15 @@ but using the folders described above.
 
 ### Cycles, Conflicts, and Folder Parsimony
 
-Cycles are handled using the property of node's module system that it
+Cycles are handled using the property of node’s module system that it
 walks up the directories looking for `node_modules` folders.  So, at every
 stage, if a package is already installed in an ancestor `node_modules`
 folder, then it is not installed at the current location.
 
 Consider the case above, where `foo -> bar -> baz`.  Imagine if, in
-addition to that, baz depended on bar, so you'd have:
+addition to that, baz depended on bar, so you’d have:
 `foo -> bar -> baz -> bar -> baz ...`.  However, since the folder
-structure is: `foo/node_modules/bar/node_modules/baz`, there's no need to
+structure is: `foo/node_modules/bar/node_modules/baz`, there’s no need to
 put another copy of bar into `.../baz/node_modules`, since when it calls
 require("bar"), it will get the copy that is installed in
 `foo/node_modules/bar`.
@@ -173,23 +173,23 @@ In this case, we might expect a folder structure like this:
                 `-- quux (3.2.0) <---[E]
 
 Since foo depends directly on `bar@1.2.3` and `baz@1.2.3`, those are
-installed in foo's `node_modules` folder.
+installed in foo’s `node_modules` folder.
 
 Even though the latest copy of blerg is 1.3.7, foo has a specific
 dependency on version 1.2.5.  So, that gets installed at [A].  Since the
-parent installation of blerg satisfies bar's dependency on `blerg@1.x`,
+parent installation of blerg satisfies bar’s dependency on `blerg@1.x`,
 it does not install another copy under [B].
 
 Bar [B] also has dependencies on baz and asdf, so those are installed in
-bar's `node_modules` folder.  Because it depends on `baz@2.x`, it cannot
+bar’s `node_modules` folder.  Because it depends on `baz@2.x`, it cannot
 re-use the `baz@1.2.3` installed in the parent `node_modules` folder [D],
 and must install its own copy [C].
 
 Underneath bar, the `baz -> quux -> bar` dependency creates a cycle.
-However, because bar is already in quux's ancestry [B], it does not
+However, because bar is already in quux’s ancestry [B], it does not
 unpack another copy of bar into that folder.
 
-Underneath `foo -> baz` [D], quux's [E] folder tree is empty, because its
+Underneath `foo -> baz` [D], quux’s [E] folder tree is empty, because its
 dependency on bar is satisfied by the parent folder copy installed at [B].
 
 For a graphical breakdown of what is installed where, use `npm ls`.

--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -47,9 +47,9 @@ When working locally in a project, a `.npmrc` file in the root of the
 project (ie, a sibling of `node_modules` and `package.json`) will set
 config values specific to this project.
 
-Note that this only applies to the root of the project that you're
+Note that this only applies to the root of the project that you’re
 running npm in.  It has no effect when your module is published.  For
-example, you can't publish a module that forces itself to install
+example, you can’t publish a module that forces itself to install
 globally, or in a different location.
 
 Additionally, this file is not read in global mode, such as when running

--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -9,7 +9,7 @@ variables, and `npmrc` files.
 The `npm config` command can be used to update and edit the contents
 of the user and global npmrc files.
 
-For a list of available configuration options, see npm-config(7).
+For a list of available configuration options, see `npm-config(7)`.
 
 ## FILES
 

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -1,9 +1,9 @@
-package.json(5) -- Specifics of npm's package.json handling
+package.json(5) -- Specifics of npm’s package.json handling
 ===========================================================
 
 ## DESCRIPTION
 
-This document is all you need to know about what's required in your package.json
+This document is all you need to know about what’s required in your package.json
 file.  It must be actual JSON, not just a JavaScript object literal.
 
 A lot of the behavior described in this document is affected by the config
@@ -12,7 +12,7 @@ settings described in `npm-config(7)`.
 ## name
 
 The *most* important things in your package.json are the name and version fields.
-Those are actually required, and your package won't install without
+Those are actually required, and your package won’t install without
 them.  The name and version together form an identifier that is assumed
 to be completely unique.  Changes to the package should come along with
 changes to the version.
@@ -23,20 +23,20 @@ Some rules:
 
 * The name must be shorter than 214 characters. This includes the scope for
   scoped packages.
-* The name can't start with a dot or an underscore.
+* The name can’t start with a dot or an underscore.
 * New packages must not have uppercase letters in the name.
 * The name ends up being part of a URL, an argument on the command line, and a
-  folder name. Therefore, the name can't contain any non-URL-safe characters.
+  folder name. Therefore, the name can’t contain any non-URL-safe characters.
 
 Some tips:
 
-* Don't use the same name as a core Node module.
-* Don't put "js" or "node" in the name.  It's assumed that it's js, since you're
+* Don’t use the same name as a core Node module.
+* Don’t put "js" or "node" in the name.  It’s assumed that it’s js, since you’re
   writing a package.json file, and you can specify the engine using the "engines"
   field.  (See below.)
 * The name will probably be passed as an argument to require(), so it should
   be something short, but also reasonably descriptive.
-* You may want to check the npm registry to see if there's something by that name
+* You may want to check the npm registry to see if there’s something by that name
   already, before you get too attached to it. <https://www.npmjs.com/>
 
 A name can be optionally prefixed by a scope, e.g. `@myorg/mypackage`. See
@@ -45,7 +45,7 @@ A name can be optionally prefixed by a scope, e.g. `@myorg/mypackage`. See
 ## version
 
 The *most* important things in your package.json are the name and version fields.
-Those are actually required, and your package won't install without
+Those are actually required, and your package won’t install without
 them.  The name and version together form an identifier that is assumed
 to be completely unique.  Changes to the package should come along with
 changes to the version.
@@ -58,27 +58,27 @@ More on version numbers and ranges at semver(7).
 
 ## description
 
-Put a description in it.  It's a string.  This helps people discover your
-package, as it's listed in `npm search`.
+Put a description in it.  It’s a string.  This helps people discover your
+package, as it’s listed in `npm search`.
 
 ## keywords
 
-Put keywords in it.  It's an array of strings.  This helps people
-discover your package as it's listed in `npm search`.
+Put keywords in it.  It’s an array of strings.  This helps people
+discover your package as it’s listed in `npm search`.
 
 ## homepage
 
 The url to the project homepage.
 
 **NOTE**: This is *not* the same as "url".  If you put a "url" field,
-then the registry will think it's a redirection to your package that has
+then the registry will think it’s a redirection to your package that has
 been published somewhere else, and spit at you.
 
-Literally.  Spit.  I'm so not kidding.
+Literally.  Spit.  I’m so not kidding.
 
 ## bugs
 
-The url to your project's issue tracker and / or the email address to which
+The url to your project’s issue tracker and / or the email address to which
 issues should be reported. These are helpful for people who encounter issues
 with your package.
 
@@ -96,10 +96,10 @@ If a url is provided, it will be used by the `npm bugs` command.
 ## license
 
 You should specify a license for your package so that people know how they are
-permitted to use it, and any restrictions you're placing on it.
+permitted to use it, and any restrictions you’re placing on it.
 
-If you're using a common license such as BSD-2-Clause or MIT, add a
-current SPDX license identifier for the license you're using, like this:
+If you’re using a common license such as BSD-2-Clause or MIT, add a
+current SPDX license identifier for the license you’re using, like this:
 
     { "license" : "BSD-3-Clause" }
 
@@ -112,7 +112,7 @@ expression syntax version 2.0 string](https://npmjs.com/package/spdx), like this
 
     { "license" : "(ISC OR GPL-3.0)" }
 
-If you are using a license that hasn't been assigned an SPDX identifier, or if
+If you are using a license that hasn’t been assigned an SPDX identifier, or if
 you are using a custom license, use the following valid SPDX expression:
 
     { "license" : "SEE LICENSE IN <filename>" }
@@ -207,7 +207,7 @@ Conversely, some files are always ignored:
 
 The main field is a module ID that is the primary entry point to your program.
 That is, if your package is named `foo`, and a user installs it, and then does
-`require("foo")`, then your main module's exports object will be returned.
+`require("foo")`, then your main module’s exports object will be returned.
 
 This should be a module ID relative to the root of your package folder.
 
@@ -216,7 +216,7 @@ much else.
 
 ## bin
 
-A lot of packages have one or more executable files that they'd like to
+A lot of packages have one or more executable files that they’d like to
 install into the PATH. npm makes this pretty easy (in fact, it uses this
 feature to install the "npm" executable.)
 
@@ -230,7 +230,7 @@ For example, myapp could have this:
 
     { "bin" : { "myapp" : "./cli.js" } }
 
-So, when you install myapp, it'll create a symlink from the `cli.js` script to
+So, when you install myapp, it’ll create a symlink from the `cli.js` script to
 `/usr/local/bin/myapp`.
 
 If you have a single executable, and its name should be the name
@@ -251,7 +251,7 @@ would be the same as this:
 Specify either a single file or an array of filenames to put in place for the
 `man` program to find.
 
-If only a single file is provided, then it's installed such that it is the
+If only a single file is provided, then it’s installed such that it is the
 result from `man <pkgname>`, regardless of its actual filename.  For example:
 
     { "name" : "foo"
@@ -263,7 +263,7 @@ result from `man <pkgname>`, regardless of its actual filename.  For example:
 
 would link the `./man/doc.1` file in such that it is the target for `man foo`
 
-If the filename doesn't start with the package name, then it's prefixed.
+If the filename doesn’t start with the package name, then it’s prefixed.
 So, this:
 
     { "name" : "foo"
@@ -291,15 +291,15 @@ will create entries for `man foo` and `man 2 foo`
 
 The CommonJS [Packages](http://wiki.commonjs.org/wiki/Packages/1.0) spec details a
 few ways that you can indicate the structure of your package using a `directories`
-object. If you look at [npm's package.json](https://registry.npmjs.org/npm/latest),
-you'll see that it has directories for doc, lib, and man.
+object. If you look at [npm’s package.json](https://registry.npmjs.org/npm/latest),
+you’ll see that it has directories for doc, lib, and man.
 
 In the future, this information may be used in other creative ways.
 
 ### directories.lib
 
 Tell people where the bulk of your library is.  Nothing special is done
-with the lib folder in any way, but it's useful meta info.
+with the lib folder in any way, but it’s useful meta info.
 
 ### directories.bin
 
@@ -345,7 +345,7 @@ Do it like this:
 
 The URL should be a publicly available (perhaps read-only) url that can be handed
 directly to a VCS program without any modification.  It should not be a url to an
-html project page that you put in your browser.  It's for computers.
+html project page that you put in your browser.  It’s for computers.
 
 For GitHub, GitHub gist, Bitbucket, or GitLab repositories you can use the same
 shortcut syntax you use for `npm install`:
@@ -487,17 +487,17 @@ in which case they will be normalized to a relative path and added to your
     }
 
 This feature is helpful for local offline development and creating
-tests that require npm installing where you don't want to hit an
+tests that require npm installing where you don’t want to hit an
 external server, but should not be used when publishing packages
 to the public registry.
 
 ## devDependencies
 
 If someone is planning on downloading and using your module in their
-program, then they probably don't want or need to download and build
+program, then they probably don’t want or need to download and build
 the external test or documentation framework that you use.
 
-In this case, it's best to map these additional items in a `devDependencies`
+In this case, it’s best to map these additional items in a `devDependencies`
 object.
 
 These things will be installed when doing `npm link` or `npm install`
@@ -524,7 +524,7 @@ For example:
 
 The `prepublish` script will be run before publishing, so that users
 can consume the functionality without requiring them to compile it
-themselves.  In dev mode (ie, locally running `npm install`), it'll
+themselves.  In dev mode (ie, locally running `npm install`), it’ll
 run this script as well, so that you can test it easily.
 
 ## peerDependencies
@@ -563,7 +563,7 @@ error. For this reason, make sure your plugin requirement is as broad as
 possible, and not to lock it down to specific patch versions.
 
 Assuming the host complies with [semver](http://semver.org/), only changes in
-the host package's major version will break your plugin. Thus, if you've worked
+the host package’s major version will break your plugin. Thus, if you’ve worked
 with every 1.x version of the host package, use `"^1.0"` or `"1.x"` to express
 this. If you depend on features introduced in 1.5.2, use `">= 1.5.2 < 2"`.
 
@@ -581,7 +581,7 @@ object.  This is a map of package name to version or url, just like the
 `dependencies` object.  The difference is that build failures do not cause
 installation to fail.
 
-It is still your program's responsibility to handle the lack of the
+It is still your program’s responsibility to handle the lack of the
 dependency.  For example, something like this:
 
     try {
@@ -601,7 +601,7 @@ dependency.  For example, something like this:
     }
 
 Entries in `optionalDependencies` will override entries of the same name in
-`dependencies`, so it's usually best to only put in one place.
+`dependencies`, so it’s usually best to only put in one place.
 
 ## engines
 
@@ -609,7 +609,7 @@ You can specify the version of node that your stuff works on:
 
     { "engines" : { "node" : ">=0.10.3 <0.12" } }
 
-And, like with dependencies, if you don't specify the version (or if you
+And, like with dependencies, if you don’t specify the version (or if you
 specify "\*" as the version), then any version of node will do.
 
 If you specify an "engines" field, then npm will require that "node" be
@@ -645,7 +645,7 @@ just prepend the blacklisted os with a '!':
 
 The host operating system is determined by `process.platform`
 
-It is allowed to both blacklist, and whitelist, although there isn't any
+It is allowed to both blacklist, and whitelist, although there isn’t any
 good reason to do this.
 
 ## cpu
@@ -667,8 +667,8 @@ If your package is primarily a command-line application that should be
 installed globally, then set this value to `true` to provide a warning
 if it is installed locally.
 
-It doesn't actually prevent users from installing it locally, but it
-does help prevent some confusion if it doesn't work as expected.
+It doesn’t actually prevent users from installing it locally, but it
+does help prevent some confusion if it doesn’t work as expected.
 
 ## private
 
@@ -683,7 +683,7 @@ param at publish-time.
 
 ## publishConfig
 
-This is a set of config values that will be used at publish-time. It's
+This is a set of config values that will be used at publish-time. It’s
 especially handy if you want to set the tag, registry or access, so that
 you can ensure that a given package is not tagged with "latest", published
 to the global public registry or that a scoped module is private by default.

--- a/doc/misc/npm-coding-style.md
+++ b/doc/misc/npm-coding-style.md
@@ -1,27 +1,27 @@
-npm-coding-style(7) -- npm's "funny" coding style
+npm-coding-style(7) -- npm’s "funny" coding style
 =================================================
 
 ## DESCRIPTION
 
-npm's coding style is a bit unconventional.  It is not different for
-difference's sake, but rather a carefully crafted style that is
+npm’s coding style is a bit unconventional.  It is not different for
+difference’s sake, but rather a carefully crafted style that is
 designed to reduce visual clutter and make bugs more apparent.
 
 If you want to contribute to npm (which is very encouraged), you should
-make your code conform to npm's style.
+make your code conform to npm’s style.
 
-Note: this concerns npm's code not the specific packages that you can download from the npm registry.
+Note: this concerns npm’s code not the specific packages that you can download from the npm registry.
 
 ## Line Length
 
-Keep lines shorter than 80 characters.  It's better for lines to be
+Keep lines shorter than 80 characters.  It’s better for lines to be
 too short than to be too long.  Break up long lists, objects, and other
 statements onto multiple lines.
 
 ## Indentation
 
 Two-spaces.  Tabs are better, but they look like hell in web browsers
-(and on GitHub), and node uses 2 spaces, so that's that.
+(and on GitHub), and node uses 2 spaces, so that’s that.
 
 Configure your editor appropriately.
 
@@ -38,8 +38,8 @@ Good:
 
     function () {
 
-If a block needs to wrap to the next line, use a curly brace.  Don't
-use it if it doesn't.
+If a block needs to wrap to the next line, use a curly brace.  Don’t
+use it if it doesn’t.
 
 Bad:
 
@@ -56,10 +56,10 @@ Good:
 
 ## Semicolons
 
-Don't use them except in four situations:
+Don’t use them except in four situations:
 
-* `for (;;)` loops.  They're actually required.
-* null loops like: `while (something) ;` (But you'd better have a good
+* `for (;;)` loops.  They’re actually required.
+* null loops like: `while (something) ;` (But you’d better have a good
   reason for doing that.)
 * `case 'foo': doSomething(); break`
 * In front of a leading `(` or `[` at the start of the line.
@@ -118,8 +118,8 @@ Good:
 Put a single space in front of ( for anything other than a function call.
 Also use a single space wherever it makes things more readable.
 
-Don't leave trailing whitespace at the end of lines.  Don't indent empty
-lines.  Don't use more spaces than are helpful.
+Don’t leave trailing whitespace at the end of lines.  Don’t indent empty
+lines.  Don’t use more spaces than are helpful.
 
 ## Functions
 
@@ -135,12 +135,12 @@ methodology.
 The callback should always be the last argument in the list.  Its first
 argument is the Error or null.
 
-Be very careful never to ever ever throw anything.  It's worse than useless.
+Be very careful never to ever ever throw anything.  It’s worse than useless.
 Just send the error message back as the first argument to the callback.
 
 ## Errors
 
-Always create a new Error object with your message.  Don't just return a
+Always create a new Error object with your message.  Don’t just return a
 string message to the callback.  Stack traces are handy.
 
 ## Logging
@@ -150,7 +150,7 @@ utility.
 
 Please clean up logs when they are no longer helpful.  In particular,
 logging the same object over and over again is not helpful.  Logs should
-report what's happening so that it's easier to track down where a fault
+report what’s happening so that it’s easier to track down where a fault
 occurs.
 
 Use appropriate log levels.  See `npm-config(7)` and search for
@@ -161,7 +161,7 @@ Use appropriate log levels.  See `npm-config(7)` and search for
 Use `lowerCamelCase` for multiword identifiers when they refer to objects,
 functions, methods, properties, or anything not specified in this section.
 
-Use `UpperCamelCase` for class names (things that you'd pass to "new").
+Use `UpperCamelCase` for class names (things that you’d pass to "new").
 
 Use `all-lower-hyphen-css-case` for multiword filenames and config keys.
 
@@ -172,16 +172,16 @@ and are rarely used.
 
 Use a single uppercase letter for function names where the function
 would normally be anonymous, but needs to call itself recursively.  It
-makes it clear that it's a "throwaway" function.
+makes it clear that it’s a "throwaway" function.
 
 ## null, undefined, false, 0
 
 Boolean variables and functions should always be either `true` or
-`false`.  Don't set it to 0 unless it's supposed to be a number.
+`false`.  Don’t set it to 0 unless it’s supposed to be a number.
 
 When something is intentionally missing or removed, set it to `null`.
 
-Don't set things to `undefined`.  Reserve that value to mean "not yet
+Don’t set things to `undefined`.  Reserve that value to mean "not yet
 set to anything."
 
 Boolean objects are verboten.

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -141,7 +141,7 @@ Tells npm to create symlinks (or `.cmd` shims on Windows) for package
 executables.
 
 Set to false to have it not do this.  This can be used to work around
-the fact that some file systems don't support symlinks, even on
+the fact that some file systems don’t support symlinks, even on
 ostensibly Unix systems.
 
 ### browser
@@ -178,7 +178,7 @@ See also the `strict-ssl` config.
 * Type: path
 
 A path to a file containing one or multiple Certificate Authority signing
-certificates. Similar to the `ca` setting, but allows for multiple CA's, as
+certificates. Similar to the `ca` setting, but allows for multiple CA’s, as
 well as for the CA information to be stored in a file on disk.
 
 ### cache
@@ -186,7 +186,7 @@ well as for the CA information to be stored in a file on disk.
 * Default: Windows: `%AppData%\npm-cache`, Posix: `~/.npm`
 * Type: path
 
-The location of npm's cache directory.  See `npm-cache(1)`
+The location of npm’s cache directory.  See `npm-cache(1)`
 
 ### cache-lock-stale
 
@@ -281,7 +281,7 @@ set.
 * Default: false
 * Type: Boolean
 
-Indicates that you don't want npm to make any changes and that it should
+Indicates that you don’t want npm to make any changes and that it should
 only report what it would have done.  This can be passed into any of the
 commands that modify your local installation, eg, `install`, `update`,
 `dedupe`, `uninstall`.  This is NOT currently honored by network related
@@ -427,8 +427,8 @@ proxy settings will be honored by the underlying `request` library.
 * Type: Boolean
 
 If true, npm will not exit with an error code when `run-script` is invoked for
-a script that isn't defined in the `scripts` section of `package.json`. This
-option can be used when it's desirable to optionally run a script when it's
+a script that isn’t defined in the `scripts` section of `package.json`. This
+option can be used when it’s desirable to optionally run a script when it’s
 present and fail if the script fails. This is useful, for example, when running
 scripts that may only apply for some builds in an otherwise generic CI setup.
 
@@ -454,21 +454,21 @@ for more information, or npm-init(1).
 * Default: ""
 * Type: String
 
-The value `npm init` should use by default for the package author's name.
+The value `npm init` should use by default for the package author’s name.
 
 ### init-author-email
 
 * Default: ""
 * Type: String
 
-The value `npm init` should use by default for the package author's email.
+The value `npm init` should use by default for the package author’s email.
 
 ### init-author-url
 
 * Default: ""
 * Type: String
 
-The value `npm init` should use by default for the package author's homepage.
+The value `npm init` should use by default for the package author’s homepage.
 
 ### init-license
 
@@ -585,7 +585,7 @@ Any "%s" in the message will be replaced with the version number.
 * Default: process.version
 * Type: semver or false
 
-The node version to use when checking a package's `engines` map.
+The node version to use when checking a package’s `engines` map.
 
 ### npat
 
@@ -751,7 +751,7 @@ Only works if there is already a package.json file present.
 
 Dependencies saved to package.json using `--save`, `--save-dev` or
 `--save-optional` will be configured with an exact version rather than
-using npm's default semver range operator.
+using npm’s default semver range operator.
 
 ### save-optional
 
@@ -856,7 +856,7 @@ See also the `ca` config.
 * Default: latest
 * Type: String
 
-If you ask npm to install a package and don't tell it a specific version, then
+If you ask npm to install a package and don’t tell it a specific version, then
 it will install the specified tag.
 
 Also the tag that is added to the package@version specified by the `npm
@@ -955,7 +955,7 @@ Only relevant when specified explicitly on the command line.
 * Default: false
 * Type: boolean
 
-If true, output the npm version as well as node's `process.versions` map, and
+If true, output the npm version as well as Node’s `process.versions` map, and
 exit successfully.
 
 Only relevant when specified explicitly on the command line.

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -639,7 +639,7 @@ standard output.
 
 ### prefix
 
-* Default: see npm-folders(5)
+* Default: see `npm-folders(5)`
 * Type: path
 
 The location to install global items.  If set on the command line, then

--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -78,7 +78,7 @@ least, you need:
   If you have a special compilation or installation script, then you
   should put it in the `scripts` object.  You should definitely have at
   least a basic smoke-test command as the "scripts.test" field.
-  See npm-scripts(7).
+  See `npm-scripts(7)`.
 
 * main:
   If you have a single module that serves as the entry point to your

--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -3,7 +3,7 @@ npm-developers(7) -- Developer Guide
 
 ## DESCRIPTION
 
-So, you've decided to use npm to develop (and maybe publish/deploy)
+So, you’ve decided to use npm to develop (and maybe publish/deploy)
 your project.
 
 Fantastic!
@@ -56,8 +56,8 @@ least, you need:
   This should be a string that identifies your project.  Please do not
   use the name to specify that it runs on node, or is in JavaScript.
   You can use the "engines" field to explicitly state the versions of
-  node (or whatever else) that your program requires, and it's pretty
-  well assumed that it's javascript.
+  node (or whatever else) that your program requires, and it’s pretty
+  well assumed that it’s javascript.
 
   It does not necessarily need to match your github repository name.
 
@@ -88,7 +88,7 @@ least, you need:
 * directories:
   This is an object mapping names to folders.  The best ones to include are
   "lib" and "doc", but if you use "man" to specify a folder full of man pages,
-  they'll get installed just like these ones.
+  they’ll get installed just like these ones.
 
 You can use `npm init` in the root of your package in order to get you
 started with a pretty basic package.json file.  See `npm-init(1)` for
@@ -96,7 +96,7 @@ more info.
 
 ## Keeping files *out* of your package
 
-Use a `.npmignore` file to keep stuff out of your package.  If there's
+Use a `.npmignore` file to keep stuff out of your package.  If there’s
 no `.npmignore` file, but there *is* a `.gitignore` file, then npm will
 ignore the stuff matched by the `.gitignore` file.  If you *want* to
 include something that is excluded by your `.gitignore` file, you can
@@ -112,7 +112,7 @@ as `.gitignore` files:
 * You can end patterns with a forward slash `/` to specify a directory.
 * You can negate a pattern by starting it with an exclamation point `!`.
 
-By default, the following paths and files are ignored, so there's no
+By default, the following paths and files are ignored, so there’s no
 need to add them to `.npmignore` explicitly:
 
 * `.*.swp`
@@ -129,7 +129,7 @@ need to add them to `.npmignore` explicitly:
 * `npm-debug.log`
 
 Additionally, everything in `node_modules` is ignored, except for
-bundled dependencies. npm automatically handles this for you, so don't
+bundled dependencies. npm automatically handles this for you, so don’t
 bother adding `node_modules` to `.npmignore`.
 
 The following paths and files are never ignored, so adding them to
@@ -153,21 +153,21 @@ More info at `npm-link(1)`.
 
 **This is important.**
 
-If you can not install it locally, you'll have
-problems trying to publish it.  Or, worse yet, you'll be able to
-publish it, but you'll be publishing a broken or pointless package.
-So don't do that.
+If you can not install it locally, you’ll have
+problems trying to publish it.  Or, worse yet, you’ll be able to
+publish it, but you’ll be publishing a broken or pointless package.
+So don’t do that.
 
 In the root of your package, do this:
 
     npm install . -g
 
-That'll show you that it's working.  If you'd rather just create a symlink
+That’ll show you that it’s working.  If you’d rather just create a symlink
 package that points to your working directory, then do this:
 
     npm link
 
-Use `npm ls -g` to see if it's there.
+Use `npm ls -g` to see if it’s there.
 
 To test a local install, go into some other folder, and then do:
 
@@ -177,7 +177,7 @@ To test a local install, go into some other folder, and then do:
 to install it locally into the node_modules folder in that other place.
 
 Then go into the node-repl, and try using require("my-thing") to
-bring in your module's main module.
+bring in your module’s main module.
 
 ## Create a User Account
 
@@ -191,7 +191,7 @@ This is documented better in npm-adduser(1).
 
 ## Publish your package
 
-This part's easy.  In the root of your folder, do this:
+This part’s easy.  In the root of your folder, do this:
 
     npm publish
 

--- a/doc/misc/npm-disputes.md
+++ b/doc/misc/npm-disputes.md
@@ -5,9 +5,9 @@ npm-disputes(7) -- Handling Module Name Disputes
 
 1. Get the author email with `npm owner ls <pkgname>`
 2. Email the author, CC <support@npmjs.com>
-3. After a few weeks, if there's no resolution, we'll sort it out.
+3. After a few weeks, if there’s no resolution, we’ll sort it out.
 
-Don't squat on package names.  Publish code or move out of the way.
+Don’t squat on package names.  Publish code or move out of the way.
 
 ## DESCRIPTION
 
@@ -16,15 +16,15 @@ later, some other user wants to use that name.  Here are some common
 ways that happens (each of these is based on actual events.)
 
 1. Joe writes a JavaScript module `foo`, which is not node-specific.
-   Joe doesn't use node at all.  Bob   wants to use `foo` in node, so he
+   Joe doesn’t use node at all.  Bob wants to use `foo` in node, so he
    wraps it in an npm module.  Some time later, Joe starts using node,
    and wants to take over management of his program.
 2. Bob writes an npm module `foo`, and publishes it.  Perhaps much
    later, Joe finds a bug in `foo`, and fixes it.  He sends a pull
-   request to Bob, but Bob doesn't have the time to deal with it,
+   request to Bob, but Bob doesn’t have the time to deal with it,
    because he has a new job and a new baby and is focused on his new
    erlang project, and kind of not involved with node any more.  Joe
-   would like to publish a new `foo`, but can't, because the name is
+   would like to publish a new `foo`, but can’t, because the name is
    taken.
 3. Bob writes a 10-line flow-control library, and calls it `foo`, and
    publishes it to the npm registry.  Being a simple little thing, it
@@ -35,10 +35,10 @@ ways that happens (each of these is based on actual events.)
 4. Bob writes a parser for the widely-known `foo` file format, because
    he needs it for work.  Then, he gets a new job, and never updates the
    prototype.  Later on, Joe writes a much more complete `foo` parser,
-   but can't publish, because Bob's `foo` is in the way.
+   but can’t publish, because Bob’s `foo` is in the way.
 
-The validity of Joe's claim in each situation can be debated.  However,
-Joe's appropriate course of action in each case is the same.
+The validity of Joe’s claim in each situation can be debated.  However,
+Joe’s appropriate course of action in each case is the same.
 
 1. `npm owner ls foo`.  This will tell Joe the email address of the
    owner (Bob).
@@ -48,8 +48,8 @@ Joe's appropriate course of action in each case is the same.
    the email.  Mention in the email that Bob can run `npm owner add
    joe foo` to add Joe as an owner of the `foo` package.
 3. After a reasonable amount of time, if Bob has not responded, or if
-   Bob and Joe can't come to any sort of resolution, email support
-   <support@npmjs.com> and we'll sort it out.  ("Reasonable" is
+   Bob and Joe can’t come to any sort of resolution, email support
+   <support@npmjs.com> and we’ll sort it out.  ("Reasonable" is
    usually at least 4 weeks, but extra time is allowed around common
    holidays.)
 
@@ -58,7 +58,7 @@ Joe's appropriate course of action in each case is the same.
 In almost every case so far, the parties involved have been able to reach
 an amicable resolution without any major intervention.  Most people
 really do want to be reasonable, and are probably not even aware that
-they're in your way.
+they’re in your way.
 
 Module ecosystems are most vibrant and powerful when they are as
 self-directed as possible.  If an admin one day deletes something you
@@ -79,13 +79,13 @@ but not limited to:
    MIT-licensed program, and then removing or changing the copyright and
    license statement).
 3. Illegal content.
-4. "Squatting" on a package name that you *plan* to use, but aren't
-   actually using.  Sorry, I don't care how great the name is, or how
+4. "Squatting" on a package name that you *plan* to use, but aren’t
+   actually using.  Sorry, I don’t care how great the name is, or how
    perfect a fit it is for the thing that someday might happen.  If
-   someone wants to use it today, and you're just taking up space with
-   an empty tarball, you're going to be evicted.
+   someone wants to use it today, and you’re just taking up space with
+   an empty tarball, you’re going to be evicted.
 5. Putting empty packages in the registry.  Packages must have SOME
-   functionality.  It can be silly, but it can't be *nothing*.  (See
+   functionality.  It can be silly, but it can’t be *nothing*.  (See
    also: squatting.)
 6. Doing weird things with the registry, like using it as your own
    personal application database or otherwise putting non-packagey

--- a/doc/misc/npm-orgs.md
+++ b/doc/misc/npm-orgs.md
@@ -17,8 +17,8 @@ The developer will be able to access packages based on the teams they are on. Ac
 
 There are two main commands:
 
-1. `npm team` see npm-access(1) for more details
-2. `npm access` see npm-team(1) for more details
+1. `npm team` see `npm-access(1)` for more details
+2. `npm access` see `npm-team(1)` for more details
 
 ## Team Admins create teams
 

--- a/doc/misc/npm-registry.md
+++ b/doc/misc/npm-registry.md
@@ -7,7 +7,7 @@ To resolve packages by name and version, npm talks to a registry website
 that implements the CommonJS Package Registry specification for reading
 package info.
 
-Additionally, npm's package registry implementation supports several
+Additionally, npm’s package registry implementation supports several
 write APIs as well, to allow for publishing packages and managing user
 account information.
 
@@ -19,7 +19,7 @@ available at <https://github.com/npm/npm-registry-couchapp>.
 The registry URL used is determined by the scope of the package (see
 `npm-scope(7)`). If no scope is specified, the default registry is used, which is
 supplied by the `registry` config parameter.  See `npm-config(1)`,
-`npmrc(5)`, and `npm-config(7)` for more on managing npm's configuration.
+`npmrc(5)`, and `npm-config(7)` for more on managing npm’s configuration.
 
 ## Can I run my own private registry?
 
@@ -29,14 +29,14 @@ The easiest way is to replicate the couch database, and use the same (or
 similar) design doc to implement the APIs.
 
 If you set up continuous replication from the official CouchDB, and then
-set your internal CouchDB as the registry config, then you'll be able
+set your internal CouchDB as the registry config, then you’ll be able
 to read any published packages, in addition to your private ones, and by
 default will only publish internally. 
 
 If you then want to publish a package for the whole world to see, you can
 simply override the `--registry` option for that `publish` command.
 
-## I don't want my package published in the official registry. It's private.
+## I don’t want my package published in the official registry. It’s private.
 
 Set `"private": true` in your package.json to prevent it from being
 published at all, or
@@ -53,7 +53,7 @@ otherwise.
 
 ## Do I have to use couchdb to build a registry that npm can talk to?
 
-No, but it's way easier.  Basically, yes, you do, or you have to
+No, but it’s way easier.  Basically, yes, you do, or you have to
 effectively implement the entire CouchDB API anyway.
 
 ## Is there a website or something to see package docs and such?

--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -54,10 +54,10 @@ single place, thus reducing complexity and variability.
 Additionally, this means that:
 
 * You can depend on `coffee-script` as a `devDependency`, and thus
-  your users don't need to have it installed.
-* You don't need to include minifiers in your package, reducing
+  your users don’t need to have it installed.
+* You don’t need to include minifiers in your package, reducing
   the size for your users.
-* You don't need to rely on your users having `curl` or `wget` or
+* You don’t need to rely on your users having `curl` or `wget` or
   other system tools on the target machines.
 
 ## DEFAULT VALUES
@@ -138,10 +138,10 @@ then the user could change the behavior by doing:
 Lastly, the `npm_lifecycle_event` environment variable is set to
 whichever stage of the cycle is being executed. So, you could have a
 single script used for different parts of the process which switches
-based on what's currently happening.
+based on what’s currently happening.
 
 Objects are flattened following this format, so if you had
-`{"scripts":{"install":"foo.js"}}` in your package.json, then you'd
+`{"scripts":{"install":"foo.js"}}` in your package.json, then you’d
 see this in the script:
 
     process.env.npm_package_scripts_install === "foo.js"
@@ -181,7 +181,7 @@ Scripts are run by passing the line as a script argument to `sh`.
 If the script exits with a code other than 0, then this will abort the
 process.
 
-Note that these script files don't have to be nodejs or even
+Note that these script files don’t have to be nodejs or even
 javascript programs. They just have to be some kind of executable
 file.
 
@@ -191,7 +191,7 @@ If you want to run a specific script at a specific lifecycle event for
 ALL packages, then you can use a hook script.
 
 Place an executable file at `node_modules/.hooks/{eventname}`, and
-it'll get run for all packages when they are going through that point
+it’ll get run for all packages when they are going through that point
 in the package lifecycle for any packages installed in that root.
 
 Hook scripts are run exactly the same way as package.json scripts.
@@ -200,10 +200,10 @@ above.
 
 ## BEST PRACTICES
 
-* Don't exit with a non-zero error code unless you *really* mean it.
+* Don’t exit with a non-zero error code unless you *really* mean it.
   Except for uninstall scripts, this will cause the npm action to
   fail, and potentially be rolled back.  If the failure is minor or
-  only will prevent some optional features, then it's better to just
+  only will prevent some optional features, then it’s better to just
   print a warning and exit successfully.
 * Try not to use scripts to do what npm can do for you.  Read through
   `package.json(5)` to see all the things that you can specify and enable
@@ -211,12 +211,12 @@ above.
   will lead to a more robust and consistent state.
 * Inspect the env to determine where to put things.  For instance, if
   the `npm_config_binroot` environment variable is set to `/home/user/bin`, then
-  don't try to install executables into `/usr/local/bin`.  The user
+  don’t try to install executables into `/usr/local/bin`.  The user
   probably set it up that way for a reason.
-* Don't prefix your script commands with "sudo".  If root permissions
-  are required for some reason, then it'll fail with that error, and
+* Don’t prefix your script commands with "sudo".  If root permissions
+  are required for some reason, then it’ll fail with that error, and
   the user will sudo the npm command in question.
-* Don't use `install`. Use a `.gyp` file for compilation, and `prepublish`
+* Don’t use `install`. Use a `.gyp` file for compilation, and `prepublish`
   for anything else. You should almost never have to explicitly set a
   preinstall or install script. If you are doing this, please consider if
   there is another option. The only valid use of `install` or `preinstall`

--- a/doc/misc/removing-npm.md
+++ b/doc/misc/removing-npm.md
@@ -14,14 +14,14 @@ Or, if that fails, get the npm source code, and do:
 ## More Severe Uninstalling
 
 Usually, the above instructions are sufficient.  That will remove
-npm, but leave behind anything you've installed.
+npm, but leave behind anything you’ve installed.
 
-If that doesn't work, or if you require more drastic measures,
+If that doesn’t work, or if you require more drastic measures,
 continue reading.
 
 Note that this is only necessary for globally-installed packages.  Local
-installs are completely contained within a project's `node_modules`
-folder.  Delete that folder, and everything is gone (unless a package's
+installs are completely contained within a project’s `node_modules`
+folder.  Delete that folder, and everything is gone (unless a package’s
 install script is particularly ill-behaved).
 
 This assumes that you installed node and npm in the default place.  If

--- a/doc/misc/semver.md
+++ b/doc/misc/semver.md
@@ -90,7 +90,7 @@ prerelease flag, and `3.4.5` is greater than `1.2.3-alpha.7`.
 
 The purpose for this behavior is twofold.  First, prerelease versions
 frequently are updated very quickly, and contain many breaking changes
-that are (by the author's design) not yet fit for public consumption.
+that are (by the author’s design) not yet fit for public consumption.
 Therefore, by default, they are excluded from range matching
 semantics.
 
@@ -261,10 +261,10 @@ The resulting output will always be 100% strict, of course.
 Strict-mode Comparators and Ranges will be strict about the SemVer
 strings that they parse.
 
-* `valid(v)`: Return the parsed version, or null if it's not valid.
+* `valid(v)`: Return the parsed version, or null if it’s not valid.
 * `inc(v, release)`: Return the version incremented by the release
   type (`major`,   `premajor`, `minor`, `preminor`, `patch`,
-  `prepatch`, or `prerelease`), or null if it's not valid
+  `prepatch`, or `prerelease`), or null if it’s not valid
   * `premajor` in one call will bump the version up to the next major
     version and down to a prerelease of that major version.
     `preminor`, and `prepatch` work the same way.
@@ -282,11 +282,11 @@ strings that they parse.
 * `gte(v1, v2)`: `v1 >= v2`
 * `lt(v1, v2)`: `v1 < v2`
 * `lte(v1, v2)`: `v1 <= v2`
-* `eq(v1, v2)`: `v1 == v2` This is true if they're logically equivalent,
-  even if they're not the exact same string.  You already know how to
+* `eq(v1, v2)`: `v1 == v2` This is true if they’re logically equivalent,
+  even if they’re not the exact same string.  You already know how to
   compare strings.
 * `neq(v1, v2)`: `v1 != v2` The opposite of `eq`.
-* `cmp(v1, comparator, v2)`: Pass in a comparison string, and it'll call
+* `cmp(v1, comparator, v2)`: Pass in a comparison string, and it’ll call
   the corresponding function above.  `"==="` and `"!=="` do simple
   string comparison, but are included for completeness.  Throws if an
   invalid comparison string is provided.
@@ -301,7 +301,7 @@ strings that they parse.
 
 ### Ranges
 
-* `validRange(range)`: Return the valid range or null if it's not valid
+* `validRange(range)`: Return the valid range or null if it’s not valid
 * `satisfies(version, range)`: Return true if the version satisfies the
   range.
 * `maxSatisfying(versions, range)`: Return the highest version in the list


### PR DESCRIPTION
- Convert typewriter apostrophes to typographic apostrophes where appropriate
  - Info on this: http://www.brunobernard.com/en/more-elegant-texts-with-typographic-apostrophe/
- Add backticks where appropriate
- Title case "Node" as this is a proper noun :)
  - https://github.com/nodejs/node/pull/3998
