### PR TITLE
npmignore should trump files array

### DIFF
--- a/test/tap/files-and-ignores.js
+++ b/test/tap/files-and-ignores.js
@@ -190,32 +190,34 @@ test('.gitignore should have identical semantics', function (t) {
   })
 })
 
-test('.npmignore should always be overridden by files array', function (t) {
+test('.npmignore should always override files array', function (t) {
   var fixture = new Tacks(
     Dir({
       'package.json': File({
         name: 'npm-test-files',
         version: '1.2.5',
         files: [
-          'include',
+          'other',
           'sub'
         ]
       }),
       '.npmignore': File(
-        'include\n' +
+        'other\n' +
         'ignore\n' +
-        'sub/included\n'
+        'sub/other\n'
       ),
-      include: File(''),
+      other: File(''),
       ignore: File(''),
       sub: Dir({
+        other: File(''),
         include: File('')
       })
     })
   )
   withFixture(t, fixture, function (done) {
     t.notOk(fileExists('ignore'), 'toplevel file excluded')
-    t.ok(fileExists('include'), 'unignored file included')
+    t.notOk(fileExists('other'), 'file included in `files` excluded')
+    t.notOk(fileExists('sub/other'), 'nested ignored file excluded')
     t.ok(fileExists('sub/include'), 'nested file included')
     done()
   })


### PR DESCRIPTION
currently, anything explicitly in files array gets included, regardless of `.npmignore` lines

**WIP** -- this is only a breaking test so far.

Related: https://github.com/npm/fstream-npm/pull/20
