### PR TITLE
Ignore invalid dependency versions when picking version to install

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -122,7 +122,15 @@ function fetchNamedPackageData (dep, next) {
     }
     function pickVersionFromRegistryDocument (pkg) {
       if (!regCache[url]) regCache[url] = pkg
-      var versions = Object.keys(pkg.versions).sort(semver.rcompare)
+      var versions = Object.keys(pkg.versions)
+
+      var invalidVersions = versions.filter(function (v) { return !semver.valid(v) })
+      if (invalidVersions.length > 0) {
+        log.warn('', 'The package %s has invalid semver-version(s): %s. This usually only happens for unofficial private registries. ' +
+            'You should delete or re-publish the invalid versions.', pkg.name, invalidVersions.join(', '))
+      }
+
+      versions = versions.filter(semver.valid).sort(semver.rcompare)
 
       if (dep.type === 'tag') {
         var tagVersion = pkg['dist-tags'][dep.spec]

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -126,7 +126,7 @@ function fetchNamedPackageData (dep, next) {
 
       var invalidVersions = versions.filter(function (v) { return !semver.valid(v) })
       if (invalidVersions.length > 0) {
-        log.warn('', 'The package %s has invalid semver-version(s): %s. This usually only happens for unofficial private registries. ' +
+        log.warn('pickVersion', 'The package %s has invalid semver-version(s): %s. This usually only happens for unofficial private registries. ' +
             'You should delete or re-publish the invalid versions.', pkg.name, invalidVersions.join(', '))
       }
 

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -130,7 +130,7 @@ function fetchNamedPackageData (dep, next) {
             'You should delete or re-publish the invalid versions.', pkg.name, invalidVersions.join(', '))
       }
 
-      versions = versions.filter(semver.valid).sort(semver.rcompare)
+      versions = versions.filter(function (v) { return semver.valid(v) }).sort(semver.rcompare)
 
       if (dep.type === 'tag') {
         var tagVersion = pkg['dist-tags'][dep.spec]

--- a/test/tap/invalid-dep-version-filtering.js
+++ b/test/tap/invalid-dep-version-filtering.js
@@ -1,0 +1,84 @@
+'use strict'
+var test = require('tap').test
+var rimraf = require('rimraf')
+var common = require('../common-tap')
+var mr = require('npm-registry-mock')
+var server
+
+var pkgA = {
+  name: 'pkg-a',
+  'dist-tags': {
+    latest: '1.0.0'
+  },
+  versions: {
+    '1.0.0': {
+      name: 'pkg-a',
+      version: '1.0.0',
+      dependencies: {
+        'pkg-b': '1.0.0'
+      },
+      dist: {
+        shasum: '3fbd9f4711a5234233dc6c9d7a052d4b9f83b416',
+        tarball: 'http://registry.npmjs.org/mkdirp/-/mkdirp-0.0.1.tgz'
+      }
+    }
+  }
+}
+
+var pkgB = {
+  name: 'pkg-b',
+  'dist-tags': {
+    latest: '1.0.0'
+  },
+  versions: {
+    '1.0.0': {
+      name: 'pkg-b',
+      version: '1.0.0',
+      dist: {
+        shasum: '3fbd9f4711a5234233dc6c9d7a052d4b9f83b416',
+        tarball: 'http://registry.npmjs.org/mkdirp/-/mkdirp-0.0.1.tgz'
+      }
+    },
+    '1.0.0rc1': {
+      name: 'pkg-b',
+      version: '1.0.0rc1',
+      dist: {
+        shasum: '3fbd9f4711a5234233dc6c9d7a052d4b9f83b416',
+        tarball: 'http://registry.npmjs.org/mkdirp/-/mkdirp-0.0.1.tgz'
+      }
+    }
+  }
+}
+
+test('setup', function (t) {
+  mr({ port: common.port, throwOnUnmatched: true }, function (err, s) {
+    t.ifError(err, 'registry mocked successfully')
+    server = s
+    t.end()
+  })
+})
+
+test('invalid versions should be ignored', function (t) {
+  server.get('/pkg-a').reply(200, pkgA)
+  server.get('/pkg-b').reply(200, pkgB)
+
+  common.npm(
+    [
+      'install',
+      '--registry', common.registry,
+      'pkg-a@1.0.0'
+    ],
+    {},
+    function (er, code, stdout, stderr) {
+      if (er) { throw er }
+      t.equal(code, 0, 'install succeded')
+      server.done()
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  server.close()
+  rimraf('node_modules/pkg-*(a|b)', t.end.bind(t))
+})


### PR DESCRIPTION
This is a fix to avoid errors for those using Sinopia and similar proxy/private registry. Related issues: #9808, #9726, #9701, #9657.

At some point npm seems to have cleaned up invalid semver versions in the registry and modify versions in flight when publishing from the CLI. This works for those that don't have a private registry/proxy, but those who do have a private registry that already have a package with invalid in the cache will get a very little informative error message:

> npm ERR! Invalid Version: 0.4.0rc8

It does not say which dependency that has an invalid version, only that something has an invalid version. It's not clear if it's the projects own package.json, a direct dependency or a transitive dependency. Nor if it's a version npm would actually resolve to or an old version we don't care about. This exception is thrown even when we don't rely on that version, it happens if any dependency has one invalid version in it's release history.

The npm-debug.log has some hints about which package this happens to, but the first time I got this error I got 4 of them, and it wasn't clear to me if the line just above the error was the same package or a log statement from another fetch happening in parallell. Unfortunately I didn't backup that log-file, but #9809 have the relevant parts from a npm-debug.log.

This fix ignores all packages with an invalid semver version. I don't think it will cause problems for public packages because the invalid versions have been fixed in the public registry, and the private registrys should just proxy the new versions. But private packages with invalid versions will also be ignored, so I added a warning for the invalid versions just in case. Please let me know if you want this to be solved in another way, or anything else :)
