### PR TITLE
help: display all commands except for affordance commands

### DIFF
--- a/lib/config/cmd.js
+++ b/lib/config/cmd.js
@@ -1,0 +1,109 @@
+// short names for common things
+var aliases = {
+  'rm': 'uninstall',
+  'r': 'uninstall',
+  'un': 'uninstall',
+  'unlink': 'uninstall',
+  'remove': 'uninstall',
+  'rb': 'rebuild',
+  'list': 'ls',
+  'la': 'ls',
+  'll': 'ls',
+  'ln': 'link',
+  'i': 'install',
+  'isntall': 'install',
+  'it': 'install-test',
+  'up': 'update',
+  'upgrade': 'update',
+  'c': 'config',
+  'dist-tags': 'dist-tag',
+  'info': 'view',
+  'show': 'view',
+  'find': 'search',
+  's': 'search',
+  'se': 'search',
+  'author': 'owner',
+  'home': 'docs',
+  'issues': 'bugs',
+  'unstar': 'star', // same function
+  'apihelp': 'help',
+  'login': 'adduser',
+  'add-user': 'adduser',
+  'tst': 'test',
+  't': 'test',
+  'find-dupes': 'dedupe',
+  'ddp': 'dedupe',
+  'v': 'view',
+  'verison': 'version'
+}
+
+// these are filenames in .
+var cmdList = [
+  'install',
+  'install-test',
+  'uninstall',
+  'cache',
+  'config',
+  'set',
+  'get',
+  'update',
+  'outdated',
+  'prune',
+  'pack',
+  'dedupe',
+
+  'rebuild',
+  'link',
+
+  'publish',
+  'star',
+  'stars',
+  'tag',
+  'adduser',
+  'logout',
+  'unpublish',
+  'owner',
+  'access',
+  'team',
+  'deprecate',
+  'shrinkwrap',
+
+  'help',
+  'help-search',
+  'ls',
+  'search',
+  'view',
+  'init',
+  'version',
+  'edit',
+  'explore',
+  'docs',
+  'repo',
+  'bugs',
+  'faq',
+  'root',
+  'prefix',
+  'bin',
+  'whoami',
+  'dist-tag',
+  'ping',
+
+  'test',
+  'stop',
+  'start',
+  'restart',
+  'run-script',
+  'completion'
+]
+
+var plumbing = [
+  'build',
+  'unbuild',
+  'xmas',
+  'substack',
+  'visnup'
+]
+
+module.exports.aliases = aliases
+module.exports.cmdList = cmdList
+module.exports.plumbing = plumbing

--- a/lib/config/cmd.js
+++ b/lib/config/cmd.js
@@ -1,40 +1,45 @@
+var assign = require('lodash.assign')
+
 // short names for common things
