### PR TITLE
lifecycle: inform users of why scripts are being ignored

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -46,7 +46,12 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
   if (!pkg) return cb(new Error('Invalid package data'))
 
   log.info('lifecycle', logid(pkg, stage), pkg._id)
-  if (!pkg.scripts || npm.config.get('ignore-scripts')) pkg.scripts = {}
+  if (!pkg.scripts) pkg.scripts = {}
+
+  if (npm.config.get('ignore-scripts')) {
+    log.info('lifecycle', logid(pkg, stage), 'ignored because ignore-scripts is set to true', pkg._id)
+    pkg.scripts = {}
+  }
 
   validWd(wd || path.resolve(npm.dir, pkg.name), function (er, wd) {
     if (er) return cb(er)


### PR DESCRIPTION
A global setting of `ignore-scripts:true` can cause `npm run-script` to silently fail to run scripts and cause issues like #12082.

This will add an info-level log. It goes from this:

<img width="629" alt="screen shot 2016-03-26 at 23 57 25" src="https://cloud.githubusercontent.com/assets/1402241/14061287/f83cc09e-f3ae-11e5-9220-2c4685acfc75.png">

to this:

<img width="993" alt="screen shot 2016-03-26 at 23 57 07" src="https://cloud.githubusercontent.com/assets/1402241/14061286/f6fc3c5a-f3ae-11e5-9349-6e21721d154f.png">
