### PR TITLE
npm: don't bail if require() onload-script throws

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -287,7 +287,12 @@
       loadCb(loadErr = er)
       onload = onload && npm.config.get('onload-script')
       if (onload) {
-        require(onload)
+        try {
+          require(onload)
+        } catch (err) {
+          log.warn('onload-script', 'failed to require onload script', onload)
+          log.warn('onload-script', err)
+        }
         onload = false
       }
     }

--- a/test/fixtures/onload.js
+++ b/test/fixtures/onload.js
@@ -1,0 +1,1 @@
+console.error('called onload')

--- a/test/tap/onload.js
+++ b/test/tap/onload.js
@@ -1,0 +1,39 @@
+var path = require('path')
+var test = require('tap').test
+var rimraf = require('rimraf')
+var common = require('../common-tap.js')
+var opts = { cwd: __dirname }
+var binDir = '../../node_modules/.bin'
+var fixture = path.resolve(__dirname, binDir)
+var onload = path.resolve(__dirname, '../fixtures/onload.js')
+
+test('setup', function (t) {
+  rimraf.sync(path.join(__dirname, 'node_modules'))
+  t.end()
+})
+
+test('npm bin with valid onload script', function (t) {
+  var args = ['--onload', onload, 'bin']
+  common.npm(args, opts, function (err, code, stdout, stderr) {
+    t.ifError(err, 'bin ran without issue')
+    t.equal(stderr.trim(), 'called onload')
+    t.equal(code, 0, 'exit ok')
+    t.equal(stdout, fixture + '\n')
+    t.end()
+  })
+})
+
+test('npm bin with invalid onload script', function (t) {
+  var onloadScript = onload + 'jsfd'
+  var args = ['--onload', onloadScript, '--loglevel=warn', 'bin']
+  common.npm(args, opts, function (err, code, stdout, stderr) {
+    t.ifError(err, 'bin ran without issue')
+    t.match(stderr, /npm WARN onload-script failed to require onload script/)
+    t.match(stderr, /MODULE_NOT_FOUND/)
+    t.notEqual(stderr.indexOf(onloadScript), -1)
+    t.equal(code, 0, 'exit ok')
+    var res = path.resolve(stdout)
+    t.equal(res, fixture + '\n')
+    t.end()
+  })
+})


### PR DESCRIPTION
instead, log the error using the warn log level and also log a notice
that the require failed.

Fixes: https://github.com/npm/npm/issues/10347
