### PR TITLE
Document the --registry flag for `npm search`

### DIFF
--- a/doc/cli/npm-search.md
+++ b/doc/cli/npm-search.md
@@ -27,6 +27,15 @@ lines. When disabled (default) search results are truncated to fit
 neatly on a single line. Modules with extremely long names will
 fall on multiple lines.
 
+### registry
+
+ * Default: https://registry.npmjs.org/
+ * Type   : url
+
+Search the specified registry for modules. If you have configured npm to point to a different default registry, 
+such as your internal private module repository, `npm search` will default to that registry when searching.
+Pass a different registry url such as the default above in order to override this setting.
+
 ## SEE ALSO
 
 * npm-registry(7)


### PR DESCRIPTION
We use an internal private module server and I was trying to search the public registry. Tried this and it worked. I looked for a default CLI page that might be the better place to indicate which flags (if there are others?) work with all CLI commands, but the docs aren't laid out that way.
