### PR TITLE
WIP: add --time-machine option (only install deps released on or before a given date)

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -271,6 +271,12 @@ global `node_modules` folder. Only your direct dependencies will show in
 `node_modules` and everything they depend on will be flattened in their
 `node_modules` folders. This obviously will eliminate some deduping.
 
+The `--ignore-versions-after=date` will cause npm to ignore versions of any package
+released after the given date.  This is a useful workaround for bugs in recent releases
+of subdeps that you don't have controlled by a shrinkwrap.  `date` may be anything
+that the `Date` constructor would parse correctly; if it is invalid, this option will
+have no effect.
+
 The `--ignore-scripts` argument will cause npm to not execute any 
 scripts defined in the package.json. See `npm-scripts(7)`.
 

--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -271,7 +271,7 @@ global `node_modules` folder. Only your direct dependencies will show in
 `node_modules` and everything they depend on will be flattened in their
 `node_modules` folders. This obviously will eliminate some deduping.
 
-The `--ignore-versions-after=date` will cause npm to ignore versions of any package
+The `--ignore-versions-after=date` argument will cause npm to ignore versions of any package
 released after the given date.  This is a useful workaround for bugs in recent releases
 of subdeps that you don't have controlled by a shrinkwrap.  `date` may be anything
 that the `Date` constructor would parse correctly; if it is invalid, this option will

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -249,29 +249,27 @@ function addNameRange (name, range, data, cb) {
     )
     engineFilter(data)
 
+    var versions = Object.keys(data.versions || {})
+    var beforeTime = new Date(npm.config.get('before-date')).getTime()
+    if (!isNaN(beforeTime)) {
+      versions = versions.filter(function (version) {
+        return new Date(data.time[version]).getTime() <= beforeTime
+      })
+    }
+
     log.silly('addNameRange', 'versions'
-             , [data.name, Object.keys(data.versions || {})])
+             , [data.name, versions || {}])
 
     // if the tagged version satisfies, then use that.
     var tagged = data['dist-tags'][npm.config.get('tag')]
     if (tagged &&
-        data.versions[tagged] &&
+        versions[tagged] &&
         semver.satisfies(tagged, range, true)) {
-      return addNamed(name, tagged, data.versions[tagged], cb)
+      return addNamed(name, tagged, versions[tagged], cb)
     }
 
     // find the max satisfying version.
