### PR TITLE
Do not call magic license values SPDX expressions

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -113,7 +113,7 @@ expression syntax version 2.0 string](https://npmjs.com/package/spdx), like this
     { "license" : "(ISC OR GPL-3.0)" }
 
 If you are using a license that hasn't been assigned an SPDX identifier, or if
-you are using a custom license, use the following valid SPDX expression:
+you are using a custom license, use a string value like this one:
 
     { "license" : "SEE LICENSE IN <filename>" }
 


### PR DESCRIPTION
This tiny PR corrects a false statement in the `license` section of the `package.json` doc page.

I must have missed this when we introduced the `SEE LICENSE IN <file>` magic value for `license`. The doc page says that such string values are valid SPDX expressions. They aren't. Rather, they're npm-specific magic values.
