### PR TITLE
Fix our tests on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 npm-debug.log
+.nyc_output/
 /test/bin
 /test/output.log
 /test/*/*/node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+environment:
+  matrix:
+    # LTS is our most important target
+    - nodejs_version: "4"
+    # latest
+    - nodejs_version: "5"
+    # I like 0.10 better than 0.12
+    - nodejs_version: "0.10"
+    - nodejs_version: "0.12"
+    # EOL summer 2016, most likely
+    - nodejs_version: "0.8"
+  COVERALLS_REPO_TOKEN:
+    secure: XdC0aySefK0HLh1GNk6aKrzZPbCfPQLyA4mYtFGEp4DrTuZA/iuCUS0LDqFYO8JQ
+platform:
+  - x86
+  - x64
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm config set spin false
+  - npm rebuild
+  - node . install -g .
+  - set "PATH=%APPDATA%\npm;C:\Program Files\Git\mingw64\libexec;%PATH%"
+  - npm install --loglevel=http
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+notifications:
+- provider: Slack
+  incoming_webhook:
+    secure: vXiG5AgpqxJsXZ0N0CTYDuVrX6RMjBybZKtOx6IbRxCyjgd+DAx6Z9/0XgYQjuof7QFJY3M/U6HxaREQVYbNVHA+C5N5dNALRbKzAC8QNbA=
+# GO_FAST
+matrix:
+  fast_finish: true
+# we don't need the builds, we just need tests
+build: off

