### PR TITLE
Update npm-disputes.md

### DIFF
--- a/doc/misc/npm-disputes.md
+++ b/doc/misc/npm-disputes.md
@@ -67,6 +67,12 @@ regardless of the justification.  When humans solve their problems by
 talking to other humans with respect, everyone has the chance to end up
 feeling good about the interaction.
 
+When npm Inc resolves a dispute, it will reach out to the original author
+of the package in a private email 24 hours before giving the package to
+the new author. This exchange gives the original author an oppurtunity
+to discuss the issue by talking to other humans, even if the ownership
+of the package ultimately changes hands to a new author.
+
 ## EXCEPTIONS
 
 Some things are not allowed, and will be removed without discussion if


### PR DESCRIPTION
Hi @izs 

I tried updating the disputes document with an "proof of concept" paragraph.

Based on recent feedback it seems like the disputes process might benefit from more "personal" discussions with the parties involved. A little human touch and an opportunity to allow parties to come to an "agree to disagree" conclusion with npm Inc might make the process more pleasant for everyone involved.

I know human problems don't always work out but making people feel like they have some kind of input even if ultimately futile can reduce frustration in the long run.

I suspect that if you do want to adjust this document, you would use different more appropriate phrasing.
Jake.
