### PR TITLE
Move preinstall to same section as install/postinstall

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -11,9 +11,7 @@ following scripts:
   install` without any arguments.)
 * publish, postpublish:
   Run AFTER the package is published.
-* preinstall:
-  Run BEFORE the package is installed
-* install, postinstall:
+* install, preinstall, postinstall:
   Run AFTER the package is installed.
 * preuninstall, uninstall:
   Run BEFORE the package is uninstalled.


### PR DESCRIPTION
Currently, due to #10379, the preinstall hook is run after the module is installed. This commit fixes the documentation to reflect this.
