### PR TITLE
doc: engineStrict is quite gone

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -654,10 +654,10 @@ field is advisory only will produce warnings when your package is installed as a
 
 ## engineStrict
 
-**This feature was deprecated with npm 3.0.0**
+**This feature was removed in npm 3.0.0**
 
 Prior to npm 3.0.0, this feature was used to treat this package as if the
-user had set `engine-strict`.
+user had set `engine-strict`. It is no longer used.
 
 ## os
 


### PR DESCRIPTION
Not "deprecated" so much as "extirpated". We should probably have better delineations about how to talk about "deprecated" features (which are still there, potentially warning people when they're used), and "removed" features (where the supporting code for the feature is no longer in the code base). Getting that in the developer handbook is something I'll try to do at some point.

**r**: @iarna
