### PR TITLE
Add INIT_CWD environment variable when npm run scripts

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -40,6 +40,20 @@ you should write:
 
 instead of `"scripts": {"test": "node_modules/.bin/tap test/\*.js"}` to run your tests.
 
+Also, `npm run` adds current working directory to `INIT_CWD`. You can run scripts in subdirectory of project. For example, you want to run babel in specific subdirectory. You should write:
+
+    "scripts": {
+      "build": "babel $INIT_CWD/src -d $INIT_CWD/lib"
+    }
+    
+or you can write:
+
+    "scripts": {
+      "build": "cd $INIT_CWD && babel src -d lib"
+    }
+    
+Now, you can run script, `npm run build` in any subdirectory you want to compiler JavaScript.
+
 `npm run` sets the `NODE` environment variable to the `node` executable with
 which `npm` is executed. Also, if the `--scripts-prepend-node-path` is passed,
 the directory within which `node` resides is added to the

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -56,6 +56,7 @@ function runScript (args, cb) {
   var pkgdir = npm.localPrefix
   var cmd = args.shift()
 
+  process.env.INIT_CWD = process.cwd()
   readJson(path.resolve(pkgdir, 'package.json'), function (er, d) {
     if (er) return cb(er)
     run(d, pkgdir, cmd, args, cb)

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -56,7 +56,6 @@ function runScript (args, cb) {
   var pkgdir = npm.localPrefix
   var cmd = args.shift()
 
-  process.env.INIT_CWD = process.cwd()
   readJson(path.resolve(pkgdir, 'package.json'), function (er, d) {
     if (er) return cb(er)
     run(d, pkgdir, cmd, args, cb)

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -78,6 +78,7 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
     env.npm_lifecycle_event = stage
     env.npm_node_execpath = env.NODE = env.NODE || process.execPath
     env.npm_execpath = require.main.filename
+    env.INIT_CWD = process.cwd()
 
     // 'nobody' typically doesn't have permission to write to /tmp
     // even if it's never used, sh freaks out.

--- a/test/tap/lifecycle-INIT_CWD.js
+++ b/test/tap/lifecycle-INIT_CWD.js
@@ -1,0 +1,58 @@
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+
+var pkg = path.resolve(__dirname, 'lifecycle-initcwd')
+var subdir = path.resolve(pkg, 'subdir')
+
+var json = {
+  name: 'init-cwd',
+  version: '1.0.0',
+  scripts: {
+    initcwd: 'echo "$INIT_CWD"'
+  }
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg)
+  mkdirp.sync(subdir)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+
+  process.chdir(subdir)
+  t.end()
+})
+
+test('make sure the env.INIT_CWD is correct', function (t) {
+  common.npm(['run-script', 'initcwd'], {
+    cwd: subdir
+  }, function (er, code, stdout) {
+    if (er) throw er
+    t.equal(code, 0, 'exit code')
+    stdout = stdout.trim().split(/\r|\n/).pop()
+    var actual = stdout
+
+    t.equal(actual, subdir)
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(subdir)
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
As the issue #12164 mentioned, npm run scripts sets the cwd to the project root path. 
When we need to run scripts in subdir, we should use the script like "cd subdir && babel src -d lib"

In some cases, we want to use the same script in different subdir, so we should add different scripts like:
"cd subdir1 && babel src -d lib", "cd subdir2 && babel src -d lib", etc.

Therefore, I add a INIT_CWD environment variable, which is add when npm run script. In the same situation, we can have only one script "cd $INIT_CWD && babel src -d lib" or "babel $INIT_CWD/src -d $INIT_CWD/lib". Type npm run script in the subdir which I want to do it and all subdir can run the same script.
