### PR TITLE
 Fix crasher when inflating shrinkwraps

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -63,23 +63,26 @@ module.exports = function fetchPackageMetadata (spec, where, tracker, done) {
     fetchOtherPackageData(spec, dep, where, addRequestedAndFinish)
   }
   function addRequestedAndFinish (er, pkg) {
-    if (pkg) {
-      pkg._requested = dep
-      pkg._spec = spec
-      pkg._where = where
-      if (!pkg._args) pkg._args = []
-      pkg._args.push([pkg._spec, pkg._where])
-      // non-npm registries can and will return unnormalized data, plus
-      // even the npm registry may have package data normalized with older
-      // normalization rules. This ensures we get package data in a consistent,
-      // stable format.
-      try {
-        normalizePackageData(pkg)
-      } catch (ex) {
-        // don't care
-      }
-    }
+    if (pkg) annotateMetadata(pkg, dep, spec, where)
     logAndFinish(er, pkg)
+  }
+}
+
+var annotateMetadata = module.exports.annotateMetadata = function (pkg, requested, spec, where) {
+  validate('OOSS', arguments)
+  pkg._requested = requested
+  pkg._spec = spec
+  pkg._where = where
+  if (!pkg._args) pkg._args = []
+  pkg._args.push([requested, where])
+  // non-npm registries can and will return unnormalized data, plus
+  // even the npm registry may have package data normalized with older
+  // normalization rules. This ensures we get package data in a consistent,
+  // stable format.
+  try {
+    normalizePackageData(pkg)
+  } catch (ex) {
+    // don't care
   }
 }
 

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -3,7 +3,9 @@ var url = require('url')
 var asyncMap = require('slide').asyncMap
 var validate = require('aproba')
 var iferr = require('iferr')
+var realizePackageSpecifier = require('realize-package-specifier')
 var fetchPackageMetadata = require('../fetch-package-metadata.js')
+var annotateMetadata = require('../fetch-package-metadata.js').annotateMetadata
 var addShrinkwrap = require('../fetch-package-metadata.js').addShrinkwrap
 var addBundled = require('../fetch-package-metadata.js').addBundled
 var inflateBundled = require('./inflate-bundled.js')
@@ -32,7 +34,11 @@ var inflateShrinkwrap = module.exports = function (tree, swdeps, finishInflating
                   child.package.version === sw.version)) {
       if (!child.fromShrinkwrap) child.fromShrinkwrap = spec
       tree.children.push(child)
-      return inflateShrinkwrap(child, sw.dependencies || {}, next)
+
+      return realizePackageSpecifier(spec, tree.path, iferr(next, function (requested) {
+        annotateMetadata(child.package, requested, spec, tree.path)
+        return inflateShrinkwrap(child, sw.dependencies || {}, next)
+      }))
     }
     fetchPackageMetadata(spec, tree.path, iferr(next, function (pkg) {
       pkg._from = sw.from || spec

--- a/test/tap/shrinkwrap-nested.js
+++ b/test/tap/shrinkwrap-nested.js
@@ -94,6 +94,26 @@ var newShrinkwrap = new Tacks(Dir({
         }
       }
     }
+  }),
+  'node_modules': Dir({
+    'modB@1': Dir({
+      'package.json': File({
+        _requested: {
+          name: 'modB',
+          raw: 'modB@file:' + modB1dir,
+          rawSpec: 'file:' + modB1dir,
+          scope: null,
+          spec: modB1dir,
+          type: 'directory'
+        },
+        dependencies: { },
+        devDependencies: { },
+        name: 'modB',
+        optionalDependencies: { },
+        readme: 'ERROR: No README data found!',
+        version: '1.0.0'
+      })
+    })
   })
 }))
 


### PR DESCRIPTION
This fixes a crasher in #12702 when using shrinkwraps and `_spec` wasn't in the package.json of dependencies on disk.

**r: @othiym23**
**r: @zkat**
