### PR TITLE
Readme: Update Windows Upgrade Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,12 @@ for testing, or running stuff without actually installing npm itself.)
 
 ## Windows Install or Upgrade
 
-You can download a zip file from <https://github.com/npm/npm/releases>, and
-unpack it in the `node_modules\npm\` folder inside node's installation folder.
-
-To upgrade to npm 2, follow the Windows upgrade instructions in
-the npm Troubleshooting Guide:
-
-<https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows>
+Many improvements for Windows users have been made in npm 3 - you will have a better
+experience if you run a recent version of npm. To upgrade, either use [Microsoft's 
+upgrade tool](https://github.com/felixrieseberg/npm-windows-upgrade), 
+[download a new version of Node](http://nodejs.org/download/), 
+or follow the Windows upgrade instructions in the 
+[npm Troubleshooting Guide](https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows).
 
 If that's not fancy enough for you, then you can fetch the code with
 git, and mess with it directly.


### PR DESCRIPTION
With npm@3 being out for a while (and it being sooooo much better for Windows users), win32 peeps will be better off with npm@3. This PR updates the readme, replacing the old "so you want npm 2" instructions.

As discussed with @iarna :fire_engine:
