### PR TITLE
Cert key doc

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -236,9 +236,8 @@ explicitly used, and that only GET requests use the cache.
 * Default: `null`
 * Type: String
 
-A client certificate to pass when accessing the registry.
-
-Note that this is the certificate _contents_ – for example:
+A client certificate to pass when accessing the registry.  Values should be in
+PEM format with newlines replaced by the string "\n". For example:
 
     cert="-----BEGIN CERTIFICATE-----\nXXXX\nXXXX\n-----END CERTIFICATE-----"
 
@@ -507,9 +506,8 @@ change.  Only the output from `npm ls --json` is currently valid.
 * Default: `null`
 * Type: String
 
-A client key to pass when accessing the registry.
-
-Note that this is the key _contents_ – for example:
+A client key to pass when accessing the registry.  Values should be in PEM
+format with newlines replaced by the string "\n". For example:
 
     key="-----BEGIN PRIVATE KEY-----\nXXXX\nXXXX\n-----END PRIVATE KEY-----"
 

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -238,6 +238,12 @@ explicitly used, and that only GET requests use the cache.
 
 A client certificate to pass when accessing the registry.
 
+Note that this is the certificate _contents_ – for example:
+
+    cert="-----BEGIN CERTIFICATE-----\nXXXX\nXXXX\n-----END CERTIFICATE-----"
+
+It is _not_ the path to a certificate file (and there is no "certfile" option).
+
 ### color
 
 * Default: true
@@ -502,6 +508,12 @@ change.  Only the output from `npm ls --json` is currently valid.
 * Type: String
 
 A client key to pass when accessing the registry.
+
+Note that this is the key _contents_ – for example:
+
+    key="-----BEGIN PRIVATE KEY-----\nXXXX\nXXXX\n-----END PRIVATE KEY-----"
+
+It is _not_ the path to a key file (and there is no "keyfile" option).
 
 ### legacy-bundling
 


### PR DESCRIPTION
https://github.com/npm/npm/issues/7672#issuecomment-83073296

"I'd love it if somebody tweaked the config documentation to make it clearer that cert, key, and ca are for file contents, not paths."

"ca" already seemed to have that explanation.  I've applied that same explanation to "cert" and "key".
