### PR TITLE
WIP: (re)enable coverage & newest standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 npm-debug.log
+.nyc_output/
 /test/bin
 /test/output.log
 /test/*/*/node_modules

--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 ;(function () { // wrapper in case we're in module_context mode
-
   // windows: running "npm blah" in this folder will invoke WSH, not node.
   /*global WScript*/
   if (typeof WScript !== 'undefined') {

--- a/lib/access.js
+++ b/lib/access.js
@@ -35,7 +35,6 @@ access.completion = function (opts, cb) {
       } else {
         return cb(null, [])
       }
-      break
     case 'public':
     case 'restricted':
     case 'ls-packages':

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -87,7 +87,7 @@
       npm.command = c
       if (commandCache[a]) return commandCache[a]
 
-      var cmd = require(__dirname + '/' + a + '.js')
+      var cmd = require(path.join(__dirname, a + '.js'))
 
       commandCache[a] = function () {
         var args = Array.prototype.slice.call(arguments, 0)

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -78,9 +78,11 @@ function exit (code, noLog) {
       }
     })
     rollbacks.length = 0
+  } else if (code && !noLog) {
+    writeLogFile(reallyExit)
+  } else {
+    rm('npm-debug.log', reallyExit)
   }
-  else if (code && !noLog) writeLogFile(reallyExit)
-  else rm('npm-debug.log', reallyExit)
 
   function reallyExit (er) {
     if (er && !code) code = typeof er.errno === 'number' ? er.errno : 1

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -292,8 +292,10 @@ function makeEnv (data, prefix, env) {
   prefix = prefix || 'npm_package_'
   if (!env) {
     env = {}
-    for (var i in process.env) if (!i.match(/^npm_/)) {
-      env[i] = process.env[i]
+    for (var i in process.env) {
+      if (!i.match(/^npm_/)) {
+        env[i] = process.env[i]
+      }
     }
 
     // npat asks for tap output
@@ -310,31 +312,33 @@ function makeEnv (data, prefix, env) {
     )
   }
 
-  for (i in data) if (i.charAt(0) !== '_') {
-    var envKey = (prefix + i).replace(/[^a-zA-Z0-9_]/g, '_')
-    if (i === 'readme') {
-      continue
-    }
-    if (data[i] && typeof data[i] === 'object') {
-      try {
-        // quick and dirty detection for cyclical structures
-        JSON.stringify(data[i])
-        makeEnv(data[i], envKey + '_', env)
-      } catch (ex) {
-        // usually these are package objects.
-        // just get the path and basic details.
-        var d = data[i]
-        makeEnv(
-          { name: d.name, version: d.version, path: d.path },
-          envKey + '_',
-          env
-        )
+  for (i in data) {
+    if (i.charAt(0) !== '_') {
+      var envKey = (prefix + i).replace(/[^a-zA-Z0-9_]/g, '_')
+      if (i === 'readme') {
+        continue
       }
-    } else {
-      env[envKey] = String(data[i])
-      env[envKey] = env[envKey].indexOf('\n') !== -1
-                      ? JSON.stringify(env[envKey])
-                      : env[envKey]
+      if (data[i] && typeof data[i] === 'object') {
+        try {
+          // quick and dirty detection for cyclical structures
+          JSON.stringify(data[i])
+          makeEnv(data[i], envKey + '_', env)
+        } catch (ex) {
+          // usually these are package objects.
+          // just get the path and basic details.
+          var d = data[i]
+          makeEnv(
+            { name: d.name, version: d.version, path: d.path },
+            envKey + '_',
+            env
+          )
+        }
+      } else {
+        env[envKey] = String(data[i])
+        env[envKey] = env[envKey].indexOf('\n') !== -1
+                        ? JSON.stringify(env[envKey])
+                        : env[envKey]
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "npm-registry-mock": "~1.0.1",
     "require-inject": "~1.3.1",
     "sprintf-js": "~1.0.3",
-    "standard": "~5.4.1",
+    "standard": "~6.0.8",
     "tacks": "~1.0.11",
     "tap": "~5.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "dumpconf": "env | grep npm | sort | uniq",
     "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rimraf test/*/*/node_modules && make doc-clean && make -j4 doc",
     "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"update AUTHORS\" || true",
-    "tap": "tap --version && tap --reporter=classic --timeout 600",
+    "tap": "tap --version && tap --coverage --reporter=classic --timeout 600",
     "test": "standard && npm run test-tap",
     "test-tap": "npm run tap -- \"test/tap/*.js\"",
     "test-node": "\"$NODE\" ./test/run.js && \"$NODE\" \"node_modules/.bin/tap\" --timeout 240 \"test/tap/*.js\""

--- a/test/tap/00-config-setup.js
+++ b/test/tap/00-config-setup.js
@@ -61,11 +61,11 @@ try {
   fs.statSync(projectConf)
 } catch (er) {
   // project conf not found, probably working with packed npm
-  fs.writeFileSync(projectConf, function () {/*
+  fs.writeFileSync(projectConf, function () { /*
 save-prefix = ~
 proprietary-attribs = false
 legacy-bundling = true
-  */}.toString().split('\n').slice(1, -1).join('\n'))
+  */ }.toString().split('\n').slice(1, -1).join('\n'))
 }
 
 var projectRc = path.join(__dirname, '..', 'fixtures', 'config', '.npmrc')

--- a/test/tap/config-edit.js
+++ b/test/tap/config-edit.js
@@ -8,7 +8,7 @@ var common = require('../common-tap.js')
 
 var pkg = path.resolve(__dirname, 'npm-global-edit')
 
-var editorSrc = function () {/*
+var editorSrc = function () { /*
 #!/usr/bin/env node
 var fs = require('fs')
 if (fs.existsSync(process.argv[2])) {
@@ -17,7 +17,7 @@ if (fs.existsSync(process.argv[2])) {
   console.log('error')
   process.exit(1)
 }
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 var editorPath = path.join(pkg, 'editor')
 
 test('setup', function (t) {

--- a/test/tap/install-link-scripts.js
+++ b/test/tap/install-link-scripts.js
@@ -28,11 +28,11 @@ var dependency = {
   }
 }
 
-var foo = function () {/*
+var foo = function () { /*
 #!/usr/bin/env node
 
 console.log('hey sup')
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
 process.env.npm_config_prefix = tmp
 

--- a/test/tap/lifecycle-path.js
+++ b/test/tap/lifecycle-path.js
@@ -54,6 +54,10 @@ test('make sure the path is correct', function (t) {
       }
       return p.replace(/\\/g, '/')
     })
+    // spawn-wrap adds itself to the path when coverage is enabled
+    actual = actual.filter(function (p) {
+      return !p.match(/\.node-spawn-wrap/)
+    })
 
     // get the ones we tacked on, then the system-specific requirements
     var expect = [

--- a/test/tap/logout-scoped.js
+++ b/test/tap/logout-scoped.js
@@ -12,11 +12,11 @@ var pkg = path.resolve(__dirname, 'logout')
 var outfile = path.join(pkg, '_npmrc')
 var opts = { cwd: pkg }
 
-var contents = function () {/*
+var contents = function () { /*
 foo=boo
 @bar:registry=http://localhost:1337
 //localhost:1337/:_authToken=glarb
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
 function mocks (server) {
   server.delete('/-/user/token/glarb')

--- a/test/tap/logout.js
+++ b/test/tap/logout.js
@@ -12,10 +12,10 @@ var pkg = path.resolve(__dirname, 'logout')
 var outfile = path.join(pkg, '_npmrc')
 var opts = { cwd: pkg }
 
-var contents = function () {/*
+var contents = function () { /*
 foo=boo
 //localhost:1337/:_authToken=glarb
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
 function mocks (server) {
   server.delete('/-/user/token/glarb')

--- a/test/tap/no-global-warns.js
+++ b/test/tap/no-global-warns.js
@@ -14,13 +14,7 @@ var toInstall = path.join(base, 'to-install')
 var config = 'prefix = ' + base
 var configPath = path.join(base, '_npmrc')
 
-var extend = Object.assign || require('util')._extend
-
-var OPTS = {
-  env: extend({
-    'npm_config_userconfig': configPath
-  }, process.env)
-}
+var OPTS = { }
 
 var installJSON = {
   name: 'to-install',
@@ -40,11 +34,18 @@ test('setup', function (t) {
 })
 
 test('no-global-warns', function (t) {
-  common.npm(['install', '-g', toInstall], OPTS, function (err, code, stdout, stderr) {
-    t.ifError(err, 'installed w/o error')
-    t.is(stderr, '', 'no warnings printed to stderr')
-    t.end()
-  })
+  common.npm(
+    [
+      'install', '-g',
+      '--userconfig=' + configPath,
+      toInstall
+    ],
+    OPTS,
+    function (err, code, stdout, stderr) {
+      t.ifError(err, 'installed w/o error')
+      t.is(stderr, '', 'no warnings printed to stderr')
+      t.end()
+    })
 })
 
 test('cleanup', function (t) {

--- a/test/tap/optional-metadep-rollback-collision.js
+++ b/test/tap/optional-metadep-rollback-collision.js
@@ -63,7 +63,7 @@ var opdep_json = {
   }
 }
 
-var badServer = function () {/*
+var badServer = function () { /*
 var createServer = require('http').createServer
 var spawn = require('child_process').spawn
 var fs = require('fs')
@@ -98,9 +98,9 @@ if (process.argv[2]) {
 
   fs.writeFileSync(pidfile, child.pid + '\n')
 }
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
-var blart = function () {/*
+var blart = function () { /*
 var rando = require('crypto').randomBytes
 var resolve = require('path').resolve
 
@@ -152,7 +152,7 @@ mkdirp(BASEDIR, function go () {
     keepItGoingLouder = {}
   }, 3 * 1000)
 })
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 test('setup', function (t) {
   cleanup()
 

--- a/test/tap/repo.js
+++ b/test/tap/repo.js
@@ -10,6 +10,7 @@ var test = require('tap').test
 var rimraf = require('rimraf')
 var fs = require('fs')
 var path = require('path')
+var fakeBrowser = path.join(__dirname, '_script.sh')
 var outFile = path.join(__dirname, '/_output')
 
 var opts = { cwd: __dirname }
@@ -17,8 +18,8 @@ var opts = { cwd: __dirname }
 test('setup', function (t) {
   var s = '#!/usr/bin/env bash\n' +
           'echo \"$@\" > ' + JSON.stringify(__dirname) + '/_output\n'
-  fs.writeFileSync(__dirname + '/_script.sh', s, 'ascii')
-  fs.chmodSync(__dirname + '/_script.sh', '0755')
+  fs.writeFileSync(fakeBrowser, s, 'ascii')
+  fs.chmodSync(fakeBrowser, '0755')
   t.pass('made script')
   t.end()
 })
@@ -29,7 +30,7 @@ test('npm repo underscore', function (t) {
       'repo', 'underscore',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -48,7 +49,7 @@ test('npm repo optimist - github (https://)', function (t) {
       'repo', 'optimist',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -67,7 +68,7 @@ test('npm repo npm-test-peer-deps - no repo', function (t) {
       'repo', 'npm-test-peer-deps',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 1, 'exit not ok')
@@ -83,7 +84,7 @@ test('npm repo test-repo-url-http - non-github (http://)', function (t) {
       'repo', 'test-repo-url-http',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -102,7 +103,7 @@ test('npm repo test-repo-url-https - non-github (https://)', function (t) {
       'repo', 'test-repo-url-https',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -121,7 +122,7 @@ test('npm repo test-repo-url-ssh - non-github (ssh://)', function (t) {
       'repo', 'test-repo-url-ssh',
       '--registry=' + common.registry,
       '--loglevel=silent',
-      '--browser=' + __dirname + '/_script.sh'
+      '--browser=' + fakeBrowser
     ], opts, function (err, code, stdout, stderr) {
       t.ifError(err, 'repo command ran without error')
       t.equal(code, 0, 'exit ok')
@@ -135,7 +136,7 @@ test('npm repo test-repo-url-ssh - non-github (ssh://)', function (t) {
 })
 
 test('cleanup', function (t) {
-  fs.unlinkSync(__dirname + '/_script.sh')
+  fs.unlinkSync(fakeBrowser)
   t.pass('cleaned up')
   t.end()
 })

--- a/test/tap/scripts-whitespace-windows.js
+++ b/test/tap/scripts-whitespace-windows.js
@@ -37,12 +37,12 @@ var dependency = {
 
 var extend = Object.assign || require('util')._extend
 
-var foo = function () {/*
+var foo = function () { /*
 #!/usr/bin/env node
 
 if (process.argv.length === 8)
   console.log('npm-test-fine')
-*/}.toString().split('\n').slice(1, -1).join('\n')
+*/ }.toString().split('\n').slice(1, -1).join('\n')
 
 test('setup', function (t) {
   cleanup()

--- a/test/tap/sorted-package-json.js
+++ b/test/tap/sorted-package-json.js
@@ -2,7 +2,6 @@ var test = require('tap').test
 var path = require('path')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
-var node = process.execPath
 var pkg = path.resolve(__dirname, 'sorted-package-json')
 var tmp = path.join(pkg, 'tmp')
 var cache = path.join(pkg, 'cache')
@@ -19,7 +18,6 @@ test('setup', function (t) {
 })
 
 test('sorting dependencies', function (t) {
-
   var before = JSON.parse(fs.readFileSync(packageJson).toString())
 
   mr({ port: common.port }, function (er, s) {


### PR DESCRIPTION
This turns on coverage again (only now all of the tests pass, with one small tweak), and also cleans up the code to pass the latest major of tap.

Also, and this is unrelated, it fixes the fact that a test was trying to set the prefix for a global install test and not doing so successfully.

Not ready to land just yet, and mostly exists so that I can see how it looks in AppVeyor.
