### PR TITLE
doc: Remove confusing ref of adduser

### DIFF
--- a/doc/cli/npm-logout.md
+++ b/doc/cli/npm-logout.md
@@ -31,14 +31,9 @@ it takes precedence.
 
 Default: none
 
-If specified, the user and login credentials given will be associated
-with the specified scope. See `npm-scope(7)`. You can use both at the same time,
-e.g.
+If specified, you will be logged out of the specified scope. See `npm-scope(7)`.
 
-    npm adduser --registry=http://myregistry.example.com --scope=@myco
-
-This will set a registry for the given scope and login or create a user for
-that registry at the same time.
+    npm logout --scope=@myco
 
 ## SEE ALSO
 


### PR DESCRIPTION
This addresses #10966. As noted in that issue, when scope is specified, it doesn't actually remove the scope config setting. I have that fixed and will submit a different PR for it.
