### PR TITLE
doc: add --ignore-scripts flag to install doc page

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -271,6 +271,9 @@ global `node_modules` folder. Only your direct dependencies will show in
 `node_modules` and everything they depend on will be flattened in their
 `node_modules` folders. This obviously will eliminate some deduping.
 
+The `--ignore-scripts` argument will cause npm to not execute any 
+scripts defined in the package.json. See `npm-scripts(7)`.
+
 The `--legacy-bundling` argument will cause npm to install the package such
 that versions of npm prior to 1.4, such as the one included with node 0.8,
 can install the package. This eliminates all automatic deduping.


### PR DESCRIPTION
I was beyond confused that this worked, but I didn't see documentation for it on the web or in the `npm help install` page.

Turns out it's documented [over here](https://docs.npmjs.com/misc/config#ignore-scripts) but I think all runtime flags to `npm install` should be readable in that commands docs.
