### PR TITLE
test: fix race condition in git tests

### DIFF
--- a/test/tap/add-remote-git-fake-windows.js
+++ b/test/tap/add-remote-git-fake-windows.js
@@ -20,7 +20,7 @@ var pjParent = JSON.stringify({
   name: 'parent',
   version: '1.2.3',
   dependencies: {
-    child: 'git://localhost:1233/child.git'
+    child: 'git://localhost:1234/child.git'
   }
 }, null, 2) + '\n'
 
@@ -92,7 +92,8 @@ function setup (cb) {
           '--listen=localhost',
           '--export-all',
           '--base-path=.',
-          '--port=1233'
+          '--reuseaddr',
+          '--port=1234'
         ],
         {
           cwd: pkg,

--- a/test/tap/add-remote-git-shrinkwrap.js
+++ b/test/tap/add-remote-git-shrinkwrap.js
@@ -20,7 +20,7 @@ var pjParent = JSON.stringify({
   name: 'parent',
   version: '1.2.3',
   dependencies: {
-    'child': 'git://localhost:1235/child.git#master'
+    'child': 'git://localhost:1234/child.git#master'
   }
 }, null, 2) + '\n'
 
@@ -68,7 +68,7 @@ test('shrinkwrap gets correct _from and _resolved (#7121)', function (t) {
       var shrinkwrap = require(resolve(pkg, 'npm-shrinkwrap.json'))
       t.equal(
         shrinkwrap.dependencies.child.from,
-        'git://localhost:1235/child.git#master',
+        'git://localhost:1234/child.git#master',
         'npm shrinkwrapped from correctly'
       )
 
@@ -82,7 +82,7 @@ test('shrinkwrap gets correct _from and _resolved (#7121)', function (t) {
 
           t.equal(
             shrinkwrap.dependencies.child.resolved,
-            'git://localhost:1235/child.git#' + treeish,
+            'git://localhost:1234/child.git#' + treeish,
             'npm shrinkwrapped resolved correctly'
           )
 
@@ -121,7 +121,8 @@ function setup (cb) {
           '--listen=localhost',
           '--export-all',
           '--base-path=.',
-          '--port=1235'
+          '--reuseaddr',
+          '--port=1234'
         ],
         {
           cwd: pkg,

--- a/test/tap/add-remote-git.js
+++ b/test/tap/add-remote-git.js
@@ -80,6 +80,7 @@ function setup (cb) {
           '--listen=localhost',
           '--export-all',
           '--base-path=.',
+          '--reuseaddr',
           '--port=1234'
         ],
         {

--- a/test/tap/git-dependency-install-link.js
+++ b/test/tap/git-dependency-install-link.js
@@ -30,7 +30,7 @@ var pjParent = JSON.stringify({
   name: 'parent',
   version: '1.2.3',
   dependencies: {
-    'child': 'git://localhost:1243/child.git'
+    'child': 'git://localhost:1234/child.git'
   }
 }, null, 2) + '\n'
 
@@ -134,7 +134,8 @@ function setup (cb) {
           '--listen=localhost',
           '--export-all',
           '--base-path=.',
-          '--port=1243'
+          '--reuseaddr',
+          '--port=1234'
         ],
         {
           cwd: pkg,

--- a/test/tap/git-dependency-install-link.js
+++ b/test/tap/git-dependency-install-link.js
@@ -30,7 +30,7 @@ var pjParent = JSON.stringify({
   name: 'parent',
   version: '1.2.3',
   dependencies: {
-    'child': 'git://localhost:1234/child.git'
+    'child': 'git://localhost:1243/child.git'
   }
 }, null, 2) + '\n'
 
@@ -134,7 +134,7 @@ function setup (cb) {
           '--listen=localhost',
           '--export-all',
           '--base-path=.',
-          '--port=1234'
+          '--port=1243'
         ],
         {
           cwd: pkg,


### PR DESCRIPTION
Every git-related test should use a different port for its spawned git server. While we can listen to a git server's process shutting down, there's no guarantee that the socket will have been returned to the OS by then, so the next server might still get an EADDRINUSE.
