### PR TITLE
chore: ignore .nyc_output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ npm-debug.log
 *.pyc
 .jshintrc
 .eslintrc
+.nyc_output
 
 # dev dependencies
 /node_modules/deep-equal/

--- a/.npmignore
+++ b/.npmignore
@@ -27,3 +27,5 @@ html/*.png
 *.pyc
 
 /test/tap/builtin-config
+
+.nyc_output


### PR DESCRIPTION
This will help avoid an accidental publish or commit filled with
code coverage data

Ref: https://github.com/npm/npm/issues/12873
