### PR TITLE
Doc: Revert "advise use of `--depth Infinity` instead of `--depth 9999`"

### DIFF
--- a/doc/cli/npm-update.md
+++ b/doc/cli/npm-update.md
@@ -22,7 +22,7 @@ or local) will be updated.
 
 As of `npm@2.6.1`, the `npm update` will only inspect top-level packages.
 Prior versions of `npm` would also recursively inspect all dependencies.
-To get the old behavior, use `npm --depth Infinity update`.
+To get the old behavior, use `npm --depth 9999 update`.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Corrects the documentation error from https://github.com/npm/npm/issues/11726 - basically, `npm --depth Infinity update` doesn't work like the docs say it does, but `npm --depth 9999 update` does.
