### PR TITLE
./ syntax must be valid in .npmignore

### DIFF
--- a/test/tap/files-and-ignores.js
+++ b/test/tap/files-and-ignores.js
@@ -92,6 +92,7 @@ test('toplevel-only and blanket ignores', function (t) {
   )
   withFixture(t, fixture, function (done) {
     t.notOk(fileExists('shallow2'), '/ file excluded')
+    t.notOk(fileExists('shallow1'), './ file excluded')
     t.ok(fileExists('sub/shallow1'), 'nested ./ file included')
     t.ok(fileExists('sub/shallow2'), 'nested / file included')
     t.ok(fileExists('sub/sub/onelevel'), 'double-nested file included')
@@ -99,7 +100,6 @@ test('toplevel-only and blanket ignores', function (t) {
     t.notOk(fileExists('deep'), 'deep file excluded')
     t.notOk(fileExists('sub/deep'), 'nested deep file excluded')
     t.notOk(fileExists('sub/sub/deep'), 'double-nested deep file excluded')
-    t.ok(fileExists('shallow1'), './ file included')
     done()
   })
 })
@@ -178,6 +178,7 @@ test('.gitignore should have identical semantics', function (t) {
   )
   withFixture(t, fixture, function (done) {
     t.notOk(fileExists('shallow2'), '/ file excluded')
+    t.notOk(fileExists('shallow1'), './ file excluded')
     t.ok(fileExists('sub/shallow1'), 'nested ./ file included')
     t.ok(fileExists('sub/shallow2'), 'nested / file included')
     t.ok(fileExists('sub/sub/onelevel'), 'double-nested file included')
@@ -185,7 +186,6 @@ test('.gitignore should have identical semantics', function (t) {
     t.notOk(fileExists('deep'), 'deep file excluded')
     t.notOk(fileExists('sub/deep'), 'nested deep file excluded')
     t.notOk(fileExists('sub/sub/deep'), 'double-nested deep file excluded')
-    t.ok(fileExists('shallow1'), './ file included')
     done()
   })
 })


### PR DESCRIPTION
Currently, `./` does not ignore files when used in `.npmignore`. This fixes it so it works as expected

**WIP** -- this is only a breaking test so far.
