### PR TITLE
cache: measure cache age from process start time

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -226,7 +226,10 @@ explicitly used, and that only GET requests use the cache.
 * Type: Number
 
 The minimum time (in seconds) to keep items in the registry cache before
-re-checking against the registry.
+re-checking against the registry, if higher than the process run time. This
+means that items added to the cache during an install are valid for the
+duration of the install, even if `npm install` takes longer than `cache-min`
+seconds.
 
 Note that no purging is done unless the `npm cache clean` command is
 explicitly used, and that only GET requests use the cache.

--- a/lib/cache/caching-client.js
+++ b/lib/cache/caching-client.js
@@ -100,6 +100,7 @@ function get_ (uri, cachePath, params, cb) {
   var etag
   var lastModified
 
+  timeout = Math.max(timeout, process.uptime())
   timeout = Math.min(timeout, npm.config.get('cache-max') || 0)
   timeout = Math.max(timeout, npm.config.get('cache-min') || -Infinity)
   if (process.env.COMP_CWORD !== undefined &&
@@ -115,10 +116,12 @@ function get_ (uri, cachePath, params, cb) {
     if (stat && timeout && timeout > 0) {
       if ((Date.now() - stat.mtime.getTime()) / 1000 < timeout) {
         log.verbose('get', uri, 'not expired, no request')
+        log.silly('get', 'cache hit with timeout', timeout)
         delete data._etag
         delete data._lastModified
         return cb(null, data, JSON.stringify(data), { statusCode: 304 })
       }
+      log.silly('get', 'cache miss with timeout', timeout)
 
       if (staleOk) {
         log.verbose('get', uri, 'staleOk, background update')

--- a/test/tap/cache-process-uptime.js
+++ b/test/tap/cache-process-uptime.js
@@ -1,0 +1,67 @@
+var npm = require.resolve('../../')
+var test = require('tap').test
+var path = require('path')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var common = require('../common-tap.js')
+var cache = path.resolve(__dirname, 'cache-process-uptime')
+var execFile = require('child_process').execFile
+var pkg = path.resolve(__dirname, '..', 'packages', 'npm-test-test-package')
+var nm = path.resolve(pkg, 'node_modules')
+var server
+
+test('mock reg', function (t) {
+  rimraf.sync(cache)
+  mkdirp.sync(cache)
+  mr({ port: common.port }, function (er, s) {
+    server = s
+    t.pass('ok')
+    t.end()
+  })
+})
+
+test('npm install with cache-min shorter than install', function (t) {
+  rimraf.sync(nm)
+  execFile(process.execPath, [
+    npm,
+    '--cache=' + cache,
+    '--registry=' + common.registry,
+    '--loglevel=silly',
+    // has to be > 0 or caching is disabled, but less than uptime, and since
+    // node startup time is 10s of ms and this is 0.1ms, it should always be
+    // less than process.uptime()
+    '--cache-min=0.00001',
+    '--cache-max=Infinity',
+    'install', 'underscore@1.5.1'
+  ], {cwd: pkg}, function (err, stdout, stderr) {
+    t.ifErr(err, 'Should not error')
+    t.match(stderr, /^npm sill get cache (hit|miss) with timeout \d/m)
+    t.notMatch(stderr, /^npm sill get cache (hit|miss) with timeout 0\.00001$/m)
+    t.end()
+  })
+})
+
+test('npm install with cache-min longer than install', function (t) {
+  rimraf.sync(nm)
+  execFile(process.execPath, [
+    npm,
+    '--cache=' + cache,
+    '--registry=' + common.registry,
+    '--loglevel=silly',
+    '--cache-min=60',
+    '--cache-max=Infinity',
+    'install', 'underscore@1.5.1'
+  ], {cwd: pkg}, function (err, stdout, stderr) {
+    t.ifErr(err, 'Should not error')
+    t.match(stderr, /^npm sill get cache (hit|miss) with timeout 60$/m)
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  server.close()
+  rimraf.sync(nm)
+  rimraf.sync(cache)
+  t.end()
+})


### PR DESCRIPTION
The default cache-min time is 10 seconds, which is shorter than the
average install time. This means that if a package has multiple
dependencies that depend on the same package there is a good chance that
a default install will result in the sub-dependencies being fetched
multiple times instead of using the copy that was put in to the cache
earlier _in the same install_.

Extend the cache-min to be at least the current age of the node process
so that objects fetched more than cache-min seconds ago are not
considered stale unless they are also older than the process.

This should save a few seconds off any moderately complex package
installation.
