### PR TITLE
Consistently try git+https before git+ssh

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -61,7 +61,7 @@ function addRemoteGit (uri, _cb) {
       return tryClone(from, parsed.toString(), false, cb)
     }
 
-    // try git:, then git+ssh:, then git+https: before failing
+    // try git:, then git+https:, then git+ssh: before failing
     tryGitProto(from, parsed, cb)
   } else {
     // verify that this is a Git URL before continuing
@@ -88,9 +88,7 @@ function tryGitProto (from, hostedInfo, cb) {
 
 function tryHTTPS (from, hostedInfo, cb) {
   var httpsURL = hostedInfo.https()
-  if (!httpsURL) {
-    return cb(new Error(from + ' can not be cloned via Git, SSH, or HTTPS'))
-  }
+  if (!httpsURL) return trySSH(from, hostedInfo, cb)
 
   log.silly('tryHTTPS', 'attempting to clone', httpsURL)
   tryClone(from, httpsURL, true, function (er) {
@@ -102,7 +100,9 @@ function tryHTTPS (from, hostedInfo, cb) {
 
 function trySSH (from, hostedInfo, cb) {
   var sshURL = hostedInfo.ssh()
-  if (!sshURL) return tryHTTPS(from, hostedInfo, cb)
+  if (!sshURL) {
+    return cb(new Error(from + ' can not be cloned via Git, HTTPS, or SSH'))
+  }
 
   log.silly('trySSH', 'attempting to clone', sshURL)
   tryClone(from, sshURL, false, cb)


### PR DESCRIPTION
This change concludes what 394c2f5a1227232c0baf42fbba1402aafe0d6ffb started (and bd6919729f9535f4e3698e78eeb2331236dcdeea slightly improved): for hosted git services, try git first, then https, then ssh. Without this fix, the situation is somewhat messy if not all urls are supported. If there is no https url, ssh won't even be attempted. Conversely, if https fails and there is no ssh url, we'd end up in an infinite loop trying https over and over again.
