### PR TITLE
install: fix race condition correcting cache directory ownership

### DIFF
--- a/lib/utils/correct-mkdir.js
+++ b/lib/utils/correct-mkdir.js
@@ -10,6 +10,13 @@ var stats = {}
 var effectiveOwner
 module.exports = function correctMkdir (path, cb) {
   cb = dezalgo(cb)
+  cb = inflight('correctMkdir:' + path, cb)
+  if (!cb) {
+    return log.verbose('correctMkdir', path, 'correctMkdir already in flight; waiting')
+  } else {
+    log.verbose('correctMkdir', path, 'correctMkdir not in flight; initializing')
+  }
+
   if (stats[path]) return cb(null, stats[path])
 
   fs.stat(path, function (er, st) {

--- a/test/tap/correct-mkdir.js
+++ b/test/tap/correct-mkdir.js
@@ -1,0 +1,58 @@
+var test = require('tap').test
+var assert = require('assert')
+var path = require('path')
+var requireInject = require('require-inject')
+var cache_dir = path.resolve(__dirname, 'correct-mkdir')
+
+test('correct-mkdir: no race conditions', function (t) {
+  var mock_fs = {}
+  var did_hook = false
+  mock_fs.stat = function (path, cb) {
+    if (path === cache_dir) {
+      // Return a non-matching owner
+      cb(null, {
+        uid: +process.uid + 1,
+        isDirectory: function () {
+          return true
+        }
+      })
+      if (!did_hook) {
+        did_hook = true
+        doHook()
+      }
+    } else {
+      assert.ok(false, 'Unhandled stat path: ' + path)
+    }
+  }
+  var chown_in_progress = 0
+  var mock_chownr = function (path, uid, gid, cb) {
+    ++chown_in_progress
+    process.nextTick(function () {
+      --chown_in_progress
+      cb(null)
+    })
+  }
+  var mocks = {
+    'graceful-fs': mock_fs,
+    'chownr': mock_chownr
+  }
+  var correctMkdir = requireInject('../../lib/utils/correct-mkdir.js', mocks)
+
+  var calls_in_progress = 3
+  function handleCallFinish () {
+    t.equal(chown_in_progress, 0, 'should not return while chown still in progress')
+    if (!--calls_in_progress) {
+      t.end()
+    }
+  }
+  function doHook () {
+    // This is fired during the first correctMkdir call, after the stat has finished
+    // but before the chownr has finished
+    // Buggy old code will fail and return a cached value before initial call is done
+    correctMkdir(cache_dir, handleCallFinish)
+  }
+  // Initial call
+  correctMkdir(cache_dir, handleCallFinish)
+  // Immediate call again in case of race condition there
+  correctMkdir(cache_dir, handleCallFinish)
+})


### PR DESCRIPTION
Previously, correctMkdir() would cache the results early within its operation (after the stat, before calling chownr) meaning that any second call would immediately return the cached results, before the earlier chownr finishes.
This causes a race condition where the initial chownr would fail with ENOENT (or similar errors) trying to scan files that were being actively created/deleted/etc by the install process.
The fix guards the whole correctMkdir function with inflight() so that multiple calls do not do chownr simultaneously nor return early.  It would also be reasonable to not cache the results until after the chownr has finished, however that would still lead to an even more subtle race condition, so the guard on the whole call is required.

This code only fires if the npm cache directory is not owned by the current user, so probably doesn't reproduce very often, though in one of my environments it was reproducing frequently.

I was able to get a relatively consistent failure with a large cache directory, using the Yahoo-wrapped NPM.  In vanilla NPM, I was unable to consistently reproduce this, so in that case it's possible some serial process makes a single call to correctMkdir before continuing with anything that might happen in parallel that might hit this race condition.  Regardless, I made a unit test which reproduces this on the old code and is resolved by the new code.

@bengl 
