### PR TITLE
improve npm search results with this workaround

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -2,6 +2,7 @@
 module.exports = exports = search
 
 var npm = require('./npm.js')
+var log = require('npmlog')
 var columnify = require('columnify')
 var updateIndex = require('./cache/update-index.js')
 
@@ -63,6 +64,9 @@ function search (args, silent, staleness, cb) {
     // prettify and print it, and then provide the raw
     // data to the cb.
     if (er || silent) return cb(er, data)
+    if (Object.keys(data).length > 10000) {
+        throw new Error("More than 10,000 matches")
+    }
     console.log(prettify(data, args))
     console.log()
     cb(null, data)

--- a/lib/search.js
+++ b/lib/search.js
@@ -64,6 +64,7 @@ function search (args, silent, staleness, cb) {
     // data to the cb.
     if (er || silent) return cb(er, data)
     console.log(prettify(data, args))
+    console.log()
     cb(null, data)
   })
 }


### PR DESCRIPTION
Fixes last search result to appear, missing newline caused last result to not appear.

Implements workaround to improve search result response time, throws error if more than 10,000 search results to avoid waiting indefinitely for error timeout, though up to 50,000 or so results may work without error as well, but response time is not acceptable
