### PR TITLE
Add 'npm version from-git'

### DIFF
--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -3,7 +3,7 @@ npm-version(1) -- Bump a package version
 
 ## SYNOPSIS
 
-    npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease]
+    npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
 
     'npm [-v | --version]' to print npm version
     'npm view <pkg> version' to view a package's published version
@@ -14,10 +14,11 @@ npm-version(1) -- Bump a package version
 Run this in a package directory to bump the version and write the new
 data back to `package.json` and, if present, `npm-shrinkwrap.json`.
 
-The `newversion` argument should be a valid semver string, *or* a
-valid second argument to semver.inc (one of `patch`, `minor`, `major`,
-`prepatch`, `preminor`, `premajor`, `prerelease`). In the second case,
+The `newversion` argument should be a valid semver string, a
+valid second argument to [semver.inc](https://github.com/npm/node-semver#functions) (one of `patch`, `minor`, `major`,
+`prepatch`, `preminor`, `premajor`, `prerelease`), or `from-git`. In the second case,
 the existing version will be incremented by 1 in the specified field.
+`from-git` will try to read the latest git tag, and use that as the new npm version.
 
 If run in a git repo, it will also create a version commit and tag.
 This behavior is controlled by `git-tag-version` (see below), and can

--- a/lib/version.js
+++ b/lib/version.js
@@ -14,7 +14,7 @@ var assert = require('assert')
 var lifecycle = require('./utils/lifecycle.js')
 var parseJSON = require('./utils/parse-json.js')
 
-version.usage = 'npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease]' +
+version.usage = 'npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]' +
                 '\n(run in package dir)\n' +
                 "'npm -v' or 'npm --version' to print npm version " +
                 '(' + npm.version + ')\n' +
@@ -46,25 +46,68 @@ function version (args, silent, cb_) {
       return cb_(er)
     }
 
-    var newVersion = semver.valid(args[0])
-    if (!newVersion) newVersion = semver.inc(data.version, args[0])
-    if (!newVersion) return cb_(version.usage)
-    if (data.version === newVersion) return cb_(new Error('Version not changed'))
-    data.version = newVersion
-    var lifecycleData = Object.create(data)
-    lifecycleData._id = data.name + '@' + newVersion
-    var localData = {}
-
-    var where = npm.prefix
-    chain([
-          [checkGit, localData],
-          [lifecycle, lifecycleData, 'preversion', where],
-          [updatePackage, newVersion, silent],
-          [lifecycle, lifecycleData, 'version', where],
-          [commit, localData, newVersion],
-          [lifecycle, lifecycleData, 'postversion', where] ],
-          cb_)
+    if (args[0] === 'from-git') {
+      retrieveTagVersion(silent, data, cb_)
+    } else {
+      var newVersion = semver.valid(args[0])
+      if (!newVersion) newVersion = semver.inc(data.version, args[0])
+      if (!newVersion) return cb_(version.usage)
+      persistVersion(newVersion, silent, data, cb_)
+    }
   })
