### PR TITLE
npm-dist-tag docs: Explain why the `latest` tag matters

### DIFF
--- a/doc/cli/npm-dist-tag.md
+++ b/doc/cli/npm-dist-tag.md
@@ -36,14 +36,27 @@ This also applies to `npm dedupe`.
 Publishing a package sets the "latest" tag to the published version unless the
 `--tag` option is used. For example, `npm publish --tag=beta`.
 
+By default, `npm install <pkg>` (without any `@<version>` or `@<tag>`
+specifier) installs the `latest` tag.
+
 ## PURPOSE
 
-Tags can be used to provide an alias instead of version numbers.  For
-example, `npm` currently uses the tag "next" to identify the upcoming
-version, and the tag "latest" to identify the current version.
+Tags can be used to provide an alias instead of version numbers.
 
-A project might choose to have multiple streams of development, e.g.,
-"stable", "canary".
+For example, a project might choose to have multiple streams of development
+and use a different tag for each stream,
+e.g., `stable`, `beta`, `dev`, `canary`.
+
+By default, the `latest` tag is used by npm to identify the current version of
+a package, and `npm install <pkg>` (without any `@<version>` or `@<tag>`
+specifier) installs the `latest` tag. Typically, projects only use the `latest`
+tag for stable release versions, and use other tags for unstable versions such
+as prereleases.
+
+The `next` tag is used by some projects to identify the upcoming version.
+
+By default, other than `latest`, no tag has any special significance to npm
+itself.
 
 ## CAVEATS
 


### PR DESCRIPTION
- Explain why one would care about the `latest` tag, by explaining its special significance to `npm install`. Currently, only its default status with respect to `npm publish` is mentioned.
- Also, avoid using npm as a meta-example, as this causes confusion between npm-the-tool and npm-the-project. The old docs made it sound like the `next` tag might've has special significance to npm-the-tool, when it was instead talking about npm-the-project (AFAIK).
- Mention common practice regarding tagging unstable releases, as this is not universally known.
  - Include the term "prerelease" for SEO's sake

Refs https://github.com/twbs/bootstrap/issues/18520
