### PR TITLE
remove faq link and command as it's removed at #10547

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ you have chosen.
 ## More Docs
 
 Check out the [docs](https://docs.npmjs.com/),
-especially the [faq](https://docs.npmjs.com/misc/faq).
 
 You can use the `npm help` command to read any of them.
 
@@ -164,6 +163,5 @@ will no doubt tell you to put the output in a gist or email.
 ## SEE ALSO
 
 * npm(1)
-* npm-faq(7)
 * npm-help(1)
 * npm-index(7)

--- a/doc/cli/npm-completion.md
+++ b/doc/cli/npm-completion.md
@@ -28,5 +28,4 @@ completions based on the arguments.
 ## SEE ALSO
 
 * npm-developers(7)
-* npm-faq(7)
 * npm(1)

--- a/doc/cli/npm-help-search.md
+++ b/doc/cli/npm-help-search.md
@@ -31,5 +31,4 @@ If false, then help-search will just list out the help topics found.
 ## SEE ALSO
 
 * npm(1)
-* npm-faq(7)
 * npm-help(1)

--- a/doc/cli/npm-help.md
+++ b/doc/cli/npm-help.md
@@ -29,7 +29,6 @@ Set to `"browser"` to view html help content in the default web browser.
 
 * npm(1)
 * README
-* npm-faq(7)
 * npm-folders(5)
 * npm-config(1)
 * npm-config(7)

--- a/doc/cli/npm-link.md
+++ b/doc/cli/npm-link.md
@@ -65,7 +65,6 @@ include that scope, e.g.
 ## SEE ALSO
 
 * npm-developers(7)
-* npm-faq(7)
 * package.json(5)
 * npm-install(1)
 * npm-folders(5)

--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -156,7 +156,6 @@ will no doubt tell you to put the output in a gist or email.
 ## SEE ALSO
 
 * npm-help(1)
-* npm-faq(7)
 * README
 * package.json(5)
 * npm-install(1)

--- a/doc/files/npm-folders.md
+++ b/doc/files/npm-folders.md
@@ -204,7 +204,6 @@ cannot be found elsewhere.  See `package.json(5)` for more information.
 
 ## SEE ALSO
 
-* npm-faq(7)
 * package.json(5)
 * npm-install(1)
 * npm-pack(1)

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -757,7 +757,6 @@ npm will default some values based on package contents.
 * npm-config(1)
 * npm-config(7)
 * npm-help(1)
-* npm-faq(7)
 * npm-install(1)
 * npm-publish(1)
 * npm-uninstall(1)

--- a/doc/misc/npm-coding-style.md
+++ b/doc/misc/npm-coding-style.md
@@ -189,5 +189,4 @@ Boolean objects are verboten.
 ## SEE ALSO
 
 * npm-developers(7)
-* npm-faq(7)
 * npm(1)

--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -211,7 +211,6 @@ Tell the world how easy it is to install your program!
 
 ## SEE ALSO
 
-* npm-faq(7)
 * npm(1)
 * npm-init(1)
 * package.json(5)

--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -85,7 +85,6 @@ var cmdList = [
   'docs',
   'repo',
   'bugs',
-  'faq',
   'root',
   'prefix',
   'bin',

--- a/lib/faq.js
+++ b/lib/faq.js
@@ -1,7 +1,0 @@
-module.exports = faq
-
-faq.usage = 'npm faq'
-
-var npm = require('./npm.js')
-
-function faq (args, cb) { npm.commands.help(['faq'], cb) }

--- a/lib/help.js
+++ b/lib/help.js
@@ -170,7 +170,6 @@ function npmUsage (valid, cb) {
     '',
     'npm <cmd> -h     quick help on <cmd>',
     'npm -l           display full usage info',
-    'npm faq          commonly asked questions',
     'npm help <term>  search for help on <term>',
     'npm help npm     involved overview',
     '',


### PR DESCRIPTION
The faq docs was already removed at #10547, but related codes and links are still there.
Also, the build system as a prepublish script in npm  to create man and html directory does not clear old docs currently. Let me create a PR for it as well later.
