### PR TITLE
Fix #11003 remove-verison-alias-from-cli

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -91,8 +91,7 @@
     't': 'test',
     'find-dupes': 'dedupe',
     'ddp': 'dedupe',
-    'v': 'view',
-    'verison': 'version'
+    'v': 'view'
   }
 
   var aliasNames = Object.keys(aliases)


### PR DESCRIPTION
I also saw `isntall` alias there but with a some code and a comment saying "  // we have our reasons "
Should this remove it to?
