### PR TITLE
tar: Restore our version of applyIgnores

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -70,6 +70,93 @@ function BundledPacker (props) {
 }
 inherits(BundledPacker, Packer)
 
+BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
+  if (!entryObj || entryObj.type !== 'Directory') {
+    // package.json files can never be ignored.
+    if (entry === 'package.json') return true
+
+    // readme files should never be ignored.
+    if (entry.match(/^readme(\.[^\.]*)$/i)) return true
+
+    // license files should never be ignored.
+    if (entry.match(/^(license|licence)(\.[^\.]*)?$/i)) return true
+
+    // copyright notice files should never be ignored.
+    if (entry.match(/^(notice)(\.[^\.]*)?$/i)) return true
+
+    // changelogs should never be ignored.
+    if (entry.match(/^(changes|changelog|history)(\.[^\.]*)?$/i)) return true
+  }
+
+  // special rules.  see below.
+  if (entry === 'node_modules' && this.packageRoot) return true
+
+  // package.json main file should never be ignored.
+  var mainFile = this.package && this.package.main
+  if (mainFile && path.resolve(this.path, entry) === path.resolve(this.path, mainFile)) return true
+
+  // some files are *never* allowed under any circumstances
+  // (VCS folders, native build cruft, npm cruft, regular cruft)
+  if (entry === '.git' ||
+      entry === 'CVS' ||
+      entry === '.svn' ||
+      entry === '.hg' ||
+      entry === '.lock-wscript' ||
+      entry.match(/^\.wafpickle-[0-9]+$/) ||
+      (this.parent && this.parent.packageRoot && this.basename === 'build' &&
+       entry === 'config.gypi') ||
+      entry === 'npm-debug.log' ||
+      entry === '.npmrc' ||
+      entry.match(/^\..*\.swp$/) ||
+      entry === '.DS_Store' ||
+      entry.match(/^\._/)
+    ) {
+    return false
+  }
+
+  // in a node_modules folder, we only include bundled dependencies
+  // also, prevent packages in node_modules from being affected
+  // by rules set in the containing package, so that
+  // bundles don't get busted.
+  // Also, once in a bundle, everything is installed as-is
+  // To prevent infinite cycles in the case of cyclic deps that are
+  // linked with npm link, even in a bundle, deps are only bundled
+  // if they're not already present at a higher level.
+  if (this.bundleMagic) {
+    // bubbling up.  stop here and allow anything the bundled pkg allows
+    if (entry.indexOf('/') !== -1) return true
+
+    // never include the .bin.  It's typically full of platform-specific
+    // stuff like symlinks and .cmd files anyway.
+    if (entry === '.bin') return false
+
+    // the package root.
+    var p = this.parent
+    // the package before this one.
+    var pp = p && p.parent
+
+    // if this entry has already been bundled, and is a symlink,
+    // and it is the *same* symlink as this one, then exclude it.
+    if (pp && pp.bundleLinks && this.bundleLinks &&
+        pp.bundleLinks[entry] &&
+        pp.bundleLinks[entry] === this.bundleLinks[entry]) {
+      return false
+    }
+
+    // since it's *not* a symbolic link, if we're *already* in a bundle,
+    // then we should include everything.
+    if (pp && pp.package && pp.basename === 'node_modules') {
+      return true
+    }
+
+    // only include it at this point if it's a bundleDependency
+    return this.isBundled(entry)
+  }
+  // if (this.bundled) return true
+
+  return Packer.prototype.applyIgnores.call(this, entry, partial, entryObj)
+}
+
 function nameMatch (name) { return function (other) { return name === moduleName(other) } }
 
 function pack_ (tarball, folder, tree, pkg, cb) {

--- a/test/tap/bundled-transitive-deps.js
+++ b/test/tap/bundled-transitive-deps.js
@@ -40,7 +40,7 @@ var fixture = new Tacks(
           version: '1.0.0'
         })
       })
-    }),
+    })
   })
 )
 

--- a/test/tap/bundled-transitive-deps.js
+++ b/test/tap/bundled-transitive-deps.js
@@ -1,0 +1,83 @@
+'use strict'
+var fs = require('fs')
+var path = require('path')
+var test = require('tap').test
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+var common = require('../common-tap.js')
+var npm = require('../../lib/npm.js')
+var tar = require('../../lib/utils/tar.js')
+
+var testdir = path.join(__dirname, path.basename(__filename, '.js'))
+var packed = path.join(testdir, 'packed')
+
+var fixture = new Tacks(
+  Dir({
+    'package.json': File({
+      name: 'bundled-transitive-deps',
+      version: '1.0.0',
+      dependencies: {
+        'a': '1.0.0'
+      },
+      bundleDependencies: [
+        'a'
+      ]
+    }),
+    node_modules: Dir({
+      'a': Dir({
+        'package.json': File({
+          name: 'a',
+          version: '1.0.0',
+          dependencies: {
+            'b': '1.0.0'
+          }
+        })
+      }),
+      'b': Dir({
+        'package.json': File({
+          name: 'b',
+          version: '1.0.0'
+        })
+      })
+    }),
+  })
+)
+
+function setup () {
+  cleanup()
+  fixture.create(testdir)
+}
+
+function cleanup () {
+  fixture.remove(testdir)
+}
+
+test('setup', function (t) {
+  setup()
+  npm.load({}, t.end)
+})
+
+test('bundled-transitive-deps', function (t) {
+  common.npm(['pack'], {cwd: testdir}, thenCheckPack)
+  function thenCheckPack (err, code, stdout, stderr) {
+    if (err) throw err
+    var tarball = stdout.trim()
+    t.comment(stderr.trim())
+    t.is(code, 0, 'pack successful')
+    tar.unpack(path.join(testdir, tarball), packed, thenCheckContents)
+  }
+  function thenCheckContents (err) {
+    t.ifError(err, 'unpack successful')
+    var transitivePackedDep = path.join(packed, 'node_modules', 'b')
+    t.doesNotThrow(transitivePackedDep + ' exists', function () {
+      fs.statSync(transitivePackedDep)
+    })
+    t.end()
+  }
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
This reverts some of #11995.  Without this, bundled dependencies don't
include transitive dependencies.
