### PR TITLE
Fix failing test

### DIFF
--- a/test/tap/outdated-symlink.js
+++ b/test/tap/outdated-symlink.js
@@ -51,19 +51,26 @@ test('setup', function (t) {
 
 test('when outdated is called linked packages should be displayed as such', function (t) {
   var regOutLinked = /my-local-package\s*1.0.0\s*linked\s*linked\n/
-  var regOutInstallOne = /async\s*0.2.9\s*0.2.9\s*1.5.2\n/
-  var regOutInstallTwo = /underscore\s*1.3.1\s*1.3.1\s*1.8.3\n/
+  var regOutInstallOne = /async\s*0.2.9\s*0.2.9\s*0.2.10\n/
+  var regOutInstallTwo = /underscore\s*1.3.1\s*1.3.1\s*1.5.1\n/
 
   console.log = function () {}
   mr({ port: common.port }, function (er, s) {
-    common.npm(['outdated', '-g'], OPTS, function (err, c, out, stderr) {
-      t.ifError(err)
-      t.ok(out.match(regOutLinked), 'Global Link format as expected')
-      t.ok(out.match(regOutInstallOne), 'Global Install format as expected')
-      t.ok(out.match(regOutInstallTwo), 'Global Install format as expected')
-      s.close()
-      t.end()
-    })
+    common.npm(
+      [
+        '--registry', common.registry,
+        'outdated', '-g'
+      ],
+      OPTS,
+      function (err, c, out, stderr) {
+        t.ifError(err)
+        t.ok(out.match(regOutLinked), 'Global Link format as expected')
+        t.ok(out.match(regOutInstallOne), 'Global Install format as expected')
+        t.ok(out.match(regOutInstallTwo), 'Global Install format as expected')
+        s.close()
+        t.end()
+      }
+    )
   })
 })
 


### PR DESCRIPTION
This test fails because `--registry` option is missing (the real npm registry is used instead of the mocked one).
