### PR TITLE
Added support for detecting outdated git packages. #8300

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -40,6 +40,7 @@ var mapToRegistry = require('./utils/map-to-registry.js')
 var isExtraneous = require('./install/is-extraneous.js')
 var recalculateMetadata = require('./install/deps.js').recalculateMetadata
 var moduleName = require('./utils/module-name.js')
+var git = require('./utils/git')
 
 function uniqName (item) {
   return item[0].path + '|' + item[1] + '|' + item[7]
@@ -337,7 +338,25 @@ function shouldUpdate (args, tree, dep, has, req, depth, pkgpath, cb, type) {
     return doIt('linked', 'linked')
   }
   if (parsed.type === 'git' || parsed.type === 'hosted') {
-    return doIt('git', 'git')
+    var gitUrlParts = (parsed.type === 'hosted' ? parsed.hosted.sshUrl : parsed.rawSpec).split('#')
+    var gitPath = gitUrlParts[0]
+    var wanted = gitUrlParts[1]
+
+    if (!gitPath || !wanted) {
+      return doIt('git', 'git')
+    }
+    if (!/\d+\.\d+\.\d+$/.test(wanted)) {
+      return doIt('git', 'git')
+    }
+
+    var tags = git.execSync([ 'ls-remote', '--tags', gitPath ]).toString()
+    var semverTags = tags.match(/\d+\.\d+\.\d+$/gm)
+    if (!semverTags) {
+      return doIt(wanted, 'git')
+    }
+
+    var sortedSemverTags = semverTags.sort(semver.rcompare)
+    return doIt(wanted, sortedSemverTags[0])
   }
 
   // search for the latest package

--- a/lib/utils/git.js
+++ b/lib/utils/git.js
@@ -1,10 +1,12 @@
 // handle some git configuration for windows
 
 exports.spawn = spawnGit
+exports.execSync = execSyncGit
 exports.chainableExec = chainableExec
 exports.whichAndExec = whichAndExec
 
 var exec = require('child_process').execFile
+var execSync = require('child_process').execFileSync
 var spawn = require('./spawn')
 var npm = require('../npm.js')
 var which = require('which')
@@ -20,6 +22,12 @@ function execGit (args, options, cb) {
   log.info('git', args)
   var fullArgs = prefixGitArgs().concat(args || [])
   return exec(git, fullArgs, options, cb)
+}
+
+function execSyncGit (args, options) {
+  log.info('git', args)
+  var fullArgs = prefixGitArgs().concat(args || [])
+  return execSync(git, fullArgs, options)
 }
 
 function spawnGit (args, options) {

--- a/test/tap/outdated-git.js
+++ b/test/tap/outdated-git.js
@@ -20,7 +20,9 @@ var json = {
   dependencies: {
     'foo-github': 'robertkowalski/foo',
     'foo-private': 'git://github.com/robertkowalski/foo-private.git',
-    'foo-private-credentials': 'git://user:pass@github.com/robertkowalski/foo-private.git'
+    'foo-private-credentials': 'git://user:pass@github.com/robertkowalski/foo-private.git',
+    'npm-outdated-git-test': 'goloroden/npm-outdated-git-test#0.1.0',
+    'npm-outdated-git-test-outdated': 'goloroden/npm-outdated-git-test#0.0.1'
   }
 }
 
@@ -31,7 +33,7 @@ test('setup', function (t) {
 
 test('discovers new versions in outdated', function (t) {
   process.chdir(pkg)
-  t.plan(5)
+  t.plan(9)
   npm.load({cache: cache, registry: common.registry, loglevel: 'silent'}, function () {
     npm.commands.outdated([], function (er, d) {
       t.equal(d[0][3], 'git')
@@ -39,6 +41,10 @@ test('discovers new versions in outdated', function (t) {
       t.equal(d[0][5], 'github:robertkowalski/foo')
       t.equal(d[1][5], 'git://github.com/robertkowalski/foo-private.git')
       t.equal(d[2][5], 'git://user:pass@github.com/robertkowalski/foo-private.git')
+      t.equal(d[3][3], '0.1.0')
+      t.equal(d[3][4], '0.1.0')
+      t.equal(d[4][3], '0.0.1')
+      t.equal(d[4][4], '0.1.0')
     })
   })
 })


### PR DESCRIPTION
Hi @othiym23!

I have started to work on updating the `outdated` command so that it [correctly detects outdated git dependencies](https://github.com/npm/npm/issues/8300). So far, things seem to work, but I am not too sure whether I got everything right. There may be a few things in the code that should be changed to better suit your way of doing things.

My primary goal so far was to show a possible way of solving this issue and to start a discussion. Maybe, if you have time, you could give me some feedback on my changes. What do you think of them? Do they head into the correct direction, or am I doing things fundamentally wrong here?

I have also added a few tests. Since they check GitHub, I needed to create a repository that has a fixed tag `0.1.0` (I need to ensure that the tags won't change, otherwise the tests break because external factors have changed).

So, I created the repository [goloroden/npm-outdated-git-test](https://github.com/goloroden/npm-outdated-git-test). Of course it would make a lot of sense to move this repository (or something similar) to the `npm` organization if this PR gets merged. Then, this also means that the tests need to be adjusted. This only affects the file `test/tap/outdated-git.js`.

Generally speaking, thanks for your great work with npm, and I hope that I maybe can provide a (very) small bit to it :-)

Looking forward to your feedback!

Golo
