### PR TITLE
added fix for npm ls --depth=0 --parseable bug and added related tests

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -434,7 +434,7 @@ function getExtras (data) {
 
 function makeParseable (data, long, dir, depth, parent, d) {
   depth = depth || 0
-
+  if (depth > npm.config.get('depth')) return [ makeParseable_(data, long, dir, depth, parent, d) ]
   return [ makeParseable_(data, long, dir, depth, parent, d) ]
   .concat(Object.keys(data.dependencies || {})
     .sort(alphasort).map(function (d) {

--- a/test/tap/ls-depth-cli.js
+++ b/test/tap/ls-depth-cli.js
@@ -159,6 +159,51 @@ test('npm ls --depth=Infinity --json', function (t) {
   )
 })
 
+test('npm ls --depth=0 --parseable --long', function (t) {
+  common.npm(
+    ['ls', '--depth=0', '--parseable', '--long'],
+    EXEC_OPTS,
+    function (er, c, out) {
+      t.ifError(er, 'npm ls ran without issue')
+      t.equal(c, 0, 'ls ran without raising error code')
+      t.has(
+        out,
+        /.*test-package-with-one-dep@0\.0\.0/,
+        'output contains test-package-with-one-dep'
+      )
+      t.doesNotHave(
+        out,
+        /.*test-package@0\.0\.0/,
+        'output not contains test-package'
+      )
+      t.end()
+    }
+  )
+})
+
+
+test('npm ls --depth=1 --parseable --long', function (t) {
+  common.npm(
+    ['ls', '--depth=1', '--parseable', '--long'],
+    EXEC_OPTS,
+    function (er, c, out) {
+      t.ifError(er, 'npm ls ran without issue')
+      t.equal(c, 0, 'ls ran without raising error code')
+      t.has(
+        out,
+        /.*test-package-with-one-dep@0\.0\.0/,
+        'output contains test-package-with-one-dep'
+      )
+      t.has(
+        out,
+        /.*test-package@0\.0\.0/,
+        'output not contains test-package'
+      )
+      t.end()
+    }
+  )
+})
+
 test('cleanup', function (t) {
   cleanup()
   t.end()


### PR DESCRIPTION
This is a fix for the bug #11495. The change stops the recursion when the depth has gone too far, where previously it always traversed all levels. This change should ideally include one additional test that makes a distinction between `--depth=1` and `--depth=Infinity` but that would require changing the underlying _npm-registry-mock_ with another level of dependency.
