### PR TITLE
docs: remove google user group link

### DIFF
--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -128,10 +128,9 @@ Contributors are listed in npm's `package.json` file.  You can view them
 easily by doing `npm view npm contributors`.
 
 If you would like to contribute, but don't know what to work on, check
-the issues list or ask on the mailing list.
+the issues list.
 
 * <https://github.com/npm/npm/issues>
-* <npm-@googlegroups.com>
 
 ## BUGS
 
@@ -139,8 +138,6 @@ When you find issues, please report them:
 
 * web:
   <https://github.com/npm/npm/issues>
-* email:
-  <npm-@googlegroups.com>
 
 Be sure to include *all* of the output from the npm command that didn't work
 as expected.  The `npm-debug.log` file is also helpful to provide.

--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -127,9 +127,10 @@ Patches welcome!
 Contributors are listed in npm's `package.json` file.  You can view them
 easily by doing `npm view npm contributors`.
 
-If you would like to contribute, but don't know what to work on, check
-the issues list.
+If you would like to contribute, but don't know what to work on, read
+the contributing guidelines and check the issues list.
 
+* https://github.com/npm/npm/wiki/Contributing-Guidelines
 * <https://github.com/npm/npm/issues>
 
 ## BUGS


### PR DESCRIPTION
two updates:
- remove the old google usergroup
- add a link to read the contributing guidelines before do contributing
