### PR TITLE
Display aliases in -h message

### DIFF
--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -4,14 +4,17 @@ var log = require('npmlog')
 var npm = require('./npm.js')
 var read = require('read')
 var userValidate = require('npm-user-validate')
+var usage = require('./utils/usage')
 var crypto
 
 try {
   crypto = require('crypto')
 } catch (ex) {}
 
-adduser.usage = 'npm adduser [--registry=url] [--scope=@orgname] [--always-auth]' +
-                '\n\naliases: login'
+adduser.usage = usage(
+  'adduser',
+  'npm adduser [--registry=url] [--scope=@orgname] [--always-auth]'
+)
 
 function adduser (args, cb) {
   if (!crypto) {

--- a/lib/bugs.js
+++ b/lib/bugs.js
@@ -1,11 +1,15 @@
 module.exports = bugs
 
-bugs.usage = 'npm bugs [<pkgname>]'
-
 var npm = require('./npm.js')
 var log = require('npmlog')
 var opener = require('opener')
 var fetchPackageMetadata = require('./fetch-package-metadata.js')
+var usage = require('./utils/usage')
+
+bugs.usage = usage(
+  'bugs',
+  'npm bugs [<pkgname>]'
+)
 
 bugs.completion = function (opts, cb) {
   // FIXME: there used to be registry completion here, but it stopped making

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,13 +1,4 @@
-
 module.exports = config
-
-config.usage = 'npm config set <key> <value>' +
-               '\nnpm config get [<key>]' +
-               '\nnpm config delete <key>' +
-               '\nnpm config list' +
-               '\nnpm config edit' +
-               '\nnpm set <key> <value>' +
-               '\nnpm get [<key>]'
 
 var log = require('npmlog')
 var npm = require('./npm.js')
@@ -19,7 +10,18 @@ var ini = require('ini')
 var editor = require('editor')
 var os = require('os')
 var umask = require('./utils/umask')
+var usage = require('./utils/usage')
 
+config.usage = usage(
+  'config',
+  'npm config set <key> <value>' +
+  '\nnpm config get [<key>]' +
+  '\nnpm config delete <key>' +
+  '\nnpm config list' +
+  '\nnpm config edit' +
+  '\nnpm set <key> <value>' +
+  '\nnpm get [<key>]'
+)
 config.completion = function (opts, cb) {
   var argv = opts.conf.argv.remain
   if (argv[1] !== 'config') argv.unshift('config')

--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -16,7 +16,8 @@ var shorthands = {
   'tst': 'test',
   't': 'test',
   'ddp': 'dedupe',
-  'v': 'view'
+  'v': 'view',
+  'run': 'run-script'
 }
 
 var affordances = {

--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -19,11 +19,15 @@ var sortActions = require('./install/diff-trees.js').sortActions
 var moduleName = require('./utils/module-name.js')
 var packageId = require('./utils/package-id.js')
 var childPath = require('./utils/child-path.js')
+var usage = require('./utils/usage')
 
 module.exports = dedupe
 module.exports.Deduper = Deduper
 
-dedupe.usage = 'npm dedupe'
+dedupe.usage = usage(
+  'dedupe',
+  'npm dedupe'
+)
 
 function dedupe (args, cb) {
   validate('AF', arguments)

--- a/lib/dist-tag.js
+++ b/lib/dist-tag.js
@@ -7,10 +7,14 @@ var semver = require('semver')
 var npm = require('./npm.js')
 var mapToRegistry = require('./utils/map-to-registry.js')
 var readLocalPkg = require('./utils/read-local-package.js')
+var usage = require('./utils/usage')
 
-distTag.usage = 'npm dist-tag add <pkg>@<version> [<tag>]' +
-                '\nnpm dist-tag rm <pkg> <tag>' +
-                '\nnpm dist-tag ls [<pkg>]'
+distTag.usage = usage(
+  'dist-tag',
+  'npm dist-tag add <pkg>@<version> [<tag>]' +
+  '\nnpm dist-tag rm <pkg> <tag>' +
+  '\nnpm dist-tag ls [<pkg>]'
+)
 
 distTag.completion = function (opts, cb) {
   var argv = opts.conf.argv.remain

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,13 +1,16 @@
 module.exports = docs
 
-docs.usage = 'npm docs <pkgname>' +
-             '\nnpm docs .'
-
 var npm = require('./npm.js')
 var opener = require('opener')
 var log = require('npmlog')
 var fetchPackageMetadata = require('./fetch-package-metadata.js')
+var usage = require('./utils/usage')
 
+docs.usage = usage(
+  'docs',
+  'npm docs <pkgname>' +
+  '\nnpm docs .'
+)
 docs.completion = function (opts, cb) {
   // FIXME: there used to be registry completion here, but it stopped making
   // sense somewhere around 50,000 packages on the registry

--- a/lib/install-test.js
+++ b/lib/install-test.js
@@ -6,10 +6,13 @@
 module.exports = installTest
 var install = require('./install.js')
 var test = require('./test.js')
+var usage = require('./utils/usage')
 
-installTest.usage = '\nnpm install-test [args]' +
-                    '\nSame args as `npm install`' +
-                    '\n\nalias: npm it'
+installTest.usage = usage(
+  'install-test',
+  '\nnpm install-test [args]' +
+  '\nSame args as `npm install`'
+)
 
 installTest.completion = install.completion
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -15,18 +15,22 @@
 module.exports = install
 module.exports.Installer = Installer
 
-install.usage = '\nnpm install (with no args, in package dir)' +
-                '\nnpm install [<@scope>/]<pkg>' +
-                '\nnpm install [<@scope>/]<pkg>@<tag>' +
-                '\nnpm install [<@scope>/]<pkg>@<version>' +
-                '\nnpm install [<@scope>/]<pkg>@<version range>' +
-                '\nnpm install <folder>' +
-                '\nnpm install <tarball file>' +
-                '\nnpm install <tarball url>' +
-                '\nnpm install <git:// url>' +
-                '\nnpm install <github username>/<github project>' +
-                '\n\nalias: npm i' +
-                '\ncommon options: [--save|--save-dev|--save-optional] [--save-exact]'
+var usage = require('./utils/usage')
+
+install.usage = usage(
+  'install',
+  '\nnpm install (with no args, in package dir)' +
+  '\nnpm install [<@scope>/]<pkg>' +
+  '\nnpm install [<@scope>/]<pkg>@<tag>' +
+  '\nnpm install [<@scope>/]<pkg>@<version>' +
+  '\nnpm install [<@scope>/]<pkg>@<version range>' +
+  '\nnpm install <folder>' +
+  '\nnpm install <tarball file>' +
+  '\nnpm install <tarball url>' +
+  '\nnpm install <git:// url>' +
+  '\nnpm install <github username>/<github project>',
+  '[--save|--save-dev|--save-optional] [--save-exact]'
+)
 
 install.completion = function (opts, cb) {
   validate('OF', arguments)

--- a/lib/link.js
+++ b/lib/link.js
@@ -10,12 +10,15 @@ var chain = require('slide').chain
 var path = require('path')
 var build = require('./build.js')
 var npa = require('npm-package-arg')
+var usage = require('./utils/usage')
 
 module.exports = link
 
-link.usage = 'npm link (in package dir)' +
-             '\nnpm link [<@scope>/]<pkg>[@<version>]' +
-             '\n\nalias: npm ln'
+link.usage = usage(
+  'link',
+  'npm link (in package dir)' +
+  '\nnpm link [<@scope>/]<pkg>[@<version>]'
+)
 
 link.completion = function (opts, cb) {
   var dir = npm.globalDir

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -19,9 +19,12 @@ var npm = require('./npm.js')
 var mutateIntoLogicalTree = require('./install/mutate-into-logical-tree.js')
 var recalculateMetadata = require('./install/deps.js').recalculateMetadata
 var packageId = require('./utils/package-id.js')
+var usage = require('./utils/usage')
 
-ls.usage = 'npm ls [[<@scope>/]<pkg> ...]' +
-    '\n\naliases: list, la, ll'
+ls.usage = usage(
+  'ls',
+  'npm ls [[<@scope>/]<pkg> ...]'
+)
 
 ls.completion = require('./utils/completion/installed-deep.js')
 

--- a/lib/owner.js
+++ b/lib/owner.js
@@ -1,14 +1,17 @@
 module.exports = owner
 
-owner.usage = 'npm owner add <user> [<@scope>/]<pkg>' +
-              '\nnpm owner rm <user> [<@scope>/]<pkg>' +
-              '\nnpm owner ls [<@scope>/]<pkg>'
-
 var npm = require('./npm.js')
 var log = require('npmlog')
 var mapToRegistry = require('./utils/map-to-registry.js')
 var readLocalPkg = require('./utils/read-local-package.js')
+var usage = require('./utils/usage')
 
+owner.usage = usage(
+  'owner',
+  'npm owner add <user> [<@scope>/]<pkg>' +
+  '\nnpm owner rm <user> [<@scope>/]<pkg>' +
+  '\nnpm owner ls [<@scope>/]<pkg>'
+)
 owner.completion = function (opts, cb) {
   var argv = opts.conf.argv.remain
   if (argv.length > 4) return cb()

--- a/lib/rebuild.js
+++ b/lib/rebuild.js
@@ -6,8 +6,12 @@ var semver = require('semver')
 var log = require('npmlog')
 var npm = require('./npm.js')
 var npa = require('npm-package-arg')
+var usage = require('./utils/usage')
 
-rebuild.usage = 'npm rebuild [[<@scope>/<name>]...]'
+rebuild.usage = usage(
+  'rebuild',
+  'npm rebuild [[<@scope>/<name>]...]'
+)
 
 rebuild.completion = require('./utils/completion/installed-deep.js')
 

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -6,9 +6,12 @@ var path = require('path')
 var readJson = require('read-package-json')
 var log = require('npmlog')
 var chain = require('slide').chain
+var usage = require('./utils/usage')
 
-runScript.usage = 'npm run-script <command> [-- <args>...]' +
-                  '\n\nalias: npm run'
+runScript.usage = usage(
+  'run-script',
+  'npm run-script <command> [-- <args>...]'
+)
 
 runScript.completion = function (opts, cb) {
   // see if there's already a package specified.

--- a/lib/search.js
+++ b/lib/search.js
@@ -4,9 +4,12 @@ module.exports = exports = search
 var npm = require('./npm.js')
 var columnify = require('columnify')
 var updateIndex = require('./cache/update-index.js')
+var usage = require('./utils/usage')
 
-search.usage = 'npm search [--long] [search terms ...]' +
-               '\n\naliases: s, se'
+search.usage = usage(
+  'search',
+  'npm search [--long] [search terms ...]'
+)
 
 search.completion = function (opts, cb) {
   var compl = {}

--- a/lib/star.js
+++ b/lib/star.js
@@ -4,9 +4,13 @@ var npm = require('./npm.js')
 var log = require('npmlog')
 var asyncMap = require('slide').asyncMap
 var mapToRegistry = require('./utils/map-to-registry.js')
+var usage = require('./utils/usage')
 
-star.usage = 'npm star [<pkg>...]\n' +
-             'npm unstar [<pkg>...]'
+star.usage = usage(
+  'star',
+  'npm star [<pkg>...]\n' +
+  'npm unstar [<pkg>...]'
+)
 
 star.completion = function (opts, cb) {
   // FIXME: there used to be registry completion here, but it stopped making

--- a/lib/uninstall.js
+++ b/lib/uninstall.js
@@ -4,9 +4,6 @@
 module.exports = uninstall
 module.exports.Uninstaller = Uninstaller
 
-uninstall.usage = 'npm uninstall [<@scope>/]<pkg>[@<version>]... [--save|--save-dev|--save-optional]' +
-                  '\n\naliases: remove, rm, r, un, unlink'
-
 var util = require('util')
 var path = require('path')
 var validate = require('aproba')
@@ -18,6 +15,12 @@ var getSaveType = require('./install/save.js').getSaveType
 var removeDeps = require('./install/deps.js').removeDeps
 var loadExtraneous = require('./install/deps.js').loadExtraneous
 var log = require('npmlog')
+var usage = require('./utils/usage')
+
+uninstall.usage = usage(
+  'uninstall',
+  'npm uninstall [<@scope>/]<pkg>[@<version>]... [--save|--save-dev|--save-optional]'
+)
 
 uninstall.completion = require('./utils/completion/installed-shallow.js')
 

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,12 +1,16 @@
 module.exports = update
 
-update.usage = 'npm update [-g] [<pkg>...]'
-
 var url = require('url')
 var log = require('npmlog')
 var chain = require('slide').chain
 var npm = require('./npm.js')
 var Installer = require('./install.js').Installer
+var usage = require('./utils/usage')
+
+update.usage = usage(
+  'update',
+  'npm update [-g] [<pkg>...]'
+)
 
 update.completion = npm.commands.outdated.completion
 

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -13,6 +13,7 @@ var Stream = require('stream').Stream
 var PATH = 'PATH'
 var uidNumber = require('uid-number')
 var umask = require('./umask')
+var usage = require('./usage')
 
 // windows calls it's path 'Path' usually, but this is not guaranteed.
 if (process.platform === 'win32') {
@@ -391,7 +392,7 @@ function cmd (stage) {
   function CMD (args, cb) {
     npm.commands['run-script']([stage].concat(args), cb)
   }
-  CMD.usage = 'npm ' + stage + ' [-- <args>]'
+  CMD.usage = usage(stage, 'npm ' + stage + ' [-- <args>]')
   var installedShallow = require('./completion/installed-shallow.js')
   CMD.completion = function (opts, cb) {
     installedShallow(opts, function (d) {

--- a/lib/utils/usage.js
+++ b/lib/utils/usage.js
@@ -1,0 +1,26 @@
+var aliases = require('../config/cmd-list').aliases
+
+module.exports = function usage (cmd, txt, opt) {
+  var post = Object.keys(aliases).reduce(function (p, c) {
+    var val = aliases[c]
+    if (val !== cmd) return p
+    return p.concat(c)
+  }, [])
+
+  if (opt || post.length > 0) txt += '\n\n'
+
+  if (post.length === 1) {
+    txt += 'aliase: '
+    txt += post.join(', ')
+  } else if (post.length > 1) {
+    txt += 'aliases: '
+    txt += post.join(', ')
+  }
+
+  if (opt) {
+    if (post.length > 0) txt += '\n'
+    txt += 'common options: ' + opt
+  }
+
+  return txt
+}

--- a/lib/view.js
+++ b/lib/view.js
@@ -1,8 +1,5 @@
 // npm view [pkg [pkg ...]]
-
 module.exports = view
-view.usage = 'npm view [<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]' +
-             '\n\naliases: info, show, v'
 
 var npm = require('./npm.js')
 var readJson = require('read-package-json')
@@ -12,6 +9,12 @@ var semver = require('semver')
 var mapToRegistry = require('./utils/map-to-registry.js')
 var npa = require('npm-package-arg')
 var path = require('path')
+var usage = require('./utils/usage')
+
+view.usage = usage(
+  'view',
+  'npm view [<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]'
+)
 
 view.completion = function (opts, cb) {
   if (opts.conf.argv.remain.length <= 2) {


### PR DESCRIPTION
Get alias list from `config/cmd-list.js` and use it to display aliases in `-h` message like:

```
$ npm -h view
npm view [<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]

aliases: v, show, info
```
