### PR TITLE
test: Fix progress config testing to ignore local user configs

### DIFF
--- a/test/tap/progress-config.js
+++ b/test/tap/progress-config.js
@@ -1,6 +1,9 @@
 'use strict'
+var path = require('path')
 var test = require('tap').test
 var log = require('npmlog')
+var fs = require('graceful-fs')
+var configName = path.join(__dirname, path.basename(__filename, '.js')) + '-npmrc'
 
 // We use requireInject to get a fresh copy of
 // the npm singleton each time we require it.
@@ -15,10 +18,15 @@ function hasOnlyAscii (s) {
   return /^[\000-\177]*$/.test(s)
 }
 
+test('setup', function (t) {
+  fs.writeFileSync(configName, '')
+  t.done()
+})
+
 test('disabled', function (t) {
   t.plan(1)
   var npm = requireInject('../../lib/npm.js', {})
-  npm.load({progress: false}, function () {
+  npm.load({userconfig: configName, progress: false}, function () {
     t.is(log.progressEnabled, false, 'should be disabled')
   })
 })
@@ -26,7 +34,7 @@ test('disabled', function (t) {
 test('enabled', function (t) {
   t.plan(1)
   var npm = requireInject('../../lib/npm.js', {})
-  npm.load({progress: true}, function () {
+  npm.load({userconfig: configName, progress: true}, function () {
     t.is(log.progressEnabled, true, 'should be enabled')
   })
 })
@@ -34,7 +42,7 @@ test('enabled', function (t) {
 test('default', function (t) {
   t.plan(1)
   var npm = requireInject('../../lib/npm.js', {})
-  npm.load({}, function () {
+  npm.load({userconfig: configName, }, function () {
     t.is(log.progressEnabled, true, 'should be enabled')
   })
 })
@@ -43,7 +51,7 @@ test('default-travis', function (t) {
   t.plan(1)
   global.process.env.TRAVIS = 'true'
   var npm = requireInject('../../lib/npm.js', {})
-  npm.load({}, function () {
+  npm.load({userconfig: configName, }, function () {
     t.is(log.progressEnabled, false, 'should be disabled')
     delete global.process.env.TRAVIS
   })
@@ -53,7 +61,7 @@ test('default-ci', function (t) {
   t.plan(1)
   global.process.env.CI = 'true'
   var npm = requireInject('../../lib/npm.js', {})
-  npm.load({}, function () {
+  npm.load({userconfig: configName, }, function () {
     t.is(log.progressEnabled, false, 'should be disabled')
     delete global.process.env.CI
   })
@@ -62,7 +70,7 @@ test('default-ci', function (t) {
 test('unicode-true', function (t) {
   t.plan(6)
   var npm = requireInject('../../lib/npm.js', {})
-  npm.load({unicode: true}, function () {
+  npm.load({userconfig: configName, unicode: true}, function () {
     Object.keys(log.gauge.theme).forEach(function (key) {
       t.notOk(hasOnlyAscii(log.gauge.theme[key]), 'only unicode')
     })
@@ -72,9 +80,14 @@ test('unicode-true', function (t) {
 test('unicode-false', function (t) {
   t.plan(6)
   var npm = requireInject('../../lib/npm.js', {})
-  npm.load({unicode: false}, function () {
+  npm.load({userconfig: configName, unicode: false}, function () {
     Object.keys(log.gauge.theme).forEach(function (key) {
       t.ok(hasOnlyAscii(log.gauge.theme[key]), 'only ASCII')
     })
   })
+})
+
+test('cleanup', function (t) {
+  fs.unlinkSync(configName)
+  t.done()
 })


### PR DESCRIPTION
Previously, _any_ local setting would cause the tests to fail as
they were trying to test what the default values for the progress
bar would be in different environments and any explicit setting
overrides those defaults.
