### PR TITLE
search.npmjs.org seems outdated

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -86,7 +86,7 @@ program that you run on your computer!</p>
   <li><a href="https://npmjs.org/doc/README.html">README</a>
   <li><a href="doc/">Help Documentation</a>
   <li><a href="doc/faq.html">FAQ</a>
-  <li><a href="https://search.npmjs.org/">Search for Packages</a>
+  <li><a href="https://www.npmjs.com/">Search for Packages</a>
   <li><a href="https://groups.google.com/group/npm-">Mailing List</a>
   <li><a href="https://github.com/npm/npm/issues">Bugs</a>
 </ul>


### PR DESCRIPTION
I can't reach a server called [`search.npmjs.org`](https://search.npmjs.org/), since there is no DNS record for it. I assume that these days one would use the search form on [`www.npmjs.com`](https://www.npmjs.com/).
