### PR TITLE
docs: update included/excluded files

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -186,9 +186,12 @@ works just like a `.gitignore`.
 Certain files are always included, regardless of settings:
 
 * `package.json`
-* `README` (and its variants)
-* `CHANGELOG` (and its variants)
+* `README`
+* `CHANGES` / `CHANGELOG` / `HISTORY`
 * `LICENSE` / `LICENCE`
+* The file in the "main" field
+
+`README`, `CHANGES` & `LICENSE` can have any case and extension.
 
 Conversely, some files are always ignored:
 
@@ -198,10 +201,11 @@ Conversely, some files are always ignored:
 * `.hg`
 * `.lock-wscript`
 * `.wafpickle-N`
-* `*.swp`
+* `.*.swp`
 * `.DS_Store`
 * `._*`
 * `npm-debug.log`
+* `.npmrc`
 
 ## main
 


### PR DESCRIPTION
This updates #9002.

While looking through the code, I noticed that there is some duplication: [this](https://github.com/npm/npm/blob/8dd78bbe6003cd377bf51bf24a1c5f8fd656265d/lib/utils/tar.js#L64-L136) and [this](https://github.com/npm/fstream-npm/blob/d57b6b24f91156067f73417dd8785c6312bfc75f/fstream-npm.js#L91-L183) is basically the same with slight differences. Shouldn't something be done about that?