+}
+
+function retrieveTagVersion (silent, data, cb_) {
+  chain([
+    verifyGit,
+    parseLastGitTag
+  ], function (er, results) {
+    if (er) return cb_(er)
+    var localData = {
+      hasGit: true,
+      existingTag: true
+    }
+
+    var version = results[results.length - 1]
+    persistVersion(version, silent, data, localData, cb_)
+  })
+}
+
+function parseLastGitTag (cb) {
+  var options = { env: process.env }
+  git.whichAndExec(['describe', '--abbrev=0'], options, function (er, stdout) {
+    if (er) {
+      if (er.message.indexOf('No names found') !== -1) return cb(new Error('No tags found'))
+      return cb(er)
+    }
+
+    var tag = stdout.trim()
+    var version = semver.valid(tag)
+    if (!version) return cb(new Error(tag + ' is not a valid version'))
+    cb(null, version)
+  })
+}
+
+function persistVersion (newVersion, silent, data, localData, cb_) {
+  if (typeof localData === 'function') {
+    cb_ = localData
+    localData = {}
+  }
+
+  if (data.version === newVersion) return cb_(new Error('Version not changed'))
+  data.version = newVersion
+  var lifecycleData = Object.create(data)
+  lifecycleData._id = data.name + '@' + newVersion
+
+  var where = npm.prefix
+  chain([
+    !localData.hasGit && [checkGit, localData],
+    [lifecycle, lifecycleData, 'preversion', where],
+    [updatePackage, newVersion, silent],
+    [lifecycle, lifecycleData, 'version', where],
+    [commit, localData, newVersion],
+    [lifecycle, lifecycleData, 'postversion', where]
+  ], cb_)
 }
 
 function readPackage (cb) {
@@ -98,7 +141,8 @@ function updatePackage (newVersion, silent, cb_) {
 function commit (localData, newVersion, cb) {
   updateShrinkwrap(newVersion, function (er, hasShrinkwrap) {
     if (er || !localData.hasGit) return cb(er)
-    _commit(newVersion, hasShrinkwrap, cb)
+    localData.hasShrinkwrap = hasShrinkwrap
+    _commit(newVersion, localData, cb)
   })
 }
 
@@ -140,8 +184,51 @@ function dump (data, cb) {
   cb()
 }
 
+function statGitFolder (cb) {
+  fs.stat(path.join(npm.localPrefix, '.git'), cb)
+}
+
+function callGitStatus (cb) {
+  git.whichAndExec(
+    [ 'status', '--porcelain' ],
+    { env: process.env },
+    cb
+  )
+}
+
+function cleanStatusLines (stdout) {
+  var lines = stdout.trim().split('\n').filter(function (line) {
+    return line.trim() && !line.match(/^\?\? /)
+  }).map(function (line) {
+    return line.trim()
+  })
+
+  return lines
+}
+
+function verifyGit (cb) {
+  function checkStatus (er) {
+    if (er) return cb(er)
+    callGitStatus(checkStdout)
+  }
+
+  function checkStdout (er, stdout) {
+    if (er) return cb(er)
+    var lines = cleanStatusLines(stdout)
+    if (lines.length > 0) {
+      return cb(new Error(
+        'Git working directory not clean.\n' + lines.join('\n')
+      ))
+    }
+
+    cb()
+  }
+
+  statGitFolder(checkStatus)
+}
+
 function checkGit (localData, cb) {
-  fs.stat(path.join(npm.localPrefix, '.git'), function (er, s) {
+  statGitFolder(function (er) {
     var doGit = !er && npm.config.get('git-tag-version')
     if (!doGit) {
       if (er) log.verbose('version', 'error checking for .git', er)
@@ -150,37 +237,29 @@ function checkGit (localData, cb) {
     }
 
     // check for git
-    git.whichAndExec(
-      [ 'status', '--porcelain' ],
-      { env: process.env },
-      function (er, stdout) {
-        if (er && er.code === 'ENOGIT') {
-          log.warn(
-            'version',
-            'This is a Git checkout, but the git command was not found.',
-            'npm could not create a Git tag for this release!'
-          )
-          return cb(null, false)
-        }
-
-        var lines = stdout.trim().split('\n').filter(function (line) {
-          return line.trim() && !line.match(/^\?\? /)
-        }).map(function (line) {
-          return line.trim()
-        })
-        if (lines.length && !npm.config.get('force')) {
-          return cb(new Error(
-            'Git working directory not clean.\n' + lines.join('\n')
-          ))
-        }
-        localData.hasGit = true
-        cb(null, true)
+    callGitStatus(function (er, stdout) {
+      if (er && er.code === 'ENOGIT') {
+        log.warn(
+          'version',
+          'This is a Git checkout, but the git command was not found.',
+          'npm could not create a Git tag for this release!'
+        )
+        return cb(null, false)
       }
-    )
+
+      var lines = cleanStatusLines(stdout)
+      if (lines.length && !npm.config.get('force')) {
+        return cb(new Error(
+          'Git working directory not clean.\n' + lines.join('\n')
+        ))
+      }
+      localData.hasGit = true
+      cb(null, true)
+    })
   })
 }
 
-function _commit (version, hasShrinkwrap, cb) {
+function _commit (version, localData, cb) {
   var packagePath = path.join(npm.localPrefix, 'package.json')
   var options = { env: process.env }
   var message = npm.config.get('message').replace(/%s/g, version)
@@ -189,9 +268,14 @@ function _commit (version, hasShrinkwrap, cb) {
   chain(
     [
       git.chainableExec([ 'add', packagePath ], options),
-      hasShrinkwrap && git.chainableExec([ 'add', 'npm-shrinkwrap.json' ], options),
+      localData.hasShrinkwrap && git.chainableExec([ 'add', 'npm-shrinkwrap.json' ], options),
       git.chainableExec([ 'commit', '-m', message ], options),
-      git.chainableExec([ 'tag', npm.config.get('tag-version-prefix') + version, flag, message ], options)
+      !localData.existingTag && git.chainableExec([
+        'tag',
+        npm.config.get('tag-version-prefix') + version,
+        flag,
+        message
+      ], options)
     ],
     cb
   )

--- a/lib/version.js
+++ b/lib/version.js
@@ -73,6 +73,9 @@ function parseLastGitTag (cb) {
     }
 
     var tag = stdout.trim()
+    var prefix = npm.config.get('tag-version-prefix')
+    // Strip the prefix from the start of the tag:
+    if (tag.indexOf(prefix) === 0) tag = tag.slice(prefix.length)
     var version = semver.valid(tag)
     if (!version) return cb(new Error(tag + ' is not a valid version'))
     cb(null, version)

--- a/lib/version.js
+++ b/lib/version.js
@@ -29,16 +29,7 @@ function version (args, silent, cb_) {
   }
   if (args.length > 1) return cb_(version.usage)
 
-  var packagePath = path.join(npm.localPrefix, 'package.json')
-  fs.readFile(packagePath, function (er, data) {
-    if (data) data = data.toString()
-    try {
-      data = parseJSON(data)
-    } catch (e) {
-      er = e
-      data = null
-    }
-
+  readPackage(function (er, data) {
     if (!args.length) return dump(data, cb_)
 
     if (er) {

--- a/test/tap/version-from-git.js
+++ b/test/tap/version-from-git.js
@@ -1,0 +1,162 @@
+var common = require('../common-tap.js')
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var npm = require('../../lib/npm.js')
+
+var pkg = path.resolve(__dirname, 'version-from-git')
+var packagePath = path.resolve(pkg, 'package.json')
+var cache = path.resolve(pkg, 'cache')
+
+var json = { name: 'cat', version: '0.1.2' }
+
+test('npm version from-git with a valid tag creates new commit', function (t) {
+  var version = '1.2.3'
+  var tag = 'v' + version
+  setup()
+  createTag(t, tag, runVersion)
+
+  function runVersion (er) {
+    t.ifError(er, 'git tag ran without error')
+    npm.config.set('sign-git-tag', false)
+    npm.commands.version(['from-git'], checkVersion)
+  }
+
+  function checkVersion (er) {
+    var git = require('../../lib/utils/git.js')
+    t.ifError(er, 'version command ran without error')
+    git.whichAndExec(
+      ['log'],
+      { cwd: pkg, env: process.env },
+      checkCommit
+    )
+  }
+
+  function checkCommit (er, log, stderr) {
+    t.ifError(er, 'git log ran without issue')
+    t.notOk(stderr, 'no error output')
+    t.ok(log.indexOf(version) !== -1, 'commited from subdirectory')
+    t.end()
+  }
+})
+
+test('npm version from-git with a valid tag updates the package.json version', function (t) {
+  var version = '1.2.3'
+  var tag = 'v' + version
+  setup()
+  createTag(t, tag, runVersion)
+
+  function runVersion (er) {
+    t.ifError(er, 'git tag ran without error')
+    npm.config.set('sign-git-tag', false)
+    npm.commands.version(['from-git'], checkManifest)
+  }
+
+  function checkManifest (er) {
+    t.ifError(er, 'npm run version ran without error')
+    fs.readFile(path.resolve(pkg, 'package.json'), 'utf8', function (er, data) {
+      t.ifError(er, 'read manifest without error')
+      var manifest = JSON.parse(data)
+      t.equal(manifest.version, version, 'updated the package.json version')
+      t.done()
+    })
+  }
+})
+
+test('npm version from-git with an existing version', function (t) {
+  var tag = 'v' + json.version
+  setup()
+  createTag(t, tag, runVersion)
+
+  function runVersion (er) {
+    t.ifError(er, 'git tag ran without error')
+    npm.config.set('sign-git-tag', false)
+    npm.commands.version(['from-git'], checkVersion)
+  }
+
+  function checkVersion (er) {
+    t.equal(er.message, 'Version not changed')
+    t.done()
+  }
+})
+
+test('npm version from-git with an invalid version tag', function (t) {
+  var tag = 'invalidversion'
+  setup()
+  createTag(t, tag, runVersion)
+
+  function runVersion (er) {
+    t.ifError(er, 'git tag ran without error')
+    npm.config.set('sign-git-tag', false)
+    npm.commands.version(['from-git'], checkVersion)
+  }
+
+  function checkVersion (er) {
+    t.equal(er.message, tag + ' is not a valid version')
+    t.done()
+  }
+})
+
+test('npm version from-git without any versions', function (t) {
+  setup()
+  createGitRepo(t, runVersion)
+
+  function runVersion (er) {
+    t.ifError(er, 'created git repo without errors')
+    npm.config.set('sign-git-tag', false)
+    npm.commands.version(['from-git'], checkVersion)
+  }
+
+  function checkVersion (er) {
+    t.equal(er.message, 'No tags found')
+    t.done()
+  }
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  // windows fix for locked files
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}
+
+function setup () {
+  cleanup()
+  mkdirp.sync(cache)
+  process.chdir(pkg)
+  fs.writeFileSync(packagePath, JSON.stringify(json), 'utf8')
+}
+
+function createGitRepo (t, cb) {
+  npm.load({ cache: cache }, function (er) {
+    t.ifError(er, 'npm load ran without issue')
+    common.makeGitRepo({
+      path: pkg,
+      added: ['package.json']
+    }, cb)
+  })
+}
+
+function createTag (t, tag, cb) {
+  var opts = { cwd: pkg, env: { PATH: process.env.PATH } }
+  npm.load({ cache: cache }, function (er) {
+    t.ifError(er, 'npm load ran without issue')
+
+    // git must be called after npm.load because it uses config
+    var git = require('../../lib/utils/git.js')
+    common.makeGitRepo({
+      path: pkg,
+      added: ['package.json'],
+      commands: [git.chainableExec(['tag', tag, '-am', tag], opts)]
+    }, cb)
+  })
+}

--- a/test/tap/version-from-git.js
+++ b/test/tap/version-from-git.js
@@ -15,11 +15,10 @@ var cache = path.resolve(pkg, 'cache')
 
 var json = { name: 'cat', version: '0.1.2' }
 
-test('npm version from-git with a valid tag creates new commit', function (t) {
+test('npm version from-git with a valid tag creates a new commit', function (t) {
   var version = '1.2.3'
-  var tag = 'v' + version
   setup()
-  createTag(t, tag, runVersion)
+  createTag(t, version, runVersion)
 
   function runVersion (er) {
     t.ifError(er, 'git tag ran without error')
@@ -40,16 +39,15 @@ test('npm version from-git with a valid tag creates new commit', function (t) {
   function checkCommit (er, log, stderr) {
     t.ifError(er, 'git log ran without issue')
     t.notOk(stderr, 'no error output')
-    t.ok(log.indexOf(version) !== -1, 'commited from subdirectory')
+    t.ok(log.indexOf(version) !== -1, 'commit was created')
     t.end()
   }
 })
 
 test('npm version from-git with a valid tag updates the package.json version', function (t) {
   var version = '1.2.3'
-  var tag = 'v' + version
   setup()
-  createTag(t, tag, runVersion)
+  createTag(t, version, runVersion)
 
   function runVersion (er) {
     t.ifError(er, 'git tag ran without error')
@@ -65,6 +63,70 @@ test('npm version from-git with a valid tag updates the package.json version', f
       t.equal(manifest.version, version, 'updated the package.json version')
       t.done()
     })
+  }
+})
+
+test('npm version from-git strips tag-version-prefix', function (t) {
+  var version = '1.2.3'
+  var prefix = 'custom-'
+  var tag = prefix + version
+  setup()
+  createTag(t, tag, runVersion)
+
+  function runVersion (er) {
+    t.ifError(er, 'git tag ran without error')
+    npm.config.set('sign-git-tag', false)
+    npm.config.set('tag-version-prefix', prefix)
+    npm.commands.version(['from-git'], checkVersion)
+  }
+
+  function checkVersion (er) {
+    var git = require('../../lib/utils/git.js')
+    t.ifError(er, 'version command ran without error')
+    git.whichAndExec(
+      ['log'],
+      { cwd: pkg, env: process.env },
+      checkCommit
+    )
+  }
+
+  function checkCommit (er, log, stderr) {
+    t.ifError(er, 'git log ran without issue')
+    t.notOk(stderr, 'no error output')
+    t.ok(log.indexOf(tag) === -1, 'commit should not include prefix')
+    t.ok(log.indexOf(version) !== -1, 'commit should include version')
+    t.end()
+  }
+})
+
+test('npm version from-git only strips tag-version-prefix if it is a prefix', function (t) {
+  var prefix = 'test'
+  var version = '1.2.3-' + prefix
+  setup()
+  createTag(t, version, runVersion)
+
+  function runVersion (er) {
+    t.ifError(er, 'git tag ran without error')
+    npm.config.set('sign-git-tag', false)
+    npm.config.set('tag-version-prefix', prefix)
+    npm.commands.version(['from-git'], checkVersion)
+  }
+
+  function checkVersion (er) {
+    var git = require('../../lib/utils/git.js')
+    t.ifError(er, 'version command ran without error')
+    git.whichAndExec(
+      ['log'],
+      { cwd: pkg, env: process.env },
+      checkCommit
+    )
+  }
+
+  function checkCommit (er, log, stderr) {
+    t.ifError(er, 'git log ran without issue')
+    t.notOk(stderr, 'no error output')
+    t.ok(log.indexOf(version) !== -1, 'commit should include the full version')
+    t.end()
   }
 })
 


### PR DESCRIPTION
Tries to use the last git tag as the new npm version, as long as it exists and is a valid version range. Fixes #9402.

Any feedback welcome!
