### PR TITLE
test: Fix npm-self-install test to install to /tmp

### DIFF
--- a/test/tap/legacy-npm-self-install.js
+++ b/test/tap/legacy-npm-self-install.js
@@ -5,8 +5,9 @@ var common = require('../common-tap.js')
 var path = require('path')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
+var osenv = require('osenv')
 var npmpath = path.resolve(__dirname, '../..')
-var basepath = path.resolve(__dirname, path.basename(__filename, '.js'))
+var basepath = path.resolve(osenv.tmpdir(), path.basename(__filename, '.js'))
 var globalpath = path.resolve(basepath, 'global')
 var extend = Object.assign || require('util')._extend
 var isWin32 = process.platform === 'win32'


### PR DESCRIPTION
Previously this was installing into a temp subdir in `test/tap`, which wouldn't catch the case where a module was installed in the local `node_modules` folder but not in dependencies, as node would look up
the tree and use the copy from the version of npm being tested.

This solves that by moving the install folder to `/tmp` (which is where it was in the original legacy test version).
