### PR TITLE
fetch-package-metadata: add dist-tags to list of valid install targets

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -150,9 +150,12 @@ function fetchNamedPackageData (dep, next) {
       }
 
       // And failing that, we error out
-      var targets = versions.length
-                  ? 'Valid install targets:\n' + versions.join(', ') + '\n'
-                  : 'No valid targets found.'
+      var targets = Object.keys(pkg['dist-tags']).filter(function (f) {
+        return versions.hasOwnProperty(f)
+      }).concat(versions)
+      targets = versions.length
+              ? 'Valid install targets:\n' + targets.join(', ') + '\n'
+              : 'No valid targets found.'
       var er = new Error('No compatible version found: ' +
                          dep.raw + '\n' + targets)
       return next(er)


### PR DESCRIPTION
I was trying to update npm with `npm install -g npm@2.x-latest` instead of `npm install -g npm@latest-2`. dist-tags are missing from this list, but they would've been helpful in that output. Also this makes it more correct :)
