### PR TITLE
Don't try to reinstall linked dependencies that don't have a version specifier

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -65,6 +65,8 @@ function doesChildVersionMatch (child, requested, requestor) {
   // we always consider deps provided by a shrinkwrap as "correct" or else
   // we'll subvert them if they're intentionally "invalid"
   if (child.parent === requestor && child.fromShrinkwrap) return true
+  // symlinked packages without a version specifier should also be assumed to be "correct"
+  if (child.parent === requestor && child.isLink && !registryTypes[requested.type]) return true
   // ranges of * ALWAYS count as a match, because when downloading we allow
   // prereleases to match * if there are ONLY prereleases
   if (requested.spec === '*') return true


### PR DESCRIPTION
With this `package.json`:

``` js
var pkgj = {
  'name': 'pkg',
  'version': '1.2.3',
  'dependencies': {
    'dep': '../foo'
  }
}
```

If I have installed `dep` into `pkg`'s `node_modules` folder via `npm link`, running `npm install` will always cause npm to attempt to reinstall all of `dep`'s dependencies directly into `pkg`.

---

With this PR, if a dependency that does not have a version specifier is linked in, npm now assumes that the dependency is valid (because we have no good way of proving otherwise).  

Mitigates #10343
