### PR TITLE
doc: add aliase command to cli docs

### DIFF
--- a/doc/cli/npm-adduser.md
+++ b/doc/cli/npm-adduser.md
@@ -5,6 +5,8 @@ npm-adduser(1) -- Add a registry user account
 
     npm adduser [--registry=url] [--scope=@orgname] [--always-auth]
 
+    aliases: login, add-user
+
 ## DESCRIPTION
 
 Create or verify a user named `<username>` in the specified registry, and

--- a/doc/cli/npm-bugs.md
+++ b/doc/cli/npm-bugs.md
@@ -5,6 +5,8 @@ npm-bugs(1) -- Bugs for a package in a web browser maybe
 
     npm bugs [<pkgname>]
 
+    aliases: issues
+
 ## DESCRIPTION
 
 This command tries to guess at the likely location of a package's

--- a/doc/cli/npm-config.md
+++ b/doc/cli/npm-config.md
@@ -11,6 +11,8 @@ npm-config(1) -- Manage the npm configuration files
     npm get <key>
     npm set <key> <value> [-g|--global]
 
+    aliases: c
+
 ## DESCRIPTION
 
 npm gets its config settings from the command line, environment

--- a/doc/cli/npm-dedupe.md
+++ b/doc/cli/npm-dedupe.md
@@ -6,6 +6,8 @@ npm-dedupe(1) -- Reduce duplication
     npm dedupe
     npm ddp
 
+    aliases: find-dupes, ddp
+
 ## DESCRIPTION
 
 Searches the local package tree and attempts to simplify the overall

--- a/doc/cli/npm-dist-tag.md
+++ b/doc/cli/npm-dist-tag.md
@@ -7,6 +7,8 @@ npm-dist-tag(1) -- Modify package distribution tags
     npm dist-tag rm <pkg> <tag>
     npm dist-tag ls [<pkg>]
 
+    aliases: dist-tags
+
 ## DESCRIPTION
 
 Add, remove, and enumerate distribution tags on a package:

--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -47,7 +47,7 @@ after packing it up into a tarball (b).
 
     By default, `npm install` will install all modules listed as dependencies
     in `package.json(5)`.
-    
+
     With the `--production` flag (or when the `NODE_ENV` environment variable
     is set to `production`), npm will not install modules listed in
     `devDependencies`.
@@ -124,7 +124,7 @@ after packing it up into a tarball (b).
           npm install node-tap --save-dev
           npm install dtrace-provider --save-optional
           npm install readable-stream --save --save-exact
-          npm install ansi-regex --save --save-bundle 
+          npm install ansi-regex --save --save-bundle
 
 
     **Note**: If there is a file or folder named `<name>` in the current

--- a/doc/cli/npm-owner.md
+++ b/doc/cli/npm-owner.md
@@ -7,6 +7,8 @@ npm-owner(1) -- Manage package owners
     npm owner rm <user> [<@scope>/]<pkg>
     npm owner ls [<@scope>/]<pkg>
 
+    aliases: author
+
 ## DESCRIPTION
 
 Manage ownership of published packages.

--- a/doc/cli/npm-search.md
+++ b/doc/cli/npm-search.md
@@ -5,7 +5,7 @@ npm-search(1) -- Search for packages
 
     npm search [-l|--long] [search terms ...]
 
-    aliases: s, se
+    aliases: s, se, find
 
 ## DESCRIPTION
 

--- a/doc/cli/npm-test.md
+++ b/doc/cli/npm-test.md
@@ -4,7 +4,8 @@ npm-test(1) -- Test a package
 ## SYNOPSIS
 
       npm test [-- <args>]
-      npm tst [-- <args>]
+
+      aliases: t, tst
 
 ## DESCRIPTION
 

--- a/doc/cli/npm-update.md
+++ b/doc/cli/npm-update.md
@@ -5,6 +5,8 @@ npm-update(1) -- Update a package
 
     npm update [-g] [<pkg>...]
 
+    aliases: up, upgrade
+
 ## DESCRIPTION
 
 This command will update all the packages listed to the latest version


### PR DESCRIPTION
Some cli docs have an aliases but some other docs doesn't have it.

e.g.
https://docs.npmjs.com/cli/search#synopsis
