### PR TITLE
Change hosted git order to https then ssh then git 

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -164,14 +164,24 @@ after packing it up into a tarball (b).
 
 * `npm install <git remote url>`:
 
-    Installs the package from the hosted git provider, cloning it with
-    `git`. First it tries via the https (git with github) and if that fails, via ssh.
+    Installs the package from the given git repository, cloning it with
+    `git`. The format of the `<git remote url>` is
 
           <protocol>://[<user>[:<password>]@]<hostname>[:<port>][:][/]<path>[#<commit-ish>]
 
     `<protocol>` is one of `git`, `git+ssh`, `git+http`, or
     `git+https`.  If no `<commit-ish>` is specified, then `master` is
     used.
+
+    If the url describes a git hosting provider known to support
+    multiple protocols, then the protocol actually specified is ignored,
+    and the protocols are tried in the order
+    `git+https` then `git+ssh` then `git`,
+    skipping protocols not supported by the provider
+    and trying the next supported protocol if one of them fails.
+    If this order causes problems, the `url.<base>.insteadOf` configuration
+    of `git` can be used; see the `git-config` man page.
+    Currently known providers include Github, Bitbucket and Gitlab.
 
     The following git environment variables are recognized by npm and will be added
     to the environment when running git:
@@ -183,7 +193,7 @@ after packing it up into a tarball (b).
     * `GIT_SSL_CAINFO`
     * `GIT_SSL_NO_VERIFY`
 
-    See the git man page for details.
+    See the `git` man page for details.
 
     Examples:
 

--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -61,8 +61,19 @@ function addRemoteGit (uri, _cb) {
       return tryClone(from, parsed.toString(), false, cb)
     }
 
-    // try git:, then git+ssh:, then git+https: before failing
-    tryGitProto(from, parsed, cb)
+    // try git:, then git+https:, then git+ssh: before failing
+    var protocols = ['https', 'ssh', 'git']
+    var services = []
+    protocols.forEach(function (protocol) {
+      var url = parsed[protocol]()
+      if (url) {
+        services.push({
+          url: url,
+          protocol: protocol
+        })
+      }
+    })
+    tryProtos(from, services, null, cb)
   } else {
     // verify that this is a Git URL before continuing
     parsed = npa(uri)
@@ -74,38 +85,18 @@ function addRemoteGit (uri, _cb) {
   }
 }
 
