### PR TITLE
fix npm crash when bundled dep lacks package.json

### DIFF
--- a/lib/install/action/extract.js
+++ b/lib/install/action/extract.js
@@ -30,6 +30,11 @@ function andUpdatePackageJson (pkg, buildpath, next) {
 function andStageBundledChildren (pkg, buildpath, log, next) {
   var staging = path.resolve(buildpath, '..')
   return iferr(next, function () {
+    for (var i = 0; i < pkg.children.length; ++i) {
+      var c = pkg.children[i]
+      if (!c.package.name) return next(c.error)
+    }
+
     asyncMap(pkg.children, andStageBundledModule(pkg, staging, buildpath), cleanupBundled)
   })
   function cleanupBundled () {

--- a/test/tap/bundled-dependencies-no-pkgjson.js
+++ b/test/tap/bundled-dependencies-no-pkgjson.js
@@ -1,0 +1,47 @@
+var test = require('tap').test
+var path = require('path')
+var fs = require('graceful-fs')
+
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var common = require('../common-tap.js')
+
+var dir = path.resolve(__dirname, 'bundled-dependencies-no-pkgjson')
+var pkg = path.resolve(dir, 'pkg-with-bundled-dep')
+var dep = path.resolve(pkg, 'node_modules', 'a-bundled-dep')
+
+var pkgJson = JSON.stringify({
+  name: 'pkg-with-bundled-dep',
+  version: '1.0.0',
+  dependencies: {
+  },
+  bundledDependencies: [
+    'a-bundled-dep'
+  ]
+}, null, 2) + '\n'
+
+test('setup', function (t) {
+  mkdirp.sync(path.join(dir, 'node_modules'))
+  mkdirp.sync(dep)
+
+  fs.writeFileSync(path.resolve(pkg, 'package.json'), pkgJson)
+  fs.writeFileSync(path.resolve(dep, 'index.js'), '')
+  t.end()
+})
+
+test('proper error on bundled dep with no package.json', function (t) {
+  t.plan(3)
+  var npmArgs = ['install', './' + path.basename(pkg)]
+
+  common.npm(npmArgs, { cwd: dir }, function (err, code, stdout, stderr) {
+    t.ifError(err, 'npm ran without issue')
+    t.notEqual(code, 0)
+    t.like(stderr, /ENOENT/, 'ENOENT should be in stderr')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  rimraf.sync(dir)
+  t.end()
+})


### PR DESCRIPTION
Until a few months ago it was possible to install bundled dependencies that did not contain a package.json. That is no longer the case. Attempting to do so with the current version of npm results in npm crashing without providing adequate information. This should make it fail with a clearer error message.

EDIT: modified the check a bit, since i was bubbling up previously ignored errors
