### PR TITLE
tar: warn when using Node 6+

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -8,6 +8,7 @@ var writeStreamAtomic = require('fs-write-stream-atomic')
 var log = require('npmlog')
 var uidNumber = require('uid-number')
 var readJson = require('read-package-json')
+var semver = require('semver')
 var tar = require('tar')
 var zlib = require('zlib')
 var fstream = require('fstream')
@@ -34,6 +35,12 @@ exports.unpack = unpack
 
 function pack (tarball, folder, pkg, cb) {
   log.verbose('tar pack', [tarball, folder])
+
+  if (semver.gte(process.version, '6.0.0')) {
+    log.warn('pack', 'Publishing and packing are buggy under Node versions greater than 6.0.0.')
+    log.warn('pack', 'Please use Node.js LTS (4.4.x) to publish packages.')
+    log.warn('pack', 'See https://github.com/npm/npm/issues/5082 for details and current status.')
+  }
 
   log.verbose('tarball', tarball)
   log.verbose('folder', folder)

--- a/test/tap/full-warning-messages.js
+++ b/test/tap/full-warning-messages.js
@@ -3,6 +3,7 @@ var test = require('tap').test
 var path = require('path')
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
+var semver = require('semver')
 var fs = require('graceful-fs')
 var common = require('../common-tap')
 
@@ -93,7 +94,12 @@ test('tree-style', function (t) {
     t.match(stdout, /modA@1.0.0/, 'modA got installed')
     t.notMatch(stdout, /modB/, 'modB not installed')
     var stderrlines = stderr.trim().split(/\n/)
-    t.is(stderrlines.length, 2, 'two lines of warnings')
+    // https://github.com/npm/npm/pull/13077
+    if (semver.gte(process.version, '6.0.0')) {
+      t.is(stderrlines.length, 5)
+    } else {
+      t.is(stderrlines.length, 2, 'two lines of warnings')
+    }
     t.match(stderr, /Skipping failed optional dependency/, 'expected optional failure warning')
     t.match(stderr, /Not compatible with your operating system or architecture/, 'reason for optional failure')
     exists(t, modJoin(base, 'modA'), 'module A')

--- a/test/tap/pack-scoped.js
+++ b/test/tap/pack-scoped.js
@@ -5,6 +5,7 @@ var fs = require('graceful-fs')
 var join = require('path').join
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
+var semver = require('semver')
 
 var pkg = join(__dirname, 'scoped_package')
 var manifest = join(pkg, 'package.json')
@@ -66,7 +67,12 @@ test('test', function (t) {
   }, function (err, code, stdout, stderr) {
     t.ifErr(err, 'npm pack finished without error')
     t.equal(code, 0, 'npm pack exited ok')
-    t.notOk(stderr, 'got stderr data: ' + JSON.stringify('' + stderr))
+    // https://github.com/npm/npm/pull/13077
+    if (semver.gte(process.version, '6.0.0')) {
+      t.is(stderr.trim().split(/\n/).length, 3)
+    } else {
+      t.notOk(stderr, 'got stderr data: ' + JSON.stringify('' + stderr))
+    }
     stdout = stdout.trim()
     var regex = new RegExp('scope-generic-package-90000.100001.5.tgz', 'ig')
     t.ok(stdout.match(regex), 'found package')

--- a/test/tap/prepublish.js
+++ b/test/tap/prepublish.js
@@ -5,6 +5,7 @@ var fs = require('graceful-fs')
 var join = require('path').join
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
+var semver = require('semver')
 
 var pkg = join(__dirname, 'prepublish_package')
 var tmp = join(pkg, 'tmp')
@@ -59,7 +60,12 @@ test('test', function (t) {
     t.equal(code, 0, 'pack finished successfully')
     t.ifErr(err, 'pack finished successfully')
 
-    t.notOk(stderr, 'got stderr data:' + JSON.stringify('' + stderr))
+    // https://github.com/npm/npm/pull/13077
+    if (semver.gte(process.version, '6.0.0')) {
+      t.is(stderr.trim().split(/\n/).length, 3)
+    } else {
+      t.notOk(stderr, 'got stderr data: ' + JSON.stringify('' + stderr))
+    }
     var c = stdout.trim()
     var regex = new RegExp('' +
       '> npm-test-prepublish@1.2.5 prepublish [^\\r\\n]+\\r?\\n' +


### PR DESCRIPTION
This should only live until the team lands a durable fix to #5082.
- [x] Tweak the message to include "4.4" as well as "Node.js LTS".

**r**: @iarna 
**r**: @zkat 

(/cc @sindresorhus)