-    var versions = Object.keys(data.versions || {})
-    var filtVersions = versions
-    var beforeTime = new Date(npm.config.get('before-date')).getTime()
-    if (!isNaN(beforeTime)) {
-      filtVersions = versions.filter(function (version) {
-        return new Date(pkg.time[version]).getTime() <= beforeTime
-      })
-    }
-
-    var ms = semver.maxSatisfying(filtVersions, range, true)
-    if (!ms) ms = semver.maxSatisfying(versions, range, true)
+    var ms = semver.maxSatisfying(versions, range, true)
     if (!ms) {
       if (range === '*' && versions.length) {
         return addNameTag(name, 'latest', data, cb)

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -250,7 +250,7 @@ function addNameRange (name, range, data, cb) {
     engineFilter(data)
 
     var versions = Object.keys(data.versions || {})
-    var beforeTime = new Date(npm.config.get('time-machine')).getTime()
+    var beforeTime = new Date(npm.config.get('ignore-versions-after')).getTime()
     if (!isNaN(beforeTime)) {
       versions = versions.filter(function (version) {
         return new Date(data.time[version]).getTime() <= beforeTime

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -250,7 +250,7 @@ function addNameRange (name, range, data, cb) {
     engineFilter(data)
 
     var versions = Object.keys(data.versions || {})
-    var beforeTime = new Date(npm.config.get('before-date')).getTime()
+    var beforeTime = new Date(npm.config.get('time-machine')).getTime()
     if (!isNaN(beforeTime)) {
       versions = versions.filter(function (version) {
         return new Date(data.time[version]).getTime() <= beforeTime

--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -262,7 +262,16 @@ function addNameRange (name, range, data, cb) {
 
     // find the max satisfying version.
     var versions = Object.keys(data.versions || {})
-    var ms = semver.maxSatisfying(versions, range, true)
+    var filtVersions = versions
+    var beforeTime = new Date(npm.config.get('before-date')).getTime()
+    if (!isNaN(beforeTime)) {
+      filtVersions = versions.filter(function (version) {
+        return new Date(pkg.time[version]).getTime() <= beforeTime
+      })
+    }
+
+    var ms = semver.maxSatisfying(filtVersions, range, true)
+    if (!ms) ms = semver.maxSatisfying(versions, range, true)
     if (!ms) {
       if (range === '*' && versions.length) {
         return addNameTag(name, 'latest', data, cb)

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -123,7 +123,7 @@ function fetchNamedPackageData (dep, next) {
     function pickVersionFromRegistryDocument (pkg) {
       if (!regCache[url]) regCache[url] = pkg
       var versions = Object.keys(pkg.versions).sort(semver.rcompare)
-      var beforeTime = new Date(npm.config.get('time-machine')).getTime()
+      var beforeTime = new Date(npm.config.get('ignore-versions-after')).getTime()
       if (!isNaN(beforeTime)) {
         versions = versions.filter(function (version) {
           return new Date(pkg.time[version]).getTime() <= beforeTime

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -123,12 +123,38 @@ function fetchNamedPackageData (dep, next) {
     function pickVersionFromRegistryDocument (pkg) {
       if (!regCache[url]) regCache[url] = pkg
       var versions = Object.keys(pkg.versions).sort(semver.rcompare)
+      var filtVersions = versions
+      var beforeTime = new Date(npm.config.get('before-date')).getTime()
+      if (!isNaN(beforeTime)) {
+        filtVersions = versions.filter(function (version) {
+          return new Date(pkg.time[version]).getTime() <= beforeTime
+        })
+      }
 
       if (dep.type === 'tag') {
         var tagVersion = pkg['dist-tags'][dep.spec]
         if (pkg.versions[tagVersion]) return returnAndAddMetadata(pkg.versions[tagVersion])
       } else {
-        var latestVersion = pkg['dist-tags'][npm.config.get('tag')] || versions[0]
+        var latestVersion = pkg['dist-tags'][npm.config.get('tag')] || filtVersions[0]
+
+        // Find the the most recent version less than or equal
+        // to latestVersion that satisfies our spec
+        for (var ii = 0; ii < filtVersions.length; ++ii) {
+          if (semver.gt(filtVersions[ii], latestVersion)) continue
+          if (semver.satisfies(filtVersions[ii], dep.spec)) {
+            return returnAndAddMetadata(pkg.versions[filtVersions[ii]])
+          }
+        }
+
+        // Failing that, try finding the most recent version that matches
+        // our spec
+        for (var jj = 0; jj < filtVersions.length; ++jj) {
+          if (semver.satisfies(filtVersions[jj], dep.spec)) {
+            return returnAndAddMetadata(pkg.versions[filtVersions[jj]])
+          }
+        }
+
+        // Failing the above, retry with versions after the before-date
 
         // Find the the most recent version less than or equal
         // to latestVersion that satisfies our spec

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -123,38 +123,18 @@ function fetchNamedPackageData (dep, next) {
     function pickVersionFromRegistryDocument (pkg) {
       if (!regCache[url]) regCache[url] = pkg
       var versions = Object.keys(pkg.versions).sort(semver.rcompare)
-      var filtVersions = versions
       var beforeTime = new Date(npm.config.get('before-date')).getTime()
       if (!isNaN(beforeTime)) {
-        filtVersions = versions.filter(function (version) {
+        versions = versions.filter(function (version) {
           return new Date(pkg.time[version]).getTime() <= beforeTime
         })
       }
 
       if (dep.type === 'tag') {
         var tagVersion = pkg['dist-tags'][dep.spec]
-        if (pkg.versions[tagVersion]) return returnAndAddMetadata(pkg.versions[tagVersion])
+        if (versions[tagVersion]) return returnAndAddMetadata(versions[tagVersion])
       } else {
-        var latestVersion = pkg['dist-tags'][npm.config.get('tag')] || filtVersions[0]
-
-        // Find the the most recent version less than or equal
-        // to latestVersion that satisfies our spec
-        for (var ii = 0; ii < filtVersions.length; ++ii) {
-          if (semver.gt(filtVersions[ii], latestVersion)) continue
-          if (semver.satisfies(filtVersions[ii], dep.spec)) {
-            return returnAndAddMetadata(pkg.versions[filtVersions[ii]])
-          }
-        }
-
-        // Failing that, try finding the most recent version that matches
-        // our spec
-        for (var jj = 0; jj < filtVersions.length; ++jj) {
-          if (semver.satisfies(filtVersions[jj], dep.spec)) {
-            return returnAndAddMetadata(pkg.versions[filtVersions[jj]])
-          }
-        }
-
-        // Failing the above, retry with versions after the before-date
+        var latestVersion = pkg['dist-tags'][npm.config.get('tag')] || versions[0]
 
         // Find the the most recent version less than or equal
         // to latestVersion that satisfies our spec

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -123,7 +123,7 @@ function fetchNamedPackageData (dep, next) {
     function pickVersionFromRegistryDocument (pkg) {
       if (!regCache[url]) regCache[url] = pkg
       var versions = Object.keys(pkg.versions).sort(semver.rcompare)
-      var beforeTime = new Date(npm.config.get('before-date')).getTime()
+      var beforeTime = new Date(npm.config.get('time-machine')).getTime()
       if (!isNaN(beforeTime)) {
         versions = versions.filter(function (version) {
           return new Date(pkg.time[version]).getTime() <= beforeTime


### PR DESCRIPTION
See https://github.com/npm/npm/issues/12994

I'm absolutely sure this will need tests and more work, I'm putting it up now to get feedback.

With these changes I was able to get back a set of working deps and subdeps in my project and create the necessary `npm-shrinkwrap.json` for them.  Yay!

Right now I just filter the versions that `fetchPackageMetadata` and `addNamedRange` take into consideration.  Are there other parts of the code looking at package versions where I need to filter out the ones after the time machine date?
