### PR TITLE
Save rawSpec for modules from git

### DIFF
--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -180,6 +180,8 @@ function computeVersionSpec (child) {
         pathname: relativePath
       })
     }
+  } else if (requested.type === 'git') {
+    return requested.rawSpec
   } else {
     return requested.spec
   }

--- a/test/tap/add-remote-git-file.js
+++ b/test/tap/add-remote-git-file.js
@@ -45,6 +45,29 @@ test('cache from repo', function (t) {
   })
 })
 
+test('save install', function (t) {
+  process.chdir(pkg)
+  fs.writeFileSync('package.json', JSON.stringify({
+    name: 'parent',
+    version: '5.4.3'
+  }, null, 2) + '\n')
+  var prev = npm.config.get('save')
+  npm.config.set('save', true)
+  npm.commands.install('.', [cloneURL], function (er) {
+    npm.config.set('save', prev)
+    t.ifError(er, 'npm installed via git')
+    var pj = JSON.parse(fs.readFileSync('package.json', 'utf-8'))
+    var dep = pj.dependencies.child
+    t.equal(
+      url.parse(dep).protocol,
+      'git+file:',
+      'npm didn\'t strip the git+ from git+file://'
+    )
+
+    t.end()
+  })
+})
+
 test('clean', function (t) {
   cleanup()
   t.end()


### PR DESCRIPTION
Since npm-package-arg strips a preceding `git+` from urls, and the stripped urls will cause trouble when loading the package the next time, we have to make sure that in this case at least we save the `rawSpec` not the `spec`.

I don't know enough about the difference between these two to judge whether we should _always_ be returning `rawSpec`. If I made the right choice, feel free to merge. If you think it should always be `rawSpec`, I can modify my PR.

Fixes #9679 and its many duplicates, namely #9732 #9873 #10284 #10594 (and perhaps some other unidentified ones as well).
