### PR TITLE
Replace cli.js with bin/npm-cli.js and remove cli.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,23 +53,23 @@ latest:
 	@echo "Installing latest published npm"
 	@echo "Use 'make install' or 'make link' to install the code"
 	@echo "in this folder that you're looking at right now."
-	node cli.js install -g -f npm ${NPMOPTS}
+	node bin/npm-cli.js install -g -f npm ${NPMOPTS}
 
 install: all
-	node cli.js install -g -f ${NPMOPTS}
+	node bin/npm-cli.js install -g -f ${NPMOPTS}
 
 # backwards compat
 dev: install
 
 link: uninstall
-	node cli.js link -f
+	node bin/npm-cli.js link -f
 
 clean: markedclean marked-manclean doc-clean uninstall
 	rm -rf npmrc
-	node cli.js cache clean
+	node bin/npm-cli.js cache clean
 
 uninstall:
-	node cli.js rm npm -g -f
+	node bin/npm-cli.js rm npm -g -f
 
 doc: $(mandocs) $(htmldocs)
 
@@ -143,19 +143,19 @@ html/doc/misc/%.html: doc/misc/%.md $(html_docdeps)
 marked: node_modules/.bin/marked
 
 node_modules/.bin/marked:
-	node cli.js install marked --no-global
+	node bin/npm-cli.js install marked --no-global
 
 marked-man: node_modules/.bin/marked-man
 
 node_modules/.bin/marked-man:
-	node cli.js install marked-man --no-global
+	node bin/npm-cli.js install marked-man --no-global
 
 doc: man
 
 man: $(cli_docs)
 
 test: doc
-	node cli.js test
+	node bin/npm-cli.js test
 
 tag:
 	npm tag npm@$(PUBLISHTAG) latest
@@ -173,7 +173,7 @@ publish: gitclean ls-ok link doc
 	npm publish --tag=$(PUBLISHTAG)
 
 release: gitclean ls-ok markedclean marked-manclean doc-clean doc
-	node cli.js prune --production
+	node bin/npm-cli.js prune --production
 	@bash scripts/release.sh
 
 sandwich:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you plan on hacking on npm, `make link` is your friend.
 
 If you've got the npm source code, you can also semi-permanently set
 arbitrary config keys using the `./configure --key=val ...`, and then
-run npm commands by doing `node cli.js <cmd> <args>`.  (This is helpful
+run npm commands by doing `node bin/npm-cli.js <cmd> <args>`.  (This is helpful
 for testing, or running stuff without actually installing npm itself.)
 
 ## Windows Install or Upgrade

--- a/cli.js
+++ b/cli.js
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('./bin/npm-cli.js')

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -76,7 +76,7 @@
       if (!loaded) {
         throw new Error(
           'Call npm.load(config, cb) before using this command.\n' +
-            'See the README.md or cli.js for example usage.'
+            'See the README.md or bin/npm-cli.js for example usage.'
         )
       }
       var a = npm.deref(c)

--- a/scripts/doc-build.sh
+++ b/scripts/doc-build.sh
@@ -62,7 +62,7 @@ src=$1
 dest=$2
 name=$(basename ${src%.*})
 date=$(date -u +'%Y-%m-%d %H:%M:%S')
-version=$(node cli.js -v)
+version=$(node bin/npm-cli.js -v)
 
 mkdir -p $(dirname $dest)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -256,8 +256,8 @@ cd "$TMP" \
         make="NOMAKE"
       fi
       if [ "$make" = "NOMAKE" ]; then
-        "$node" cli.js rm npm -gf
-        "$node" cli.js install -gf
+        "$node" bin/npm-cli.js rm npm -gf
+        "$node" bin/npm-cli.js install -gf
       fi) \
   && cd "$BACK" \
   && rm -rf "$TMP" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,7 @@ set -e
 
 rm -rf release *.tgz || true
 mkdir release
-node ./cli.js pack --loglevel error >/dev/null
+node ./bin/npm-cli.js pack --loglevel error >/dev/null
 mv *.tgz release
 cd release
 tar xzf *.tgz
@@ -18,12 +18,12 @@ mv package node_modules/npm
 
 # make the zip for windows users
 cp node_modules/npm/bin/*.cmd .
-zipname=npm-$(node ../cli.js -v).zip
+zipname=npm-$(node ../bin/npm-cli.js -v).zip
 zip -q -9 -r -X "$zipname" *.cmd node_modules
 
 # make the tar for node's deps
 cd node_modules
-tarname=npm-$(node ../../cli.js -v).tgz
+tarname=npm-$(node ../../bin/npm-cli.js -v).tgz
 tar czf "$tarname" npm
 
 cd ..


### PR DESCRIPTION
The first of the `cli.js` was used for the bin field in package.json, but now it is used only by internal build codes. Also, some docs pointed it as an example instead of `bin/npm-cli.js`.
