### PR TITLE
src: Handle errors from `andRecalculateMetadata`

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -75,6 +75,7 @@ function outdated (args, silent, cb) {
   if (npm.config.get('depth') === Infinity) npm.config.set('depth', 0)
 
   readPackageTree(dir, andRecalculateMetadata(function (er, tree) {
+    if (er) return cb(er)
     mutateIntoLogicalTree(tree)
     outdated_(args, '', tree, {}, 0, function (er, list) {
       list = uniq(list || []).sort(function (aa, bb) {


### PR DESCRIPTION
In `outdated.js` the errors from `andRecalculateMetadata`
were swallowed resulting in the cryptic errors seen in #9720.
This fixes this and handles the error so that the npm logs
the actual error.
