### PR TITLE
doc: Be clearer about the effects of defining `engines`

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -655,8 +655,8 @@ are capable of properly installing your program.  For example:
 
     { "engines" : { "npm" : "~1.0.20" } }
 
-Note that, unless the user has set the `engine-strict` config flag, this
-field is advisory only.
+Unless the user has set the `engine-strict` config flag, this
+field is advisory only will produce warnings when your package is installed as a dependency.
 
 ## engineStrict
 


### PR DESCRIPTION
The current behavior is when packages with an `engines` entry are installed a dependency npm produces a warning if necessary.
