### PR TITLE
Rewrite how recalculateMetadata flags missing dependencies

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -363,6 +363,7 @@ Installer.prototype.loadIdealTree = function (cb) {
     [this, this.loadAllDepsIntoIdealTree],
     [this, this.finishTracker, 'loadAllDepsIntoIdealTree'],
 
+    // TODO: Remove this (should no longer be necessary, instead counter productive)
     [this, function (next) { recalculateMetadata(this.idealTree, log, next) }],
     [this, this.debugTree, 'idealTree:prePrune', 'idealTree'],
     [this, function (next) { next(pruneTree(this.idealTree)) }]
@@ -678,6 +679,7 @@ Installer.prototype.printInstalled = function (cb) {
   })
   log.showProgress()
   if (!addedOrMoved.length) return cb()
+  // TODO: remove the recalculateMetadata, should not be needed
   recalculateMetadata(this.idealTree, log, iferr(cb, function (tree) {
     log.clearProgress()
     // These options control both how installs happen AND how `ls` shows output.

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -78,6 +78,7 @@ function doesChildVersionMatch (child, requested, requestor) {
   return semver.satisfies(child.package.version, requested.spec)
 }
 
+// TODO: Rename to maybe computeMetadata or computeRelationships
 exports.recalculateMetadata = function (tree, log, next) {
   recalculateMetadata(tree, log, {}, next)
 }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -102,18 +102,20 @@ function recalculateMetadata (tree, log, seen, next) {
   if (seen[tree.path]) return next()
   seen[tree.path] = true
   if (tree.parent == null) resetMetadata(tree)
-  function markDeps (spec, done) {
-    validate('SF', arguments)
-    var matched = spec.match(/^(@?[^@]+)@(.*)$/)
-    childDependencySpecifier(tree, matched[1], matched[2], function (er, req) {
+
+  function markDeps (toMark, done) {
+    var name = toMark.name
+    var spec = toMark.spec
+    var kind = toMark.kind
+    childDependencySpecifier(tree, name, spec, function (er, req) {
       if (er || !req.name) return done()
       var child = findRequirement(tree, req.name, req)
       if (child) {
         resolveWithExistingModule(child, tree, log, andIgnoreErrors(done))
-      } else if (tree.package.dependencies[req.name] != null) {
+      } else if (kind === 'dep') {
         tree.missingDeps[req.name] = req.rawSpec
         done()
-      } else if (tree.package.devDependencies[req.name] != null) {
+      } else if (kind === 'dev') {
         tree.missingDevDeps[req.name] = req.rawSpec
         done()
       } else {
@@ -121,15 +123,20 @@ function recalculateMetadata (tree, log, seen, next) {
       }
     })
   }
-  function specs (deps) {
-    return Object.keys(deps).map(function (depname) { return depname + '@' + deps[depname] })
+
+  function Markable (name, spec, kind) {
+    return {name: name, spec: spec, kind: kind}
+  }
+
+  function makeMarkable (deps, kind) {
+    if (!deps) return []
+    return Object.keys(deps).map(function (depname) { return Markable(depname, deps[depname], kind) })
   }
 
   // Ensure dependencies and dev dependencies are marked as required
-  var tomark = specs(tree.package.dependencies)
-  if (!tree.parent && (npm.config.get('dev') || !npm.config.get('production'))) {
-    tomark = union(tomark, specs(tree.package.devDependencies))
-  }
+  var tomark = makeMarkable(tree.package.dependencies, 'dep')
+  if (!tree.parent) tomark = union(tomark, makeMarkable(tree.package.devDependencies, 'dev'))
+
   // Ensure any children ONLY from a shrinkwrap are also included
   var childrenOnlyInShrinkwrap = tree.children.filter(function (child) {
     return child.fromShrinkwrap &&
@@ -137,7 +144,13 @@ function recalculateMetadata (tree, log, seen, next) {
       !tree.package.devDependencies[child.package.name]
   })
   var tomarkOnlyInShrinkwrap = childrenOnlyInShrinkwrap.map(function (child) {
-    return child.package._spec
+    var name = child.package.name
+    var matched = child.package._spec.match(/^@?[^@]+@(.*)$/)
+    var spec = matched ? matched[1] : child.package._spec
+    var kind = tree.package.dependencies[name] ? 'dep'
+             : tree.package.devDependencies[name] ? 'dev'
+             : 'dep'
+    return Markable(name, spec, kind)
   })
   tomark = union(tomark, tomarkOnlyInShrinkwrap)
 


### PR DESCRIPTION
We keep track of missing dependencies and missing dev dependencies separately. This allows things like `npm ls` to make decisions about what it wants to warn about.

Despite having concrete lists of dependencies and dev dependencies we were guessing as to which was which. This _usually_ works fine, but in cases where dependencies and dev dependencies share a requirement but not precisely the same version, it could lead to misleading error messages.

Further, things in the shrinkwrap that are not in the package.json were not being reported at all.

This PR includes three things:
1. It rewrites `markDeps` to take an object with name, spec & kind (`prod` or `dev`). Previously it took a string of `name@spec` and extracted name & spec from that.
2. When a dependency is both a prod and a dev dep, it will be correctly categorized. Previously if the dev spec didn't match it would still be flagged as a prod mismatch.
3. Reminders that we don't want to call recalculateMetadata quite as often as we currently are.
