### PR TITLE
add npm registry autocompletion

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -28,6 +28,7 @@ install.usage = '\nnpm install (with no args, in package dir)' +
                 '\n\nalias: npm i' +
                 '\ncommon options: [--save|--save-dev|--save-optional] [--save-exact]'
 
+var lastCompletionRequest
 install.completion = function (opts, cb) {
   validate('OF', arguments)
   // install can complete to a folder with a package.json, or any package.
@@ -82,9 +83,22 @@ install.completion = function (opts, cb) {
     })
   }
 
-  // FIXME: there used to be registry completion here, but it stopped making
-  // sense somewhere around 50,000 packages on the registry
-  cb()
+  var requestCallback = function (error, response, body) {
+    if (!error && response.statusCode === 200) {
+      try {
+        var suggestions = JSON.parse(body).sections.packages.map(function (item) {
+          return item.value
+        })
+      } catch (e) {
+        cb()
+      }
+      cb(null, suggestions)
+    } else {
+      cb()
+    }
+  }
+  if (lastCompletionRequest) lastCompletionRequest.abort()
+  lastCompletionRequest = request('https://ac.cnstrc.com/autocomplete/' + opts.word + '?autocomplete_key=2BhWUxtsm80gVBQ1jtTW', requestCallback)
 }
 
 // system packages
@@ -93,6 +107,7 @@ var path = require('path')
 
 // dependencies
 var log = require('npmlog')
+var request = require('request')
 var readPackageTree = require('read-package-tree')
 var chain = require('slide').chain
 var asyncMap = require('slide').asyncMap


### PR DESCRIPTION
This uses https://constructor.io/ which is what https://www.npmjs.com/ uses for their autocomplete in their dropdown. This is mindful to abort any pending requests to the api if another autocomplete request happens, and can degrade nicely.