--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 ;(function () { // wrapper in case we're in module_context mode
-
   // windows: running "npm blah" in this folder will invoke WSH, not node.
   /*global WScript*/
   if (typeof WScript !== 'undefined') {

--- a/lib/access.js
+++ b/lib/access.js
@@ -35,7 +35,6 @@ access.completion = function (opts, cb) {
       } else {
         return cb(null, [])
       }
-      break
     case 'public':
     case 'restricted':
     case 'ls-packages':

--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -443,7 +443,7 @@ function getResolved (uri, treeish) {
   // Checks for known protocols:
   // http:, https:, ssh:, and git:, with optional git+ prefix.
   if (!parsed.protocol ||
-      !parsed.protocol.match(/^(((git\+)?(https?|ssh))|git|file):$/)) {
+      !parsed.protocol.match(/^(((git\+)?(https?|ssh|file))|git|file):$/)) {
     uri = 'git+ssh://' + uri
   }
 

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -1,4 +1,3 @@
-
 module.exports = completion
 
 completion.usage = 'source <(npm completion)'
@@ -14,6 +13,7 @@ var configNames = Object.keys(configTypes)
 var shorthandNames = Object.keys(shorthands)
 var allConfs = configNames.concat(shorthandNames)
 var once = require('once')
+var isWindowsShell = require('./utils/is-windows-shell.js')
 
 completion.completion = function (opts, cb) {
   if (opts.w > 3) return cb()
@@ -45,7 +45,7 @@ completion.completion = function (opts, cb) {
 }
 
 function completion (args, cb) {
-  if (process.platform === 'win32' && !(/^MINGW(32|64)$/.test(process.env.MSYSTEM))) {
+  if (isWindowsShell) {
     var e = new Error('npm completion supported only in MINGW / Git bash on Windows')
     e.code = 'ENOTSUP'
     e.errno = require('constants').ENOTSUP

--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -10,6 +10,7 @@ var ini = require('ini')
 var Umask = configDefs.Umask
 var mkdirp = require('mkdirp')
 var umask = require('../utils/umask')
+var isWindows = require('../utils/is-windows.js')
 
 exports.load = load
 exports.Conf = Conf
@@ -391,7 +392,7 @@ function parseField (f, k) {
   f = envReplace(f)
 
   if (isPath) {
-    var homePattern = process.platform === 'win32' ? /^~(\/|\\)/ : /^~\//
+    var homePattern = isWindows ? /^~(\/|\\)/ : /^~\//
     if (f.match(homePattern) && process.env.HOME) {
       f = path.resolve(process.env.HOME, f.substr(2))
     }

--- a/lib/explore.js
+++ b/lib/explore.js
@@ -9,15 +9,30 @@ var npm = require('./npm.js')
 var spawn = require('./utils/spawn')
 var path = require('path')
 var fs = require('graceful-fs')
+var isWindowsShell = require('./utils/is-windows-shell.js')
+var escapeExecPath = require('./utils/escape-exec-path.js')
+var escapeArg = require('./utils/escape-arg.js')
 
 function explore (args, cb) {
   if (args.length < 1 || !args[0]) return cb(explore.usage)
   var p = args.shift()
-  args = args.join(' ').trim()
-  if (args) args = ['-c', args]
-  else args = []
 
   var cwd = path.resolve(npm.dir, p)
+  var opts = {cwd: cwd, stdio: 'inherit'}
+
+  var shellArgs = []
+  if (args) {
+    if (isWindowsShell) {
+      var execCmd = escapeExecPath(args.shift())
+      var execArgs = [execCmd].concat(args.map(escapeArg))
+      opts.windowsVerbatimArguments = true
+      shellArgs = ['/d', '/s', '/c'].concat(execArgs)
+    } else {
+      shellArgs.unshift('-c')
+      shellArgs = ['-c', args.map(escapeArg).join(' ').trim()]
+    }
+  }
+
   var sh = npm.config.get('shell')
   fs.stat(cwd, function (er, s) {
     if (er || !s.isDirectory()) {
@@ -26,17 +41,17 @@ function explore (args, cb) {
       ))
     }
 
-    if (!args.length) {
+    if (!shellArgs.length) {
       console.log(
         '\nExploring ' + cwd + '\n' +
           "Type 'exit' or ^D when finished\n"
       )
     }
 
-    var shell = spawn(sh, args, { cwd: cwd, stdio: 'inherit' })
+    var shell = spawn(sh, shellArgs, opts)
     shell.on('close', function (er) {
       // only fail if non-interactive.
-      if (!args.length) return cb()
+      if (!shellArgs.length) return cb()
       cb(er)
     })
   })

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -87,7 +87,7 @@
       npm.command = c
       if (commandCache[a]) return commandCache[a]
 
-      var cmd = require(__dirname + '/' + a + '.js')
+      var cmd = require(path.join(__dirname, a + '.js'))
 
       commandCache[a] = function () {
         var args = Array.prototype.slice.call(arguments, 0)

--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -59,7 +59,7 @@ function rmStuff (pkg, folder, cb) {
   // if it's global, and folder is in {prefix}/node_modules,
   // then bins are in {prefix}/bin
   // otherwise, then bins are in folder/../.bin
-  var parent = path.dirname(folder)
+  var parent = pkg.name[0] === '@' ? path.dirname(path.dirname(folder)) : path.dirname(folder)
   var gnm = npm.dir
   var top = gnm === parent
 

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -78,9 +78,11 @@ function exit (code, noLog) {
       }
     })
     rollbacks.length = 0
+  } else if (code && !noLog) {
+    writeLogFile(reallyExit)
+  } else {
+    rm('npm-debug.log', reallyExit)
   }
-  else if (code && !noLog) writeLogFile(reallyExit)
-  else rm('npm-debug.log', reallyExit)
 
   function reallyExit (er) {
     if (er && !code) code = typeof er.errno === 'number' ? er.errno : 1

--- a/lib/utils/escape-arg.js
+++ b/lib/utils/escape-arg.js
@@ -1,0 +1,27 @@
+'use strict'
+var path = require('path')
+var isWindowsShell = require('./is-windows-shell.js')
+
+/***
+Escape the name of an executable suitable for passing to the system shell.
+
+Windows is easy, wrap in double quotes and you're done, as there's no
+facility to create files with quotes in their names.
+
+Unix-likes are a little more complicated, wrap in single quotes and escape
+any single quotes in the filename.
+***/
+
+module.exports = escapify
+
+function escapify (str) {
+  if (isWindowsShell) {
+    return '"' + path.normalize(str) + '"'
+  } else {
+    if (/[^-_.~/\w]/.test(str)) {
+      return "'" + str.replace(/'/g, "'\"'\"'") + "'"
+    } else {
+      return str
+    }
+  }
+}

--- a/lib/utils/escape-arg.js
+++ b/lib/utils/escape-arg.js
@@ -2,7 +2,7 @@
 var path = require('path')
 var isWindowsShell = require('./is-windows-shell.js')
 
-/***
+/*
 Escape the name of an executable suitable for passing to the system shell.
 
 Windows is easy, wrap in double quotes and you're done, as there's no
@@ -10,7 +10,7 @@ facility to create files with quotes in their names.
 
 Unix-likes are a little more complicated, wrap in single quotes and escape
 any single quotes in the filename.
-***/
+*/
 
 module.exports = escapify
 

--- a/lib/utils/escape-exec-path.js
+++ b/lib/utils/escape-exec-path.js
@@ -1,0 +1,32 @@
+'use strict'
+var path = require('path')
+var isWindowsShell = require('./is-windows-shell.js')
+
+/***
+Escape the name of an executable suitable for passing to the system shell.
+
+Windows is easy, wrap in double quotes and you're done, as there's no
+facility to create files with quotes in their names.
+
+Unix-likes are a little more complicated, wrap in single quotes and escape
+any single quotes in the filename.
+***/
+
+module.exports = escapify
+
+function windowsQuotes (str) {
+  if (!/ /.test(str)) return str
+  return '"' + str + '"'
+}
+
+function escapify (str) {
+   if (isWindowsShell) {
+    return path.normalize(str).split(/\\/).map(windowsQuotes).join('\\')
+  } else {
+    if (/[^-_.~/\w]/.test(str)) {
+      return "'" + str.replace(/'/g, "'\"'\"'") + "'"
+    } else {
+      return str
+    }
+  }
+}

--- a/lib/utils/escape-exec-path.js
+++ b/lib/utils/escape-exec-path.js
@@ -2,7 +2,7 @@
 var path = require('path')
 var isWindowsShell = require('./is-windows-shell.js')
 
-/***
+/*
 Escape the name of an executable suitable for passing to the system shell.
 
 Windows is easy, wrap in double quotes and you're done, as there's no
@@ -10,7 +10,7 @@ facility to create files with quotes in their names.
 
 Unix-likes are a little more complicated, wrap in single quotes and escape
 any single quotes in the filename.
-***/
+*/
 
 module.exports = escapify
 
@@ -20,13 +20,11 @@ function windowsQuotes (str) {
 }
 
 function escapify (str) {
-   if (isWindowsShell) {
+  if (isWindowsShell) {
     return path.normalize(str).split(/\\/).map(windowsQuotes).join('\\')
+  } else if (/[^-_.~/\w]/.test(str)) {
+    return "'" + str.replace(/'/g, "'\"'\"'") + "'"
   } else {
-    if (/[^-_.~/\w]/.test(str)) {
-      return "'" + str.replace(/'/g, "'\"'\"'") + "'"
-    } else {
-      return str
-    }
+    return str
   }
 }

--- a/lib/utils/git.js
+++ b/lib/utils/git.js
@@ -32,14 +32,10 @@ function chainableExec () {
   return [execGit].concat(args)
 }
 
-function whichGit (cb) {
-  return which(git, cb)
-}
-
 function whichAndExec (args, options, cb) {
   assert.equal(typeof cb, 'function', 'no callback provided')
   // check for git
-  whichGit(function (err) {
+  which(git, function (err) {
     if (err) {
       err.code = 'ENOGIT'
       return cb(err)

--- a/lib/utils/is-windows-bash.js
+++ b/lib/utils/is-windows-bash.js
@@ -1,0 +1,3 @@
+'use strict'
+var isWindows = require('./is-windows.js')
+module.exports = isWindows && /^MINGW(32|64)$/.test(process.env.MSYSTEM)

--- a/lib/utils/is-windows-shell.js
+++ b/lib/utils/is-windows-shell.js
@@ -1,0 +1,4 @@
+'use strict'
+var isWindows = require('./is-windows.js')
+var isWindowsBash = require('./is-windows-bash.js')
+module.exports = isWindows && !isWindowsBash

--- a/lib/utils/is-windows.js
+++ b/lib/utils/is-windows.js
@@ -1,0 +1,2 @@
+'use strict'
+module.exports = process.platform === 'win32'

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -293,8 +293,10 @@ function makeEnv (data, prefix, env) {
   prefix = prefix || 'npm_package_'
   if (!env) {
     env = {}
-    for (var i in process.env) if (!i.match(/^npm_/)) {
-      env[i] = process.env[i]
+    for (var i in process.env) {
+      if (!i.match(/^npm_/)) {
+        env[i] = process.env[i]
+      }
     }
 
     // npat asks for tap output
@@ -311,31 +313,33 @@ function makeEnv (data, prefix, env) {
     )
   }
 
-  for (i in data) if (i.charAt(0) !== '_') {
-    var envKey = (prefix + i).replace(/[^a-zA-Z0-9_]/g, '_')
-    if (i === 'readme') {
-      continue
-    }
-    if (data[i] && typeof data[i] === 'object') {
-      try {
-        // quick and dirty detection for cyclical structures
-        JSON.stringify(data[i])
-        makeEnv(data[i], envKey + '_', env)
-      } catch (ex) {
-        // usually these are package objects.
-        // just get the path and basic details.
-        var d = data[i]
-        makeEnv(
-          { name: d.name, version: d.version, path: d.path },
-          envKey + '_',
-          env
-        )
+  for (i in data) {
+    if (i.charAt(0) !== '_') {
+      var envKey = (prefix + i).replace(/[^a-zA-Z0-9_]/g, '_')
+      if (i === 'readme') {
+        continue
       }
-    } else {
-      env[envKey] = String(data[i])
-      env[envKey] = env[envKey].indexOf('\n') !== -1
-                      ? JSON.stringify(env[envKey])
-                      : env[envKey]
+      if (data[i] && typeof data[i] === 'object') {
+        try {
+          // quick and dirty detection for cyclical structures
+          JSON.stringify(data[i])
+          makeEnv(data[i], envKey + '_', env)
+        } catch (ex) {
+          // usually these are package objects.
+          // just get the path and basic details.
+          var d = data[i]
+          makeEnv(
+            { name: d.name, version: d.version, path: d.path },
+            envKey + '_',
+            env
+          )
+        }
+      } else {
+        env[envKey] = String(data[i])
+        env[envKey] = env[envKey].indexOf('\n') !== -1
+                        ? JSON.stringify(env[envKey])
+                        : env[envKey]
+      }
     }
   }
 

--- a/lib/utils/link.js
+++ b/lib/utils/link.js
@@ -55,19 +55,15 @@ function link (from, to, gently, abs, cb) {
   if (npm.config.get('force')) gently = false
 
   to = path.resolve(to)
-  var target = from = path.resolve(from)
-  if (!abs && process.platform !== 'win32') {
-    // junctions on windows must be absolute
-    target = path.relative(path.dirname(to), from)
-    // if there is no folder in common, then it will be much
-    // longer, and using a relative link is dumb.
-    if (target.length >= from.length) target = from
-  }
+  var toDir = path.dirname(to)
+  var absTarget = path.resolve(toDir, from)
+  var relativeTarget = path.relative(toDir, absTarget)
+  var target = abs ? absTarget : relativeTarget
 
   chain(
     [
-      [ensureFromIsNotSource, from, to],
-      [fs, 'stat', from],
+      [ensureFromIsNotSource, absTarget, to],
+      [fs, 'stat', absTarget],
       [rm, to, gently],
       [mkdir, path.dirname(to)],
       [fs, 'symlink', target, to, 'junction']

--- a/lib/utils/module-name.js
+++ b/lib/utils/module-name.js
@@ -11,7 +11,7 @@ function pathToPackageName (dir) {
   if (dir === '') return ''
   var name = path.relative(path.resolve(dir, '..'), dir)
   var scoped = path.relative(path.resolve(dir, '../..'), dir)
-  if (scoped[0] === '@') return scoped
+  if (scoped[0] === '@') return scoped.replace(/\\/g, '/')
   return name
 }
 

--- a/node_modules/normalize-git-url/test/basic.js~
+++ b/node_modules/normalize-git-url/test/basic.js~
@@ -1,0 +1,56 @@
+var test = require('tap').test
+
+var normalize = require('../normalize-git-url.js')
+
+test('basic normalization tests', function (t) {
+  t.same(
+    normalize('git+ssh://user@hostname:project.git#commit-ish'),
+    { url: 'user@hostname:project.git', branch: 'commit-ish' }
+  )
+  t.same(
+    normalize('git+http://user@hostname/project/blah.git#commit-ish'),
+    { url: 'http://user@hostname/project/blah.git', branch: 'commit-ish' }
+  )
+  t.same(
+    normalize('git+https://user@hostname/project/blah.git#commit-ish'),
+    { url: 'https://user@hostname/project/blah.git', branch: 'commit-ish' }
+  )
+  t.same(
+    normalize('git+ssh://git@github.com:npm/npm.git#v1.0.27'),
+    { url: 'git@github.com:npm/npm.git', branch: 'v1.0.27' }
+  )
+  t.same(
+    normalize('git+ssh://git@github.com:org/repo#dev'),
+    { url: 'git@github.com:org/repo', branch: 'dev' }
+  )
+  t.same(
+    normalize('git+ssh://git@github.com/org/repo#dev'),
+    { url: 'ssh://git@github.com/org/repo', branch: 'dev' }
+  )
+  t.same(
+    normalize('git+ssh://foo:22/some/path'),
+    { url: 'ssh://foo:22/some/path', branch: 'master' }
+  )
+  t.same(
+    normalize('git@github.com:org/repo#dev'),
+    { url: 'git@github.com:org/repo', branch: 'dev' }
+  )
+  t.same(
+    normalize('git+https://github.com/KenanY/node-uuid'),
+    { url: 'https://github.com/KenanY/node-uuid', branch: 'master' }
+  )
+  t.same(
+    normalize('git+https://github.com/KenanY/node-uuid#7a018f2d075b03a73409e8356f9b29c9ad4ea2c5'),
+    { url: 'https://github.com/KenanY/node-uuid', branch: '7a018f2d075b03a73409e8356f9b29c9ad4ea2c5' }
+  )
+  t.same(
+    normalize('git+ssh://git@git.example.com:b/b.git#v1.0.0'),
+    { url: 'git@git.example.com:b/b.git', branch: 'v1.0.0' }
+  )
+  t.same(
+    normalize('git+ssh://git@github.com:npm/npm-proto.git#othiym23/organized'),
+    { url: 'git@github.com:npm/npm-proto.git', branch: 'othiym23/organized' }
+  )
+
+  t.end()
+})

--- a/node_modules/npm-package-arg/.travis.yml
+++ b/node_modules/npm-package-arg/.travis.yml
@@ -8,4 +8,3 @@ node_js:
   - "0.8"
 sudo: false
 script: "npm test"
-

--- a/node_modules/npm-package-arg/package.json
+++ b/node_modules/npm-package-arg/package.json
@@ -1,8 +1,8 @@
 {
   "_args": [
     [
-      "npm-package-arg@~4.1.0",
-      "/Users/rebecca/code/npm"
+      "npm-package-arg@4.1.1",
+      "/Users/zkat/Documents/code/npm"
     ]
   ],
   "_from": "npm-package-arg@>=4.1.0 <4.2.0",
@@ -23,11 +23,11 @@
   "_phantomChildren": {},
   "_requested": {
     "name": "npm-package-arg",
-    "raw": "npm-package-arg@~4.1.0",
-    "rawSpec": "~4.1.0",
+    "raw": "npm-package-arg@4.1.1",
+    "rawSpec": "4.1.1",
     "scope": null,
-    "spec": ">=4.1.0 <4.2.0",
-    "type": "range"
+    "spec": "4.1.1",
+    "type": "version"
   },
   "_requiredBy": [
     "/",
@@ -38,8 +38,8 @@
   "_resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.1.tgz",
   "_shasum": "86d9dca985b4c5e5d59772dfd5de6919998a495a",
   "_shrinkwrap": null,
-  "_spec": "npm-package-arg@~4.1.0",
-  "_where": "/Users/rebecca/code/npm",
+  "_spec": "npm-package-arg@4.1.1",
+  "_where": "/Users/zkat/Documents/code/npm",
   "author": {
     "email": "i@izs.me",
     "name": "Isaac Z. Schlueter",

--- a/node_modules/realize-package-specifier/index.js
+++ b/node_modules/realize-package-specifier/index.js
@@ -33,7 +33,9 @@ module.exports = function (spec, where, cb) {
         dep.name = null
       }
     }
-    if (dep.type == "local" || dep.type == "directory") dep.spec = specpath
+    if (dep.type == "local" || dep.type == "directory") {
+      dep.spec = path.resolve(specpath)
+    }
     cb(null, dep)
   }
 }

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "dumpconf": "env | grep npm | sort | uniq",
     "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rimraf test/*/*/node_modules && make doc-clean && make -j4 doc",
     "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"update AUTHORS\" || true",
-    "tap": "tap --timeout 240",
+    "tap": "tap --coverage --reporter=classic --timeout 300",
     "test": "standard && npm run test-tap",
     "test-tap": "npm run tap -- \"test/tap/*.js\"",
     "test-node": "\"$NODE\" \"node_modules/.bin/tap\" --timeout 240 \"test/tap/*.js\""

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "require-inject": "~1.3.1",
     "sprintf-js": "~1.0.3",
     "standard": "~5.4.1",
+    "standard": "~6.0.8",
     "tacks": "~1.2.1",
     "tap": "~5.7.1"
   },

--- a/test/common-tap.js
+++ b/test/common-tap.js
@@ -88,3 +88,7 @@ exports.makeGitRepo = function (params, cb) {
 
   chain(commands, cb)
 }
+
+var isWindows = exports.isWindows = process.platform === 'win32'
+// Differentiate cmd/powershell from gitbash (mintty & mingw)
+exports.isWindowsShell = isWindows && process.env.TERM !== 'xterm'

--- a/test/common-tap.js
+++ b/test/common-tap.js
@@ -48,8 +48,7 @@ exports.npm = function (cmd, opts, cb) {
 
   var stdout = ''
   var stderr = ''
-  var node = process.execPath
-  var child = spawn(node, cmd, opts)
+  var child = spawn(nodeBin, cmd, opts)
 
   if (child.stderr) {
     child.stderr.on('data', function (chunk) {
@@ -97,6 +96,26 @@ exports.makeGitRepo = function (params, cb) {
   chain(commands, cb)
 }
 
-var isWindows = exports.isWindows = process.platform === 'win32'
-// Differentiate cmd/powershell from gitbash (mintty & mingw)
-exports.isWindowsShell = isWindows && process.env.TERM !== 'xterm'
+exports.readBinLink = function (path) {
+  if (isWindows) {
+    return readCmdShim.sync(path)
+  } else {
+    return fs.readlinkSync(path)
+  }
+}
+
+exports.skipIfWindows = function (why) {
+  if (!isWindows) return
+  console.log('1..1')
+  if (!why) why = 'this test not available on windows'
+  console.log('ok 1 # skip ' + why)
+  process.exit(0)
+}
+
+exports.pendIfWindows = function (why) {
+  if (!isWindows) return
+  console.log('1..1')
+  if (!why) why = 'this test is pending further changes on windows'
+  console.log('not ok 1 # todo ' + why)
+  process.exit(0)
+}

--- a/test/common-tap.js
+++ b/test/common-tap.js
@@ -1,3 +1,8 @@
+'use strict'
+var fs = require('graceful-fs')
+var readCmdShim = require('read-cmd-shim')
+var isWindows = require('../lib/utils/is-windows.js')
+
 // cheesy hackaround for test deps (read: nock) that rely on setImmediate
 if (!global.setImmediate || !require('timers').setImmediate) {
   require('timers').setImmediate = global.setImmediate = function () {
@@ -25,8 +30,11 @@ process.env.random_env_var = 'foo'
 process.env.npm_config_node_version = process.version.replace(/-.*$/, '')
 
 var bin = exports.bin = require.resolve('../bin/npm-cli.js')
+
 var chain = require('slide').chain
 var once = require('once')
+
+var nodeBin = exports.nodeBin = process.env.npm_node_execpath || process.env.NODE || process.execPath
 
 exports.npm = function (cmd, opts, cb) {
   cb = once(cb)

--- a/test/tap/00-config-setup.js
+++ b/test/tap/00-config-setup.js
@@ -21,7 +21,7 @@ exports.ucData =
     'sign-git-tag': true,
     message: 'v%s',
     'strict-ssl': false,
-    'tmp': process.env.HOME + '/.tmp',
+    'tmp': path.normalize(process.env.HOME + '/.tmp'),
     _auth: 'dXNlcm5hbWU6cGFzc3dvcmQ=',
     _token:
      { AuthSession: 'yabba-dabba-doodle',
@@ -38,10 +38,10 @@ Object.keys(process.env).forEach(function (k) {
   }
 })
 process.env.npm_config_userconfig = exports.userconfig
-process.env.npm_config_other_env_thing = 1000
+process.env.npm_config_other_env_thing = '1000'
 process.env.random_env_var = 'asdf'
 process.env.npm_config__underbar_env_thing = 'underful'
-process.env.NPM_CONFIG_UPPERCASE_ENV_THING = 42
+process.env.NPM_CONFIG_UPPERCASE_ENV_THING = '42'
 
 exports.envData = {
   userconfig: exports.userconfig,
@@ -61,11 +61,11 @@ try {
   fs.statSync(projectConf)
 } catch (er) {
   // project conf not found, probably working with packed npm
-  fs.writeFileSync(projectConf, function () {/*
+  fs.writeFileSync(projectConf, function () { /*
 save-prefix = ~
 proprietary-attribs = false
 legacy-bundling = true
-  */}.toString().split('\n').slice(1, -1).join('\n'))
+  */ }.toString().split('\n').slice(1, -1).join('\n'))
 }
 
 var projectRc = path.join(__dirname, '..', 'fixtures', 'config', '.npmrc')

--- a/test/tap/bugs.js
+++ b/test/tap/bugs.js
@@ -1,9 +1,6 @@
-if (process.platform === 'win32') {
-  console.error('skipping test, because windows and shebangs')
-  process.exit(0)
-}
-
 var common = require('../common-tap.js')
+common.pendIfWindows('not working because Windows and shebangs')
+
 var mr = require('npm-registry-mock')
 
 var test = require('tap').test

--- a/test/tap/builtin-config.js
+++ b/test/tap/builtin-config.js
@@ -14,7 +14,7 @@ var folder = path.resolve(__dirname, 'builtin-config')
 var test = require('tap').test
 var npm = path.resolve(__dirname, '../..')
 var spawn = require('child_process').spawn
-var node = process.execPath
+var node = common.nodeBin
 
 test('setup', function (t) {
   t.plan(1)
@@ -34,9 +34,10 @@ test('install npm into first folder', function (t) {
               '--prefix=' + folder + '/first',
               '--ignore-scripts',
               '--cache=' + folder + '/cache',
-              '--loglevel=silent',
-              '--tmp=' + folder + '/tmp']
-  common.npm(args, {stdio: 'inherit'}, function (er, code) {
+              '--tmp=' + folder + '/tmp',
+              '--loglevel=warn',
+              '--progress']
+  common.npm(args, {}, function (er, code) {
     if (er) throw er
     t.equal(code, 0)
     t.end()
@@ -49,8 +50,7 @@ test('write npmrc file', function (t) {
               '--prefix=' + folder + '/first',
               '--cache=' + folder + '/cache',
               '--tmp=' + folder + '/tmp',
-              '--',
-              node, __filename, 'write-builtin', process.pid
+              '--', node, __filename, 'write-builtin', process.pid
              ],
              {'stdio': 'inherit'},
              function (er, code) {
@@ -73,9 +73,9 @@ test('use first npm to install second npm', function (t) {
     {},
     function (er, code, so) {
       if (er) throw er
-      t.equal(code, 0)
+      t.equal(code, 0, 'got npm root')
       var root = so.trim()
-      t.ok(fs.statSync(root).isDirectory())
+      t.ok(fs.statSync(root).isDirectory(), 'npm root is dir')
 
       var bin = path.resolve(root, 'npm/bin/npm-cli.js')
       spawn(
@@ -87,11 +87,12 @@ test('use first npm to install second npm', function (t) {
           '--prefix=' + folder + '/second',
           '--cache=' + folder + '/cache',
           '--tmp=' + folder + '/tmp'
-        ]
+        ],
+        {}
       )
       .on('error', function (er) { throw er })
       .on('close', function (code) {
-        t.equal(code, 0, 'code is zero')
+        t.equal(code, 0, 'second npm install')
         t.end()
       })
     }
@@ -120,9 +121,9 @@ test('verify that the builtin config matches', function (t) {
                             var secondRoot = so.trim()
                             var firstRc = path.resolve(firstRoot, 'npm', 'npmrc')
                             var secondRc = path.resolve(secondRoot, 'npm', 'npmrc')
-                            var firstData = fs.readFileSync(firstRc, 'utf8')
-                            var secondData = fs.readFileSync(secondRc, 'utf8')
-                            t.equal(firstData, secondData)
+                            var firstData = fs.readFileSync(firstRc, 'utf8').split(/\r?\n/)
+                            var secondData = fs.readFileSync(secondRc, 'utf8').split(/\r?\n/)
+                            t.isDeeply(firstData, secondData)
                             t.end()
                           })
              })

--- a/test/tap/cache-shasum.js
+++ b/test/tap/cache-shasum.js
@@ -1,4 +1,3 @@
-var npm = require.resolve('../../')
 var test = require('tap').test
 var path = require('path')
 var rimraf = require('rimraf')
@@ -6,7 +5,6 @@ var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
 var common = require('../common-tap.js')
 var cache = path.resolve(__dirname, 'cache-shasum')
-var spawn = require('child_process').spawn
 var sha = require('sha')
 var server
 
@@ -21,20 +19,15 @@ test('mock reg', function (t) {
 })
 
 test('npm cache add request', function (t) {
-  var c = spawn(process.execPath, [
-    npm, 'cache', 'add', 'request@2.27.0',
+  common.npm([
+    'cache', 'add', 'request@2.27.0',
     '--cache=' + cache,
     '--registry=' + common.registry,
-    '--loglevel=quiet'
-  ])
-  c.stderr.pipe(process.stderr)
-
-  c.stdout.on('data', function (d) {
-    t.fail('Should not get data on stdout: ' + d)
-  })
-
-  c.on('close', function (code) {
-    t.notOk(code, 'exit ok')
+    '--loglevel=error'
+  ], {}, function (err, code, stdout) {
+    if (err) throw err
+    t.is(code, 0, 'cmd ran without error')
+    t.is(stdout, '', 'should not get data on stdout')
     t.end()
   })
 })
@@ -53,6 +46,5 @@ test('compare', function (t) {
 
 test('cleanup', function (t) {
   server.close()
-  rimraf.sync(cache)
-  t.end()
+  rimraf(cache, t.end)
 })

--- a/test/tap/check-permissions.js
+++ b/test/tap/check-permissions.js
@@ -78,9 +78,14 @@ function writableTests (t, writable) {
   writable(writableDir, function (er) {
     t.error(er, 'writable dir is writable')
   })
-  writable(nonWritableDir, function (er) {
-    t.ok(er, 'non-writable dir resulted in an error')
-  })
+  if (process.platform !== 'win32') {
+    // Windows folders cannot be set to be read-only.
+    writable(nonWritableDir, function (er) {
+      t.ok(er, 'non-writable dir resulted in an error')
+    })
+  } else {
+    t.pass('windows folders cannot be read-only')
+  }
 }
 
 function cleanup () {

--- a/test/tap/config-certfile.js
+++ b/test/tap/config-certfile.js
@@ -12,7 +12,8 @@ test('cafile loads as ca', function (t) {
     if (er) throw er
 
     t.same(conf.get('cafile'), cafile)
-    t.same(conf.get('ca').join('\n'), fs.readFileSync(cafile, 'utf8').trim())
+    var ca = fs.readFileSync(cafile, 'utf8').trim()
+    t.same(conf.get('ca').join(ca.match(/\r/g) ? '\r\n' : '\n'), ca)
     t.end()
   })
 })

--- a/test/tap/config-edit.js
+++ b/test/tap/config-edit.js
@@ -8,7 +8,7 @@ var common = require('../common-tap.js')
 
 var pkg = path.resolve(__dirname, 'npm-global-edit')
 
-var editorSrc = function () {/*
+var editorSrc = function () { /*
 #!/usr/bin/env node
 var fs = require('fs')
 if (fs.existsSync(process.argv[2])) {
@@ -17,7 +17,7 @@ if (fs.existsSync(process.argv[2])) {
   console.log('error')
   process.exit(1)
 }
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 var editorPath = path.join(pkg, 'editor')
 
 test('setup', function (t) {
@@ -38,7 +38,9 @@ test('saving configs', function (t) {
     cwd: pkg,
     env: {
       PATH: process.env.PATH,
-      EDITOR: editorPath
+      // We rely on the cwd + relative path combo here because otherwise,
+      // this test will break if there's spaces in the editorPath
+      EDITOR: 'node editor'
     }
   }
   common.npm(

--- a/test/tap/dedupe-scoped.js
+++ b/test/tap/dedupe-scoped.js
@@ -11,12 +11,12 @@ var modules = join(pkg, 'node_modules')
 
 var EXEC_OPTS = { cwd: pkg }
 
-var body = function () {/*
-@scope/shared@2.1.6 node_modules/first/node_modules/@scope/shared -> node_modules/@scope/shared
-firstUnique@0.6.0 node_modules/first/node_modules/firstUnique -> node_modules/firstUnique
-secondUnique@1.2.0 node_modules/second/node_modules/secondUnique -> node_modules/secondUnique
-- @scope/shared@2.1.6 node_modules/second/node_modules/@scope/shared
-*/}.toString().split('\n').slice(1, -1)
+var body = [
+  '@scope/shared@2.1.6 node_modules/first/node_modules/@scope/shared -> node_modules/@scope/shared',
+  'firstUnique@0.6.0 node_modules/first/node_modules/firstUnique -> node_modules/firstUnique',
+  'secondUnique@1.2.0 node_modules/second/node_modules/secondUnique -> node_modules/secondUnique',
+  '- @scope/shared@2.1.6 node_modules/second/node_modules/@scope/shared'
+]
 
 var deduper = {
   'name': 'dedupe',
@@ -79,7 +79,7 @@ test('dedupe finds the common scoped modules and moves it up one level', functio
       t.notOk(code, 'npm ran without issue')
       t.notOk(stderr, 'npm printed no errors')
       t.same(
-        stdout.trim().split('\n').map(ltrimm),
+        stdout.trim().replace(/\\/g, '/').split('\n').map(ltrimm),
         body.map(ltrimm),
         'got expected output'
       )

--- a/test/tap/do-not-remove-other-bins.js
+++ b/test/tap/do-not-remove-other-bins.js
@@ -93,7 +93,7 @@ test('verify bins', function (t) {
   var bin = path.dirname(
     path.resolve(
       installBin,
-      fs.readlinkSync(path.join(installBin, 'testbin'))))
+      common.readBinLink(path.join(installBin, 'testbin'))))
   t.is(bin, path.join(installPath, 'node_modules', 'b'))
   t.end()
 })
@@ -114,7 +114,7 @@ test('verify postremoval bins', function (t) {
   var bin = path.dirname(
     path.resolve(
       installBin,
-      fs.readlinkSync(path.join(installBin, 'testbin'))))
+      common.readBinLink(path.join(installBin, 'testbin'))))
   t.is(bin, path.join(installPath, 'node_modules', 'b'))
   t.end()
 })

--- a/test/tap/extraneous-dep-cycle-ls-ok.js
+++ b/test/tap/extraneous-dep-cycle-ls-ok.js
@@ -57,7 +57,7 @@ var expected = pkg + '\n' +
                '  └── moduleB@1.0.0\n\n'
 
 test('extraneous-dep-cycle', function (t) {
-  common.npm(['ls'], {cwd: pkg}, function (er, code, stdout, stderr) {
+  common.npm(['ls', '--unicode=true'], {cwd: pkg}, function (er, code, stdout, stderr) {
     t.ifErr(er, 'install finished successfully')
     t.is(stdout, expected, 'ls output shows module')
     t.end()

--- a/test/tap/gently-rm-linked-module.js
+++ b/test/tap/gently-rm-linked-module.js
@@ -1,28 +1,52 @@
+var common = require('../common-tap.js')
+
 var basename = require('path').basename
 var resolve = require('path').resolve
 var fs = require('graceful-fs')
 var test = require('tap').test
-var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
-
-var common = require('../common-tap.js')
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+var Symlink = Tacks.Symlink
+var extend = Object.assign || require('util')._extend
+var isWindows = require('../../lib/utils/is-windows.js')
 
 var base = resolve(__dirname, basename(__filename, '.js'))
-var pkg = resolve(base, 'gently-rm-linked')
-var dep = resolve(base, 'test-linked')
-var glb = resolve(base, 'test-global')
-var lnk = resolve(base, 'test-global-link')
+var fixture = new Tacks(Dir({
+  'working-dir': Dir({
+    'node_modules': Dir({}) // so it doesn't try to install into npm's own node_modules
+  }),
+  'test-module': Dir({
+    'package.json': File({
+      name: '@test/linked',
+      version: '1.0.0',
+      bin: {
+        linked: './index.js'
+      }
+    }),
+    'index.js': File("module.exports = function () { console.log('whoop whoop') }")
+  }),
+  'global-dir': Dir({}),
+  'linked-global-dir': Symlink('global-dir')
+}))
 
-var EXEC_OPTS = { cwd: pkg }
+var workingDir = resolve(base, 'working-dir')
+var toInstall = resolve(base, 'test-module')
+var linkedGlobal = resolve(base, 'linked-global-dir')
 
-var index = "module.exports = function () { console.log('whoop whoop') }"
+var env = extend({}, process.env)
 
-var fixture = {
-  name: '@test/linked',
-  version: '1.0.0',
-  bin: {
-    linked: './index.js'
-  }
+// We set the global install location via env var here
+// instead of passing it in via `--prefix` because
+// `--prefix` ALSO changes the current package location.
+// And we don't ue the PREFIX env var because
+// npm_config_prefix takes precedence over it and is
+// passed in when running from the npm test suite.
+env.npm_config_prefix = linkedGlobal
+var EXEC_OPTS = {
+  cwd: workingDir,
+  env: env
 }
 
 test('setup', function (t) {
@@ -36,32 +60,41 @@ test('install and link', function (t) {
   // link our test module into the global folder
   common.npm(
     [
-      '--prefix', lnk,
       '--loglevel', 'error',
       'link',
-      dep
+      toInstall
     ],
     EXEC_OPTS,
-    function (er, code, stdout, stderr) {
+    function (er, code) {
       if (er) throw er
       t.is(code, 0, 'link succeeded')
-      t.is(stderr, '', 'no log output')
-      t.ok(doesModuleExist(), 'installed ok')
+      var globalBin = resolve(linkedGlobal, isWindows ? '.' : 'bin', 'linked')
+      var globalModule = resolve(linkedGlobal, isWindows ? '.' : 'lib', 'node_modules', '@test', 'linked')
+      var localBin = resolve(workingDir, 'node_modules', '.bin', 'linked')
+      var localModule = resolve(workingDir, 'node_modules', '@test', 'linked')
+      try {
+        t.ok(fs.statSync(globalBin), 'global bin exists')
+        t.is(fs.lstatSync(globalModule).isSymbolicLink(), true, 'global module is link')
+        t.ok(fs.statSync(localBin), 'local bin exists')
+        t.is(fs.lstatSync(localModule).isSymbolicLink(), true, 'local module is link')
+      } catch (ex) {
+        t.ifError(ex, 'linking happened')
+      }
+      if (code !== 0) return t.end()
 
       // and try removing it and make sure that succeeds
       common.npm(
         [
           '--global',
-          '--prefix', lnk,
           '--loglevel', 'error',
           'rm', '@test/linked'
         ],
         EXEC_OPTS,
-        function (er, code, stdout, stderr) {
+        function (er, code) {
           if (er) throw er
           t.is(code, 0, 'rm succeeded')
-          t.is(stderr, '', 'no log output')
-          t.notOk(doesModuleExist(), 'removed ok')
+          t.throws(function () { fs.statSync(globalBin) }, 'global bin removed')
+          t.throws(function () { fs.statSync(globalModule) }, 'global module removed')
           t.end()
         }
       )
@@ -75,32 +108,11 @@ test('cleanup', function (t) {
   t.end()
 })
 
-function doesModuleExist () {
-  var binPath = resolve(lnk, 'bin', 'linked')
-  var pkgPath = resolve(lnk, 'lib', 'node_modules', '@test', 'linked')
-  try {
-    fs.statSync(binPath)
-    fs.statSync(pkgPath)
-    return true
-  } catch (ex) {
-    return false
-  }
-}
-
 function cleanup () {
-  rimraf.sync(pkg)
-  rimraf.sync(dep)
-  rimraf.sync(lnk)
-  rimraf.sync(glb)
+  fixture.remove(base)
+  rimraf.sync(base)
 }
 
 function setup () {
-  mkdirp.sync(pkg)
-  mkdirp.sync(glb)
-  fs.symlinkSync(glb, lnk)
-  // so it doesn't try to install into npm's own node_modules
-  mkdirp.sync(resolve(pkg, 'node_modules'))
-  mkdirp.sync(dep)
-  fs.writeFileSync(resolve(dep, 'package.json'), JSON.stringify(fixture))
-  fs.writeFileSync(resolve(dep, 'index.js'), index)
+  fixture.create(base)
 }

--- a/test/tap/git-cache-locking.js
+++ b/test/tap/git-cache-locking.js
@@ -6,6 +6,7 @@ var mkdirp = require('mkdirp')
 var pkg = path.resolve(__dirname, 'git-cache-locking')
 var tmp = path.join(pkg, 'tmp')
 var cache = path.join(pkg, 'cache')
+var shallowClone = Object.assign || require('util')._extend
 
 test('setup', function (t) {
   rimraf.sync(pkg)
@@ -17,6 +18,12 @@ test('git-cache-locking: install a git dependency', function (t) {
   // disable git integration tests on Travis.
   if (process.env.TRAVIS) return t.end()
 
+  var gitEnv = shallowClone({}, process.env)
+  gitEnv.npm_config_cache = cache
+  gitEnv.npm_config_tmp = tmp
+  gitEnv.npm_config_prefix = pkg
+  gitEnv.npm_config_global = 'false'
+
   // package c depends on a.git#master and b.git#master
   // package b depends on a.git#master
   common.npm([
@@ -24,17 +31,9 @@ test('git-cache-locking: install a git dependency', function (t) {
     'git://github.com/nigelzor/npm-4503-c.git'
   ], {
     cwd: pkg,
-    env: {
-      npm_config_cache: cache,
-      npm_config_tmp: tmp,
-      npm_config_prefix: pkg,
-      npm_config_global: 'false',
-      HOME: process.env.HOME,
-      Path: process.env.PATH,
-      PATH: process.env.PATH
-    }
+    env: gitEnv
   }, function (err, code, stdout, stderr) {
-    t.ifErr(err, 'npm install finished without error')
+    if (err) throw err
     t.equal(0, code, 'npm install should succeed')
     t.end()
   })

--- a/test/tap/git-dependency-install-link.js
+++ b/test/tap/git-dependency-install-link.js
@@ -13,6 +13,7 @@ var common = require('../common-tap.js')
 
 var pkg = resolve(__dirname, 'git-dependency-install-link')
 var repo = resolve(__dirname, 'git-dependency-install-link-repo')
+var prefix = resolve(__dirname, 'git-dependency-install-link-prefix')
 var cache = resolve(pkg, 'cache')
 
 var daemon
@@ -25,6 +26,7 @@ var EXEC_OPTS = {
   cwd: pkg,
   cache: cache
 }
+process.env.npm_config_prefix = prefix
 
 var pjParent = JSON.stringify({
   name: 'parent',
@@ -63,7 +65,7 @@ test('setup', function (t) {
 test('install from git repo [no --link]', function (t) {
   process.chdir(pkg)
 
-  common.npm(['install', '--loglevel', 'error'], EXEC_OPTS, function (err, code, stdout, stderr) {
+  common.npm(['install'], EXEC_OPTS, function (err, code, stdout, stderr) {
     t.ifError(err, 'npm install failed')
 
     t.dissimilar(stderr, /Command failed:/, 'expect git to succeed')
@@ -82,11 +84,13 @@ test('install from git repo [with --link]', function (t) {
   process.chdir(pkg)
   rimraf.sync(resolve(pkg, 'node_modules'))
 
-  common.npm(['install', '--link', '--loglevel', 'error'], EXEC_OPTS, function (err, code, stdout, stderr) {
+  common.npm(['install', '--link'], EXEC_OPTS, function (err, code, stdout, stderr) {
     t.ifError(err, 'npm install --link failed')
+    t.equal(code, 0, 'npm install --link returned non-0 code')
 
     t.dissimilar(stderr, /Command failed:/, 'expect git to succeed')
     t.dissimilar(stderr, /version not found/, 'should not go to repository')
+    t.equal(stderr, '', 'no actual output on stderr')
 
     readJson(resolve(pkg, 'node_modules', 'child', 'package.json'), function (err, data) {
       t.ifError(err, 'error reading child package.json')
@@ -170,5 +174,6 @@ function setup (cb) {
 function cleanup () {
   process.chdir(osenv.tmpdir())
   rimraf.sync(repo)
+  rimraf.sync(prefix)
   rimraf.sync(pkg)
 }

--- a/test/tap/git-npmignore.js
+++ b/test/tap/git-npmignore.js
@@ -1,21 +1,50 @@
-var cat = require('graceful-fs').writeFileSync
-var exec = require('child_process').exec
+var child_process = require('child_process')
 var readdir = require('graceful-fs').readdirSync
+var path = require('path')
 var resolve = require('path').resolve
 
-var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var test = require('tap').test
-var tmpdir = require('osenv').tmpdir
 var which = require('which')
 
 var common = require('../common-tap.js')
+var escapeArg = require('../../lib/utils/escape-arg.js')
+var Tacks = require('tacks')
+var Dir = Tacks.Dir
+var File = Tacks.File
 
-var pkg = resolve(__dirname, 'git-npmignore')
-var dep = resolve(pkg, 'deps', 'gitch')
+var fixture = new Tacks(Dir({
+  deps: Dir({
+    gitch: Dir({
+      '.npmignore': File(
+        't.js\n'
+      ),
+      '.gitignore': File(
+        'node_modules/\n'
+      ),
+      'a.js': File(
+        "console.log('hi');"
+      ),
+      't.js': File(
+        "require('tap').test(function (t) { t.pass('I am a test!'); t.end(); });"
+      ),
+      'package.json': File({
+        name: 'gitch',
+        version: '1.0.0',
+        private: true,
+        main: 'a.js'
+      })
+    })
+  }),
+  'node_modules': Dir({
+  })
+}))
+
+var testdir = resolve(__dirname, path.basename(__filename, '.js'))
+var dep = resolve(testdir, 'deps', 'gitch')
 var packname = 'gitch-1.0.0.tgz'
-var packed = resolve(pkg, packname)
-var modules = resolve(pkg, 'node_modules')
+var packed = resolve(testdir, packname)
+var modules = resolve(testdir, 'node_modules')
 var installed = resolve(modules, 'gitch')
 var expected = [
   'a.js',
@@ -23,18 +52,11 @@ var expected = [
   '.npmignore'
 ].sort()
 
-var EXEC_OPTS = { cwd: pkg }
+var NPM_OPTS = { cwd: testdir }
 
-var gitignore = 'node_modules/\n'
-var npmignore = 't.js\n'
-
-var a = "console.log('hi');"
-var t = "require('tap').test(function (t) { t.pass('I am a test!'); t.end(); });"
-var fixture = {
-  'name': 'gitch',
-  'version': '1.0.0',
-  'private': true,
-  'main': 'a.js'
+function exec (todo, opts, cb) {
+  console.log('    # EXEC:', todo)
+  child_process.exec(todo, opts, cb)
 }
 
 test('setup', function (t) {
@@ -50,7 +72,10 @@ test('npm pack directly from directory', function (t) {
 })
 
 test('npm pack via git', function (t) {
-  packInstallTest('git+file://' + dep, t)
+  var urlPath = dep
+    .replace(/\\/g, '/') // fixup slashes for Windows
+    .replace(/^\/+/, '') // remove any leading slashes
+  packInstallTest('git+file:///' + urlPath, t)
 })
 
 test('cleanup', function (t) {
@@ -60,31 +85,32 @@ test('cleanup', function (t) {
 })
 
 function packInstallTest (spec, t) {
+  console.log('    # pack', spec)
   common.npm(
     [
-      '--loglevel', 'silent',
+      '--loglevel', 'error',
       'pack', spec
     ],
-    EXEC_OPTS,
+    NPM_OPTS,
     function (err, code, stdout, stderr) {
-      t.ifError(err, 'npm pack ran without error')
-      t.notOk(code, 'npm pack exited cleanly')
-      t.notOk(stderr, 'npm pack ran silently')
-      t.equal(stdout.trim(), packname, 'got expected package name')
+      if (err) throw err
+      t.is(code, 0, 'npm pack exited cleanly')
+      t.is(stderr, '', 'npm pack ran silently')
+      t.is(stdout.trim(), packname, 'got expected package name')
 
       common.npm(
         [
-          '--loglevel', 'silent',
+          '--loglevel', 'error',
           'install', packed
         ],
-        EXEC_OPTS,
+        NPM_OPTS,
         function (err, code, stdout, stderr) {
-          t.ifError(err, 'npm install ran without error')
-          t.notOk(code, 'npm install exited cleanly')
-          t.notOk(stderr, 'npm install ran silently')
+          if (err) throw err
+          t.is(code, 0, 'npm install exited cleanly')
+          t.is(stderr, '', 'npm install ran silently')
 
           var actual = readdir(installed).sort()
-          t.same(actual, expected, 'no unexpected files in packed directory')
+          t.isDeeply(actual, expected, 'no unexpected files in packed directory')
 
           rimraf(packed, function () {
             t.end()
@@ -96,72 +122,71 @@ function packInstallTest (spec, t) {
 }
 
 function cleanup () {
-  process.chdir(tmpdir())
-  rimraf.sync(pkg)
+  fixture.remove(testdir)
+  rimraf.sync(testdir)
 }
 
 function setup (cb) {
   cleanup()
 
-  mkdirp.sync(modules)
-  mkdirp.sync(dep)
-
-  process.chdir(dep)
-
-  cat(resolve(dep, '.npmignore'), npmignore)
-  cat(resolve(dep, '.gitignore'), gitignore)
-  cat(resolve(dep, 'a.js'), a)
-  cat(resolve(dep, 't.js'), t)
-  cat(resolve(dep, 'package.json'), JSON.stringify(fixture))
+  fixture.create(testdir)
 
   common.npm(
     [
-      '--loglevel', 'silent',
+      '--loglevel', 'error',
       'cache', 'clean'
     ],
-    EXEC_OPTS,
+    NPM_OPTS,
     function (er, code, _, stderr) {
       if (er) return cb(er)
       if (code) return cb(new Error('npm cache nonzero exit: ' + code))
       if (stderr) return cb(new Error('npm cache clean error: ' + stderr))
 
-      which('git', function found (er, git) {
+      which('git', function found (er, gitPath) {
         if (er) return cb(er)
 
-        exec(git + ' init', init)
+        var git = escapeArg(gitPath)
+
+        exec(git + ' init', {cwd: dep}, init)
 
         function init (er, _, stderr) {
           if (er) return cb(er)
           if (stderr) return cb(new Error('git init error: ' + stderr))
 
-          exec(git + " config user.name 'Phantom Faker'", user)
+          exec(git + " config user.name 'Phantom Faker'", {cwd: dep}, user)
         }
 
         function user (er, _, stderr) {
           if (er) return cb(er)
           if (stderr) return cb(new Error('git config error: ' + stderr))
 
-          exec(git + ' config user.email nope@not.real', email)
+          exec(git + ' config user.email nope@not.real', {cwd: dep}, email)
         }
 
         function email (er, _, stderr) {
           if (er) return cb(er)
           if (stderr) return cb(new Error('git config error: ' + stderr))
 
-          exec(git + ' add .', addAll)
+          exec(git + ' config core.autocrlf input', {cwd: dep}, autocrlf)
+        }
+
+        function autocrlf (er, _, stderr) {
+          if (er) return cb(er)
+          if (stderr) return cb(new Error('git config error: ' + stderr))
+
+          exec(git + ' add .', {cwd: dep}, addAll)
         }
 
         function addAll (er, _, stderr) {
           if (er) return cb(er)
           if (stderr) return cb(new Error('git add . error: ' + stderr))
 
-          exec(git + ' commit -m boot', commit)
+          exec(git + ' commit -m boot', {cwd: dep}, commit)
         }
 
         function commit (er, _, stderr) {
           if (er) return cb(er)
           if (stderr) return cb(new Error('git commit error: ' + stderr))
-
           cb()
         }
       })

--- a/test/tap/github-shortcut.js
+++ b/test/tap/github-shortcut.js
@@ -32,10 +32,10 @@ test('github-shortcut', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }
@@ -52,8 +52,8 @@ test('github-shortcut', function (t) {
     loglevel: 'silent'
   }
   t.plan(1 + cloneUrls.length)
-  npm.load(opts, function (er) {
-    t.ifError(er, 'npm loaded without error')
+  npm.load(opts, function (err) {
+    t.ifError(err, 'npm loaded without error')
     npm.commands.install(['foo/private'], function (er, result) {
       t.end()
     })

--- a/test/tap/graceful-restart.js
+++ b/test/tap/graceful-restart.js
@@ -70,7 +70,7 @@ test('graceless restart', function (t) {
   createChild(['run-script', 'restart'], function (err, code, out) {
     t.ifError(err, 'restart finished successfully')
     t.equal(code, 0, 'npm run-script exited with code')
-    t.equal(out, outGraceless, 'expected all scripts to run')
+    t.equal(out.replace(/\r/g, ''), outGraceless, 'expected all scripts to run')
     t.end()
   })
 })
@@ -80,7 +80,7 @@ test('graceful restart', function (t) {
   createChild(['run-script', 'restart'], function (err, code, out) {
     t.ifError(err, 'restart finished successfully')
     t.equal(code, 0, 'npm run-script exited with code')
-    t.equal(out, outGraceful, 'expected only *restart scripts to run')
+    t.equal(out.replace(/\r/g, ''), outGraceful, 'expected only *restart scripts to run')
     t.end()
   })
 })

--- a/test/tap/install-bad-man.js
+++ b/test/tap/install-bad-man.js
@@ -21,6 +21,8 @@ var json = {
   man: [ './install-bad-man.1.lol' ]
 }
 
+common.pendIfWindows('man pages do not get installed on Windows')
+
 test('setup', function (t) {
   setup()
   t.pass('setup ran')

--- a/test/tap/install-link-scripts.js
+++ b/test/tap/install-link-scripts.js
@@ -24,15 +24,15 @@ var dependency = {
   name: 'dep',
   version: '1.0.0',
   scripts: {
-    install: './bin/foo'
+    install: 'node ./bin/foo'
   }
 }
 
-var foo = function () {/*
+var foo = function () { /*
 #!/usr/bin/env node
 
 console.log('hey sup')
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
 process.env.npm_config_prefix = tmp
 

--- a/test/tap/install-man.js
+++ b/test/tap/install-man.js
@@ -11,6 +11,8 @@ var common = require('../common-tap.js')
 var pkg = resolve(__dirname, 'install-man')
 var target = resolve(__dirname, 'install-man-target')
 
+common.pendIfWindows('man pages do not get installed on Windows')
+
 var EXEC_OPTS = {
   cwd: target
 }

--- a/test/tap/install-save-local.js
+++ b/test/tap/install-save-local.js
@@ -53,7 +53,7 @@ test('\'npm install --save ../local/path\' should save to package.json', functio
       var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
       t.is(Object.keys(pkgJson.dependencies).length, 1, 'only one dep')
       t.ok(
-        /file:.*?[/]package-local-dependency$/.test(pkgJson.dependencies['package-local-dependency']),
+        /file:.*?[/\\]package-local-dependency$/.test(pkgJson.dependencies['package-local-dependency']),
         'local package saved correctly'
       )
       t.end()
@@ -82,7 +82,7 @@ test('\'npm install --save-dev ../local/path\' should save to package.json', fun
       var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
       t.is(Object.keys(pkgJson.devDependencies).length, 1, 'only one dep')
       t.ok(
-        /file:.*?[/]package-local-dev-dependency$/.test(pkgJson.devDependencies['package-local-dev-dependency']),
+        /file:.*?[/\\]package-local-dev-dependency$/.test(pkgJson.devDependencies['package-local-dev-dependency']),
         'local package saved correctly'
       )
 

--- a/test/tap/install-scoped-already-installed.js
+++ b/test/tap/install-scoped-already-installed.js
@@ -125,7 +125,7 @@ test('cleanup', function (t) {
 })
 
 function contains (list, element) {
-  var matcher = new RegExp(element + '$')
+  var matcher = new RegExp(element.replace(/\//g, '[\\\\/]') + '$')
   for (var i = 0; i < list.length; ++i) {
     if (matcher.test(list[i])) {
       return true

--- a/test/tap/install-scoped-link.js
+++ b/test/tap/install-scoped-link.js
@@ -8,6 +8,8 @@ var osenv = require('osenv')
 var rimraf = require('rimraf')
 var test = require('tap').test
 
+var escapeExecPath = require('../../lib/utils/escape-exec-path')
+
 var common = require('../common-tap.js')
 
 var pkg = path.join(__dirname, 'install-scoped-link')
@@ -16,7 +18,7 @@ var modules = path.join(work, 'node_modules')
 
 var EXEC_OPTS = { cwd: work }
 
-var world = 'console.log("hello blrbld")\n'
+var world = '#!/usr/bin/env node\nconsole.log("hello blrbld")\n'
 
 var json = {
   name: '@scoped/package',
@@ -61,7 +63,7 @@ test('installing package with links', function (t) {
       var hello = path.join(modules, '.bin', 'hello')
       t.ok(existsSync(hello), 'binary link exists')
 
-      exec('node ' + hello, function (err, stdout, stderr) {
+      exec(escapeExecPath(hello), function (err, stdout, stderr) {
         t.ifError(err, 'command ran fine')
         t.notOk(stderr, 'got no error output back')
         t.equal(stdout, 'hello blrbld\n', 'output was as expected')

--- a/test/tap/legacy-bundled-git.js
+++ b/test/tap/legacy-bundled-git.js
@@ -69,8 +69,6 @@ test('bundled-git', function (t) {
   common.npm(['install', '--global-style', fixturepath], {cwd: basepath}, installCheckAndTest)
   function installCheckAndTest (err, code, stdout, stderr) {
     if (err) throw err
-    console.error(stderr)
-    console.log(stdout)
     t.is(code, 0, 'install went ok')
 
     var actual = require(path.resolve(installedpath, 'node_modules/glob/node_modules/minimatch/package.json'))
@@ -82,8 +80,6 @@ test('bundled-git', function (t) {
   }
   function removeCheckAndDone (err, code, stdout, stderr) {
     if (err) throw err
-    console.error(stderr)
-    console.log(stdout)
     t.is(code, 0, 'remove went ok')
     t.done()
   }

--- a/test/tap/legacy-missing-bindir.js
+++ b/test/tap/legacy-missing-bindir.js
@@ -48,8 +48,6 @@ test('missing-bindir', function (t) {
 
   function installCheckAndTest (err, code, stdout, stderr) {
     if (err) throw err
-    if (stderr) console.error(stderr)
-    console.log(stdout)
     t.is(code, 0, 'install went ok')
     t.is(installedExists('README'), true, 'README')
     t.is(installedExists('package.json'), true, 'package.json')
@@ -58,8 +56,6 @@ test('missing-bindir', function (t) {
 
   function removeCheckAndDone (err, code, stdout, stderr) {
     if (err) throw err
-    console.error(stderr)
-    console.log(stdout)
     t.is(code, 0, 'remove went ok')
     t.done()
   }

--- a/test/tap/legacy-npm-self-install.js
+++ b/test/tap/legacy-npm-self-install.js
@@ -50,7 +50,7 @@ test('npm-self-install', function (t) {
   env.npm_config_user_agent = null
   env.npm_config_color = 'always'
   env.npm_config_progress = 'always'
-  var PATH = env.PATH.split(pathsep)
+  var PATH = env.PATH ? env.PATH.split(pathsep) : []
   var binpath = isWin32 ? globalpath : path.join(globalpath, 'bin')
   var cmdname = isWin32 ? 'npm.cmd' : 'npm'
   PATH.unshift(binpath)
@@ -63,7 +63,7 @@ test('npm-self-install', function (t) {
     if (err) throw err
     t.is(code, 0, 'install went ok')
     t.is(exists(binpath, cmdname), true, 'binary was installed')
-    t.is(exists(globalpath, 'lib', 'node_modules', 'npm'), true, 'module path exists')
+    t.is(exists(globalpath, isWin32 ? '' : 'lib', 'node_modules', 'npm'), true, 'module path exists')
     common.npm(['ls', '--json', '--depth=0'], {cwd: basepath, env: env}, lsCheckAndRemove)
   }
   function lsCheckAndRemove (err, code, stdout, stderr) {
@@ -73,7 +73,7 @@ test('npm-self-install', function (t) {
     var installed = JSON.parse(stdout.trim())
     t.is(Object.keys(installed.dependencies).length, 1, 'one thing installed')
     t.is(path.resolve(globalpath, installed.dependencies.npm.from), tarball, 'and it was our npm tarball')
-    common.npm(['rm', 'npm'], {cwd: basepath, env: env, stdio: 'inherit'}, removeCheck)
+    common.npm(['rm', 'npm'], {cwd: basepath, env: env}, removeCheck)
   }
   function removeCheck (err, code) {
     if (err) throw err

--- a/test/tap/legacy-test-package.js
+++ b/test/tap/legacy-test-package.js
@@ -36,24 +36,18 @@ test('test-package', function (t) {
 
   function installCheckAndTest (err, code, stdout, stderr) {
     if (err) throw err
-    console.error(stderr)
-    console.log(stdout)
     t.is(code, 0, 'install went ok')
     common.npm(['test'], {cwd: installedpath}, testCheckAndRemove)
   }
 
   function testCheckAndRemove (err, code, stdout, stderr) {
     if (err) throw err
-    console.error(stderr)
-    console.log(stdout)
     t.is(code, 0, 'npm test w/o test is ok')
     common.npm(['rm', fixturepath], {cwd: basepath}, removeCheckAndDone)
   }
 
   function removeCheckAndDone (err, code, stdout, stderr) {
     if (err) throw err
-    console.error(stderr)
-    console.log(stdout)
     t.is(code, 0, 'remove went ok')
     t.done()
   }

--- a/test/tap/legacy-url-dep.js
+++ b/test/tap/legacy-url-dep.js
@@ -37,8 +37,6 @@ test('url-dep', function (t) {
   common.npm(['install', fixturepath], {cwd: basepath}, installCheckAndTest)
   function installCheckAndTest (err, code, stdout, stderr) {
     if (err) throw err
-    console.error(stderr)
-    console.log(stdout)
     t.is(code, 0, 'install went ok')
     t.done()
   }

--- a/test/tap/lifecycle-path.js
+++ b/test/tap/lifecycle-path.js
@@ -63,6 +63,10 @@ test('make sure the path is correct', function (t) {
       }
       return p.replace(/\\/g, '/')
     })
+    // spawn-wrap adds itself to the path when coverage is enabled
+    actual = actual.filter(function (p) {
+      return !p.match(/\.node-spawn-wrap/)
+    })
 
     // get the ones we tacked on, then the system-specific requirements
     var expect = [

--- a/test/tap/lifecycle-path.js
+++ b/test/tap/lifecycle-path.js
@@ -7,28 +7,18 @@ var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
+var isWindows = require('../../lib/utils/is-windows.js')
 
 var pkg = path.resolve(__dirname, 'lifecycle-path')
-var link = path.resolve(pkg, 'node-bin')
 
 var PATH
-if (process.platform === 'win32') {
+if (isWindows) {
   // On Windows the 'comspec' environment variable is used,
   // so cmd.exe does not need to be on the path.
-  PATH = 'C:\\foo\\bar'
+  PATH = path.dirname(process.env.ComSpec)
 } else {
   // On non-Windows, without the path to the shell, nothing usually works.
   PATH = '/bin:/usr/bin'
-}
-
-var printPath = 'console.log(process.env.PATH)\n'
-
-var json = {
-  name: 'glorb',
-  version: '1.2.3',
-  scripts: {
-    path: './node-bin/node print-path.js'
-  }
 }
 
 test('setup', function (t) {
@@ -36,25 +26,26 @@ test('setup', function (t) {
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
+    JSON.stringify({}, null, 2)
   )
-  fs.writeFileSync(path.join(pkg, 'print-path.js'), printPath)
-  fs.symlinkSync(path.dirname(process.execPath), link, 'dir')
   t.end()
 })
 
 test('make sure the path is correct', function (t) {
-  common.npm(['run-script', 'path'], {
+  common.npm(['run-script', 'env'], {
     cwd: pkg,
     env: {
-      PATH: PATH,
-      stdio: [ 0, 'pipe', 2 ]
-    }
+      PATH: PATH
+    },
+    stdio: [ 0, 'pipe', 2 ]
   }, function (er, code, stdout) {
     if (er) throw er
     t.equal(code, 0, 'exit code')
-    // remove the banner, we just care about the last line
-    stdout = stdout.trim().split(/\r|\n/).pop()
+    var lineMatch = function (line) {
+      return /^PATH=/i.test(line)
+    }
+    // extract just the path value
+    stdout = stdout.split(/\r?\n/).filter(lineMatch).pop().replace(/^PATH=/, '')
     var pathSplit = process.platform === 'win32' ? ';' : ':'
     var root = path.resolve(__dirname, '../..')
     var actual = stdout.split(pathSplit).map(function (p) {
@@ -73,9 +64,9 @@ test('make sure the path is correct', function (t) {
       '{{ROOT}}/bin/node-gyp-bin',
       '{{ROOT}}/test/tap/lifecycle-path/node_modules/.bin',
       path.dirname(process.execPath)
-    ].concat(PATH.split(pathSplit).map(function (p) {
+    ].concat(PATH.split(pathSplit)).map(function (p) {
       return p.replace(/\\/g, '/')
-    }))
+    })
     t.same(actual, expect)
     t.end()
   })

--- a/test/tap/logout-scoped.js
+++ b/test/tap/logout-scoped.js
@@ -12,11 +12,11 @@ var pkg = path.resolve(__dirname, 'logout')
 var outfile = path.join(pkg, '_npmrc')
 var opts = { cwd: pkg }
 
-var contents = function () {/*
+var contents = function () { /*
 foo=boo
 @bar:registry=http://localhost:1337
 //localhost:1337/:_authToken=glarb
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
 function mocks (server) {
   server.delete('/-/user/token/glarb')
@@ -47,7 +47,7 @@ test('npm logout', function (t) {
         t.notOk(code, 'exited OK')
 
         var config = fs.readFileSync(outfile, 'utf8')
-        t.equal(config, 'foo=boo\n', 'creds gone')
+        t.equal(config.trim(), 'foo=boo', 'creds gone')
         s.close()
         t.end()
       }

--- a/test/tap/logout.js
+++ b/test/tap/logout.js
@@ -12,10 +12,10 @@ var pkg = path.resolve(__dirname, 'logout')
 var outfile = path.join(pkg, '_npmrc')
 var opts = { cwd: pkg }
 
-var contents = function () {/*
+var contents = function () { /*
 foo=boo
 //localhost:1337/:_authToken=glarb
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
 function mocks (server) {
   server.delete('/-/user/token/glarb')
@@ -45,7 +45,7 @@ test('npm logout', function (t) {
         t.notOk(code, 'exited OK')
 
         var config = fs.readFileSync(outfile, 'utf8')
-        t.equal(config, 'foo=boo\n', 'creds gone')
+        t.notMatch(config, /localhost/, 'creds gone')
         s.close()
         t.end()
       }

--- a/test/tap/ls-l-depth-0.js
+++ b/test/tap/ls-l-depth-0.js
@@ -53,6 +53,7 @@ test('#6311: npm ll --depth=0 duplicates listing', function (t) {
     [
       '--loglevel', 'silent',
       '--registry', common.registry,
+      '--unicode=true',
       'install', dep
     ],
     EXEC_OPTS,
@@ -72,6 +73,7 @@ test('#6311: npm ll --depth=0 duplicates listing', function (t) {
         [
           '--loglevel', 'silent',
           'ls', '--long',
+          '--unicode=true',
           '--depth', '0'
         ],
         EXEC_OPTS,

--- a/test/tap/no-global-warns.js
+++ b/test/tap/no-global-warns.js
@@ -14,13 +14,7 @@ var toInstall = path.join(base, 'to-install')
 var config = 'prefix = ' + base
 var configPath = path.join(base, '_npmrc')
 
-var extend = Object.assign || require('util')._extend
-
-var OPTS = {
-  env: extend({
-    'npm_config_userconfig': configPath
-  }, process.env)
-}
+var OPTS = { }
 
 var installJSON = {
   name: 'to-install',
@@ -40,11 +34,18 @@ test('setup', function (t) {
 })
 
 test('no-global-warns', function (t) {
-  common.npm(['install', '-g', toInstall], OPTS, function (err, code, stdout, stderr) {
-    t.ifError(err, 'installed w/o error')
-    t.is(stderr, '', 'no warnings printed to stderr')
-    t.end()
-  })
+  common.npm(
+    [
+      'install', '-g',
+      '--userconfig=' + configPath,
+      toInstall
+    ],
+    OPTS,
+    function (err, code, stdout, stderr) {
+      t.ifError(err, 'installed w/o error')
+      t.is(stderr, '', 'no warnings printed to stderr')
+      t.end()
+    })
 })
 
 test('cleanup', function (t) {

--- a/test/tap/optional-metadep-rollback-collision.js
+++ b/test/tap/optional-metadep-rollback-collision.js
@@ -63,7 +63,7 @@ var opdep_json = {
   }
 }
 
-var badServer = function () {/*
+var badServer = function () { /*
 var createServer = require('http').createServer
 var spawn = require('child_process').spawn
 var fs = require('fs')
@@ -98,9 +98,9 @@ if (process.argv[2]) {
 
   fs.writeFileSync(pidfile, child.pid + '\n')
 }
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
-var blart = function () {/*
+var blart = function () { /*
 var rando = require('crypto').randomBytes
 var resolve = require('path').resolve
 
@@ -152,7 +152,7 @@ mkdirp(BASEDIR, function go () {
     keepItGoingLouder = {}
   }, 3 * 1000)
 })
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 test('setup', function (t) {
   cleanup()
 

--- a/test/tap/outdated-depth-integer.js
+++ b/test/tap/outdated-depth-integer.js
@@ -3,7 +3,8 @@ var test = require('tap').test
 var rimraf = require('rimraf')
 var npm = require('../../')
 var mr = require('npm-registry-mock')
-var pkg = __dirname + '/outdated-depth-integer'
+var path = require('path')
+var pkg = path.resolve('outdated-depth-integer')
 
 var osenv = require('osenv')
 var mkdirp = require('mkdirp')

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -104,7 +104,7 @@ test('it should not throw', function (t) {
           }
           npm.outdated(function (er, d) {
             t.ifError(er, 'outdated success')
-
+            output = output.map(function (x) { return x.replace(/\r/g, '') })
             console.log = originalLog
 
             t.same(output, expOut)

--- a/test/tap/publish-access-unscoped-restricted-fails.js
+++ b/test/tap/publish-access-unscoped-restricted-fails.js
@@ -4,59 +4,35 @@ var path = require('path')
 var test = require('tap').test
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
-
-var npm = require('../../')
 var common = require('../common-tap.js')
 
 var pkg = path.join(__dirname, 'publish-access-unscoped')
 
 test('setup', function (t) {
-  mkdirp(path.join(pkg, 'cache'), function () {
-    var configuration = {
-      cache: path.join(pkg, 'cache'),
-      loglevel: 'silent',
-      registry: common.registry
-    }
-
-    npm.load(configuration, next)
-  })
-
-  function next (er) {
-    t.ifError(er, 'npm loaded successfully')
-
-    process.chdir(pkg)
-    fs.writeFile(
-      path.join(pkg, 'package.json'),
-      JSON.stringify({
-        name: 'publish-access',
-        version: '1.2.5'
-      }),
-      'ascii',
-      function (er) {
-        t.ifError(er)
-
-        t.pass('setup done')
-        t.end()
-      }
-    )
-  }
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify({
+      name: 'publish-access',
+      version: '1.2.5'
+    }))
+  t.pass('setup done')
+  t.end()
 })
 
 test('unscoped packages cannot be restricted', function (t) {
-  npm.config.set('access', 'restricted')
-  npm.commands.publish([], false, function (er) {
-    t.ok(er, 'got an error back')
-    t.equal(er.message, "Can't restrict access to unscoped packages.")
+  var args = ['--access=restricted', '--loglevel=warn', '--registry=' + common.registry]
+  var opts = {stdio: [0, 1, 'pipe'], cwd: pkg}
+  common.npm(['publish'].concat(args), opts, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.notEqual(code, 0, 'publish not successful')
+    t.match(stderr, "Can't restrict access to unscoped packages.")
 
     t.end()
   })
 })
 
 test('cleanup', function (t) {
-  process.chdir(__dirname)
-  rimraf(pkg, function (er) {
-    t.ifError(er)
-
-    t.end()
-  })
+  rimraf.sync(pkg)
+  t.end()
 })

--- a/test/tap/publish-config.js
+++ b/test/tap/publish-config.js
@@ -29,7 +29,7 @@ test(function (t) {
     res.end(JSON.stringify({
       error: 'sshhh. naptime nao. \\^O^/ <(YAWWWWN!)'
     }))
-    child.kill('SIGHUP')
+    child.kill('SIGINT')
   }).listen(common.port, function () {
     t.pass('server is listening')
 

--- a/test/tap/repo.js
+++ b/test/tap/repo.js
@@ -1,8 +1,3 @@
-if (process.platform === 'win32') {
-  console.error('skipping test, because windows and shebangs')
-  process.exit(0)
-}
-
 var common = require('../common-tap.js')
 var mr = require('npm-registry-mock')
 
@@ -10,15 +5,18 @@ var test = require('tap').test
 var rimraf = require('rimraf')
 var fs = require('fs')
 var path = require('path')
+var fakeBrowser = path.join(__dirname, '_script.sh')
 var outFile = path.join(__dirname, '/_output')
 
 var opts = { cwd: __dirname }
 
+common.pendIfWindows('This is trickier to convert without opening new shells')
+
 test('setup', function (t) {
   var s = '#!/usr/bin/env bash\n' +
           'echo \"$@\" > ' + JSON.stringify(__dirname) + '/_output\n'
-  fs.writeFileSync(__dirname + '/_script.sh', s, 'ascii')
-  fs.chmodSync(__dirname + '/_script.sh', '0755')
+  fs.writeFileSync(fakeBrowser, s, 'ascii')
+  fs.chmodSync(fakeBrowser, '0755')
   t.pass('made script')
   t.end()
 })
@@ -29,7 +27,7 @@ test('npm repo underscore', function (t) {
       'repo', 'underscore',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -48,7 +46,7 @@ test('npm repo optimist - github (https://)', function (t) {
       'repo', 'optimist',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -67,7 +65,7 @@ test('npm repo npm-test-peer-deps - no repo', function (t) {
       'repo', 'npm-test-peer-deps',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 1, 'exit not ok')
@@ -83,7 +81,7 @@ test('npm repo test-repo-url-http - non-github (http://)', function (t) {
       'repo', 'test-repo-url-http',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -102,7 +100,7 @@ test('npm repo test-repo-url-https - non-github (https://)', function (t) {
       'repo', 'test-repo-url-https',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -121,7 +119,7 @@ test('npm repo test-repo-url-ssh - non-github (ssh://)', function (t) {
       'repo', 'test-repo-url-ssh',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -135,7 +133,7 @@ test('npm repo test-repo-url-ssh - non-github (ssh://)', function (t) {
 })
 
 test('cleanup', function (t) {
-  fs.unlinkSync(__dirname + '/_script.sh')
+  fs.unlinkSync(fakeBrowser)
   t.pass('cleaned up')
   t.end()
 })

--- a/test/tap/scripts-whitespace-windows.js
+++ b/test/tap/scripts-whitespace-windows.js
@@ -37,12 +37,12 @@ var dependency = {
 
 var extend = Object.assign || require('util')._extend
 
-var foo = function () {/*
+var foo = function () { /*
 #!/usr/bin/env node
 
 if (process.argv.length === 8)
   console.log('npm-test-fine')
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
 test('setup', function (t) {
   cleanup()

--- a/test/tap/spawn-enoent-help.js
+++ b/test/tap/spawn-enoent-help.js
@@ -6,6 +6,8 @@ var common = require('../common-tap.js')
 
 var pkg = path.resolve(__dirname, 'spawn-enoent-help')
 
+common.pendIfWindows('man pages are not built on Windows')
+
 test('setup', function (t) {
   rimraf.sync(pkg)
   mkdirp.sync(pkg)

--- a/test/tap/symlink-cycle.js
+++ b/test/tap/symlink-cycle.js
@@ -57,5 +57,5 @@ function setup () {
     path.join(cycle, 'package.json'),
     JSON.stringify(cycleJSON, null, 2)
   )
-  fs.symlinkSync(cycle, path.join(cycle, 'node_modules', 'cycle'))
+  fs.symlinkSync(cycle, path.join(cycle, 'node_modules', 'cycle'), 'junction')
 }

--- a/test/tap/umask-lifecycle.js
+++ b/test/tap/umask-lifecycle.js
@@ -6,24 +6,30 @@ var rimraf = require('rimraf')
 var test = require('tap').test
 var sprintf = require('sprintf-js').sprintf
 
+var escapeExecPath = require('../../lib/utils/escape-exec-path.js')
+var escapeArg = require('../../lib/utils/escape-arg.js')
 var common = require('../common-tap.js')
 var pkg = path.resolve(__dirname, 'umask-lifecycle')
+
+var nodeCmd = escapeExecPath(common.nodeBin)
+var npmCmd = nodeCmd + ' ' + escapeArg(common.bin)
+var umaskScript = npmCmd + ' config get umask && ' + nodeCmd + ' -pe "[process.env.npm_config_umask, process.umask()]"'
 
 var pj = JSON.stringify({
   name: 'x',
   version: '1.2.3',
-  scripts: { umask: '$npm_execpath config get umask && echo "$npm_config_umask" && node -pe "process.umask()"' }
+  scripts: { umask: umaskScript }
 }, null, 2) + '\n'
 
 var umask = process.umask()
 var expected = [
   '',
   '> x@1.2.3 umask ' + path.join(__dirname, 'umask-lifecycle'),
-  '> $npm_execpath config get umask && echo "$npm_config_umask" && node -pe "process.umask()"',
+  '> ' + umaskScript,
   '',
   sprintf('%04o', umask),
-  sprintf('%04o', umask),
-  sprintf('%d', umask),
+  "[ '" + sprintf('%04o', umask) + "', " +
+    sprintf('%d', umask) + ' ]',
   ''
 ].join('\n')
 

--- a/test/tap/unit-child-path.js
+++ b/test/tap/unit-child-path.js
@@ -1,9 +1,16 @@
 'use strict'
 var test = require('tap').test
 var childPath = require('../../lib/utils/child-path.js')
+var path = require('path')
 
 test('childPath', function (t) {
-  t.is(childPath('/path/to', {name: 'abc'}), '/path/to/node_modules/abc', 'basic use')
-  t.is(childPath('/path/to', {package: {name: '@zed/abc'}}), '/path/to/node_modules/@zed/abc', 'scoped use')
+  t.is(
+    path.resolve(childPath('/path/to', {name: 'abc'})),
+    path.resolve('/path/to/node_modules/abc'),
+    'basic use')
+  t.is(
+    path.resolve(childPath('/path/to', {package: {name: '@zed/abc'}})),
+    path.resolve('/path/to/node_modules/@zed/abc'),
+    'scoped use')
   t.end()
 })

--- a/test/tap/unit-link.js
+++ b/test/tap/unit-link.js
@@ -1,0 +1,281 @@
+'use strict'
+var util = require('util')
+var test = require('tap').test
+var requireInject = require('require-inject')
+var dezalgo = require('dezalgo')
+var mkdirp = require('mkdirp')
+var path = require('path')
+
+test('gently/force', function (t) {
+  t.plan(5)
+
+  linkOk(t, 'gently=true, force=false, works', {
+    // args
+    from: 'wibble',
+    to: '/foo/bar/baz',
+    gently: true,
+    abs: true,
+    force: false,
+
+    // expect
+    rm: {'/foo/bar/baz': {gently: true}},
+    mkdir: {'/foo/bar': true},
+    lstat: {'/foo/bar/wibble': {isLink: false}},
+    stat: {'/foo/bar/wibble': true},
+    symlink: {'/foo/bar/wibble': {'/foo/bar/baz': 'junction'}},
+    readlink: {}
+  })
+
+  linkNotOk(t, 'gently=true, force=false, does not work', {
+    // args
+    from: 'wibble',
+    to: '/foo/bar/baz',
+    gently: true,
+    abs: true,
+    force: false,
+
+    // expect
+    rm: {'/foo/bar/baz': {gently: false}},
+    mkdir: {'/foo/bar': true},
+    lstat: {'/foo/bar/wibble': {isLink: false}},
+    stat: {'/foo/bar/wibble': true},
+    symlink: {'/foo/bar/wibble': {'/foo/bar/baz': 'junction'}},
+    readlink: {}
+  })
+
+  linkOk(t, 'gently=false, force=false, aok', {
+    // args
+    from: 'wibble',
+    to: '/foo/bar/baz',
+    gently: false,
+    abs: true,
+    force: false,
+
+    // expect
+    rm: {'/foo/bar/baz': {gently: false}},
+    mkdir: {'/foo/bar': true},
+    lstat: {'/foo/bar/wibble': {isLink: false}},
+    stat: {'/foo/bar/wibble': true},
+    symlink: {'/foo/bar/wibble': {'/foo/bar/baz': 'junction'}},
+    readlink: {}
+  })
+
+  linkOk(t, 'gently=true, force=true, aok', {
+    // args
+    from: 'wibble',
+    to: '/foo/bar/baz',
+    gently: true,
+    abs: true,
+    force: true,
+
+    // expect
+    rm: {'/foo/bar/baz': {gently: false}},
+    mkdir: {'/foo/bar': true},
+    lstat: {'/foo/bar/wibble': {isLink: false}},
+    stat: {'/foo/bar/wibble': true},
+    symlink: {'/foo/bar/wibble': {'/foo/bar/baz': 'junction'}},
+    readlink: {}
+  })
+
+  linkOk(t, 'gently=false, force=true, aok', {
+    // args
+    from: 'wibble',
+    to: '/foo/bar/baz',
+    gently: false,
+    abs: true,
+    force: true,
+
+    // expect
+    rm: {'/foo/bar/baz': {gently: false}},
+    mkdir: {'/foo/bar': true},
+    lstat: {'/foo/bar/wibble': {isLink: false}},
+    stat: {'/foo/bar/wibble': true},
+    symlink: {'/foo/bar/wibble': {'/foo/bar/baz': 'junction'}},
+    readlink: {}
+  })
+})
+
+test('abs, noabs', function (t) {
+  t.plan(4)
+
+  linkOk(t, 'abs', {
+    // args
+    from: 'wibble',
+    to: '/foo/bar/baz',
+    gently: true,
+    abs: true,
+    force: false,
+
+    // expect
+    rm: {'/foo/bar/baz': {gently: true}},
+    mkdir: {'/foo/bar': true},
+    lstat: {'/foo/bar/wibble': {isLink: false}},
+    stat: {'/foo/bar/wibble': true},
+    symlink: {'/foo/bar/wibble': {'/foo/bar/baz': 'junction'}},
+    readlink: {}
+  })
+
+  linkOk(t, 'relative', {
+    // args
+    from: 'wibble',
+    to: '/foo/bar/baz',
+    gently: true,
+    abs: false,
+    force: false,
+
+    // expect
+    rm: {'/foo/bar/baz': {gently: true}},
+    mkdir: {'/foo/bar': true},
+    lstat: {'/foo/bar/wibble': {isLink: false}},
+    stat: {'/foo/bar/wibble': true},
+    symlink: {'wibble': {'/foo/bar/baz': 'junction'}},
+    readlink: {}
+  })
+
+  linkOk(t, 'relative ..', {
+    // args
+    from: '../wibble/bark/blump',
+    to: '/foo/bar/baz',
+    gently: true,
+    abs: false,
+    force: false,
+
+    // expect
+    rm: {'/foo/bar/baz': {gently: true}},
+    mkdir: {'/foo/bar': true},
+    lstat: {'/foo/wibble/bark/blump': {isLink: false}},
+    stat: {'/foo/wibble/bark/blump': true},
+    symlink: {'../wibble/bark/blump': {'/foo/bar/baz': 'junction'}},
+    readlink: {}
+  })
+
+  linkOk(t, 'relative .. deep', {
+    // args
+    from: 'zib/zap/../../../wibble/bark/blump',
+    to: '/foo/bar/baz',
+    gently: true,
+    abs: false,
+    force: false,
+
+    // expect
+    rm: {'/foo/bar/baz': {gently: true}},
+    mkdir: {'/foo/bar': true},
+    lstat: {'/foo/wibble/bark/blump': {isLink: false}},
+    stat: {'/foo/wibble/bark/blump': true},
+    symlink: {'../wibble/bark/blump': {'/foo/bar/baz': 'junction'}},
+    readlink: {}
+  })
+})
+
+function linkOk (t, msg, opts) {
+  testLink(opts, function (err) {
+    t.ifError(err, msg)
+  })
+}
+
+function linkNotOk (t, msg, opts) {
+  testLink(opts, function (err) {
+    t.ok(err, msg)
+  })
+}
+
+function platformPath (unixPath) {
+  if (unixPath[0] === '/') {
+    return path.resolve(unixPath)
+  } else {
+    return path.join.apply(path, unixPath.split('/'))
+  }
+}
+
+function platformerize (obj) {
+  Object.keys(obj).forEach(function (key) {
+    var newKey = platformPath(key)
+    if (typeof obj[key] === 'object') {
+      platformerize(obj[key])
+    } else if (typeof obj[key] === 'string') {
+      obj[key] = platformPath(obj[key])
+    }
+    if (newKey !== key) {
+      obj[newKey] = obj[key]
+      delete obj[key]
+    }
+  })
+}
+
+function testLink (opts, cb) {
+  var mkdirpMock = dezalgo(function (dir, cb) {
+    if (opts.mkdir[dir]) {
+      cb()
+    } else {
+      cb(new Error('mkdirp failed: ' + util.inspect(dir)))
+    }
+  })
+  // sync version used by istanbul for test coverage
+  // we shouldn't have to do this ;.;
+  // require-inject and/or instanbul will need patching
+  mkdirpMock.sync = mkdirp.sync
+
+  // convert any paths in our opts into platform specific paths, for windows support.
+  platformerize(opts)
+
+  var link = requireInject('../../lib/utils/link.js', {
+    '../../lib/npm.js': {
+      config: {
+        get: function (name) {
+          if (name !== 'force') return new Error('unknown config key: ' + name)
+          return opts.force
+        }
+      }
+    },
+    '../../lib/utils/gently-rm.js': dezalgo(function (toRemove, gently, cb) {
+      if (opts.rm[toRemove] && opts.rm[toRemove].gently === gently) {
+        cb()
+      } else {
+        cb(new Error('Removing toRemove: ' + util.inspect(toRemove) +
+          ' gently: ' + util.inspect(gently) +
+          ' not allowed: ' + util.inspect(opts.rm)))
+      }
+    }),
+    'mkdirp': mkdirpMock,
+    'graceful-fs': {
+      'stat': dezalgo(function (file, cb) {
+        if (opts.stat[file]) {
+          cb(null, {})
+        } else {
+          cb(new Error('stat failed for: ' + util.inspect(file)))
+        }
+      }),
+      'lstat': dezalgo(function (file, cb) {
+        if (opts.lstat[file]) {
+          var linkStat = opts.lstat[file]
+          cb(null, {
+            isSymbolicLink: function () {
+              return linkStat.isLink
+            }
+          })
+        } else {
+          cb(new Error('lstat failed for: ' + util.inspect(file)))
+        }
+      }),
+      'symlink': dezalgo(function (from, to, type, cb) {
+        if (!cb) {
+          cb = type
+          type = null
+        }
+        if (opts.symlink[from] && opts.symlink[from][to] === type) {
+          cb()
+        } else {
+          cb(new Error('symlink failed from: ' + util.inspect(from) + ' to: ' + util.inspect(to) + ' type: ' + util.inspect(type)))
+        }
+      }),
+      'readlink': function (file, cb) {
+        if (opts.readlink[file]) {
+          cb()
+        } else {
+          cb(new Error('readlink failed for: ' + util.inspect(file)))
+        }
+      }
+    }
+  })
+  link(opts.from, opts.to, opts.gently, opts.abs, cb)
+}

--- a/test/tap/unpack-foreign-tarball.js
+++ b/test/tap/unpack-foreign-tarball.js
@@ -21,8 +21,7 @@ var EXEC_OPTS = {
     'npm_config_cache': cache,
     'npm_config_tmp': tmp
   },
-  cwd: pkg,
-  stdio: [ 'pipe', 'pipe', 2 ]
+  cwd: pkg
 }
 
 function verify (t, files, err, code) {

--- a/test/tap/unpublish-config.js
+++ b/test/tap/unpublish-config.js
@@ -44,7 +44,7 @@ test('cursory test of unpublishing with config', function (t) {
     res.end(JSON.stringify({
       error: 'shh no tears, only dreams now'
     }))
-    child.kill('SIGHUP')
+    child.kill('SIGINT')
   }).listen(common.port, function () {
     t.pass('server is listening')
 

--- a/test/tap/verify-no-lifecycle-on-repo.js
+++ b/test/tap/verify-no-lifecycle-on-repo.js
@@ -4,7 +4,8 @@ var fs = require('graceful-fs')
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var test = require('tap').test
-var common = require('../common-tap.js')
+var requireInject = require('require-inject')
+require('../common-tap.js')
 
 var base = path.join(__dirname, path.basename(__filename, '.js'))
 
@@ -20,6 +21,17 @@ var baseJSON = {
   }
 }
 
+var lastOpened
+var npm = requireInject.installGlobally('../../lib/npm.js', {
+  '../../lib/utils/lifecycle.js': function (pkg, stage, wd, unsafe, failOk, cb) {
+    cb(new Error("Shouldn't be calling lifecycle scripts"))
+  },
+  opener: function (url, options, cb) {
+    lastOpened = {url: url, options: options}
+    cb()
+  }
+})
+
 test('setup', function (t) {
   cleanup()
   setup()
@@ -27,11 +39,14 @@ test('setup', function (t) {
 })
 
 test('repo', function (t) {
-  common.npm(['repo', '--browser=echo'], {cwd: base}, function (er, code, stdout, stderr) {
-    t.ifError(er, 'npm config ran without issue')
-    t.is(code, 0, 'exited with a non-error code')
-    t.is(stderr, '', 'Ran without errors')
-    t.end()
+  process.chdir(base)
+  npm.load({browser: 'echo'}, function () {
+    npm.commands.repo([], function (err) {
+      t.ifError(err, 'no errors')
+      t.match(lastOpened.url, baseJSON.repository.url, 'opened the right url')
+      t.is(lastOpened.options.command, 'echo', 'opened with a specified browser')
+      t.end()
+    })
   })
 })
 

--- a/test/tap/version-lifecycle.js
+++ b/test/tap/version-lifecycle.js
@@ -21,11 +21,10 @@ test('npm version <semver> with failing preversion lifecycle script', function (
     version: '0.0.0',
     description: 'Test for npm version if preversion script fails',
     scripts: {
-      preversion: './fail.sh'
+      preversion: 'node ./fail.js'
     }
   }), 'utf8')
-  fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', 'utf8')
-  fs.chmodSync(path.resolve(pkg, 'fail.sh'), 448)
+  fs.writeFileSync(path.resolve(pkg, 'fail.js'), 'process.exit(50)', 'utf8')
   npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
     var version = require('../../lib/version')
     version(['patch'], function (err) {
@@ -44,11 +43,10 @@ test('npm version <semver> with failing version lifecycle script', function (t) 
     version: '0.0.0',
     description: 'Test for npm version if postversion script fails',
     scripts: {
-      version: './fail.sh'
+      version: 'node ./fail.js'
     }
   }), 'utf8')
-  fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', 'utf8')
-  fs.chmodSync(path.resolve(pkg, 'fail.sh'), 448)
+  fs.writeFileSync(path.resolve(pkg, 'fail.js'), 'process.exit(50)', 'utf8')
   npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
     var version = require('../../lib/version')
     version(['patch'], function (err) {
@@ -67,11 +65,10 @@ test('npm version <semver> with failing postversion lifecycle script', function 
     version: '0.0.0',
     description: 'Test for npm version if postversion script fails',
     scripts: {
-      postversion: './fail.sh'
+      postversion: 'node ./fail.js'
     }
   }), 'utf8')
-  fs.writeFileSync(path.resolve(pkg, 'fail.sh'), 'exit 50', 'utf8')
-  fs.chmodSync(path.resolve(pkg, 'fail.sh'), 448)
+  fs.writeFileSync(path.resolve(pkg, 'fail.js'), 'process.exit(50)', 'utf8')
   npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
     var version = require('../../lib/version')
     version(['patch'], function (err) {
@@ -90,9 +87,9 @@ test('npm version <semver> execution order', function (t) {
     version: '0.0.0',
     description: 'Test for npm version if postversion script fails',
     scripts: {
-      preversion: './preversion.sh',
-      version: './version.sh',
-      postversion: './postversion.sh'
+      preversion: 'node ./preversion.js',
+      version: 'node ./version.js',
+      postversion: 'node ./postversion.js'
     }
   }), 'utf8')
   makeScript('preversion')
@@ -143,14 +140,31 @@ function setup () {
 }
 
 function makeScript (lifecycle) {
-  var contents = [
-    'cp package.json ' + lifecycle + '-package.json',
-    'git add ' + lifecycle + '-package.json',
-    'git status --porcelain > ' + lifecycle + '-git.txt'
-  ].join('\n')
-  var scriptPath = path.join(pkg, lifecycle + '.sh')
-  fs.writeFileSync(scriptPath, contents, 'utf-8')
-  fs.chmodSync(scriptPath, 448)
+  function contents (lifecycle) {
+    var fs = require('fs')
+    var exec = require('child_process').exec
+    fs.createReadStream('package.json')
+      .pipe(fs.createWriteStream(lifecycle + '-package.json'))
+      .on('close', function () {
+        exec(
+          'git add ' + lifecycle + '-package.json',
+          function () {
+            exec(
+              'git status --porcelain',
+              function (err, stdout) {
+                if (err) throw err
+                fs.writeFileSync(lifecycle + '-git.txt', stdout)
+              }
+            )
+          }
+        )
+      })
+  }
+  var scriptPath = path.join(pkg, lifecycle + '.js')
+  fs.writeFileSync(
+    scriptPath,
+    '(' + contents.toString() + ')(\'' + lifecycle + '\')',
+    'utf-8')
 }
 
 function readPackage (lifecycle) {

--- a/test/tap/version-update-shrinkwrap.js
+++ b/test/tap/version-update-shrinkwrap.js
@@ -110,15 +110,12 @@ test('npm version <semver> updates shrinkwrap and updates git', function (t) {
 })
 
 test('cleanup', function (t) {
-  // windows fix for locked files
-  process.chdir(osenv.tmpdir())
-
-  rimraf.sync(pkg)
+  cleanup()
   t.end()
 })
 
 function setup () {
-  rimraf.sync(pkg)
+  cleanup()
   mkdirp.sync(pkg)
   mkdirp.sync(cache)
   var contents = {
@@ -131,4 +128,11 @@ function setup () {
   fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify(contents), 'utf8')
   fs.writeFileSync(path.resolve(pkg, 'npm-shrinkwrap.json'), JSON.stringify(contents), 'utf8')
   process.chdir(pkg)
+}
+
+function cleanup () {
+  // windows fix for locked files
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(cache)
+  rimraf.sync(pkg)
 }


### PR DESCRIPTION
Making a PR for this to track our work. 

After cloning the repo make sure you do an `npm rebuild` in order to get cmdshims for your binaries.

Also be aware that `tap`'s glob support doesn't seem to support windows-type-slashes, so `npm run tap test/tap/l*.js` works but `npm run tap test\tap\l*.js` does not.

I've not tested test/tap/registry.js as I don't have couchdb in windows as yet.

Currently failing tests are: (as run from the "Github Shell", which is a powershell with git stuff in the path)
## @iarna
#### subshell issues
- [x] test/tap/builtin-config.js _fails when run from a path with a space in its name_
- [x] test/tap/verify-no-lifecycle-on-repo.js _(opened up a new cmd window‼)_
#### symlinks
- [x] test/tap/do-not-remove-other-bins.js
- [x] test/tap/gently-rm-linked-module.js _fails when run with `npm run tap`
- [x] test/tap/gently-rm-symlinked-global-dir.js
- [x] test/tap/lifecycle-path.js (yes, this one is in $PATH too)
- [x] test/tap/publish-access-unscoped-restricted-fails.js
- [x] test/tap/symlink-cycle.js
- [x] test/tap/unit-gentlyrm.js
#### unicode not defaulting to true
- [x] test/tap/extraneous-dep-cycle-ls-ok.js _fails only because we're not defaulting unicode to true_
- [x] test/tap/ls-l-depth-0.js _fails only because we're not defaulting unicode to true_
#### $PATH
- [x] test/tap/lifecycle-path.js _pmfi?_
#### $ var substitutions
- [x] test/tap/umask-lifecycle.js
#### config/env parsing issues

Usually just stuff with strings ending up as numbers, I think
- [x] test/tap/config-basic.js
- [x] test/tap/config-builtin.js
## @zkat
#### git-related
- [x] test/tap/add-remote-git-file.js
- [x] test/tap/github-shortcut.js
- [x] test/tap/version-update-shrinkwrap.js
- [x] test/tap/version-lifecycle.js
#### simple pathname matches
- [x] test/tap/dedupe-scoped.js
- [x] test/tap/outdated-depth-integer.js
- [x] test/tap/unit-child-path.js
- [x] test/tap/unit-module-name.js
- [x] test/tap/unit-package-id.js
#### maximum callstack exceeded :scream:
- [x] test/tap/legacy-\* _(fail for many reasons, not the least that mkdirp.sync is blowing the stack recursing: there may also be a Tacks bug)_
#### `\r\n` issues
- [x] test/tap/config-certfile.js (there looks like some `\r` chars are missing? in the cert as read?)
- [x] test/tap/graceful-restart.js (this one is a simple issue with `\r\n` in the test checks)
- [x] test/tap/outdated.js
#### Misc
- [x] test/tap/check-permissions.js
- [x] test/tap/config-edit.js _fails if there's a space in your path_
- [x] test/tap/cruft-test.js
- [x] test/tap/install-scoped-link.js _fails if there's a space in your path_
- [x] test/tap/git-cache-no-hooks.js _only fails with `npm t`_
- [x] test/tap/logout.js
- [x] test/tap/outdated-depth-deep.js _fails when run from a path with a space in its name_
## Unassigned
#### ENOSYS kill
- [x] test/tap/publish-config.js
- [x] test/tap/unpublish-config.js
#### misc

These are either unclear problems, or ungrouped ones that don't seem to have other related ones.
- [x] test/tap/config-project.js
- [x] test/tap/git-cache-locking.js
- [x] test/tap/git-npmignore.js
- [x] test/tap/git-races.js _fails if there's a space in your path_
- [x] test/tap/install-bad-man.js
- [x] test/tap/install-link-scripts.js
- [x] test/tap/install-man.js
- [x] test/tap/install-save-local.js
- [x] test/tap/install-scoped-already-installed.js
- [x] test/tap/logout-scoped.js
- [x] test/tap/shrinkwrap-save-with-existing-dev-deps.js
- [x] test/tap/sorted-package-json.js
- [x] test/tap/spawn-enoent-help.js
- [x] test/tap/cache-shasum.js _fails if there's a space in your path_
