### PR TITLE
windows: fix custom node-gyp env var quoting

### DIFF
--- a/bin/node-gyp-bin/node-gyp.cmd
+++ b/bin/node-gyp-bin/node-gyp.cmd
@@ -1,5 +1,5 @@
 if not defined npm_config_node_gyp (
   node "%~dp0\..\..\node_modules\node-gyp\bin\node-gyp.js" %*
 ) else (
-  node %npm_config_node_gyp% %*
+  node "%npm_config_node_gyp%" %*
 )


### PR DESCRIPTION
npm sets node_config_node_gyp without quotes, so its usage should be
quoted. Indeed, it is a better practice to define environment variables
that contain paths without quotes and quote their usage.
