### PR TITLE
fix npm 3.9.1 crash caused by process.nextTick() recursion on Node.js 0.10

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -86,7 +86,7 @@ function childDependencySpecifier (tree, name, spec, cb) {
   if (!tree.resolved) tree.resolved = {}
   if (!tree.resolved[name]) tree.resolved[name] = {}
   if (tree.resolved[name][spec]) {
-    return process.nextTick(function () {
+    return setImmediate(function () {
       cb(null, tree.resolved[name][spec])
     })
   }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -31,6 +31,9 @@ var moduleName = require('../utils/module-name.js')
 // The export functions in this module mutate a dependency tree, adding
 // items to them.
 
+// Node 0.8 compatibility
+var nextTick = (typeof setImmediate === 'function') ? setImmediate : process.nextTick
+
 function isDep (tree, child, cb) {
   var name = moduleName(child)
   var prodVer = isProdDep(tree, name)
@@ -86,7 +89,7 @@ function childDependencySpecifier (tree, name, spec, cb) {
   if (!tree.resolved) tree.resolved = {}
   if (!tree.resolved[name]) tree.resolved[name] = {}
   if (tree.resolved[name][spec]) {
-    return setImmediate(function () {
+    return nextTick(function () {
       cb(null, tree.resolved[name][spec])
     })
   }


### PR DESCRIPTION
## The crash

I get lots of these:

```
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
```

and then the process dies saying this:

```
node.js:0
// Copyright Joyent, Inc. and other Node contributors.
^
RangeError: Maximum call stack size exceeded
```
## The failing test

I have a project with a large number of dependencies, some private. Older versions of npm are fine, but using npm 3.9.0 or npm 3.9.1 on Node 0.10 the first 'npm install' works, and subsequent runs crash, presumably while npm is building up the installed dependency tree.
## The fix

Replacing process.nextTick() with setImmediate() fixes this. My test case has lots of private packages and is hard to share in public. I'm hoping the fix is clear enough to use as is.