-var aliases = {
-  'rm': 'uninstall',
-  'r': 'uninstall',
+var shorthands = {
   'un': 'uninstall',
-  'unlink': 'uninstall',
-  'remove': 'uninstall',
   'rb': 'rebuild',
   'list': 'ls',
-  'la': 'ls',
-  'll': 'ls',
   'ln': 'link',
   'i': 'install',
-  'isntall': 'install',
   'it': 'install-test',
   'up': 'update',
-  'upgrade': 'update',
   'c': 'config',
-  'dist-tags': 'dist-tag',
-  'info': 'view',
-  'show': 'view',
-  'find': 'search',
   's': 'search',
   'se': 'search',
+  'unstar': 'star', // same function
+  'tst': 'test',
+  't': 'test',
+  'ddp': 'dedupe',
+  'v': 'view'
+}
+
+var affordances = {
+  'la': 'ls',
+  'll': 'ls',
+  'verison': 'version',
+  'isntall': 'install',
+  'dist-tags': 'dist-tag',
+  'apihelp': 'help',
+  'find-dupes': 'dedupe',
+  'upgrade': 'update',
+  'login': 'adduser',
+  'add-user': 'adduser',
   'author': 'owner',
   'home': 'docs',
   'issues': 'bugs',
-  'unstar': 'star', // same function
-  'apihelp': 'help',
-  'login': 'adduser',
-  'add-user': 'adduser',
-  'tst': 'test',
-  't': 'test',
-  'find-dupes': 'dedupe',
-  'ddp': 'dedupe',
-  'v': 'view',
-  'verison': 'version'
+  'info': 'view',
+  'show': 'view',
+  'find': 'search',
+  'unlink': 'uninstall',
+  'remove': 'uninstall',
+  'rm': 'uninstall',
+  'r': 'uninstall'
 }
 
 // these are filenames in .
@@ -103,7 +108,8 @@ var plumbing = [
   'substack',
   'visnup'
 ]
-
-module.exports.aliases = aliases
+module.exports.aliases = assign({}, shorthands, affordances)
+module.exports.shorthands = shorthands
+module.exports.affordances = affordances
 module.exports.cmdList = cmdList
 module.exports.plumbing = plumbing

--- a/lib/help.js
+++ b/lib/help.js
@@ -12,6 +12,9 @@ var npm = require('./npm.js')
 var log = require('npmlog')
 var opener = require('opener')
 var glob = require('glob')
+var cmdList = require('./config/cmd').cmdList
+var shorthands = require('./config/cmd').shorthands
+var commands = cmdList.concat(Object.keys(shorthands))
 
 function help (args, cb) {
   var argv = npm.config.get('argv').cooked
@@ -163,7 +166,7 @@ function npmUsage (valid, cb) {
     '',
     'where <command> is one of:',
     npm.config.get('long') ? usages()
-        : '    ' + wrap(Object.keys(npm.commands)),
+        : '    ' + wrap(commands),
     '',
     'npm <cmd> -h     quick help on <cmd>',
     'npm -l           display full usage info',

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -27,6 +27,9 @@
   var which = require('which')
   var CachingRegClient = require('./cache/caching-client.js')
   var parseJSON = require('./utils/parse-json.js')
+  var aliases = require('./config/cmd').aliases
+  var cmdList = require('./config/cmd').cmdList
+  var plumbing = require('./config/cmd').plumbing
 
   npm.config = {
     loaded: false,
@@ -55,113 +58,8 @@
   }
 
   var commandCache = {}
-
-  // short names for common things
-  var aliases = {
-    'rm': 'uninstall',
-    'r': 'uninstall',
-    'un': 'uninstall',
-    'unlink': 'uninstall',
-    'remove': 'uninstall',
-    'rb': 'rebuild',
-    'list': 'ls',
-    'la': 'ls',
-    'll': 'ls',
-    'ln': 'link',
-    'i': 'install',
-    'isntall': 'install',
-    'it': 'install-test',
-    'up': 'update',
-    'upgrade': 'update',
-    'c': 'config',
-    'dist-tags': 'dist-tag',
-    'info': 'view',
-    'show': 'view',
-    'find': 'search',
-    's': 'search',
-    'se': 'search',
-    'author': 'owner',
-    'home': 'docs',
-    'issues': 'bugs',
-    'unstar': 'star', // same function
-    'apihelp': 'help',
-    'login': 'adduser',
-    'add-user': 'adduser',
-    'tst': 'test',
-    't': 'test',
-    'find-dupes': 'dedupe',
-    'ddp': 'dedupe',
-    'v': 'view',
-    'verison': 'version'
-  }
-
   var aliasNames = Object.keys(aliases)
 
-  // these are filenames in .
-  var cmdList = [
-    'install',
-    'install-test',
-    'uninstall',
-    'cache',
-    'config',
-    'set',
-    'get',
-    'update',
-    'outdated',
-    'prune',
-    'pack',
-    'dedupe',
-
-    'rebuild',
-    'link',
-
-    'publish',
-    'star',
-    'stars',
-    'tag',
-    'adduser',
-    'logout',
-    'unpublish',
-    'owner',
-    'access',
-    'team',
-    'deprecate',
-    'shrinkwrap',
-
-    'help',
-    'help-search',
-    'ls',
-    'search',
-    'view',
-    'init',
-    'version',
-    'edit',
-    'explore',
-    'docs',
-    'repo',
-    'bugs',
-    'faq',
-    'root',
-    'prefix',
-    'bin',
-    'whoami',
-    'dist-tag',
-    'ping',
-
-    'test',
-    'stop',
-    'start',
-    'restart',
-    'run-script',
-    'completion'
-  ]
-  var plumbing = [
-    'build',
-    'unbuild',
-    'xmas',
-    'substack',
-    'visnup'
-  ]
   var littleGuys = [ 'isntall' ]
   var fullList = cmdList.concat(aliasNames).filter(function (c) {
     return plumbing.indexOf(c) === -1

--- a/node_modules/lodash.assign/LICENSE
+++ b/node_modules/lodash.assign/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2016 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/lodash.assign/README.md
+++ b/node_modules/lodash.assign/README.md
@@ -1,0 +1,18 @@
+# lodash.assign v4.0.6
+
+The [lodash](https://lodash.com/) method `_.assign` exported as a [Node.js](https://nodejs.org/) module.
+
+## Installation
+
+Using npm:
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save lodash.assign
+```
+
+In Node.js:
+```js
+var assign = require('lodash.assign');
+```
+
+See the [documentation](https://lodash.com/docs#assign) or [package source](https://github.com/lodash/lodash/blob/4.0.6-npm-packages/lodash.assign) for more details.

--- a/node_modules/lodash.assign/index.js
+++ b/node_modules/lodash.assign/index.js
@@ -1,0 +1,393 @@
+/**
+ * lodash 4.0.6 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modularize exports="npm" -o ./`
+ * Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2016 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */
+var keys = require('lodash.keys'),
+    rest = require('lodash.rest');
+
+/** Used as references for various `Number` constants. */
+var MAX_SAFE_INTEGER = 9007199254740991;
+
+/** `Object#toString` result references. */
+var funcTag = '[object Function]',
+    genTag = '[object GeneratorFunction]';
+
+/** Used to detect unsigned integer values. */
+var reIsUint = /^(?:0|[1-9]\d*)$/;
+
+/**
+ * Checks if `value` is a valid array-like index.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
+ * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
+ */
+function isIndex(value, length) {
+  value = (typeof value == 'number' || reIsUint.test(value)) ? +value : -1;
+  length = length == null ? MAX_SAFE_INTEGER : length;
+  return value > -1 && value % 1 == 0 && value < length;
+}
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * of values.
+ */
+var objectToString = objectProto.toString;
+
+/** Built-in value references. */
+var propertyIsEnumerable = objectProto.propertyIsEnumerable;
+
+/** Detect if properties shadowing those on `Object.prototype` are non-enumerable. */
+var nonEnumShadows = !propertyIsEnumerable.call({ 'valueOf': 1 }, 'valueOf');
+
+/**
+ * Assigns `value` to `key` of `object` if the existing value is not equivalent
+ * using [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
+ * for equality comparisons.
+ *
+ * @private
+ * @param {Object} object The object to modify.
+ * @param {string} key The key of the property to assign.
+ * @param {*} value The value to assign.
+ */
+function assignValue(object, key, value) {
+  var objValue = object[key];
+  if (!(hasOwnProperty.call(object, key) && eq(objValue, value)) ||
+      (value === undefined && !(key in object))) {
+    object[key] = value;
+  }
+}
+
+/**
+ * The base implementation of `_.property` without support for deep paths.
+ *
+ * @private
+ * @param {string} key The key of the property to get.
+ * @returns {Function} Returns the new function.
+ */
+function baseProperty(key) {
+  return function(object) {
+    return object == null ? undefined : object[key];
+  };
+}
+
+/**
+ * Copies properties of `source` to `object`.
+ *
+ * @private
+ * @param {Object} source The object to copy properties from.
+ * @param {Array} props The property names to copy.
+ * @param {Object} [object={}] The object to copy properties to.
+ * @returns {Object} Returns `object`.
+ */
+function copyObject(source, props, object) {
+  return copyObjectWith(source, props, object);
+}
+
+/**
+ * This function is like `copyObject` except that it accepts a function to
+ * customize copied values.
+ *
+ * @private
+ * @param {Object} source The object to copy properties from.
+ * @param {Array} props The property names to copy.
+ * @param {Object} [object={}] The object to copy properties to.
+ * @param {Function} [customizer] The function to customize copied values.
+ * @returns {Object} Returns `object`.
+ */
+function copyObjectWith(source, props, object, customizer) {
+  object || (object = {});
+
+  var index = -1,
+      length = props.length;
+
+  while (++index < length) {
+    var key = props[index];
+
+    var newValue = customizer
+      ? customizer(object[key], source[key], key, object, source)
+      : source[key];
+
+    assignValue(object, key, newValue);
+  }
+  return object;
+}
+
+/**
+ * Creates a function like `_.assign`.
+ *
+ * @private
+ * @param {Function} assigner The function to assign values.
+ * @returns {Function} Returns the new assigner function.
+ */
+function createAssigner(assigner) {
+  return rest(function(object, sources) {
+    var index = -1,
+        length = sources.length,
+        customizer = length > 1 ? sources[length - 1] : undefined,
+        guard = length > 2 ? sources[2] : undefined;
+
+    customizer = typeof customizer == 'function'
+      ? (length--, customizer)
+      : undefined;
+
+    if (guard && isIterateeCall(sources[0], sources[1], guard)) {
+      customizer = length < 3 ? undefined : customizer;
+      length = 1;
+    }
+    object = Object(object);
+    while (++index < length) {
+      var source = sources[index];
+      if (source) {
+        assigner(object, source, index, customizer);
+      }
+    }
+    return object;
+  });
+}
+
+/**
+ * Gets the "length" property value of `object`.
+ *
+ * **Note:** This function is used to avoid a [JIT bug](https://bugs.webkit.org/show_bug.cgi?id=142792)
+ * that affects Safari on at least iOS 8.1-8.3 ARM64.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @returns {*} Returns the "length" value.
+ */
+var getLength = baseProperty('length');
+
+/**
+ * Checks if the given arguments are from an iteratee call.
+ *
+ * @private
+ * @param {*} value The potential iteratee value argument.
+ * @param {*} index The potential iteratee index or key argument.
+ * @param {*} object The potential iteratee object argument.
+ * @returns {boolean} Returns `true` if the arguments are from an iteratee call, else `false`.
+ */
+function isIterateeCall(value, index, object) {
+  if (!isObject(object)) {
+    return false;
+  }
+  var type = typeof index;
+  if (type == 'number'
+      ? (isArrayLike(object) && isIndex(index, object.length))
+      : (type == 'string' && index in object)) {
+    return eq(object[index], value);
+  }
+  return false;
+}
+
+/**
+ * Checks if `value` is likely a prototype object.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a prototype, else `false`.
+ */
+function isPrototype(value) {
+  var Ctor = value && value.constructor,
+      proto = (typeof Ctor == 'function' && Ctor.prototype) || objectProto;
+
+  return value === proto;
+}
+
+/**
+ * Performs a [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
+ * comparison between two values to determine if they are equivalent.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to compare.
+ * @param {*} other The other value to compare.
+ * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+ * @example
+ *
+ * var object = { 'user': 'fred' };
+ * var other = { 'user': 'fred' };
+ *
+ * _.eq(object, object);
+ * // => true
+ *
+ * _.eq(object, other);
+ * // => false
+ *
+ * _.eq('a', 'a');
+ * // => true
+ *
+ * _.eq('a', Object('a'));
+ * // => false
+ *
+ * _.eq(NaN, NaN);
+ * // => true
+ */
+function eq(value, other) {
+  return value === other || (value !== value && other !== other);
+}
+
+/**
+ * Checks if `value` is array-like. A value is considered array-like if it's
+ * not a function and has a `value.length` that's an integer greater than or
+ * equal to `0` and less than or equal to `Number.MAX_SAFE_INTEGER`.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is array-like, else `false`.
+ * @example
+ *
+ * _.isArrayLike([1, 2, 3]);
+ * // => true
+ *
+ * _.isArrayLike(document.body.children);
+ * // => true
+ *
+ * _.isArrayLike('abc');
+ * // => true
+ *
+ * _.isArrayLike(_.noop);
+ * // => false
+ */
+function isArrayLike(value) {
+  return value != null && isLength(getLength(value)) && !isFunction(value);
+}
+
+/**
+ * Checks if `value` is classified as a `Function` object.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+ * @example
+ *
+ * _.isFunction(_);
+ * // => true
+ *
+ * _.isFunction(/abc/);
+ * // => false
+ */
+function isFunction(value) {
+  // The use of `Object#toString` avoids issues with the `typeof` operator
+  // in Safari 8 which returns 'object' for typed array and weak map constructors,
+  // and PhantomJS 1.9 which returns 'function' for `NodeList` instances.
+  var tag = isObject(value) ? objectToString.call(value) : '';
+  return tag == funcTag || tag == genTag;
+}
+
+/**
+ * Checks if `value` is a valid array-like length.
+ *
+ * **Note:** This function is loosely based on [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
+ * @example
+ *
+ * _.isLength(3);
+ * // => true
+ *
+ * _.isLength(Number.MIN_VALUE);
+ * // => false
+ *
+ * _.isLength(Infinity);
+ * // => false
+ *
+ * _.isLength('3');
+ * // => false
+ */
+function isLength(value) {
+  return typeof value == 'number' &&
+    value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
+}
+
+/**
+ * Checks if `value` is the [language type](https://es5.github.io/#x8) of `Object`.
+ * (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+ * @example
+ *
+ * _.isObject({});
+ * // => true
+ *
+ * _.isObject([1, 2, 3]);
+ * // => true
+ *
+ * _.isObject(_.noop);
+ * // => true
+ *
+ * _.isObject(null);
+ * // => false
+ */
+function isObject(value) {
+  var type = typeof value;
+  return !!value && (type == 'object' || type == 'function');
+}
+
+/**
+ * Assigns own enumerable properties of source objects to the destination
+ * object. Source objects are applied from left to right. Subsequent sources
+ * overwrite property assignments of previous sources.
+ *
+ * **Note:** This method mutates `object` and is loosely based on
+ * [`Object.assign`](https://mdn.io/Object/assign).
+ *
+ * @static
+ * @memberOf _
+ * @category Object
+ * @param {Object} object The destination object.
+ * @param {...Object} [sources] The source objects.
+ * @returns {Object} Returns `object`.
+ * @example
+ *
+ * function Foo() {
+ *   this.c = 3;
+ * }
+ *
+ * function Bar() {
+ *   this.e = 5;
+ * }
+ *
+ * Foo.prototype.d = 4;
+ * Bar.prototype.f = 6;
+ *
+ * _.assign({ 'a': 1 }, new Foo, new Bar);
+ * // => { 'a': 1, 'c': 3, 'e': 5 }
+ */
+var assign = createAssigner(function(object, source) {
+  if (nonEnumShadows || isPrototype(source) || isArrayLike(source)) {
+    copyObject(source, keys(source), object);
+    return;
+  }
+  for (var key in source) {
+    if (hasOwnProperty.call(source, key)) {
+      assignValue(object, key, source[key]);
+    }
+  }
+});
+
+module.exports = assign;

--- a/node_modules/lodash.assign/node_modules/lodash.rest/LICENSE
+++ b/node_modules/lodash.assign/node_modules/lodash.rest/LICENSE
@@ -1,0 +1,22 @@
+Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2016 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/lodash.assign/node_modules/lodash.rest/README.md
+++ b/node_modules/lodash.assign/node_modules/lodash.rest/README.md
@@ -1,0 +1,18 @@
+# lodash.rest v4.0.1
+
+The [lodash](https://lodash.com/) method `_.rest` exported as a [Node.js](https://nodejs.org/) module.
+
+## Installation
+
+Using npm:
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save lodash.rest
+```
+
+In Node.js:
+```js
+var rest = require('lodash.rest');
+```
+
+See the [documentation](https://lodash.com/docs#rest) or [package source](https://github.com/lodash/lodash/blob/4.0.1-npm-packages/lodash.rest) for more details.

--- a/node_modules/lodash.assign/node_modules/lodash.rest/index.js
+++ b/node_modules/lodash.assign/node_modules/lodash.rest/index.js
@@ -1,0 +1,247 @@
+/**
+ * lodash 4.0.1 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modularize exports="npm" -o ./`
+ * Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2016 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */
+
+/** Used as the `TypeError` message for "Functions" methods. */
+var FUNC_ERROR_TEXT = 'Expected a function';
+
+/** Used as references for various `Number` constants. */
+var INFINITY = 1 / 0,
+    MAX_INTEGER = 1.7976931348623157e+308,
+    NAN = 0 / 0;
+
+/** `Object#toString` result references. */
+var funcTag = '[object Function]',
+    genTag = '[object GeneratorFunction]';
+
+/** Used to match leading and trailing whitespace. */
+var reTrim = /^\s+|\s+$/g;
+
+/** Used to detect bad signed hexadecimal string values. */
+var reIsBadHex = /^[-+]0x[0-9a-f]+$/i;
+
+/** Used to detect binary string values. */
+var reIsBinary = /^0b[01]+$/i;
+
+/** Used to detect octal string values. */
+var reIsOctal = /^0o[0-7]+$/i;
+
+/** Built-in method references without a dependency on `root`. */
+var freeParseInt = parseInt;
+
+/**
+ * A faster alternative to `Function#apply`, this function invokes `func`
+ * with the `this` binding of `thisArg` and the arguments of `args`.
+ *
+ * @private
+ * @param {Function} func The function to invoke.
+ * @param {*} thisArg The `this` binding of `func`.
+ * @param {...*} args The arguments to invoke `func` with.
+ * @returns {*} Returns the result of `func`.
+ */
+function apply(func, thisArg, args) {
+  var length = args.length;
+  switch (length) {
+    case 0: return func.call(thisArg);
+    case 1: return func.call(thisArg, args[0]);
+    case 2: return func.call(thisArg, args[0], args[1]);
+    case 3: return func.call(thisArg, args[0], args[1], args[2]);
+  }
+  return func.apply(thisArg, args);
+}
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/**
+ * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * of values.
+ */
+var objectToString = objectProto.toString;
+
+/* Built-in method references for those with the same name as other `lodash` methods. */
+var nativeMax = Math.max;
+
+/**
+ * Creates a function that invokes `func` with the `this` binding of the
+ * created function and arguments from `start` and beyond provided as an array.
+ *
+ * **Note:** This method is based on the [rest parameter](https://mdn.io/rest_parameters).
+ *
+ * @static
+ * @memberOf _
+ * @category Function
+ * @param {Function} func The function to apply a rest parameter to.
+ * @param {number} [start=func.length-1] The start position of the rest parameter.
+ * @returns {Function} Returns the new function.
+ * @example
+ *
+ * var say = _.rest(function(what, names) {
+ *   return what + ' ' + _.initial(names).join(', ') +
+ *     (_.size(names) > 1 ? ', & ' : '') + _.last(names);
+ * });
+ *
+ * say('hello', 'fred', 'barney', 'pebbles');
+ * // => 'hello fred, barney, & pebbles'
+ */
+function rest(func, start) {
+  if (typeof func != 'function') {
+    throw new TypeError(FUNC_ERROR_TEXT);
+  }
+  start = nativeMax(start === undefined ? (func.length - 1) : toInteger(start), 0);
+  return function() {
+    var args = arguments,
+        index = -1,
+        length = nativeMax(args.length - start, 0),
+        array = Array(length);
+
+    while (++index < length) {
+      array[index] = args[start + index];
+    }
+    switch (start) {
+      case 0: return func.call(this, array);
+      case 1: return func.call(this, args[0], array);
+      case 2: return func.call(this, args[0], args[1], array);
+    }
+    var otherArgs = Array(start + 1);
+    index = -1;
+    while (++index < start) {
+      otherArgs[index] = args[index];
+    }
+    otherArgs[start] = array;
+    return apply(func, this, otherArgs);
+  };
+}
+
+/**
+ * Checks if `value` is classified as a `Function` object.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+ * @example
+ *
+ * _.isFunction(_);
+ * // => true
+ *
+ * _.isFunction(/abc/);
+ * // => false
+ */
+function isFunction(value) {
+  // The use of `Object#toString` avoids issues with the `typeof` operator
+  // in Safari 8 which returns 'object' for typed array constructors, and
+  // PhantomJS 1.9 which returns 'function' for `NodeList` instances.
+  var tag = isObject(value) ? objectToString.call(value) : '';
+  return tag == funcTag || tag == genTag;
+}
+
+/**
+ * Checks if `value` is the [language type](https://es5.github.io/#x8) of `Object`.
+ * (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+ * @example
+ *
+ * _.isObject({});
+ * // => true
+ *
+ * _.isObject([1, 2, 3]);
+ * // => true
+ *
+ * _.isObject(_.noop);
+ * // => true
+ *
+ * _.isObject(null);
+ * // => false
+ */
+function isObject(value) {
+  var type = typeof value;
+  return !!value && (type == 'object' || type == 'function');
+}
+
+/**
+ * Converts `value` to an integer.
+ *
+ * **Note:** This function is loosely based on [`ToInteger`](http://www.ecma-international.org/ecma-262/6.0/#sec-tointeger).
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to convert.
+ * @returns {number} Returns the converted integer.
+ * @example
+ *
+ * _.toInteger(3);
+ * // => 3
+ *
+ * _.toInteger(Number.MIN_VALUE);
+ * // => 0
+ *
+ * _.toInteger(Infinity);
+ * // => 1.7976931348623157e+308
+ *
+ * _.toInteger('3');
+ * // => 3
+ */
+function toInteger(value) {
+  if (!value) {
+    return value === 0 ? value : 0;
+  }
+  value = toNumber(value);
+  if (value === INFINITY || value === -INFINITY) {
+    var sign = (value < 0 ? -1 : 1);
+    return sign * MAX_INTEGER;
+  }
+  var remainder = value % 1;
+  return value === value ? (remainder ? value - remainder : value) : 0;
+}
+
+/**
+ * Converts `value` to a number.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to process.
+ * @returns {number} Returns the number.
+ * @example
+ *
+ * _.toNumber(3);
+ * // => 3
+ *
+ * _.toNumber(Number.MIN_VALUE);
+ * // => 5e-324
+ *
+ * _.toNumber(Infinity);
+ * // => Infinity
+ *
+ * _.toNumber('3');
+ * // => 3
+ */
+function toNumber(value) {
+  if (isObject(value)) {
+    var other = isFunction(value.valueOf) ? value.valueOf() : value;
+    value = isObject(other) ? (other + '') : other;
+  }
+  if (typeof value != 'string') {
+    return value === 0 ? value : +value;
+  }
+  value = value.replace(reTrim, '');
+  var isBinary = reIsBinary.test(value);
+  return (isBinary || reIsOctal.test(value))
+    ? freeParseInt(value.slice(2), isBinary ? 2 : 8)
+    : (reIsBadHex.test(value) ? NAN : +value);
+}
+
+module.exports = rest;

--- a/node_modules/lodash.assign/node_modules/lodash.rest/package.json
+++ b/node_modules/lodash.assign/node_modules/lodash.rest/package.json
@@ -1,0 +1,105 @@
+{
+  "_args": [
+    [
+      "lodash.rest@^4.0.0",
+      "/Users/watilde/Development/npm/node_modules/lodash.assign"
+    ]
+  ],
+  "_from": "lodash.rest@>=4.0.0 <5.0.0",
+  "_id": "lodash.rest@4.0.1",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/lodash.assign/lodash.rest",
+  "_nodeVersion": "5.4.0",
+  "_npmOperationalInternal": {
+    "host": "packages-5-east.internal.npmjs.com",
+    "tmp": "tmp/lodash.rest-4.0.1.tgz_1454484670768_0.6682933256961405"
+  },
+  "_npmUser": {
+    "email": "john.david.dalton@gmail.com",
+    "name": "jdalton"
+  },
+  "_npmVersion": "2.14.15",
+  "_phantomChildren": {},
+  "_requested": {
+    "name": "lodash.rest",
+    "raw": "lodash.rest@^4.0.0",
+    "rawSpec": "^4.0.0",
+    "scope": null,
+    "spec": ">=4.0.0 <5.0.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "/lodash.assign"
+  ],
+  "_resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz",
+  "_shasum": "cbecbb84e68e499a1b242baf9b27bb63ef4dd980",
+  "_shrinkwrap": null,
+  "_spec": "lodash.rest@^4.0.0",
+  "_where": "/Users/watilde/Development/npm/node_modules/lodash.assign",
+  "author": {
+    "email": "john.david.dalton@gmail.com",
+    "name": "John-David Dalton",
+    "url": "http://allyoucanleet.com/"
+  },
+  "bugs": {
+    "url": "https://github.com/lodash/lodash/issues"
+  },
+  "contributors": [
+    {
+      "email": "john.david.dalton@gmail.com",
+      "name": "John-David Dalton",
+      "url": "http://allyoucanleet.com/"
+    },
+    {
+      "email": "blaine@iceddev.com",
+      "name": "Blaine Bublitz",
+      "url": "https://github.com/phated"
+    },
+    {
+      "email": "mathias@qiwi.be",
+      "name": "Mathias Bynens",
+      "url": "https://mathiasbynens.be/"
+    }
+  ],
+  "dependencies": {},
+  "description": "The lodash method `_.rest` exported as a module.",
+  "devDependencies": {},
+  "directories": {},
+  "dist": {
+    "shasum": "cbecbb84e68e499a1b242baf9b27bb63ef4dd980",
+    "tarball": "http://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz"
+  },
+  "homepage": "https://lodash.com/",
+  "icon": "https://lodash.com/icon.svg",
+  "keywords": [
+    "lodash-modularized",
+    "rest"
+  ],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "email": "john.david.dalton@gmail.com",
+      "name": "jdalton"
+    },
+    {
+      "email": "mathias@qiwi.be",
+      "name": "mathias"
+    },
+    {
+      "email": "blaine@iceddev.com",
+      "name": "phated"
+    }
+  ],
+  "name": "lodash.rest",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lodash/lodash.git"
+  },
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash/lodash-cli for testing details.\""
+  },
+  "version": "4.0.1"
+}

--- a/node_modules/lodash.assign/package.json
+++ b/node_modules/lodash.assign/package.json
@@ -1,0 +1,108 @@
+{
+  "_args": [
+    [
+      "lodash.assign",
+      "/Users/watilde/Development/npm"
+    ]
+  ],
+  "_from": "lodash.assign@latest",
+  "_id": "lodash.assign@4.0.6",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/lodash.assign",
+  "_nodeVersion": "5.5.0",
+  "_npmOperationalInternal": {
+    "host": "packages-13-west.internal.npmjs.com",
+    "tmp": "tmp/lodash.assign-4.0.6.tgz_1456902661442_0.5403113286010921"
+  },
+  "_npmUser": {
+    "email": "john.david.dalton@gmail.com",
+    "name": "jdalton"
+  },
+  "_npmVersion": "2.14.17",
+  "_phantomChildren": {},
+  "_requested": {
+    "name": "lodash.assign",
+    "raw": "lodash.assign",
+    "rawSpec": "",
+    "scope": null,
+    "spec": "latest",
+    "type": "tag"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.6.tgz",
+  "_shasum": "93a881377a8160862a27b7b629bc19ed6593c0e1",
+  "_shrinkwrap": null,
+  "_spec": "lodash.assign",
+  "_where": "/Users/watilde/Development/npm",
+  "author": {
+    "email": "john.david.dalton@gmail.com",
+    "name": "John-David Dalton",
+    "url": "http://allyoucanleet.com/"
+  },
+  "bugs": {
+    "url": "https://github.com/lodash/lodash/issues"
+  },
+  "contributors": [
+    {
+      "email": "john.david.dalton@gmail.com",
+      "name": "John-David Dalton",
+      "url": "http://allyoucanleet.com/"
+    },
+    {
+      "email": "blaine.bublitz@gmail.com",
+      "name": "Blaine Bublitz",
+      "url": "https://github.com/phated"
+    },
+    {
+      "email": "mathias@qiwi.be",
+      "name": "Mathias Bynens",
+      "url": "https://mathiasbynens.be/"
+    }
+  ],
+  "dependencies": {
+    "lodash.keys": "^4.0.0",
+    "lodash.rest": "^4.0.0"
+  },
+  "description": "The lodash method `_.assign` exported as a module.",
+  "devDependencies": {},
+  "directories": {},
+  "dist": {
+    "shasum": "93a881377a8160862a27b7b629bc19ed6593c0e1",
+    "tarball": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.6.tgz"
+  },
+  "homepage": "https://lodash.com/",
+  "icon": "https://lodash.com/icon.svg",
+  "keywords": [
+    "lodash-modularized",
+    "assign"
+  ],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "email": "john.david.dalton@gmail.com",
+      "name": "jdalton"
+    },
+    {
+      "email": "mathias@qiwi.be",
+      "name": "mathias"
+    },
+    {
+      "email": "blaine@iceddev.com",
+      "name": "phated"
+    }
+  ],
+  "name": "lodash.assign",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lodash/lodash.git"
+  },
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash/lodash-cli for testing details.\""
+  },
+  "version": "4.0.6"
+}

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "lodash._cacheindexof",
     "lodash._createcache",
     "lodash._getnative",
+    "lodash.assign",
     "lodash.clonedeep",
     "lodash.isarray",
     "lodash.keys",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "init-package-json": "~1.9.3",
     "lockfile": "~1.0.1",
     "lodash._baseuniq": "~4.5.0",
+    "lodash.assign": "~4.0.6",
     "lodash.clonedeep": "~4.3.1",
     "lodash.isarray": "~4.0.0",
     "lodash.keys": "~4.0.5",


### PR DESCRIPTION
Fixes https://github.com/npm/npm/issues/11003. There are many aliases in npm.js, but actually they involve 2 different concepts, "shorthands" and "affordances". I put a `cmd.js` to the config directory to reuse the list as a module and separate shorthands and affordance from aliases. Then eventually call the cmd.js from `npm.js` and `help.js` appropriately.

config/cmd.js
- add a command list file as cmd.js
- separate shorthands and affordance from aliases in cmd.js

npm.js
- replace hard corded command list with cmd.js

help.js
- display all commands except for affordance commands

dependency
- add lodash.assign@4.0.6
