### PR TITLE
fix: Intermittent EPERM issues when renaming Windows files during install

### DIFF
--- a/lib/cache/add-local-tarball.js
+++ b/lib/cache/add-local-tarball.js
@@ -168,7 +168,14 @@ function addTmpTarball_ (tgz, data, shasum, cb) {
       var read = fs.createReadStream(tgz)
       var write = writeStreamAtomic(target, { mode: npm.modes.file })
       var fin = cs.uid && cs.gid ? chown : done
-      read.on("error", cb).pipe(write).on("error", cb).on("close", fin)
+      var errorHandler = function(er) {
+        if (er.code === "EPERM" && process.platform === "win32") {
+          fin()
+        } else {
+          cb(er)
+        }
+      }
+      read.on("error", cb).pipe(write).on("error", errorHandler).on("close", fin)
     })
 
   })


### PR DESCRIPTION
Copying behaviour of fix for #9696. Fixes #12059.
