### PR TITLE
updated to current syntax

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -34,7 +34,7 @@ following scripts:
   stop and start scripts if no `restart` script is provided.
 
 Additionally, arbitrary scripts can be executed by running `npm
-run-script <pkg> <stage>`. *Pre* and *post* commands with matching
+run-script <stage>`. *Pre* and *post* commands with matching
 names will be run for those as well (e.g. `premyscript`, `myscript`,
 `postmyscript`).
 


### PR DESCRIPTION
It looks like it was not updated with current `npm run-script` syntax, since it now acceps only one parameter.
If I am not wrong, running scripts of `<pkg>` dependencies was supported in previous versions (what a pity it was removed), so I updated documentation.
