### PR TITLE
addRemoteTarball: reuse cached packages

### DIFF
--- a/lib/cache/add-remote-tarball.js
+++ b/lib/cache/add-remote-tarball.js
@@ -12,8 +12,33 @@ var addLocalTarball = require('./add-local-tarball.js')
 var cacheFile = require('npm-cache-filename')
 var rimraf = require('rimraf')
 var pulseTillDone = require('../utils/pulse-till-done.js')
+var cachedPackageRoot = require('./cached-package-root.js')
+var readPackageJson = require('read-package-json')
 
 module.exports = addRemoteTarball
+
+function extractVersionFromUrl (url) {
+  var match = url.match(/(\d+\.\d+\.\d+(-.+)?)\.tgz(\?.*)?$/)
+  return match && match[1]
+}
+
+function findInCache (u, pkgData, shasum, cb) {
+  if (!pkgData.name) return cb()
+  var ver = extractVersionFromUrl(u)
+  if (!ver) return cb()
+
+  var pkgroot = cachedPackageRoot({ name: pkgData.name, version: ver })
+  var pkgjson = path.join(pkgroot, 'package', 'package.json')
+  readPackageJson(pkgjson, function (err, pkgData) {
+    if (err && err.code === 'ENOENT') return cb()
+    if (err) return cb(err)
+    if (pkgData._resolved === u) {
+      var pkgtgz = path.join(pkgroot, 'package.tgz')
+      return cb(null, pkgtgz, pkgData)
+    }
+    return cb()
+  })
+}
 
 function addRemoteTarball (u, pkgData, shasum, auth, cb_) {
   assert(typeof u === 'string', 'must have module URL')
@@ -28,29 +53,37 @@ function addRemoteTarball (u, pkgData, shasum, auth, cb_) {
     cb_(er, data)
   }
 
-  cb_ = inflight(u, cb_)
-  if (!cb_) return log.verbose('addRemoteTarball', u, 'already in flight; waiting')
-  log.verbose('addRemoteTarball', u, 'not in flight; adding')
+  findInCache(u, pkgData, shasum, function (err, cachedTarballPath, pkgData) {
+    if (err) return cb(err)
+    if (cachedTarballPath) {
+      log.silly('addRemoteTarball', u, 'found in cache', cachedTarballPath)
+      return addLocalTarball(cachedTarballPath, pkgData, shasum, cb)
+    }
 
-  // XXX Fetch direct to cache location, store tarballs under
-  // ${cache}/registry.npmjs.org/pkg/-/pkg-1.2.3.tgz
-  var tmp = cacheFile(npm.tmp, u)
+    cb_ = inflight(u, cb_)
+    if (!cb_) return log.verbose('addRemoteTarball', u, 'already in flight; waiting')
+    log.verbose('addRemoteTarball', u, 'not in flight; adding')
 
-  function next (er, resp, shasum) {
-    if (er) return cb(er)
-    addLocalTarball(tmp, pkgData, shasum, cleanup)
-  }
-  function cleanup (er, data) {
-    if (er) return cb(er)
-    rimraf(tmp, function () {
-      cb(er, data)
+    // XXX Fetch direct to cache location, store tarballs under
+    // ${cache}/registry.npmjs.org/pkg/-/pkg-1.2.3.tgz
+    var tmp = cacheFile(npm.tmp, u)
+
+    function next (er, resp, shasum) {
+      if (er) return cb(er)
+      addLocalTarball(tmp, pkgData, shasum, cleanup)
+    }
+    function cleanup (er, data) {
+      if (er) return cb(er)
+      rimraf(tmp, function () {
+        cb(er, data)
+      })
+    }
+
+    log.verbose('addRemoteTarball', [u, shasum])
+    mkdir(path.dirname(tmp), function (er) {
+      if (er) return cb(er)
+      addRemoteTarball_(u, tmp, shasum, auth, next)
     })
-  }
-
-  log.verbose('addRemoteTarball', [u, shasum])
-  mkdir(path.dirname(tmp), function (er) {
-    if (er) return cb(er)
-    addRemoteTarball_(u, tmp, shasum, auth, next)
   })
 }
 


### PR DESCRIPTION
When adding a package via a URL pointing to a tarball, we can try to use a
cached version by attempting to extract the version from the URL and performing
a cache lookup using the name and version. If the cached package was resolved
using the exact same URL then we can reuse it. This makes it safe for packages
added from other sources, or with unusual URL formats from which we cannot
extract the version.

When the cache is primed, this results in a noticeable speed improvement for shrinkwrapped installs (along with the obvious reduction in network traffic).

Happy to add test(s) if this looks good.
