### PR TITLE
gitignore: add /test/npm_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ npm-debug.log
 /npm-*.tgz
 /node_modules/npm-registry-client/test/fixtures
 /test/fixtures/config/userconfig-with-gc
+/test/npm_cache
 /node_modules/npm-registry-couchapp
 *.pyc
 .jshintrc


### PR DESCRIPTION
This file is just kind of annoying to have in git status all the time, and I figure we may as well ignore it.
