### PR TITLE
Update default value documentation for color variable

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -240,7 +240,7 @@ A client certificate to pass when accessing the registry.
 
 ### color
 
-* Default: true on Posix, false on Windows
+* Default: true
 * Type: Boolean or `"always"`
 
 If false, never shows colors.  If `"always"` then always shows colors.


### PR DESCRIPTION
The docs state that the default value of `color` is `false` on Windows. After executing the following command on 3 different Windows machines, I've found that the default value is actually `true`:

``` bat
npm config ls -l
```
