### PR TITLE
cache: ignore enoent on chownr while adding packages to cache

### DIFF
--- a/lib/cache/add-local.js
+++ b/lib/cache/add-local.js
@@ -107,7 +107,10 @@ function addLocalDirectory (p, pkgData, shasum, cb) {
 
             if (!cs || isNaN(cs.uid) || isNaN(cs.gid)) wrapped()
 
-            chownr(made || tgz, cs.uid, cs.gid, wrapped)
+            chownr(made || tgz, cs.uid, cs.gid, function (er) {
+              if (er && er.code === 'ENOENT') return wrapped()
+              wrapped(er)
+            })
           })
         }
       })

--- a/lib/utils/correct-mkdir.js
+++ b/lib/utils/correct-mkdir.js
@@ -112,6 +112,7 @@ function makeDirectory (path, cb) {
 
 function setPermissions (path, st, cb) {
   chownr(path, st.uid, st.gid, function (er) {
+    if (er && er.code === 'ENOENT') return cb(null, st)
     return cb(er, st)
   })
 }


### PR DESCRIPTION
Fixes #12669 (See ticket for more information about the issue)
