### PR TITLE
lib: check parent is there before checking target

### DIFF
--- a/lib/install/filter-invalid-actions.js
+++ b/lib/install/filter-invalid-actions.js
@@ -21,7 +21,7 @@ module.exports = function (top, differences, next) {
   while (action = differences.shift()) {
     var cmd = action[0]
     var pkg = action[1]
-    if (pkg.isInLink || pkg.parent.target || pkg.parent.isLink) {
+    if (pkg.isInLink || (pkg.parent && (pkg.parent.target || pkg.parent.isLink))) {
       // we want to skip warning if this is a child of another module that we're removing
       if (!pkg.parent.removing) {
         log.warn('skippingAction', 'Module is inside a symlinked module: not running ' +


### PR DESCRIPTION
if the parent is not available, this would bomb at runtime with the
error,

```
TypeError: Cannot read property 'target' of null
```
