### PR TITLE
Handle trailing unescaped backslash in arg

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -168,9 +168,13 @@ function run (pkg, wd, cmd, args, cb) {
 
 // join arguments after '--' and pass them to script,
 // handle special characters such as ', ", ' '.
+// if arg ends in trailing backlash, ensure it is escaped
 function joinArgs (args) {
   var joinedArgs = ''
   args.forEach(function (arg) {
+    if (arg.slice(-1) === '\\' && arg.slice(-2) !== '\\') {
+      arg += '\\'
+    }
     joinedArgs += ' "' + arg.replace(/"/g, '\\"') + '"'
   })
   return joinedArgs


### PR DESCRIPTION
This is a small fix in reference to https://github.com/npm/npm/issues/12472, where if an arg is passed that ends in a backslash (such as an auto-completed path), joinArgs will escape the doublequote it appends to each arg, and the value returned is not what it is expected to be.
