### PR TITLE
install: Make install reports only include versions installed

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -667,7 +667,7 @@ Installer.prototype.printInstalled = function (cb) {
     return !child.failed && (mutation === 'add' || mutation === 'update')
   }).map(function (action) {
     var child = action[1]
-    return packageId(child)
+    return child.path
   })
   log.showProgress()
   if (!addedOrMoved.length) return cb()

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -60,8 +60,7 @@ var lsFromTree = ls.fromTree = function (dir, physicalTree, args, silent, cb) {
       var p = npa(a)
       var name = p.name
       var ver = semver.validRange(p.rawSpec) || ''
-
-      return [ name, ver ]
+      return [ name, ver, a ]
     })
   }
 
@@ -280,15 +279,20 @@ function filterFound (root, args) {
   if (!args.length) return root
   var deps = root.dependencies
   if (deps) {
-    Object.keys(deps).forEach(function (d) {
-      var dep = filterFound(deps[d], args)
+    Object.keys(deps).forEach(function (depName) {
+      var dep = filterFound(deps[depName], args)
       if (dep.peerMissing) return
 
       // see if this one itself matches
       var found = false
-      for (var i = 0; !found && i < args.length; i++) {
-        if (d === args[i][0]) {
-          found = semver.satisfies(dep.version, args[i][1], true)
+      for (var ii = 0; !found && ii < args.length; ii++) {
+        var argName = args[ii][0]
+        var argVersion = args[ii][1]
+        var argRaw = args[ii][2]
+        if (depName === argName) {
+          found = semver.satisfies(dep.version, argVersion, true)
+        } else if (dep.path === argRaw) {
+          found = true
         }
       }
       // included explicitly
@@ -296,7 +300,7 @@ function filterFound (root, args) {
       // included because a child was included
       if (dep._found && !root._found) root._found = 1
       // not included
-      if (!dep._found) delete deps[d]
+      if (!dep._found) delete deps[depName]
     })
   }
   if (!root._found) root._found = false

--- a/test/tap/install-report-just-installed.js
+++ b/test/tap/install-report-just-installed.js
@@ -1,0 +1,76 @@
+'use strict'
+var path = require('path')
+var test = require('tap').test
+var Tacks = require('tacks')
+var Dir = Tacks.Dir
+var File = Tacks.File
+var common = require('../common-tap.js')
+
+var testdir = path.resolve(__dirname, path.basename(__filename, '.js'))
+var fixture = new Tacks(Dir({
+  node_modules: Dir({
+    a: Dir({
+      'package.json': File({
+        name: 'a',
+        version: '1.0.0',
+        dependencies: {
+          b: '1.0.0'
+        }
+      }),
+      node_modules: Dir({
+        b: Dir({
+          'package.json': File({
+            name: 'b',
+            version: '1.0.0'
+          })
+        })
+      })
+    })
+  }),
+  'b-src': Dir({
+    'package.json': File({
+      name: 'b',
+      version: '1.0.0'
+    })
+  })
+}))
+
+function setup () {
+  cleanup()
+  fixture.create(testdir)
+}
+
+function cleanup () {
+  fixture.remove(testdir)
+}
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+test('install-report', function (t) {
+  common.npm(['install', '--json', 'b-src'], {cwd: testdir}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'installed successfully')
+    t.is(stderr, '', 'no warnings')
+    try {
+      var report = JSON.parse(stdout)
+      t.pass('stdout was json')
+    } catch (ex) {
+      t.fail('stdout was json')
+      console.error(ex)
+      t.skip(2)
+      return t.end()
+    }
+    var depNames = Object.keys(report.dependencies)
+    t.is(depNames.length, 1, 'one dependency reported as installed')
+    t.ok(report.dependencies.b, 'that dependency was `b`')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
This makes install select modules to display by install path.  Previously it
was using name@version, which worked as long as you didn't have duplicates
in your tree, but was basically wrong forever if you did (as in npm's own
tree).
