### PR TITLE
ls: Do not set process.exitCode when ls is executed during the unbuild phase

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -95,7 +95,17 @@ var lsFromTree = ls.fromTree = function (dir, physicalTree, args, silent, cb) {
   }
   console.log(out)
 
-  if (args.length && !data._found) process.exitCode = 1
+  // The 'ls' command can be called directly from the command line or for
+  // providing informational output during an 'npm install' (in the unbuild phase).
+  // Executing 'npm ls <module>' for a module that is not installed results
+  // in a exit code of 1. Executing 'npm ls --production <module>' for a
+  // module that is not listed as a production dependency will also exit with 1.
+  // If this same behaviour is followed during 'npm install --production <module>'
+  // it becomes impossible to install a module without also specifying '--save'.
+  // To resolve this we check that we are not in the unbuild phase before setting
+  // process.exitCode. See: https://github.com/npm/npm/pull/11703
+
+  if (args.length && !data._found && npm.command !== 'unbuild') process.exitCode = 1
 
   var er
   // if any errors were found, then complain and exit status 1

--- a/test/tap/install-cli-production-nosave.js
+++ b/test/tap/install-cli-production-nosave.js
@@ -1,0 +1,69 @@
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+var server
+
+var pkg = path.join(__dirname, 'install-cli-production-nosave')
+
+var EXEC_OPTS = { cwd: pkg }
+
+var PACKAGE_JSON1 = {
+  name: 'install-cli-production-nosave',
+  version: '0.0.1',
+  dependencies: {
+  }
+}
+
+test('setup', function (t) {
+  setup()
+  mr({ port: common.port }, function (er, s) {
+    t.ifError(er, 'started mock registry')
+    server = s
+    t.end()
+  })
+})
+
+test('install --production <module> without --save exits successfully', function (t) {
+  common.npm(
+    [
+      '--registry', common.registry,
+      '--loglevel', 'silent',
+      'install', '--production', 'underscore'
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'npm install ran without issue')
+      t.notOk(code, 'npm install exited with code 0')
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  server.close()
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}
+
+function setup () {
+  cleanup()
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(PACKAGE_JSON1, null, 2)
+  )
+
+  process.chdir(pkg)
+}


### PR DESCRIPTION
Prevents invalid error status when `npm install --production <module>` is used.
Fixes: #11699

My thinking behind this is that `ls` is purely informational when executed as part of an `npm install` (in the unbuild phase). It shouldn't be responsible for deciding if the install should fail (i.e. shouldn't set the process exit code).

When you execute it via `npm ls <package>` (etc.) then it's valid that it may exit with a failure code if `<package>` is not found (the existing behaviour).
