### PR TITLE
When shrinkwrapping dev dependencies, missing dev dependencies should be an error

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -91,6 +91,18 @@ function shrinkwrapDeps (dev, problems, deps, tree, seen) {
         (topname ? ', required by ' + topname : ''))
     }
   })
+  if (dev) {
+    Object.keys(tree.missingDevDeps).forEach(function (name) {
+      var invalid = tree.children.filter(function (dep) { return moduleName(dep) === name })[0]
+      if (invalid) {
+        problems.push('invalid dev dep: have ' + invalid.package._id + ' (expected: ' + tree.missingDevDeps[name] + ') ' + invalid.path)
+      } else if (!tree.package.optionalDependencies || !tree.package.optionalDependencies[name]) {
+        var topname = packageId(tree)
+        problems.push('missing dev dep: ' + name + '@' + tree.package.dependencies[name] +
+          (topname ? ', required by ' + topname : ''))
+      }
+    })
+  }
   tree.children.sort(function (aa, bb) { return moduleName(aa).localeCompare(moduleName(bb)) }).forEach(function (child) {
     if (!dev && isOnlyDev(child)) {
       log.warn('shrinkwrap', 'Excluding devDependency: %s', packageId(child), child.parent.package.dependencies)


### PR DESCRIPTION
As with the changes to `ls`, if you are explicitly are shrinkwrapping dev dependencies then it's reasonable to insist that they all be installed.
