### PR TITLE
config: fix a shorthand value of `-n`

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -385,7 +385,7 @@ exports.shorthands = {
   E: ['--save-exact'],
   O: ['--save-optional'],
   y: ['--yes'],
-  n: ['--no-yes'],
+  n: ['--yes', false],
   B: ['--save-bundle'],
   C: ['--prefix']
 }


### PR DESCRIPTION
In docs, a shorthand `-n` means `--yes false`, but the code has `--no-yes`. I di grep `--no-yes` in all codes of npm cli, but I couldn't find it anywhere so I think the code is little bit old and the docs is correct.

refs: [npm-config.md#shorthands-and-other-cli-niceties](https://github.com/npm/npm/blob/master/doc/misc/npm-config.md#shorthands-and-other-cli-niceties)
