### PR TITLE
Do not swallow errors, when reading invalid tgz files

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -277,8 +277,8 @@ function hasTarHeader (c) {
 
 function untarStream (tarball, cb) {
   validate('SF', arguments)
-  
-  var cbOnceForError= once(cb)
+
+  var cbOnceForError = once(cb)
   var stream
   var file = stream = fs.createReadStream(tarball)
   var tounpipe = [file]

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -277,15 +277,15 @@ function hasTarHeader (c) {
 
 function untarStream (tarball, cb) {
   validate('SF', arguments)
-  cb = once(cb)
-
+  
+  var cbOnceForError= once(cb)
   var stream
   var file = stream = fs.createReadStream(tarball)
   var tounpipe = [file]
   file.on('error', function (er) {
     er = new Error('Error extracting ' + tarball + ' archive: ' + er.message)
     er.code = 'EREADFILE'
-    cb(er)
+    cbOnceForError(er)
   })
   file.on('data', function OD (c) {
     if (hasGzipHeader(c)) {
@@ -297,7 +297,7 @@ function untarStream (tarball, cb) {
       if (file.destroy) file.destroy()
       var er = new Error('Non-gzip/tarball ' + tarball)
       er.code = 'ENOTTARBALL'
-      return cb(er)
+      return cbOnceForError(er)
     }
     file.removeListener('data', OD)
     file.emit('data', c)
@@ -309,7 +309,7 @@ function untarStream (tarball, cb) {
     gunzip.on('error', function (er) {
       er = new Error('Error extracting ' + tarball + ' archive: ' + er.message)
       er.code = 'EGUNZIP'
-      cb(er)
+      cbOnceForError(er)
     })
     tounpipe.push(gunzip)
     stream = gunzip
@@ -321,7 +321,7 @@ function untarStream (tarball, cb) {
     untar.on('error', function (er) {
       er = new Error('Error extracting ' + tarball + ' archive: ' + er.message)
       er.code = 'EUNTAR'
-      cb(er)
+      cbOnceForError(er)
     })
     tounpipe.push(untar)
     stream = untar


### PR DESCRIPTION
When Errors occur reading tgz files (why ever) npm says
`npm ERR! cb() never called!`
instead of printing a meaningful error.
This PR fixes it.
