### PR TITLE
lifecycle: prefer current node in run-script

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -83,6 +83,9 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
   // the bundled one will be used for installing things.
   pathArr.unshift(path.join(__dirname, "..", "..", "bin", "node-gyp-bin"))
 
+  // prefer current node interpreter in child scripts
+  pathArr.push(path.dirname(process.execPath))
+
   if (env[PATH]) pathArr.push(env[PATH])
   env[PATH] = pathArr.join(process.platform === "win32" ? ";" : ":")
 

--- a/test/tap/lifecycle-path.js
+++ b/test/tap/lifecycle-path.js
@@ -67,7 +67,8 @@ test('make sure the path is correct', function (t) {
     // get the ones we tacked on, then the system-specific requirements
     var expect = [
       '{{ROOT}}/bin/node-gyp-bin',
-      '{{ROOT}}/test/tap/lifecycle-path/node_modules/.bin'
+      '{{ROOT}}/test/tap/lifecycle-path/node_modules/.bin',
+      path.dirname(process.execPath)
     ].concat(PATH.split(pathSplit).map(function (p) {
       return p.replace(/\\/g, '/')
     }))


### PR DESCRIPTION
This is a backport of #11204 by @segrey to 2.x branch which I believe was lost.

Fixes: #11175
Fixes: #9253

As mentioned in https://github.com/npm/npm/pull/11204#issuecomment-186705334 current behaviour of `npm@latest-2x` is really annoying in cases where one can't have nodejs + npm installed globally. 

For example our internal build farms have different nodejs versions installed to `/opt/nodejs/<ver>`, so we run `npm` with `/opt/nodejs/<N>/bin/node /opt/nodejs/<N>/bin/npm` from our build scripts. Everything works fine for projects that run nodejs-0.10 or node-5 that have `npm@1x` and `npm@3x` accordingly and which don't have the bug. But for projects that use nodejs-4 builds might fail if one uses an npm module that needs `#!/usr/bin/env node` to run.
