### PR TITLE
doc: briefly explain what's included in `npm publish`

### DIFF
--- a/doc/cli/npm-publish.md
+++ b/doc/cli/npm-publish.md
@@ -11,9 +11,12 @@ npm-publish(1) -- Publish a package
 
 ## DESCRIPTION
 
-Publishes a package to the registry so that it can be installed by name. See
-`npm-developers(7)` for details on what's included in the published package, as
-well as details on how the package is built.
+Publishes a package to the registry so that it can be installed by name. All
+files in the package directory are included if no local `.gitignore` or
+`.npmignore` file exists. If both files exist and a file is ignored by
+`.gitignore` but not by `.npmignore` then it will be included.  See
+`npm-developers(7)` for full details on what's included in the published
+package, as well as details on how the package is built.
 
 By default npm will publish to the public registry. This can be overridden by
 specifying a different default registry or using a `npm-scope(7)` in the name


### PR DESCRIPTION
In [this Twitter thread](https://twitter.com/beaugunderson/status/688544393918156801) I walk through how after publishing versions from many modules (38) I managed to not know that `npm publish` includes all files that are not explicitly ignored by a local `.gitignore` or `.npmignore` (or disallowed by `.gitignore` but allowed by `.npmignore`), and found that I'd managed to include security credentials (since revoked) in published versions of one of my modules, and junk files in many others. I think it would be great to briefly note what's included in the `npm publish` documentation itself (my suggested description of the behavior may be too simplistic, but I wanted to have a starting point).
