### PR TITLE
Fix #10974 - deprecate works on all version by default

### DIFF
--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -37,6 +37,10 @@ function deprecate (args, cb) {
   // fetch the data and make sure it exists.
   var p = npa(pkg)
 
+  // npa makes the default spec "latest", but for deprecation
+  // "*" is the appropriate default.
+  if (p.rawSpec === '') p.spec = '*'
+
   mapToRegistry(p.name, npm.config, function (er, uri, auth) {
     if (er) return cb(er)
 

--- a/test/tap/deprecate.js
+++ b/test/tap/deprecate.js
@@ -126,6 +126,30 @@ test('npm deprecate bad semver range', function (t) {
   })
 })
 
+test('npm deprecate a package with no semver range', function (t) {
+  var deprecated = JSON.parse(JSON.stringify(cache))
+  deprecated.versions = {
+    '0.0.0': { deprecated: 'make it dead' },
+    '0.0.1': { deprecated: 'make it dead' },
+    '0.0.2': { deprecated: 'make it dead' }
+  }
+  server.get('/cond?write=true').reply(200, cache)
+  server.put('/cond', deprecated).reply(201, { deprecated: true })
+  common.npm([
+    'deprecate',
+    'cond',
+    'make it dead',
+    '--registry', common.registry,
+    '--loglevel', 'silent'
+  ], {},
+  function (er, code, stdout, stderr) {
+    t.ifError(er, 'npm deprecate')
+    t.equal(stderr, '', 'no error output')
+    t.equal(code, 0, 'exited OK')
+    t.end()
+  })
+})
+
 test('cleanup', function (t) {
   server.close()
   t.ok(true)


### PR DESCRIPTION
When a semver spec is not supplied, npa supplies a default spec of
'latest'. This is usually correct, but for deprecation the default has
been to apply to all versions of a package.

This patch just checks the raw spec and if it's empty it overrides with
with the '*' version range, which is what people in the issue discussion
were doing anyway.

This includes a working test. -POLM
