### PR TITLE
lifecycle: remove early exit callback if we cannot write to working directory. Also fix log message

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -56,9 +56,8 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
           wd.indexOf(pkg.name) !== wd.length - pkg.name.length) &&
         !unsafe && pkg.scripts[stage]) {
       log.warn('lifecycle', logid(pkg, stage), 'cannot run in wd',
-        '%s %s (wd=%s)', pkg._id, pkg.scripts[stage], wd
+        pkg._id, pkg.scripts[stage], '(wd=' + wd + ')'
       )
-      return cb()
     }
 
     // set the env variables, then run scripts as a child process.


### PR DESCRIPTION
Currently if the working directory is not writable by the current user and you run `sudo npm install`. The warning message and callback referenced in this PR get invoked resulting in a `WARN` message but not a failure of the install (exit code 0), because npm reduces privileges while running.

This PR changes this behavior by continuing to try and run and possibly failing the install (exit code 1) if it cannot run to completion.

This PR also fixes the existing log message which currently prints `cannot run in wd %s %s (wd=%s)...` instead of performing the proper substitutions.
