### PR TITLE
doc: add workaround for running scripts of dependencies

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -36,7 +36,8 @@ following scripts:
 Additionally, arbitrary scripts can be executed by running `npm
 run-script <stage>`. *Pre* and *post* commands with matching
 names will be run for those as well (e.g. `premyscript`, `myscript`,
-`postmyscript`).
+`postmyscript`). Scripts from dependencies can be run with `npm explore
+<pkg> -- npm run <stage>`.
 
 ## COMMON USES
 


### PR DESCRIPTION
Add npm explore workaround for running scripts from a dependency.
Related to the removal of the earlier possibility of running these scripts with `npm run <pkg> <script>` (removed from this doc in https://github.com/npm/npm/commit/70a3ae4d4ec76b3ec51f00bf5261f1147829f9fe).

Workaround mentioned in https://github.com/npm/npm/issues/9186.
Ref https://github.com/npm/docs/issues/704.
