### PR TITLE
Fix #11863: Mention node_modules ignore [DOCS]

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -206,6 +206,7 @@ Conversely, some files are always ignored:
 * `._*`
 * `npm-debug.log`
 * `.npmrc`
+* `node_modules`
 
 ## main
 


### PR DESCRIPTION
This fixes #11863 by mentioning that the `node_modules` folder is always ignored.
