### PR TITLE
"Silent" disables printing dependency tree

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -296,6 +296,10 @@ The `--only={prod[uction]|dev[elopment]}` argument will cause either only
 See `npm-config(7)`.  Many of the configuration params have some
 effect on installation, since that's most of what npm does.
 
+By default, after `npm install` finishes installing successfully it prints
+a dependency tree, similar to `npm ls`. If `loglevel` is set to `silent`, this
+behavior is disabled.
+
 ## ALGORITHM
 
 To install a package, npm uses the following algorithm:

--- a/lib/install.js
+++ b/lib/install.js
@@ -272,8 +272,10 @@ Installer.prototype.run = function (cb) {
         [this, this.saveToDependencies])
     }
   }
-  postInstallSteps.push(
-    [this, this.printInstalled])
+  if (npm.config.get('loglevel') !== 'silent') {
+    postInstallSteps.push(
+      [this, this.printInstalled])
+  }
 
   var self = this
   chain(installSteps, function (installEr) {

--- a/test/tap/install-cli-silent.js
+++ b/test/tap/install-cli-silent.js
@@ -1,0 +1,61 @@
+var fs = require('graceful-fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+var server
+
+var pkg = path.resolve(__dirname, 'install-cli-silent')
+
+var EXEC_OPTS = { cwd: pkg }
+
+var json = {
+  name: 'install-cli-silent',
+  description: 'fixture',
+  version: '0.0.1'
+}
+
+test('setup', function (t) {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  mr({ port: common.port }, function (er, s) {
+    t.ifError(er, 'started mock registry')
+    server = s
+    t.end()
+  })
+})
+
+test('does not print dependency tree with --loglevel silent', function (t) {
+  common.npm(
+    [
+      '--registry', common.registry,
+      '--loglevel', 'silent',
+      'install', 'async'
+    ],
+    EXEC_OPTS,
+    function (err, code, stdout) {
+      t.ifError(err, 'install --loglevel silent success')
+      t.notOk(code, 'npm install exited with code 0')
+      t.notOk(stdout.length, 'npm install should not print output')
+
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  server.close()
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+
+  t.end()
+})


### PR DESCRIPTION
I know there are several requests to make `npm install` stop printing the dependency tree (See #2040, #10732, and #11121). This pull request disables printing the dependency tree after installing is finished, if `loglevel` is set to `silent`.

Includes documentation (a note added to `npm-install.md` explaining the change in behavior) and a tap test.
