### PR TITLE
Implement handling for 'shasum_in_headers' metadata flag.

### DIFF
--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -207,9 +207,9 @@ function addNameVersion (name, v, data, cb) {
         }
         tb = url.format(tb)
 
-        // Only add non-shasum'ed packages if --forced. Only ancient things
-        // would lack this for good reasons nowadays.
-        if (!dist.shasum && !npm.config.get('force')) {
+        // Only add non-shasum'ed packages if --forced or 'shasum_in_headers' is true.
+        // Only ancient things would lack this for good reasons nowadays.
+        if (!dist.shasum_in_headers && !dist.shasum && !npm.config.get('force')) {
           return cb(new Error('package lacks shasum: ' + packageId(data)))
         }
 

--- a/lib/cache/add-remote-tarball.js
+++ b/lib/cache/add-remote-tarball.js
@@ -12,6 +12,7 @@ var addLocalTarball = require('./add-local-tarball.js')
 var cacheFile = require('npm-cache-filename')
 var rimraf = require('rimraf')
 var pulseTillDone = require('../utils/pulse-till-done.js')
+var packageId = require('../utils/package-id.js')
 
 module.exports = addRemoteTarball
 
@@ -50,11 +51,11 @@ function addRemoteTarball (u, pkgData, shasum, auth, cb_) {
   log.verbose('addRemoteTarball', [u, shasum])
   mkdir(path.dirname(tmp), function (er) {
     if (er) return cb(er)
-    addRemoteTarball_(u, tmp, shasum, auth, next)
+    addRemoteTarball_(u, tmp, shasum, pkgData, auth, next)
   })
 }
 
-function addRemoteTarball_ (u, tmp, shasum, auth, cb) {
+function addRemoteTarball_ (u, tmp, shasum, pkgData, auth, cb) {
   // Tuned to spread 3 attempts over about a minute.
   // See formula at <https://github.com/tim-kos/node-retry>.
   var operation = retry.operation({
@@ -70,7 +71,7 @@ function addRemoteTarball_ (u, tmp, shasum, auth, cb) {
       'fetch attempt', currentAttempt,
       'at', (new Date()).toLocaleTimeString()
     )
-    fetchAndShaCheck(u, tmp, shasum, auth, function (er, response, shasum) {
+    fetchAndShaCheck(u, tmp, shasum, pkgData, auth, function (er, response, shasum) {
       // Only retry on 408, 5xx or no `response`.
       var sc = response && response.statusCode
       var statusRetry = !sc || (sc === 408 || sc >= 500)
@@ -83,12 +84,20 @@ function addRemoteTarball_ (u, tmp, shasum, auth, cb) {
   })
 }
 
-function fetchAndShaCheck (u, tmp, shasum, auth, cb) {
+function fetchAndShaCheck (u, tmp, shasum, pkgData, auth, cb) {
   cb = pulseTillDone('fetchTarball', cb)
   npm.registry.fetch(u, { auth: auth }, function (er, response) {
     if (er) {
       log.error('fetch failed', u)
       return cb(er, response)
+    }
+
+    if (!shasum) {
+      if (response.headers['x-shasum']) {
+        shasum = response.headers['x-shasum']
+      } else if (typeof pkgData.dist !== 'undefined' && pkgData.dist.shasum_in_headers) {
+        return cb(new Error('package lacks shasum: ' + packageId(pkgData)), response)
+      }
     }
 
     var tarball = writeStreamAtomic(tmp, { mode: npm.modes.file })


### PR DESCRIPTION
This is a follow-up regarding my previous [pull request](https://github.com/npm/npm/pull/12719). Given your feedback I restructured my approach to not remove but only defer the checksum generation to the actual tarball download HTTP response. This approach allows both the ability to generate tarballs on-the-fly while still providing the safety of the checksum validation via a custom  `X-Shasum` header in the tarball download response. This will only be activated if the `shasum_in_headers` flag in the package metadata is set to true.

Would this approach be any more feasible?
