### PR TITLE
cache: ignore failures replacing package.json

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -337,6 +337,7 @@ function afterAdd (cb) { return function (er, data) {
 
   // Save the resolved, shasum, etc. into the data so that the next
   // time we load from this cached data, we have all the same info.
+  // Ignore if it fails.
   var pj = path.join(cachedPackageRoot(data), "package", "package.json")
 
   var done = inflight(pj, cb)
@@ -347,7 +348,7 @@ function afterAdd (cb) { return function (er, data) {
     if (er) return done(er)
     writeFileAtomic(pj, JSON.stringify(data), {chown : cs}, function (er) {
       if (!er) log.verbose("afterAdd", pj, "written")
-      return done(er, data)
+      return done(null, data)
     })
   })
 }}


### PR DESCRIPTION
As reported in https://github.com/npm/npm/issues/9696 , `npm install` fails frequently on slow Windows machines.

This happens because npm uses `write-file-atomic` to overwrite `package.json` in the cache, and it is not possible to write atomically to a file in Windows as it is done in UNIX. To replace a file, it cannot be open at the same time, either for reading or for other calls to `write-file-atomic`.

Failures writing to `package.json` are already ignored in [another place](https://github.com/npm/npm/blob/v2.14.13/lib/cache/caching-client.js#L183). Not saving cache information here does not seem to be an issue, but can there be a reason why we might not want to do this? @othiym23

Fixes: https://github.com/npm/npm/issues/7885
Fixes: https://github.com/npm/npm/issues/9696
