### PR TITLE
List packages which were involved in an unresolved package error.

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -452,7 +452,10 @@ function replaceModule (obj, key, child) {
 function resolveWithNewModule (pkg, tree, log, next) {
   validate('OOOF', arguments)
   if (pkg.type) {
-    return fetchPackageMetadata(pkg, packageRelativePath(tree), log.newItem('fetchMetadata'), iferr(next, function (pkg) {
+    return fetchPackageMetadata(pkg, packageRelativePath(tree), log.newItem('fetchMetadata'), iferr(function (error) {
+      error.message += 'Requested by ' + flatNameFromTree(tree) + '\n'
+      return next(error)
+    }, function (pkg) {
       resolveWithNewModule(pkg, tree, log, next)
     }))
   }


### PR DESCRIPTION
While trying to install https://github.com/DefinitelyTyped/definitelytyped.github.io dependencies, I was unable to resolve some dependencies.

However, `npm` wasn't very helpful in telling me from where the dependency came:

```
npm WARN deprecated lodash@2.4.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0
loadDep:eco -> 304        \ |###########################################--------------------------------------------------------------------------------------|
npm ERR! Windows_NT 6.1.7601
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install"
npm ERR! node v5.6.0
npm ERR! npm  v3.6.0

npm ERR! No compatible version found: eco@~1.1.0
npm ERR! Valid install targets:
npm ERR! 1.1.0-rc-3, 1.1.0-rc-2, 1.1.0-rc-1, 1.0.3, 1.0.2, 1.0.1, 1.0.0
npm ERR!
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     E:\Tom\Documents\GIT\definitelytyped.github.io\npm-debug.log
```

I can certainly see it's unable to resolve `eco@~1.1.0`, however I have no clear indication of where this dependency comes from.

This little change adds a line at the end of the given error which looks like "Requested by /docpad-plugin-eco".

```
npm WARN deprecated lodash@2.4.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0
loadDep:eco -> 304        \ |###########################################--------------------------------------------------------------------------------------|
npm ERR! Windows_NT 6.1.7601
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install"
npm ERR! node v5.6.0
npm ERR! npm  v3.6.0

npm ERR! No compatible version found: eco@~1.1.0
npm ERR! Valid install targets:
npm ERR! 1.1.0-rc-3, 1.1.0-rc-2, 1.1.0-rc-1, 1.0.3, 1.0.2, 1.0.1, 1.0.0
npm ERR! Requested by /docpad-plugin-eco
npm ERR!
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     E:\Tom\Documents\GIT\definitelytyped.github.io\npm-debug.log
```

Since I am very unfamiliar with the npm code, I've only made sure it was returning me what I expected to see, however the error handling may not be at the most appropriate place and done the proper way, so please advise.
