### PR TITLE
More _from metadata fixes for shrinkwrap reliability (#11736 and #12347)

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -39,6 +39,14 @@ function addRemoteGit (uri, _cb) {
   assert(typeof _cb === 'function', 'must have callback')
   var cb = dezalgo(_cb)
 
+  // Set the data._from value to the package name & uri used to specify the dependency
+  // This ensures that shrinkwraps work reliably
+  function finish(er, data) {
+    if (er) return cb(er)
+    data._from = data.name + '@' + uri
+    cb(er, data)
+  }
+
   log.verbose('addRemoteGit', 'caching', uri)
 
   // the URL comes in exactly as it was passed on the command line, or as
@@ -58,11 +66,11 @@ function addRemoteGit (uri, _cb) {
 
     // prefer explicit URLs to pushing everything through shortcuts
     if (parsed.getDefaultRepresentation() !== 'shortcut') {
-      return tryClone(from, parsed.toString(), false, cb)
+      return tryClone(from, parsed.toString(), false, finish)
     }
 
     // try git:, then git+ssh:, then git+https: before failing
-    tryGitProto(from, parsed, cb)
+    tryGitProto(from, parsed, finish)
   } else {
     // verify that this is a Git URL before continuing
     parsed = npa(uri)
@@ -70,7 +78,7 @@ function addRemoteGit (uri, _cb) {
       return cb(new Error(uri + 'is not a Git or GitHub URL'))
     }
 
-    tryClone(parsed.rawSpec, uri, false, cb)
+    tryClone(parsed.rawSpec, uri, false, finish)
   }
 }
 
@@ -375,14 +383,6 @@ function updateSubmodules (from, resolvedURL, tmpdir, cb) {
         // https://github.com/npm/npm/issues/6400
         addLocal(spec, null, function (er, data) {
           if (data) {
-            if (npm.config.get('save-exact')) {
-              log.verbose('addRemoteGit', 'data._from:', resolvedURL, '(save-exact)')
-              data._from = resolvedURL
-            } else {
-              log.verbose('addRemoteGit', 'data._from:', from)
-              data._from = from
-            }
-
             log.verbose('addRemoteGit', 'data._resolved:', resolvedURL)
             data._resolved = resolvedURL
           }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -72,7 +72,7 @@ function doesChildVersionMatch (child, requested, requestor) {
     if (childReq.rawSpec === requested.rawSpec) return true
     if (childReq.type === requested.type && childReq.spec === requested.spec) return true
   }
-  if (!registryTypes[requested.type]) return requested.rawSpec === child.package._from
+  if (!registryTypes[requested.type]) return requested.raw === child.package._from
   return semver.satisfies(child.package.version, requested.spec)
 }
 


### PR DESCRIPTION
One of these @iarna has already mentioned in comments in #12347.

These fixes both related to improving `npm shrinkwrap` reliability by getting more a consistent definition of `_from` values.

It still needs tests, which I'll try and get to over the next few days, but I wanted to expose my work-to-date.
