### PR TITLE
fix(versions): loose semver parsing when sorting versions, fixes #11836

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -118,7 +118,8 @@ function fetchNamedPackageData (dep, next) {
     }
     function pickVersionFromRegistryDocument (pkg) {
       if (!regCache[url]) regCache[url] = pkg
-      var versions = Object.keys(pkg.versions).sort(semver.rcompare)
+      var loose = true
+      var versions = semver.rsort(Object.keys(pkg.versions), loose)
 
       if (dep.type === 'tag') {
         var tagVersion = pkg['dist-tags'][dep.spec]


### PR DESCRIPTION
Since versions can be loose (like handlerbars that has `1.0.5beta`) we get an exception trying to sort them without loose flag set.
