### PR TITLE
Fix unreadable text in `npm outdated` using solarized dark theme

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -142,8 +142,6 @@ function makePretty (p) {
     columns[0] = color[has === want || want === 'linked' ? 'yellow' : 'red'](columns[0]) // dep
     columns[2] = color.green(columns[2]) // want
     columns[3] = color.magenta(columns[3]) // latest
-    columns[4] = color.brightBlack(columns[4]) // dir
-    if (long) columns[5] = color.brightBlack(columns[5]) // type
   }
 
   return columns


### PR DESCRIPTION
Fixes #12842
