### PR TITLE
checks whether package is corrupt and throws better error with tests

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -2,6 +2,7 @@ exports = module.exports = lifecycle
 exports.cmd = cmd
 exports.makeEnv = makeEnv
 exports._incorrectWorkingDirectory = _incorrectWorkingDirectory
+exports._validPackage = _validPackage
 
 var log = require('npmlog')
 var spawn = require('./spawn')
@@ -43,14 +44,18 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
   }
 
   while (pkg && pkg._data) pkg = pkg._data
-  if (!pkg) return cb(new Error('Invalid package data'))
+  if (!_validPackage(pkg)) {
+    log.warn('lifecycle', logid(pkg, stage), 'package corrupt, should delete', wd)
+    var er = new Error('Invalid package data')
+    er.code = 'ELIFECYCLE'
+    return cb(er)
+  }
 
   log.info('lifecycle', logid(pkg, stage), pkg._id)
   if (!pkg.scripts || npm.config.get('ignore-scripts')) pkg.scripts = {}
 
   validWd(wd || path.resolve(npm.dir, pkg.name), function (er, wd) {
     if (er) return cb(er)
-
     unsafe = unsafe || npm.config.get('unsafe-perm')
 
     if ((wd.indexOf(npm.dir) !== 0 || _incorrectWorkingDirectory(wd, pkg)) &&
@@ -129,6 +134,11 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
     ],
     done
   )
+}
+
+function _validPackage (pkg) {
+  // sometimes pkg has no name field, caused dedupe to fail for empty mv package
+  return (pkg && typeof pkg.name !== 'undefined')
 }
 
 function validWd (d, cb) {

--- a/test/tap/lifecycle.js
+++ b/test/tap/lifecycle.js
@@ -42,3 +42,21 @@ test('lifecycle : rejects wd for ', function (t) {
     t.end()
   })
 })
+
+test('lifecycle : nameless pkg is invalid', function (t) {
+  npm.load({}, function () {
+    var pkg = {}
+
+    t.equal(lifecycle._validPackage(pkg), false)
+    t.end()
+  })
+})
+
+test('lifecycle : named pkg is ok', function (t) {
+  npm.load({}, function () {
+    var pkg = { name: 'such-good-name' }
+
+    t.equal(lifecycle._validPackage(pkg), true)
+    t.end()
+  })
+})


### PR DESCRIPTION
Unmessed up version of https://github.com/npm/npm/pull/11185 to fix cryptic error when deduping and a package name cannot be resolved due to corrupted node module.
