### PR TITLE
process.installPrefix was removed as of 0.8.x.

### DIFF
--- a/doc/files/npm-folders.md
+++ b/doc/files/npm-folders.md
@@ -20,12 +20,10 @@ This document will tell you what it puts where.
 ### prefix Configuration
 
 The `prefix` config defaults to the location where node is installed.
-On most systems, this is `/usr/local`, and most of the time is the same
-as node's `process.installPrefix`.
-
-On windows, this is the exact location of the node.exe binary.  On Unix
-systems, it's one level up, since node is typically installed at
-`{prefix}/bin/node` rather than `{prefix}/node.exe`.
+On most systems, this is `/usr/local`. On windows, this is the exact 
+location of the node.exe binary.  On Unix systems, it's one level up, 
+since node is typically installed at `{prefix}/bin/node` rather than 
+`{prefix}/node.exe`.
 
 When the `global` flag is set, npm installs things into this prefix.
 When it is not set, it uses the root of the current package, or the


### PR DESCRIPTION
Currently, [the docs](https://docs.npmjs.com/files/folders) indicate that one should consult `process.installPrefix` to find the npm install directory. This is well out of date. `process.installPrefix` was removed [here](https://github.com/nodejs/node-v0.x-archive/pull/3483). 

It was announced in the [changelog for v0.8](https://github.com/jhnns/node/wiki/API-changes-between-v0.6-and-v0.8):

> `process.installPrefix` has been removed (#3483). `process.installPrefix` was (accidentally) always > undefined in node v0.6.

So, it should be removed from the docs.
