### PR TITLE
Do not recurse into packages already marked as failed

### DIFF
--- a/lib/install/actions.js
+++ b/lib/install/actions.js
@@ -53,7 +53,7 @@ function markAsFailed (pkg) {
   pkg.failed = true
   pkg.requires.forEach(function (req) {
     req.requiredBy = req.requiredBy.filter(function (reqReqBy) { return reqReqBy !== pkg })
-    if (req.requiredBy.length === 0 && !req.userRequired && !req.existing) {
+    if (req.requiredBy.length === 0 && !req.userRequired && !req.existing && !req.failed) {
       markAsFailed(req)
     }
   })


### PR DESCRIPTION
Fixes issue #12781 

On encountering an error, a pkg and its requires are marked as failed with a recursive function. When a package has circular dependencies this can result in an infinite recursion.
