### PR TITLE
Use simple progress bar when unicode option is false

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -371,6 +371,12 @@
           log.disableProgress()
         }
 
+        if (config.get('unicode')) {
+          log.enableUnicode()
+        } else {
+          log.disableUnicode()
+        }
+
         // at this point the configs are all set.
         // go ahead and spin up the registry client.
         npm.registry = new CachingRegClient(npm.config)

--- a/test/tap/progress-config.js
+++ b/test/tap/progress-config.js
@@ -11,6 +11,10 @@ var requireInject = require('require-inject')
 // Make sure existing environment vars don't muck up the test
 process.env = {}
 
+function hasOnlyAscii (s) {
+  return /^[\000-\177]*$/.test(s)
+}
+
 test('disabled', function (t) {
   t.plan(1)
   var npm = requireInject('../../lib/npm.js', {})
@@ -52,5 +56,25 @@ test('default-ci', function (t) {
   npm.load({}, function () {
     t.is(log.progressEnabled, false, 'should be disabled')
     delete global.process.env.CI
+  })
+})
+
+test('unicode-true', function (t) {
+  t.plan(6)
+  var npm = requireInject('../../lib/npm.js', {})
+  npm.load({unicode: true}, function () {
+    Object.keys(log.gauge.theme).forEach(function (key) {
+      t.notOk(hasOnlyAscii(log.gauge.theme[key]), 'only unicode')
+    })
+  })
+})
+
+test('unicode-false', function (t) {
+  t.plan(6)
+  var npm = requireInject('../../lib/npm.js', {})
+  npm.load({unicode: false}, function () {
+    Object.keys(log.gauge.theme).forEach(function (key) {
+      t.ok(hasOnlyAscii(log.gauge.theme[key]), 'only ASCII')
+    })
   })
 })


### PR DESCRIPTION
Fixes #11781 and https://github.com/watilde/npm/issues/3, referenced [the commit](https://github.com/npm/npm/commit/423d8f7e8a291ecceab121b9d2ea207c809e17fd) that was also providing an option to the npmlog.

Docs has already existed, it means this PR is like a bug fix in spite of providing an option to npmlog, I guess. https://github.com/npm/npm/blob/master/doc/misc/npm-config.md#unicode
