### PR TITLE
Report missing dev deps when you ask for a listing of dev deps.

### DIFF
--- a/lib/install/mutate-into-logical-tree.js
+++ b/lib/install/mutate-into-logical-tree.js
@@ -70,18 +70,27 @@ function translateTree_ (tree, seen) {
   tree.children.forEach(function (child) {
     pkg.dependencies[moduleName(child)] = translateTree_(child, seen)
   })
-  Object.keys(tree.missingDeps).forEach(function (name) {
+
+  function markMissing (name, requiredBy) {
     if (pkg.dependencies[name]) {
+      if (pkg.dependencies[name].missing) return
       pkg.dependencies[name].invalid = true
       pkg.dependencies[name].realName = name
       pkg.dependencies[name].extraneous = false
     } else {
       pkg.dependencies[name] = {
-        requiredBy: tree.missingDeps[name],
+        requiredBy: requiredBy,
         missing: true,
         optional: !!pkg.optionalDependencies[name]
       }
     }
+  }
+
+  Object.keys(tree.missingDeps).forEach(function (name) {
+    markMissing(name, tree.missingDeps[name])
+  })
+  Object.keys(tree.missingDevDeps).forEach(function (name) {
+    markMissing(name, tree.missingDevDeps[name])
   })
   var checkForMissingPeers = (tree.parent ? [] : [tree]).concat(tree.children)
   checkForMissingPeers.filter(function (child) {


### PR DESCRIPTION
This allows `ls` to, when asked to show dev dependences, eg, `npm ls --dev`, complain about missing dev deps.

New functionality, it will need a test. We may want to take a moment to evaluate the UX for this too– `npm ls` filters these as you'd anticipate, but at the moment it reports these as just `UNMET DEPENDENCY` and I would be inclined to make that `UNMET DEV DEPENDENCY`, mirroring what we do with optional dependencies.
