### PR TITLE
npm ls & friends shouldn't introspect into linked packages

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -101,6 +101,7 @@ function recalculateMetadata (tree, log, seen, next) {
   validate('OOOF', arguments)
   if (seen[tree.path]) return next()
   seen[tree.path] = true
+  if (tree.isLink) return next()
   if (tree.parent == null) resetMetadata(tree)
   function markDeps (spec, done) {
     validate('SF', arguments)
@@ -368,6 +369,7 @@ exports.loadDeps = loadDeps
 function loadDeps (tree, log, next) {
   validate('OOF', arguments)
   if (tree.loaded || (tree.parent && tree.parent.failed)) return andFinishTracker.now(log, next)
+  if (tree.isLink) return andFinishTracker.now(log, next)
   if (tree.parent) tree.loaded = true
   if (!tree.package.dependencies) tree.package.dependencies = {}
   asyncMap(Object.keys(tree.package.dependencies), function (dep, done) {
@@ -555,6 +557,7 @@ function validateAllPeerDeps (tree, onInvalid, seen) {
   validate('OFO', arguments)
   if (seen[tree.path]) return
   seen[tree.path] = true
+  if (tree.isLink) return
   validatePeerDeps(tree, onInvalid)
   tree.children.forEach(function (child) { validateAllPeerDeps(child, onInvalid, seen) })
 }

--- a/lib/install/mutate-into-logical-tree.js
+++ b/lib/install/mutate-into-logical-tree.js
@@ -67,7 +67,7 @@ function translateTree_ (tree, seen) {
   if (pkg._dependencies) return pkg
   pkg._dependencies = pkg.dependencies
   pkg.dependencies = {}
-  tree.children.forEach(function (child) {
+  !tree.isLink && tree.children.forEach(function (child) {
     pkg.dependencies[moduleName(child)] = translateTree_(child, seen)
   })
   Object.keys(tree.missingDeps).forEach(function (name) {

--- a/test/tap/link.js
+++ b/test/tap/link.js
@@ -9,6 +9,7 @@ var writeFileSync = require('fs').writeFileSync
 var common = require('../common-tap.js')
 
 var link = path.join(__dirname, 'link')
+var linkDep = path.join(link, 'node_modules', 'link-dep')
 var linkScoped = path.join(__dirname, 'link-scoped')
 var linkInstall = path.join(__dirname, 'link-install')
 var linkInside = path.join(linkInstall, 'node_modules', 'inside')
@@ -25,6 +26,21 @@ var OPTS = {
 
 var readJSON = {
   name: 'foo',
+  version: '1.0.0',
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: 'echo \"Error: no test specified\" && exit 1'
+  },
+  dependencies: {
+    'fooDep': '1.0.0'
+  },
+  author: '',
+  license: 'ISC'
+}
+
+var readDepJSON = {
+  name: 'fooDep',
   version: '1.0.0',
   description: '',
   main: 'index.js',
@@ -90,6 +106,8 @@ test('create global link', function (t) {
       t.equal(c, 0)
       t.equal(stderr, '', 'got expected stderr')
       t.has(out, /foo@1.0.0/, 'creates global link ok')
+      t.notMatch(out, /extraneous/, 'ls does not list any extraneous dependencies')
+      t.notMatch(out, /fooDep/, 'ls does not list transitive dependencies of linked packages')
       t.end()
     })
   })
@@ -190,6 +208,11 @@ function setup () {
   writeFileSync(
     path.join(link, 'package.json'),
     JSON.stringify(readJSON, null, 2)
+  )
+  mkdirp.sync(linkDep)
+  writeFileSync(
+    path.join(linkDep, 'package.json'),
+    JSON.stringify(readDepJSON, null, 2)
   )
   mkdirp.sync(linkScoped)
   writeFileSync(

--- a/test/tap/rm-linked.js
+++ b/test/tap/rm-linked.js
@@ -96,6 +96,7 @@ test('uninstall the global linked package', function (t) {
       t.ifError(err)
       t.equal(c, 0)
       t.has(out, /baz@1.0.0/, "uninstall didn't remove dep")
+      t.notMatch(out, /extraneous/, "doesn't leave behind extraneous packages")
       t.end()
     })
   })


### PR DESCRIPTION
This prevents `npm ls` from listing the dependencies of linked packages, and prevents a similar (and useless) traversal from running when we run commands like `npm install` and `npm update`.

This represents a behavior-change, although the existing behavior is confusing (and often buggy) in the most-common use-case, where the linked package's devDependencies are installed, which isn't something we typically expect to see in our dependencies.

I believe that _any_ decisions or inferences that we make about how to traverse linked packages (and what to print in `npm ls`) is going to lead to ambiguous or confusing behavior.  We already don't traverse the children of extraneous packages, and I think that it makes the most sense to extend that behavior to linked packages as well.

See #11911