-function tryGitProto (from, hostedInfo, cb) {
-  var gitURL = hostedInfo.git()
-  if (!gitURL) return tryHTTPS(from, hostedInfo, cb)
-
-  log.silly('tryGitProto', 'attempting to clone', gitURL)
-  tryClone(from, gitURL, true, function (er) {
-    if (er) return tryHTTPS(from, hostedInfo, cb)
-
-    cb.apply(this, arguments)
-  })
-}
-
-function tryHTTPS (from, hostedInfo, cb) {
-  var httpsURL = hostedInfo.https()
-  if (!httpsURL) {
-    return cb(new Error(from + ' can not be cloned via Git, SSH, or HTTPS'))
+function tryProtos (from, services, previousError, cb) {
+  if (services.length === 0) {
+    return cb(previousError ||
+              new Error(from + ' can not be cloned via HTTPS, SSH or Git'))
   }
-
-  log.silly('tryHTTPS', 'attempting to clone', httpsURL)
-  tryClone(from, httpsURL, true, function (er) {
-    if (er) return trySSH(from, hostedInfo, cb)
-
+  var service = services.shift()
+  var silent = (service.protocol !== 'ssh')
+  log.silly('tryProtos', 'attempting to clone', service.url)
+  tryClone(from, service.url, silent, function (er) {
+    if (er) return tryProtos(from, services, er, cb)
     cb.apply(this, arguments)
   })
-}
-
-function trySSH (from, hostedInfo, cb) {
-  var sshURL = hostedInfo.ssh()
-  if (!sshURL) return tryHTTPS(from, hostedInfo, cb)
-
-  log.silly('trySSH', 'attempting to clone', sshURL)
-  tryClone(from, sshURL, false, cb)
 }
 
 function tryClone (from, combinedURL, silent, cb) {

--- a/test/tap/gist-short-shortcut-package.js
+++ b/test/tap/gist-short-shortcut-package.js
@@ -27,9 +27,9 @@ test('setup', function (t) {
 
 test('gist-short-shortcut-package', function (t) {
   var cloneUrls = [
-    ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs first'],
-    ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs second'],
-    ['git@gist.github.com:/deadbeef.git', 'GitHub gist shortcuts try SSH third']
+    ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs first'],
+    ['git@gist.github.com:/deadbeef.git', 'GitHub gist shortcuts try SSH second'],
+    ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs third']
   ]
   var npm = requireInject.installGlobally('../../lib/npm.js', {
     'child_process': {

--- a/test/tap/gist-short-shortcut.js
+++ b/test/tap/gist-short-shortcut.js
@@ -24,9 +24,9 @@ test('setup', function (t) {
 
 test('gist-shortcut', function (t) {
   var cloneUrls = [
-    ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs first'],
-    ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs second'],
-    ['git@gist.github.com:/deadbeef.git', 'GitHub gist shortcuts try SSH third']
+    ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs first'],
+    ['git@gist.github.com:/deadbeef.git', 'GitHub gist shortcuts try SSH second'],
+    ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs third']
   ]
   var npm = requireInject.installGlobally('../../lib/npm.js', {
     'child_process': {

--- a/test/tap/gist-shortcut-package.js
+++ b/test/tap/gist-shortcut-package.js
@@ -27,9 +27,9 @@ test('setup', function (t) {
 
 test('gist-shortcut-package', function (t) {
   var cloneUrls = [
-    ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs first'],
-    ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs second'],
-    ['git@gist.github.com:/deadbeef.git', 'GitHub gist shortcuts try SSH third']
+    ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs first'],
+    ['git@gist.github.com:/deadbeef.git', 'GitHub gist shortcuts try SSH second'],
+    ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs third']
   ]
   var npm = requireInject.installGlobally('../../lib/npm.js', {
     'child_process': {

--- a/test/tap/gist-shortcut.js
+++ b/test/tap/gist-shortcut.js
@@ -24,9 +24,9 @@ test('setup', function (t) {
 
 test('gist-shortcut', function (t) {
   var cloneUrls = [
-    ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs first'],
-    ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs second'],
-    ['git@gist.github.com:/deadbeef.git', 'GitHub gist shortcuts try SSH third']
+    ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs first'],
+    ['git@gist.github.com:/deadbeef.git', 'GitHub gist shortcuts try SSH second'],
+    ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs third']
   ]
   var npm = requireInject.installGlobally('../../lib/npm.js', {
     'child_process': {

--- a/test/tap/github-shortcut-package.js
+++ b/test/tap/github-shortcut-package.js
@@ -27,9 +27,9 @@ test('setup', function (t) {
 
 test('github-shortcut-package', function (t) {
   var cloneUrls = [
-    ['git://github.com/foo/private.git', 'GitHub shortcuts try git URLs first'],
-    ['https://github.com/foo/private.git', 'GitHub shortcuts try HTTPS URLs second'],
-    ['git@github.com:foo/private.git', 'GitHub shortcuts try SSH third']
+    ['https://github.com/foo/private.git', 'GitHub shortcuts try HTTPS URLs first'],
+    ['git@github.com:foo/private.git', 'GitHub shortcuts try SSH second'],
+    ['git://github.com/foo/private.git', 'GitHub shortcuts try git URLs third']
   ]
   var npm = requireInject.installGlobally('../../lib/npm.js', {
     'child_process': {

--- a/test/tap/github-shortcut.js
+++ b/test/tap/github-shortcut.js
@@ -24,9 +24,9 @@ test('setup', function (t) {
 
 test('github-shortcut', function (t) {
   var cloneUrls = [
-    ['git://github.com/foo/private.git', 'GitHub shortcuts try git URLs first'],
-    ['https://github.com/foo/private.git', 'GitHub shortcuts try HTTPS URLs second'],
-    ['git@github.com:foo/private.git', 'GitHub shortcuts try SSH third']
+    ['https://github.com/foo/private.git', 'GitHub shortcuts try HTTPS URLs first'],
+    ['git@github.com:foo/private.git', 'GitHub shortcuts try SSH second'],
+    ['git://github.com/foo/private.git', 'GitHub shortcuts try git URLs third']
   ]
   var npm = requireInject.installGlobally('../../lib/npm.js', {
     'child_process': {


### PR DESCRIPTION
This way, authenticated connections are preferred over unauthenticated ones.
The order is now easier to adjust, since it's just an array.

This supersedes #11087 and fixes #9470.

I'm not sure about the rationale behind the `silent` argument. It used to be `true` for git and https, but `false` for ssh. Is that because ssh is more likely to ask for a password (if `GIT_ASKPASS` is set appropriately), so you want to show the command to go with that? Or is that because ssh was the last protocol to try, so you wanted to show one clone command before giving up? In my commit here I'm assuming the former, but I'm not sure, and the commit message of 6b0f58877f37df9904490ffbaaad33862bd36dce didn't explain. It would be possible to change condition to `services.length !== 0`.
