### PR TITLE
lifecycle: propagate SIGTERM to child

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -233,6 +233,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
     }
     procError(er)
   })
+  process.once('SIGTERM', procKill)
 
   function procError (er) {
     if (progressEnabled) log.enableProgress()
@@ -248,7 +249,11 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
       er.script = cmd
       er.pkgname = pkg.name
     }
+    process.removeListener('SIGTERM', procKill)
     return cb(er)
+  }
+  function procKill () {
+    proc.kill()
   }
 }
 


### PR DESCRIPTION
When one runs for example `npm run-script`, any SIGTERM to npm will orphanize the child process. This is a simple fix for this (potential) issue. Now whenever npm launches a child through lifecycle, any SIGTERM signal is simply propagated to the child for the duration of the process.

This behavior of npm when getting a SIGTERM seems to be what makes sense to most people (see the discussion in #4603), and makes `npm run-script` more friendly in various development scenarios.
