### PR TITLE
Fix Alias name from 'verison' to 'version'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -373,3 +373,4 @@ Lewis Cowper <lewis.cowper@googlemail.com>
 Adam Byrne <misterbyrne@gmail.com>
 gnerkus <ifeanyioraelosi@gmail.com>
 Robert Ludwig <rob.ludwig@rideamigos.com>
+Tony Archer <tony@zeg.io>

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -92,7 +92,7 @@
     'find-dupes': 'dedupe',
     'ddp': 'dedupe',
     'v': 'view',
-    'verison': 'version'
+    'version': 'version'
   }
 
   var aliasNames = Object.keys(aliases)


### PR DESCRIPTION
Nothing major here, but version is misspelled in the help text, this fixes it.
