### PR TITLE
Encoding package tarball url for scoped packages

### DIFF
--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -190,10 +190,23 @@ function addNameVersion (name, v, data, cb) {
       mapToRegistry(name, npm.config, function (er, _, auth, ruri) {
         if (er) return cb(er)
 
+        // For scoped packages, encoding the package name may be needed
+        // http://registry/@scope/package/-/@scope/package-0.0.0.tgz
+        // ---->
+        // http://registry/@scope%2fpackage/-/@scope%2fpackage-0.0.0.tgz
+        function getEncodedTarballUrl (name, tarball) {
+          // Encoding is only needed for scoped packages
+          if (/@.+\/.+/.test(name)) {
+            tarball = tarball.replace(RegExp(name, 'g'), name.replace('/', '%2f'))
+            log.verbose('fetch', 'tarball url encoding needed', 'new tarball url', tarball)
+          }
+          return tarball
+        }
+
         // Use the same protocol as the registry.  https registry --> https
         // tarballs, but only if they're the same hostname, or else detached
         // tarballs may not work.
-        var tb = url.parse(dist.tarball)
+        var tb = url.parse(getEncodedTarballUrl(name, dist.tarball))
         var rp = url.parse(ruri)
         if (tb.hostname === rp.hostname && tb.protocol !== rp.protocol) {
           tb.protocol = rp.protocol

--- a/test/tap/enconding-tar-ball-for-scoped-packages.js
+++ b/test/tap/enconding-tar-ball-for-scoped-packages.js
@@ -1,0 +1,80 @@
+'use strict'
+var test = require('tap').test
+var npm = require('../../lib/npm')
+var stream = require('readable-stream')
+
+var moduleName = 'xyzzy-wibble'
+var testModule = {
+  name: moduleName,
+  'dist-tags': {
+    latest: '1.3.0'
+  },
+  versions: {
+    '1.3.0': {
+      name: moduleName,
+      version: '1.3.0',
+      dist: {
+        shasum: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        tarball: 'https://registry.npmjs.org/xyzzy-wibble/-/xyzzy-wibble-1.3.0.tgz'
+      }
+    }
+  }
+}
+
+var scopedModuleName = '@scope/xyzzy-wibble'
+var scopedTestModule = {
+  name: scopedModuleName,
+  'dist-tags': {
+    latest: '1.8.0'
+  },
+  versions: {
+    '1.8.0': {
+      name: scopedModuleName,
+      version: '1.8.0',
+      dist: {
+        shasum: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        tarball: 'https://registry.npmjs.org/@scope/xyzzy-wibble/-/@scope/xyzzy-wibble-1.8.0.tgz'
+      }
+    }
+  }
+}
+
+var lastTarball
+
+test('setup', function (t) {
+  npm.load({loglevel: 'silly'}, function (a, b) {
+    npm.registry = {
+      fetch: function (u, opts, cb) {
+        lastTarball = u
+
+        setTimeout(function () {
+          var empty = new stream.Readable()
+          empty.push(null)
+          cb(null, empty)
+        })
+      }
+    }
+    t.end()
+  })
+})
+
+var addNamed = require('../../lib/cache/add-named.js')
+test('verify_regular_module', function (t) {
+  t.plan(2)
+
+  // tarball for regular module is not encoded
+  addNamed('xyzzy-wibble', '*', testModule, function (err, pkg) {
+    t.error(err, 'Succesfully resolved regular module')
+    t.is(lastTarball, 'https://registry.npmjs.org/xyzzy-wibble/-/xyzzy-wibble-1.3.0.tgz')
+  })
+})
+
+test('verify_scoped_module', function (t) {
+  t.plan(2)
+
+  // tarball for scoped module is encoded
+  addNamed('@scope/xyzzy-wibble', '*', scopedTestModule, function (err, pkg) {
+    t.error(err, 'Succesfully resolved scoped module')
+    t.is(lastTarball, 'https://registry.npmjs.org/@scope%2fxyzzy-wibble/-/@scope%2fxyzzy-wibble-1.8.0.tgz')
+  })
+})


### PR DESCRIPTION
We have our private couchdb registry to keep our scoped packages but also continuously syncing with the official registry.

I hit this issue: https://github.com/npm/npm/issues/8770

I worked in a fix and committed it to this pull request.

Please bear with me as this is my first time contributing to npm. I tried to validate the tests, but several tests were broken even before my changes.

Please share any feedback.
