### PR TITLE
Only list runtime dependencies when doing `npm ls --production`

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -117,12 +117,18 @@ function filterByEnv (data) {
   var dev = npm.config.get('dev') || /^dev(elopment)?$/.test(npm.config.get('only'))
   var production = npm.config.get('production') || /^prod(uction)?$/.test(npm.config.get('only'))
   var dependencies = {}
-  var devDependencies = data.devDependencies || []
+  var devKeys = Object.keys(data.devDependencies || [])
+  var prodKeys = Object.keys(data._dependencies || [])
   Object.keys(data.dependencies).forEach(function (name) {
-    var keys = Object.keys(devDependencies)
-    if (dev && !production && keys.indexOf(name) === -1) return
-    if (!dev && keys.indexOf(name) !== -1 && data.dependencies[name].missing) return
-    dependencies[name] = data.dependencies[name]
+    if (!dev && devKeys.indexOf(name) !== -1 && data.dependencies[name].missing) {
+      return
+    }
+
+    if ((dev && devKeys.indexOf(name) !== -1) ||            // only --dev
+        (production && prodKeys.indexOf(name) !== -1) ||    // only --production
+        (!dev && !production)) {                            // no --production|--dev|--only=xxx
+      dependencies[name] = data.dependencies[name]
+    }
   })
   data.dependencies = dependencies
 }

--- a/test/tap/ls-production-and-dev.js
+++ b/test/tap/ls-production-and-dev.js
@@ -17,10 +17,12 @@ var json = {
   name: 'ls-env',
   version: '0.0.0',
   dependencies: {
-    'test-package-with-one-dep': '0.0.0'
+    'test-package-with-one-dep': '0.0.0',
+    'test-repo-url-ssh': '0.0.1'
   },
   devDependencies: {
-    'test-package-with-one-dep': '0.0.0'
+    'test-package-with-one-dep': '0.0.0',
+    'test-repo-url-https': '0.0.1'
   }
 }
 
@@ -56,6 +58,16 @@ test('npm ls --dev', function (t) {
       stdout,
       /test-package-with-one-dep@0\.0\.0/,
       'output contains test-package-with-one-dep@0.0.0'
+    )
+    t.has(
+      stdout,
+      /test-repo-url-https@0\.0\.1/,
+      'output contains test-repo-url-https@0.0.1'
+    )
+    t.doesNotHave(
+      stdout,
+      /test-repo-url-ssh@0\.0\.1/,
+      'output does NOT contain test-repo-url-ssh@0.0.1'
     )
     t.end()
   })
@@ -95,6 +107,16 @@ test('npm ls --production', function (t) {
       stdout,
       /test-package-with-one-dep@0\.0\.0/,
       'output contains test-package-with-one-dep@0.0.0'
+    )
+    t.has(
+      stdout,
+      /test-repo-url-ssh@0\.0\.1/,
+      'output contains test-repo-url-ssh@0.0.1'
+    )
+    t.doesNotHave(
+      stdout,
+      /test-repo-url-https@0\.0\.1/,
+      'output does NOT contain test-repo-url-https@0.0.1'
     )
     t.end()
   })


### PR DESCRIPTION
fix #11559
