### PR TITLE
run-script: avoid $PATH pollution if possible

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -41,8 +41,8 @@ you should write:
 instead of `"scripts": {"test": "node_modules/.bin/tap test/\*.js"}` to run your tests.
 
 `npm run` sets the `NODE` environment variable to the `node` executable with
-which `npm` is executed, and adds the directory within which it resides to the
-`PATH`, too.
+which `npm` is executed. Also, the directory within which it resides is added to the
+`PATH`, if the `node` executable is not in the `PATH`.
 
 If you try to run a script without having a `node_modules` directory and it fails,
 you will be given a warning to run `npm install`, just in case you've forgotten.

--- a/test/common-tap.js
+++ b/test/common-tap.js
@@ -45,6 +45,7 @@ exports.npm = function (cmd, opts, cb) {
   if (!opts.env.npm_config_cache) {
     opts.env.npm_config_cache = npm_config_cache
   }
+  nodeBin = opts.nodeExecPath || nodeBin
 
   var stdout = ''
   var stderr = ''


### PR DESCRIPTION
Let's avoid prepending current node directory to the PATH if current node can be found in the PATH.
It will probably fix #12318
