### PR TITLE
[doc] Fix defining when node-gyp rebuild is called

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -731,10 +731,10 @@ npm will default some values based on package contents.
   If there is a `server.js` file in the root of your package, then npm
   will default the `start` command to `node server.js`.
 
-* `"scripts":{"preinstall": "node-gyp rebuild"}`
+* `"scripts":{"install": "node-gyp rebuild"}`
 
-  If there is a `binding.gyp` file in the root of your package, npm will
-  default the `preinstall` command to compile using node-gyp.
+  If there is a `binding.gyp` file in the root of your package and you have not defined an `install` or `preinstall` script, npm will
+  default the `install` command to compile using node-gyp.
 
 * `"contributors": [...]`
 


### PR DESCRIPTION
It is called during install instead of preinstall stage. This now matches https://docs.npmjs.com/misc/scripts#default-values
