### PR TITLE
Warn if argument starts with non-ascii dash

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -96,6 +96,14 @@
         }
         if (args.length === 1) args.unshift([])
 
+        // Options are prefixed by a hyphen-minus (-, \u2d).
+        // Other dash-type chars look similar but are invalid.
+        Array(args[0]).forEach(function (arg) {
+          if (/^[\u2010-\u2015\u2212\uFE58\uFE63\uFF0D]/.test(arg)) {
+            log.error('arg', 'Argument starts with non-ascii dash, this is probably invalid:', arg)
+          }
+        })
+
         npm.registry.version = npm.version
         if (!npm.registry.refer) {
           npm.registry.refer = [a].concat(args[0]).map(function (arg) {

--- a/test/tap/no-ascii-dash.js
+++ b/test/tap/no-ascii-dash.js
@@ -1,0 +1,36 @@
+'use strict'
+var test = require('tap').test
+var common = require('../common-tap.js')
+
+test('valid option specifiers', function (t) {
+  common.npm(['-hyphen-minus'], {}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(stderr, '', 'hyphen-minus (-)')
+    t.done()
+  })
+})
+
+var dashLikeChars = {
+  '\u2010': 'hyphen',
+  '\u2011': 'non-breaking-hyphen',
+  '\u2012': 'figure-dash',
+  '\u2013': 'endash',
+  '\u2014': 'emdash',
+  '\u2015': 'horizontal-bar',
+  '\u2212': 'minus',
+  '\ufe58': 'small-emdash',
+  '\ufe63': 'small-hyphen-minus',
+  '\uff0d': 'full-width-hyphen-minus'
+}
+
+test('invalid option specifiers', function (t) {
+  var dashes = Object.keys(dashLikeChars)
+  t.plan(dashes.length)
+  dashes.forEach(function (dash) {
+    var name = dashLikeChars[dash]
+    common.npm([dash + name], {}, function (err, code, stdout, stderr) {
+      if (err) throw err
+      t.match(stderr, new RegExp('npm ERR.*' + dash + name), name + ' (' + dash + ')')
+    })
+  })
+})


### PR DESCRIPTION
Options can only start with ascii dashes.  Ordinarily this isn't a problem but many web documentation tools "helpfully" convert `--` into an emdash (—).  When user's copy and paste from this documentation this makes commands mysteriously fail.

We should at least warn if someone is setting off this foot gun (which is what this patch currently does). Possibly we should just refuse to run, as I can't think of a scenario where this would be appropriate behavior.
