### PR TITLE
doc: Further ways the `dependencies` list in package.json can be supplied.

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -430,6 +430,12 @@ For example, these are all valid:
       }
     }
 
+The `dependencies` list can also be specified in the following ways, but these are **not** recommended:
+
+* As a list, eg. `{ "dependencies": ["foo-bar@^6.0.0", "dyl-thr@2.1.5"] }`
+* As a single comma-separated string, eg. `{ "dependencies": "foo-bar@^6.0.0,dyl-thr@2.1.5" }`
+
+
 ### URLs as Dependencies
 
 You may specify a tarball URL in place of a version range.


### PR DESCRIPTION
Includes the as-an-array and as-a-string methods.

It'd be nice to write down some of the (discouraged, but possible) ways packages can be specified. I only recently become aware of these `dependencies` options when I stumbled across [this tweet](https://twitter.com/sebmck/status/691027859981365252); I'm working on something that reads parts of `package.json` files, and I was surprised to see this was possible.

(Happy to take feedback, or leave these out of the docs.)
