### PR TITLE
Change working directory for `npm run scriptname` in pkg.json

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -343,3 +343,4 @@ ekmartin <mail@ekmartin.com>
 Rafał Pocztarski <r.pocztarski@gmail.com>
 Ashley Williams <ashley666ashley@gmail.com>
 Mark Reeder <mreeder@uber.com>
+Robert Jefe Lindstaedt <robert.lindstaedt@gmail.com>

--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -30,6 +30,21 @@ environment variables that will be available to the script at runtime. If an
 "env" command is defined in your package it will take precedence over the
 built-in.
 
+It is also possible to run certain scripts in other working directories. This is
+enabled by `node`s `child_process` `cwd`-option. For that you need specify a
+run-script in the `scripts` objects as follows:
+
+```
+{
+  "scripts": {
+    "change-cwd": {
+      "cwd": "test/fixtures/",
+      "run": "node -e \"console.log(process.cwd())\""
+      }
+  }
+}
+```
+
 In addition to the shell's pre-existing `PATH`, `npm run` adds
 `node_modules/.bin` to the `PATH` provided to scripts. Any binaries provided by
 locally-installed dependencies can be used without the `node_modules/.bin`

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -54,6 +54,22 @@ function runScript (args, cb) {
 
   readJson(path.resolve(pkgdir, 'package.json'), function (er, d) {
     if (er) return cb(er)
+
+    // alter pkgdir here
+    if (d.scripts && d.scripts.hasOwnProperty('_cwdChanges')) {
+      var script = []
+      if (d.scripts._cwdChanges.length > 0) {
+          // there can be only one element here. So filter it...
+        script = d.scripts._cwdChanges.filter(function (el) {
+          return el.cmd === cmd
+        })[0]
+        if (script) {
+          // ...so get it here
+          pkgdir = path.resolve(pkgdir, script.cwd)
+        }
+      }
+    }
+
     run(d, pkgdir, cmd, args, cb)
   })
 }

--- a/node_modules/read-package-json/test/advanced.js
+++ b/node_modules/read-package-json/test/advanced.js
@@ -1,0 +1,30 @@
+var path = require('path')
+var tap = require('tap')
+var readJson = require('../')
+
+tap.test('script cwd test', function (t) {
+  var p = path.resolve(__dirname, 'fixtures/scripts.json')
+  readJson(p, function (er, data) {
+    if (er) throw er
+    advanced_(t, data)
+  })
+})
+
+function advanced_ (t, data) {
+  var testCmdName = 'change-cwd-test'
+  var changeCwdPath = 'test/fixtures/'
+  var cmdValue = 'node -e \"console.log(process.cwd())\"'
+
+  var newPropName = '_cwdChanges'
+  var newPropValue = {
+    'cmd': testCmdName,
+    'cwd': changeCwdPath,
+    'run': cmdValue
+  }
+
+  t.ok(data)
+  t.ok(data.scripts.hasOwnProperty(newPropName))
+  t.deepEqual(data.scripts[newPropName][0], newPropValue)
+  t.deepEqual(data.scripts[testCmdName], cmdValue)
+  t.end()
+}

--- a/node_modules/read-package-json/test/fixtures/scripts.json
+++ b/node_modules/read-package-json/test/fixtures/scripts.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "change-cwd-test": {
+      "cwd": "test/fixtures/",
+      "run": "node -e \"console.log(process.cwd())\""
+      }
+  }
+}

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -62,6 +62,17 @@ var preversionOnly = {
   }
 }
 
+var cwdChange = {
+  name: 'scripted',
+  version: '1.2.3',
+  scripts: {
+    'change-cwd': {
+      'cwd': '..',
+      'run': 'node -e "console.log(process.cwd())"'
+    }
+  }
+}
+
 function testOutput (t, command, er, code, stdout, stderr) {
   var lines
 
@@ -252,6 +263,47 @@ test('npm run-script no-params (direct only)', function (t) {
   writeMetadata(both)
 
   common.npm(['run-script'], opts, function (err, code, stdout, stderr) {
+    t.ifError(err, 'ran run-script without parameters without crashing')
+    t.notOk(code, 'npm exited without error code')
+    t.notOk(stderr, 'npm printed nothing to stderr')
+    t.equal(stdout, expected, 'got expected output')
+    t.end()
+  })
+})
+
+test('npm run-script change-cwd', function (t) {
+  var expected = [
+    'Scripts available in scripted via `npm run-script`:',
+    '  change-cwd',
+    '    node -e "console.log(process.cwd())"',
+    ''
+  ].join('\n')
+
+  writeMetadata(cwdChange)
+
+  common.npm(['run-script'], opts, function (err, code, stdout, stderr) {
+    t.ifError(err, 'ran run-script without parameters without crashing')
+    t.notOk(code, 'npm exited without error code')
+    t.notOk(stderr, 'npm printed nothing to stderr')
+    t.equal(stdout, expected, 'got expected output')
+    t.comment(stdout)
+    t.end()
+  })
+})
+
+test('npm run-script change-cwd and expect to have cahnged cwd to test/tap', function (t) {
+  var expected = [
+    '',
+    '> scripted@1.2.3 change-cwd ' + __dirname,
+    '> node -e "console.log(process.cwd())"',
+    '',
+    '' + __dirname,
+    ''
+  ].join('\n')
+
+  writeMetadata(cwdChange)
+
+  common.npm(['run-script', 'change-cwd'], opts, function (err, code, stdout, stderr) {
     t.ifError(err, 'ran run-script without parameters without crashing')
     t.notOk(code, 'npm exited without error code')
     t.notOk(stderr, 'npm printed nothing to stderr')


### PR DESCRIPTION
This commit adds the above mentioned feature by checking whether the package
JSON includes a script in the form of...

```
{
  "scripts": {
    "change-cwd-test": {
       "cwd": "test/fixtures/",
       "run": "node -e \"console.log(process.cwd())\""
    }
   }
}
```

It then attaches a un-enumerable array to the `scripts` objects, which the `npm`
client can check for during execution.

From the `npm` client's POV, this seems a little odd since it needs to transform
a lot. But in order to pass hard checks here and w/ `npm` and not to break, this
seemed to be necessary for the author.

**Background:**
This described in greater detail the referenced issue. Fundamentally though, 
this for enabling `npm` to be more of a build tool. For example some programs 
such as make don't allow non-cwd runs. And in order to not `cd` to it, this is 
supposed to greatly help.

Credit: @eljefedelrodeodeljefe
Reviewed-By:
ISSUE: npm#10957
