### PR TITLE
doc: Add directories.test doc

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -329,6 +329,11 @@ maybe, someday.
 
 Put example scripts in here.  Someday, it might be exposed in some clever way.
 
+### directories.test
+
+Put your tests in here. It is currently not exposed, but it might be in the
+future.
+
 ## repository
 
 Specify the place where your code lives. This is helpful for people who


### PR DESCRIPTION
I raised npm/docs#476 when I discovered what I thought was unusual behaviour with the directories parameter after `npm init`-ing, and then I discovered it was just an undocumented feature. So I did some digging over in that issue, and this PR is the end result.

Given the `directories.test` is similarly unexposed as with a few of the other `directories.*` properties, I figured keeping a similar writing style when mentioning it was 👍.

Thanks! 💖
