### PR TITLE
[doc] Fix the def of the default `install` script

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -71,7 +71,7 @@ npm will default some script values based on package contents.
 
 * `"install": "node-gyp rebuild"`:
 
-  If there is a `binding.gyp` file in the root of your package, npm will
+  If there is a `binding.gyp` file in the root of your package and you haven't defined your own `install` or `preinstall` scripts, npm will
   default the `install` command to compile using node-gyp.
 
 ## USER


### PR DESCRIPTION
This is a followup from #12586 and it’s behavior is defined in the following code https://github.com/npm/read-package-json/blob/master/read-json.js#L146-L164
