### PR TITLE
install: Add --from-cache to force using the cache

### DIFF
--- a/lib/cache/caching-client.js
+++ b/lib/cache/caching-client.js
@@ -99,6 +99,7 @@ function get_ (uri, cachePath, params, cb) {
   var stat = params.stat
   var etag
   var lastModified
+  var fromCache = npm.config.get('from-cache')
 
   timeout = Math.min(timeout, npm.config.get('cache-max') || 0)
   timeout = Math.max(timeout, npm.config.get('cache-min') || -Infinity)
@@ -112,8 +113,8 @@ function get_ (uri, cachePath, params, cb) {
     if (data._etag) etag = data._etag
     if (data._lastModified) lastModified = data._lastModified
 
-    if (stat && timeout && timeout > 0) {
-      if ((Date.now() - stat.mtime.getTime()) / 1000 < timeout) {
+    if (fromCache || (stat && timeout && timeout > 0)) {
+      if (fromCache || (Date.now() - stat.mtime.getTime()) / 1000 < timeout) {
         log.verbose('get', uri, 'not expired, no request')
         delete data._etag
         delete data._lastModified

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -140,6 +140,8 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'fetch-retry-mintimeout': 10000,
     'fetch-retry-maxtimeout': 60000,
 
+    'from-cache': false,
+
     git: 'git',
     'git-tag-version': true,
 
@@ -250,6 +252,7 @@ exports.types = {
   'fetch-retry-factor': Number,
   'fetch-retry-mintimeout': Number,
   'fetch-retry-maxtimeout': Number,
+  'from-cache': Boolean,
   git: String,
   'git-tag-version': Boolean,
   global: Boolean,


### PR DESCRIPTION
When passed, the registry client will favour taking modules from cache instead of hitting the network.

Begins to address #2568.

This does not fully address #2358 (`--offline`) since git urls and github shorthands are as of yet not handled (and may even complicate our lives further, as per #5941 and #6024). This is why I haven't documented the flag yet: does this flag along help enough to warrant its existence, or should it be dismissed until a real `--offline` flag is brought forth?

Another question: I'm a bit unsure how to go about testing this. I poked around [npm-registry-mock](https://github.com/npm/npm-registry-mock) and the tests a bit but haven't found what I need to test whether the registry was hit or not. Is there any precedent that I missed?
