### PR TITLE
generate a consistent shasum for git dependencies

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -281,7 +281,7 @@ function add (args, where, cb) {
     switch (p.type) {
       case 'local':
       case 'directory':
-        addLocal(p, null, cb)
+        addLocal(p, null, null, cb)
         break
       case 'remote':
         // get auth, if possible

--- a/lib/cache/add-local.js
+++ b/lib/cache/add-local.js
@@ -18,7 +18,7 @@ var iferr = require('iferr')
 
 module.exports = addLocal
 
-function addLocal (p, pkgData, cb_) {
+function addLocal (p, pkgData, shasum, cb_) {
   assert(typeof p === 'object', 'must have spec info')
   assert(typeof cb === 'function', 'must have callback')
 
@@ -38,9 +38,9 @@ function addLocal (p, pkgData, cb_) {
   }
 
   if (p.type === 'directory') {
-    addLocalDirectory(p.spec, pkgData, null, cb)
+    addLocalDirectory(p.spec, pkgData, shasum, cb)
   } else {
-    addLocalTarball(p.spec, pkgData, null, cb)
+    addLocalTarball(p.spec, pkgData, shasum, cb)
   }
 }
 

--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -346,12 +346,12 @@ function checkoutTreeish (from, resolvedURL, resolvedTreeish, tmpdir, cb) {
       }
       log.verbose('checkoutTreeish', from, 'checkout', stdout)
 
-      updateSubmodules(from, resolvedURL, tmpdir, cb)
+      updateSubmodules(from, resolvedURL, resolvedTreeish, tmpdir, cb)
     }
   )
 }
 
-function updateSubmodules (from, resolvedURL, tmpdir, cb) {
+function updateSubmodules (from, resolvedURL, resolvedTreeish, tmpdir, cb) {
   var args = ['submodule', '-q', 'update', '--init', '--recursive']
   git.whichAndExec(
     args,
@@ -373,7 +373,7 @@ function updateSubmodules (from, resolvedURL, tmpdir, cb) {
 
         // ensure pack logic is applied
         // https://github.com/npm/npm/issues/6400
-        addLocal(spec, null, function (er, data) {
+        addLocal(spec, null, resolvedTreeish, function (er, data) {
           if (data) {
             if (npm.config.get('save-exact')) {
               log.verbose('addRemoteGit', 'data._from:', resolvedURL, '(save-exact)')


### PR DESCRIPTION
Formerly, the shasum was generated from a tar.gz file which was
generated from a cloned git tree. Because git doesn't keep track of file
metadata such as timestamps, the tar.gz file generated from the cloned
git tree has a different shasum during every npm install.

So instead of generating a shasum in this way, we use the sha1 from the
git tree where the source was obtained. The result is a shasum that is
always the same for a given git tree. This allows systems like docker
build to make use of the build cache for build steps that involve
running `npm install` with git-based dependencies.
