### PR TITLE
doc: Describe how `npm run` sets `NODE` and `PATH` in more detail

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -40,6 +40,10 @@ you should write:
 
 instead of `"scripts": {"test": "node_modules/.bin/tap test/\*.js"}` to run your tests.
 
+`npm run` sets the `NODE` environment variable to the `node` executable with
+which `npm` is executed, and adds the directory within which it resides to the
+`PATH`, too.
+
 If you try to run a script without having a `node_modules` directory and it fails,
 you will be given a warning to run `npm install`, just in case you've forgotten.
 


### PR DESCRIPTION
Note that `npm run` changes `PATH` to include the current node interpreter’s directory.

Ref: #12318
