### PR TITLE
Run install in git checkouts before adding them

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -346,6 +346,20 @@ function checkoutTreeish (from, resolvedURL, resolvedTreeish, tmpdir, cb) {
       }
       log.verbose('checkoutTreeish', from, 'checkout', stdout)
 
+      installAndPack(from, resolvedURL, tmpdir, cb)
+    }
+  )
+}
+
+// do the equivalent of "npm install && npm pack" for the package
+// https://github.com/npm/npm/issues/3055
+function installAndPack (from, resolvedURL, tmpdir, cb) {
+  log.info('addRemoteGit', 'running install in', tmpdir)
+  npm.commands.install(
+    tmpdir, [],
+    function (er) {
+      if (er) return cb(er)
+
       // convince addLocal that the checkout is a local dependency
       realizePackageSpecifier(tmpdir, function (er, spec) {
         if (er) {


### PR DESCRIPTION
With this change, adding a module from a git location is essentially the same as
- cloning and checking out the module into a temporary directory
- running `npm install` in there (so all devDependencies are there, and the prepublish script gets run)
- running `npm pack` and adding the resulting tarball to your project

First suggested by me in https://github.com/npm/npm/issues/3055#issuecomment-139665209, this idea saw a lot of positive feedback. The main benefits are:
- The repository is treated as a _source repository_, which means you'll have to assume that all dev dependencies and all prepublish scripts might be needed.  For every point and purpose, building from that temporary directory is just like what you'd do prior to publishing, which should work if the package is sufficiently portable.
- The permanently installed part is like a _published package_, though, with everything those have, but without anything `.npmignore` got rid of, and without unneccessary dev dependencies.  For every point and purpose, the installed package behaves just like what you'd get from the registry if it were installed there.

Fortunately, the “clone to temporary directory” part was already there. Furthermore, `npm pack` already involves creating a complete cache entry, and there is no need to copy the resulting tarball anywhere else the way pack does.  So we actually do less than `npm pack` would.  The main new addition is the call to `npm install` which was missing before.

This fixes #3055.
