### PR TITLE
Fix uninstall leaving nested modules directories with .bin

### DIFF
--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -80,11 +80,12 @@ function rmBins (pkg, folder, parent, top, cb) {
     } else {
       gentlyRm(path.resolve(binRoot, b), true, folder, cb)
     }
-  }, function (err) {
-    if (err) return cb(err)
-    if (!top) return gentlyRm(binRoot, true, parent, cb)
-    return cb()
-  })
+  }, gentlyRmBinRoot)
+
+  function gentlyRmBinRoot (err) {
+    if (err || top) return cb(err)
+    return gentlyRm(binRoot, true, parent, cb)
+  }
 }
 
 function rmMans (pkg, folder, parent, top, cb) {

--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -80,7 +80,11 @@ function rmBins (pkg, folder, parent, top, cb) {
     } else {
       gentlyRm(path.resolve(binRoot, b), true, folder, cb)
     }
-  }, cb)
+  }, function (err) {
+    if (err) return cb(err)
+    if (!top) return gentlyRm(binRoot, true, parent, cb)
+    return cb()
+  })
 }
 
 function rmMans (pkg, folder, parent, top, cb) {

--- a/test/tap/uninstall-link-clean.js
+++ b/test/tap/uninstall-link-clean.js
@@ -1,0 +1,117 @@
+var fs = require('graceful-fs')
+var path = require('path')
+var existsSync = fs.existsSync || path.existsSync
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+
+var pkg = path.join(__dirname, 'uninstall-link-clean')
+var dep = path.join(__dirname, 'dep')
+var work = path.join(__dirname, 'uninstall-link-clean-TEST')
+var modules = path.join(work, 'node_modules')
+
+var EXEC_OPTS = { cwd: work }
+
+var world = 'console.log("hello blrbld")\n'
+
+var json = {
+  name: 'package',
+  version: '0.0.0',
+  bin: {
+    hello: './world.js'
+  },
+  dependencies: {
+    'dep': 'file:../dep'
+  }
+}
+
+var pjDep = {
+  name: 'dep',
+  version: '0.0.0',
+  bin: {
+    hello: './world.js'
+  }
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  fs.writeFileSync(path.join(pkg, 'world.js'), world)
+
+  mkdirp.sync(dep)
+  fs.writeFileSync(
+    path.join(dep, 'package.json'),
+    JSON.stringify(pjDep, null, 2)
+  )
+  fs.writeFileSync(path.join(dep, 'world.js'), world)
+
+  mkdirp.sync(modules)
+  process.chdir(work)
+
+  t.end()
+})
+
+test('installing package with links', function (t) {
+  common.npm(
+    [
+      '--loglevel', 'silent',
+      'install', pkg
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'install ran to completion without error')
+      t.notOk(code, 'npm install exited with code 0')
+
+      t.ok(
+        existsSync(path.join(modules, 'package', 'package.json')),
+        'package installed'
+      )
+      t.ok(existsSync(path.join(modules, '.bin')), 'binary link directory exists')
+      t.ok(existsSync(path.join(modules, 'package', 'node_modules', '.bin')),
+        'nested binary link directory exists')
+
+      t.end()
+    }
+  )
+})
+
+test('uninstalling package with links', function (t) {
+  common.npm(
+    [
+      '--loglevel', 'silent',
+      'uninstall', 'package'
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'uninstall ran to completion without error')
+      t.notOk(code, 'npm uninstall exited with code 0')
+
+      t.notOk(existsSync(path.join(modules, 'package')),
+        'package directory no longer exists')
+      t.notOk(existsSync(path.join(modules, 'package', 'node_modules', '.bin')),
+        'nested binary link directory no longer exists')
+
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(dep)
+  rimraf.sync(work)
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
Fixes #10887 #10938

I haven't added a test for the main modules' `node_module/.bin`, this removes `node_module/*/node_modules/.bin` so that empty modules can be removed.
