### PR TITLE
makefile: add doc-clean to `make publish`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ ls-ok:
 gitclean:
 	git clean -fd
 
-publish: gitclean ls-ok link doc
+publish: gitclean ls-ok link doc-clean doc
 	@git push origin :v$(shell npm -v) 2>&1 || true
 	git push origin $(BRANCH) &&\
 	git push origin --tags &&\

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
   },
   "scripts": {
     "dumpconf": "env | grep npm | sort | uniq",
-    "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rimraf test/*/*/node_modules && make -j4 doc",
+    "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rimraf test/*/*/node_modules && make doc-clean && make -j4 doc",
     "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"update AUTHORS\" || true",
     "tap": "tap --timeout 240",
     "test": "standard && npm run test-tap",


### PR DESCRIPTION
from #12143. The official [release process](https://github.com/npm/npm/wiki/Release-Process#thursday-cutting-the-release) has a release command `make publish` and the command does not do clean docs before releasing new version. It means there is a possibility that some compiled docs files which is removed a long time ago exist in release codes, depends on the local of the release manager.
