### PR TITLE
Fix flappy test/tap/peer-deps-invalid.js due to race in peer-dep handling

### DIFF
--- a/test/tap/peer-deps-invalid.js
+++ b/test/tap/peer-deps-invalid.js
@@ -74,8 +74,8 @@ test('installing dependencies that have conflicting peerDependencies', function 
         } else {
           t.equal(err.code, "EPEERINVALID")
           t.equal(err.packageName, "underscore")
-          t.equal(err.packageVersion, "1.3.3")
-          t.equal(err.message, "The package underscore@1.3.3 does not satisfy its siblings' peerDependencies requirements!")
+          t.match(err.packageVersion, /^1\.3\.[13]$/)
+          t.match(err.message, /^The package underscore@1\.3\.[13] does not satisfy its siblings' peerDependencies requirements!$/)
         }
         s.close() // shutdown mock registry.
         t.end()

--- a/test/tap/peer-deps-invalid.js
+++ b/test/tap/peer-deps-invalid.js
@@ -6,73 +6,66 @@ var mr = require('npm-registry-mock')
 var osenv = require('osenv')
 var rimraf = require('rimraf')
 var test = require('tap').test
+var Tacks = require('tacks')
+var Dir = Tacks.Dir
+var File = Tacks.File
 
 var npm = require('../../')
 var common = require('../common-tap')
 
-var pkg = path.resolve(__dirname, 'peer-deps-invalid')
-var cache = path.resolve(pkg, 'cache')
+var testdir = path.resolve(__dirname, path.basename(__filename, '.js'))
+var cachedir = path.resolve(testdir, 'cache')
 
-var json = {
-  author: 'Domenic Denicola <domenic@domenicdenicola.com> (http://domenicdenicola.com/)',
-  name: 'peer-deps-invalid',
-  version: '0.0.0',
-  dependencies: {
-    'npm-test-peer-deps-file': 'http://localhost:1337/ok.js',
-    'npm-test-peer-deps-file-invalid': 'http://localhost:1337/invalid.js'
-  }
-}
-
-var fileFail = function () {
-/**package
-* { "name": "npm-test-peer-deps-file-invalid"
-* , "main": "index.js"
-* , "version": "1.2.3"
-* , "description":"This one should conflict with the other one"
-* , "peerDependencies": { "underscore": "1.3.3" }
-* }
-**/
-  module.exports = 'I\'m just a lonely index, naked as the day I was born.'
-}.toString().split('\n').slice(1, -1).join('\n')
-
-var fileOK = function () {
-/**package
-* { "name": "npm-test-peer-deps-file"
-* , "main": "index.js"
-* , "version": "1.2.3"
-* , "description":"No package.json in sight!"
-* , "peerDependencies": { "underscore": "1.3.1" }
-* , "dependencies": { "mkdirp": "0.3.5" }
-* }
-**/
-  module.exports = 'I\'m just a lonely index, naked as the day I was born.'
-}.toString().split('\n').slice(1, -1).join('\n')
+var fixtures = new Tacks(Dir({
+  cache: Dir({}),
+  'package.json': File({
+    author: 'Domenic Denicola <domenic@domenicdenicola.com> (http://domenicdenicola.com/)',
+    name: 'peer-deps-invalid',
+    version: '0.0.0',
+    dependencies: {
+      'npm-test-peer-deps-file': 'file-ok/',
+      'npm-test-peer-deps-file-invalid': 'file-fail/'
+    }
+  }),
+  'file-ok': Dir({
+    'package.json': File({
+      name: 'npm-test-peer-deps-file',
+      main: 'index.js',
+      version: '1.2.3',
+      description:'This one should conflict with the other one',
+      peerDependencies: { underscore: '1.3.1' },
+      dependencies: { mkdirp: '0.3.5' }
+    }),
+    'index.js': File(
+      "module.exports = 'I\'m just a lonely index, naked as the day I was born.'"
+    ),
+  }),
+  'file-fail': Dir({
+    'package.json': File({
+      name: 'npm-test-peer-deps-file-invalid',
+      main: 'index.js',
+      version: '1.2.3',
+      description:'This one should conflict with the other one',
+      peerDependencies: { underscore: '1.3.3' }
+    }),
+    'index.js': File(
+      "module.exports = 'I\'m just a lonely index, naked as the day I was born.'"
+    ),
+  }),
+}))
 
 test('setup', function (t) {
   cleanup()
-  mkdirp.sync(cache)
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  fs.writeFileSync(path.join(pkg, 'file-ok.js'), fileOK)
-  fs.writeFileSync(path.join(pkg, 'file-fail.js'), fileFail)
-
-  process.chdir(pkg)
+  fixtures.create(testdir)
+  process.chdir(testdir)
   t.end()
 })
 
 test('installing dependencies that have conflicting peerDependencies', function (t) {
-  var customMocks = {
-    'get': {
-      '/ok.js': [200, path.join(pkg, 'file-ok.js')],
-      '/invalid.js': [200, path.join(pkg, 'file-fail.js')]
-    }
-  }
-  mr({port: common.port, mocks: customMocks}, function (err, s) { // create mock registry.
+  mr({port: common.port}, function (err, s) { // create mock registry.
     t.ifError(err, 'mock registry started')
     npm.load({
-      cache: pkg + "/cache",
+      cache: cachedir,
       registry: common.registry
     }, function () {
       npm.commands.install([], function (err) {
@@ -97,6 +90,5 @@ test('cleanup', function (t) {
 })
 
 function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
+  fixtures.remove(testdir)
 }


### PR DESCRIPTION
This is a fix for #11688, by making the test resilient to a race in npm@2– the race means that in the case of a peer dependency conflict, we can't say in advance which of the conflicting peers will produce the error message. All we can say is that one of them WILL.
