### PR TITLE
Correct the name property max length constraint verbiage

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -21,7 +21,7 @@ The name is what your thing is called.
 
 Some rules:
 
-* The name must be shorter than 214 characters. This includes the scope for
+* The name must be less than or equal to 214 characters. This includes the scope for
   scoped packages.
 * The name can't start with a dot or an underscore.
 * New packages must not have uppercase letters in the name.


### PR DESCRIPTION
The verbiage describing the maximum length of the `package.json` file's `name` property was incorrect, as it led one to believe that the maximum length is 213 characters. I've updated it to be consistent with what's documented [here](https://github.com/npm/validate-npm-package-name#naming-rules).
