### PR TITLE
A collection of patches necessary for prerelease versions of node to pass the test suite

### DIFF
--- a/lib/utils/gently-rm.js
+++ b/lib/utils/gently-rm.js
@@ -165,18 +165,60 @@ function clobberFail (target, msg) {
   return er
 }
 
+function isENOENT (err) {
+  return err && err.code === 'ENOENT'
+}
+
+function notENOENT (err) {
+  return !isENOENT(err)
+}
+
+function skipENOENT (cb) {
+  return function (err, value) {
+    if (isENOENT(err)) {
+      return cb(null, false)
+    } else {
+      return cb(err, value)
+    }
+  }
+}
+
+function errorsToValues (fn) {
+  return function () {
+    var args = Array.prototype.slice.call(arguments)
+    var cb = args.pop()
+    args.push(function (err, value) {
+      if (err) {
+        return cb(null, err)
+      } else {
+        return cb(null, value)
+      }
+    })
+    fn.apply(null, args)
+  }
+}
+
+function isNotError (value) {
+  return !(value instanceof Error)
+}
+
 exports._isEverInside = isEverInside
 // return the first of path, where target (or anything it symlinks to)
 // isInside the path (or anything it symlinks to)
 function isEverInside (target, paths, cb) {
   validate('SAF', arguments)
-  function skipENOENT (er) {
-    if (er.code === 'ENOENT') return cb(null, false)
-    return cb(er)
-  }
-  asyncMap(paths, readAllLinks, iferr(skipENOENT, function (resolvedPaths) {
-    readAllLinks(target, iferr(skipENOENT, function (targets) {
-      cb(null, areAnyInsideAny(targets, resolvedPaths))
+  asyncMap(paths, errorsToValues(readAllLinks), iferr(cb, function (resolvedPaths) {
+    var errorFree = resolvedPaths.filter(isNotError)
+    if (errorFree.length === 0) {
+      var badErrors = resolvedPaths.filter(notENOENT)
+      if (badErrors.length === 0) {
+        return cb(null, false)
+      } else {
+        return cb(badErrors[0])
+      }
+    }
+    readAllLinks(target, iferr(skipENOENT(cb), function (targets) {
+      cb(null, areAnyInsideAny(targets, errorFree))
     }))
   }))
 }

--- a/test/tap/unit-gentlyrm.js
+++ b/test/tap/unit-gentlyrm.js
@@ -222,7 +222,7 @@ test('areAnyInsideAny', function (t) {
 })
 
 test('isEverInside', function (t) {
-  t.plan(13)
+  t.plan(15)
 
   var mocks = mockWith({
     '/path/other/link': { type: 'symlink', dest: '../to/file' },
@@ -234,6 +234,11 @@ test('isEverInside', function (t) {
 
   var gentlyRm = requireInject('../../lib/utils/gently-rm.js', mocks)
   var isEverInside = gentlyRm._isEverInside
+
+  isEverInside('/path/to/file', ['/path/to', '/path/to/invalid'], function (er, inside) {
+    t.ifError(er)
+    t.isDeeply(inside, {target: '/path/to/file', path: '/path/to'}, 'bad paths are ignored if something matches')
+  })
 
   isEverInside('/path/to/invalid', ['/path/to/invalid'], function (er, inside) {
     t.is(er && er.code, 'EINVAL', 'errors bubble out')


### PR DESCRIPTION
These are:
1. Using the new `npm-install-checks@3.0.0`, warn engine failures the way we warn everything else, after the install summary tree at the end.
2. For the purposes of package-level engine checks, ignore the fact that a node version is a prerelease.
3. Add a tree-level check for prerelease node versions and warn once.
4. Use the `node-version` config option to suppress node prerelease warnings while testing.
5. Make sure our environment (including that config option above) is passed through to all execs of npm.
6. And finally, but hardly least of all, fix a bug in gentlyrm that made it think that it didn't have rights to ANY files if ANY of the core npm controlled paths were missing.
