### PR TITLE
Change outdated output to match user preference

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -83,10 +83,15 @@ function outdated (args, silent, cb) {
       })
       if (er || silent || list.length === 0) return cb(er, list)
       log.disableProgress()
+
+      var listType = false
+
       if (npm.config.get('json')) {
         console.log(makeJSON(list))
+        listType = makeJSON(list)
       } else if (npm.config.get('parseable')) {
         console.log(makeParseable(list))
+        listType = makeParseable(list)
       } else {
         var outList = list.map(makePretty)
         var outHead = [ 'Package',
@@ -110,7 +115,7 @@ function outdated (args, silent, cb) {
         }
         console.log(table(outTable, tableOpts))
       }
-      cb(null, list.map(function (item) { return [item[0].parent.path].concat(item.slice(1, 7)) }))
+      cb(null, listType || list.map(function (item) { return [item[0].parent.path].concat(item.slice(1, 7)) }))
     })
   }))
 }

--- a/test/tap/outdated-local.js
+++ b/test/tap/outdated-local.js
@@ -117,39 +117,11 @@ test('outdated support local modules', function (t) {
           npm.outdated(function (er, d) {
             t.ifError(er, 'outdated success')
             t.ok(verify(d, [
-              [
-                path.resolve(__dirname, 'outdated-local'),
-                'local-module',
-                '1.0.0',
-                '1.1.0',
-                '1.1.0',
-                'file:local-module'
-              ],
-              [
-                path.resolve(__dirname, 'outdated-local'),
-                '@scoped/another-local-module',
-                '1.0.0',
-                '1.2.0',
-                '1.2.0',
-                'file:another-local-module'
-              ],
-              [
-                path.resolve(__dirname, 'outdated-local'),
-                'underscore',
-                '1.3.1',
-                '1.6.1',
-                '1.5.1',
-                'file:underscore'
-              ],
-              [
-                path.resolve(__dirname, 'outdated-local'),
-                'optimist',
-                '0.4.0',
-                '0.6.0',
-                '0.6.0',
-                'optimist@0.6.0'
-              ]
-            ]), 'got expected outdated output')
+              path.resolve(__dirname, '/outdated-local/node_modules/@scoped/another-local-module:@scoped/another-local-module@1.2.0:@scoped/another-local-module@1.0.0:@scoped/another-local-module@1.2.0'),
+              path.resolve(__dirname, '/outdated-local/node_modules/local-module:local-module@1.1.0:local-module@1.0.0:local-module@1.1.0'),
+              path.resolve(__dirname, '/outdated-local/node_modules/optimist:optimist@0.6.0:optimist@0.4.0:optimist@0.6.0'),
+              path.resolve(__dirname, '/outdated-local/node_modules/underscore:underscore@1.6.1:underscore@1.3.1:underscore@1.5.1')
+            ].join('\n')), 'got expected outdated output')
             s.close()
           })
         })

--- a/test/tap/outdated-long.js
+++ b/test/tap/outdated-long.js
@@ -48,16 +48,11 @@ test('it should not throw', function (t) {
   ]
 
   var expData = [
-    [
-      pkg,
-      'underscore',
-      '1.3.1',
-      '1.3.1',
-      '1.5.1',
-      '1.3.1',
-      'dependencies'
-    ]
-  ]
+    [pkg, 'node_modules', 'underscore'].join('/'),
+    '1.3.1',
+    '1.3.1',
+    '1.5.1:dependencies'
+  ].join(':underscore@')
 
   console.log = function () {
     output.push.apply(output, arguments)

--- a/test/tap/outdated-private.js
+++ b/test/tap/outdated-private.js
@@ -67,15 +67,12 @@ test('outdated ignores private modules', function (t) {
           bumpLocalPrivate()
           npm.outdated(function (er, d) {
             t.ifError(er, 'outdated success')
-            t.deepEqual(d, [[
-              path.resolve(__dirname, 'outdated-private'),
-              'underscore',
+            t.deepEqual(d, [
+              path.resolve(__dirname, 'outdated-private/node_modules/underscore'),
+              '1.5.1',
               '1.3.1',
-              '1.5.1',
-              '1.5.1',
-              'underscore@1.5.1',
-              null
-            ]])
+              '1.5.1'
+            ].join(':underscore@'))
             s.close()
           })
         })

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -59,33 +59,24 @@ test('it should not throw', function (t) {
 
   var expData = [
     [
-      pkg,
-      'async',
+      [pkg, 'node_modules', 'async'].join('/'),
       '0.2.9',
       '0.2.9',
-      '0.2.10',
-      '0.2.9',
-      null
-    ],
+      '0.2.10'
+    ].join(':async@'),
     [
-      pkg,
-      'checker',
+      [pkg, 'node_modules', 'checker'].join('/'),
       '0.5.1',
       '0.5.1',
-      '0.5.2',
-      '0.5.1',
-      null
-    ],
+      '0.5.2'
+    ].join(':checker@'),
     [
-      pkg,
-      'underscore',
+      [pkg, 'node_modules', 'underscore'].join('/'),
       '1.3.1',
       '1.3.1',
-      '1.5.1',
-      '1.3.1',
-      null
-    ]
-  ]
+      '1.5.1'
+    ].join(':underscore@')
+  ].join('\n')
 
   console.log = function () {}
   mr({ port: common.port }, function (er, s) {


### PR DESCRIPTION
I got confused as to why when you use `npm.command.outdated` you end up with a slightly oddball looking array of arrays, whilst the console shows something completely different. 
If the user requests a list view with e.g. `--json` or `npm.config.set('json')` I feel like outdated should not just `console.log` that result but also return it.
- This PR returns `makeJSON` or `makeParseable` versions of the outdated package lists, rather than just logging them
- The benefit is that when using `npm.command.outdated` you don't have to grok `stdout` if you want the json/parseable formats.
- Default API return signature remains the same

@iarna I did a `git log -p -S 'list.map(function (item) { return [item[0].parent.path'` and got a commit from back in which changed the API structure to what it is now, from `null`.

https://github.com/npm/npm/commit/7e188d77efc7d7f75152a09c3325d9023fd5328b

I'm not sure why the `list.map` looks the way it does, and am happy to make more changes to this PR if needs be! It doesn't look like it's harming any of the tests though, now that I've changed the expected formatting output.

Tools like [updtr](https://github.com/peerigon/updtr/blob/master/lib/run.js#L35) are already using forked child processes and listening to the stdout, rather than calling npm directly. I think this could possibly change if the `outdated` module is updated.
