### PR TITLE
help people know they need to install peer deps

### DIFF
--- a/lib/install/validate-tree.js
+++ b/lib/install/validate-tree.js
@@ -39,7 +39,7 @@ function thenValidateAllPeerDeps (idealTree, next) {
   validate('OF', arguments)
   validateAllPeerDeps(idealTree, function (tree, pkgname, version) {
     var warn = new Error(packageId(tree) + ' requires a peer of ' + pkgname + '@' +
-      version + ' but none was installed.')
+      version + ' but none is installed. You must install peer dependencies yourself.')
     warn.code = 'EPEERINVALID'
     idealTree.warnings.push(warn)
   })

--- a/test/tap/install-scoped-with-peer-dependency.js
+++ b/test/tap/install-scoped-with-peer-dependency.js
@@ -30,7 +30,7 @@ test('it should install peerDependencies in same tree level as the parent packag
   common.npm(['install', '--loglevel=warn', './package'], EXEC_OPTS, function (err, code, stdout, stderr) {
     t.ifError(err, 'install local package successful')
     t.equal(code, 0, 'npm install exited with code')
-    t.match(stderr, /npm WARN @scope[/]package@0[.]0[.]0 requires a peer of underscore@[*] but none was installed[.]\n/,
+    t.match(stderr, /npm WARN @scope[/]package@0[.]0[.]0 requires a peer of underscore@[*] but none is installed[.]\n/,
       'npm install warned about unresolved peer dep')
 
     t.end()


### PR DESCRIPTION
In our experience with React Router most people think the current messaging is an error.

> npm WARN EPEERINVALID react-router@1.0.2 requires a peer of history@1.13.x but none was installed.

They see this and then open an issue on our project.

Maybe somebody else can think of a better phrase, but here's my attempt at making it clearer that this is not an error, but a task the person reading it needs to complete.
