### PR TITLE
Make "JSON" snippets valid JSON

### DIFF
--- a/doc/cli/npm-update.md
+++ b/doc/cli/npm-update.md
@@ -44,16 +44,17 @@ on dependencies, `dep1` (`dep2`, .. etc.).  The published versions of `dep1` are
 
 ```
 {
-  dist-tags: { latest: "1.2.2" },
-  versions: { "1.2.2",
-              "1.2.1",
-              "1.2.0",
-              "1.1.2",
-              "1.1.1",
-              "1.0.0",
-              "0.4.1",
-              "0.4.0",
-              "0.2.0"
+  "dist-tags": { "latest": "1.2.2" },
+  "versions": {
+    "1.2.2",
+    "1.2.1",
+    "1.2.0",
+    "1.1.2",
+    "1.1.1",
+    "1.0.0",
+    "0.4.1",
+    "0.4.0",
+    "0.2.0"
   }
 }
 ```
@@ -63,8 +64,8 @@ on dependencies, `dep1` (`dep2`, .. etc.).  The published versions of `dep1` are
 If `app`'s `package.json` contains:
 
 ```
-dependencies: {
-  dep1: "^1.1.1"
+"dependencies": {
+  "dep1": "^1.1.1"
 }
 ```
 
@@ -76,8 +77,8 @@ Then `npm update` will install `dep1@1.2.2`, because `1.2.2` is `latest` and
 However, if `app`'s `package.json` contains:
 
 ```
-dependencies: {
-  dep1: "~1.1.1"
+"dependencies": {
+  "dep1": "~1.1.1"
 }
 ```
 
@@ -91,8 +92,8 @@ which is `1.1.2`.
 Suppose `app` has a caret dependency on a version below `1.0.0`, for example:
 
 ```
-dependencies: {
-  dep1: "^0.2.0"
+"dependencies": {
+  "dep1": "^0.2.0"
 }
 ```
 
@@ -102,8 +103,8 @@ versions which satisfy `^0.2.0`.
 If the dependence were on `^0.4.0`:
 
 ```
-dependencies: {
-  dep1: "^0.4.0"
+"dependencies": {
+  "dep1": "^0.4.0"
 }
 ```
 
@@ -118,8 +119,8 @@ the minimum required dependency in `package.json`, you can use
 `package.json` contains:
 
 ```
-dependencies: {
-  dep1: "^1.1.1"
+"dependencies": {
+  "dep1": "^1.1.1"
 }
 ```
 
@@ -127,8 +128,8 @@ Then `npm update --save` will install `dep1@1.2.2` (i.e., `latest`),
 and `package.json` will be modified:
 
 ```
-dependencies: {
-  dep1: "^1.2.2"
+"dependencies": {
+  "dep1": "^1.2.2"
 }
 ```
 


### PR DESCRIPTION
Documentation for `package.json` [states](https://docs.npmjs.com/files/package.json) that it "must be actual JSON, not just a JavaScript object literal".
