### PR TITLE
npm run should use shell defined in npm config to spawn new processes

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -43,6 +43,16 @@ instead of `"scripts": {"test": "node_modules/.bin/tap test/\*.js"}` to run your
 If you try to run a script without having a `node_modules` directory and it fails,
 you will be given a warning to run `npm install`, just in case you've forgotten.
 
+## CONFIGURATION
+
+### shell
+
+* Default: SHELL environment variable, or "bash" on Posix, or "cmd" on
+  Windows
+* Type: path
+
+The shell to run for the `npm run-script` command.
+
 ## SEE ALSO
 
 * npm-scripts(7)

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -213,7 +213,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
     conf.gid = gid ^ 0
   }
 
-  var sh = 'sh'
+  var sh = npm.config.get('shell')
   var shFlag = '-c'
 
   if (process.platform === 'win32') {
@@ -224,6 +224,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
 
   log.verbose('lifecycle', logid(pkg, stage), 'PATH:', env[PATH])
   log.verbose('lifecycle', logid(pkg, stage), 'CWD:', wd)
+  log.verbose('lifecycle', logid(pkg, stage), 'SHELL:', sh)
   log.silly('lifecycle', logid(pkg, stage), 'Args:', [shFlag, cmd])
 
   var progressEnabled = log.progressEnabled

--- a/test/tap/lifecycle-path.js
+++ b/test/tap/lifecycle-path.js
@@ -44,7 +44,7 @@ test('setup', function (t) {
 })
 
 test('make sure the path is correct', function (t) {
-  common.npm(['run-script', 'path'], {
+  common.npm(['run-script', 'path', '--shell', 'sh'], {
     cwd: pkg,
     env: {
       PATH: PATH,

--- a/test/tap/lifecycle-runcmd.js
+++ b/test/tap/lifecycle-runcmd.js
@@ -1,0 +1,83 @@
+if (process.platform === 'win32') {
+  console.error('skipping test, because windows and shebangs')
+  process.exit(0)
+}
+
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+
+var pkg = path.resolve(__dirname, 'lifecycle-runcmd')
+var link = path.resolve(pkg, 'node-bin')
+
+var PATH = '/bin:/usr/bin'
+
+var testShFileName = path.join(pkg, 'testsh')
+
+var json = {
+  name: 'glorb',
+  version: '1.2.3',
+  scripts: {
+    shell: 'ok'
+  }
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  fs.writeFileSync(testShFileName, '#!/bin/bash\necho $@\n')
+  fs.chmodSync(testShFileName, '755')
+  fs.symlinkSync(path.dirname(process.execPath), link, 'dir')
+  t.end()
+})
+
+test('make sure that nonexistant shell fails', function (t) {
+  common.npm(['run-script', 'shell', '--shell', 'nosuchshell'], {
+    cwd: pkg,
+    env: {
+      PATH: PATH,
+      stdio: [0, 'pipe', 2]
+    }
+  }, function (er, code, stdout) {
+    if (er) throw er
+    t.equal(code, 1, 'exit code')
+    t.end()
+  })
+})
+
+test('make sure the shell is correct', function (t) {
+  common.npm(['run-script', 'shell', '--shell', testShFileName], {
+    cwd: pkg,
+    env: {
+      PATH: PATH,
+      stdio: [ 0, 'pipe', 2 ]
+    }
+  }, function (er, code, stdout) {
+    if (er) throw er
+    t.equal(code, 0, 'exit code')
+    var actual = stdout.trim().split(/\r|\n/).pop()
+    var expected = '-c ok'
+    t.equal(actual, expected)
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}

--- a/test/tap/registry.js
+++ b/test/tap/registry.js
@@ -49,7 +49,7 @@ function runTests () {
         env: env,
         stdio: 'inherit'
       }
-      common.npm(['test', '--', '-Rtap'], opts, function (err, code) {
+      common.npm(['run', 'test', '--shell', 'sh', '--', '-Rtap'], opts, function (err, code) {
         if (err) { throw err }
         if (code) {
           return test('need test to work', function (t) {


### PR DESCRIPTION
Due to a feature/bug in the default /bin/sh of **debian** / **ubuntu** (`dash(1)`), `npm run` will fail, if the current working directory contains a percent symbol ("%").
`npm run` will add to environment variable `PATH`  `$PWD/node_modules/.bin` as described in [npm-run-script.md](https://github.com/npm/npm/blob/master/doc/cli/npm-run-script.md) and triggers the [feature/bug in DASH](http://www.mail-archive.com/dash%40vger.kernel.org/msg00970.html) because the current working directory contains a "%".
On systems, where /bin/sh is a bash (like OpenSuSE) or another not affected shell (like KSH), this is not an issue.
# how to reproduce

```
mkdir /tmp/%
cd /tmp/%
cat <<_EOF > package.json
{
  "name": "test",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "dependencies": {},
  "devDependencies": {
    "karma": "^0.13.21"
  },
  "scripts": {
    "test": "karma start --single-run"
  },
  "author": "",
  "license": "ISC"
}
_EOF
npm install
npm test
```

Output of `npm test`:

```
/tmp/%$ npm test

> test@1.0.0 test /tmp/%
> karma start --single-run

sh: 1: karma: not found
npm ERR! Test failed.  See above for more details.
```
# solution

Instead of spawning a hard coded `'sh` subprocess [lifecycle.js line 216](https://github.com/npm/npm/blob/94929cf05854886b1aa9b611ad3bbb6dbbb575f3/lib/utils/lifecycle.js#L216), it would be more consistent to use the `npm config` value `shell` like [explore.js line 21](https://github.com/npm/npm/blob/94929cf05854886b1aa9b611ad3bbb6dbbb575f3/lib/explore.js#L21)

With this PR, `npm test` will work properly unless your configured shell is dash with `npm config set /bin/dash`.

As `npm run` support setting configuration as parameter,

```
npm run test --shell /bin/dash
```

will still fail,

```
npm run test --shell /bin/bash
```

will work fine.

This PR also enables user to easily use a shell which might not be in located in default PATH environment or a alternative shell. This might be helpful for Jenkins instances on exotic UN*X systems.
