### PR TITLE
fstream@1.0.10, revert Node 6 warning, clean up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: node_js
 node_js:
-  - "6"
+  # LTS is our most important target
   - "4"
-  - "5"
-  - "0.12"
+  # next LTS and master is next most important
+  - "6"
+  # still in LTS maintenance until fall 2016
+  # (also still in wide use)
   - "0.10"
-  - "0.8"
+  # will be unsupported as soon as 6 becomes LTS and 7 released
+  - "5"
+  # technically in LTS / distros, unbeloved
+  - "0.12"
 env:
   - DEPLOY_VERSION=testing
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,15 @@ environment:
   matrix:
     # LTS is our most important target
     - nodejs_version: "4"
-    # latest
-    - nodejs_version: "5"
-    # I like 0.10 better than 0.12
+    # next LTS and master is next most important
+    - nodejs_version: "6"
+    # still in LTS maintenance until fall 2016
+    # (also still in wide use)
     - nodejs_version: "0.10"
+    # will be unsupported as soon as 6 becomes LTS and 7 released
+    - nodejs_version: "5"
+    # technically in LTS / distros, unbeloved
     - nodejs_version: "0.12"
-    # EOL summer 2016, most likely
-    - nodejs_version: "0.8"
   COVERALLS_REPO_TOKEN:
     secure: XdC0aySefK0HLh1GNk6aKrzZPbCfPQLyA4mYtFGEp4DrTuZA/iuCUS0LDqFYO8JQ
 platform:

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -8,7 +8,6 @@ var writeStreamAtomic = require('fs-write-stream-atomic')
 var log = require('npmlog')
 var uidNumber = require('uid-number')
 var readJson = require('read-package-json')
-var semver = require('semver')
 var tar = require('tar')
 var zlib = require('zlib')
 var fstream = require('fstream')
@@ -35,12 +34,6 @@ exports.unpack = unpack
 
 function pack (tarball, folder, pkg, cb) {
   log.verbose('tar pack', [tarball, folder])
-
-  if (semver.gte(process.version, '6.0.0')) {
-    log.warn('pack', 'Publishing and packing are buggy under Node versions greater than 6.0.0.')
-    log.warn('pack', 'Please use Node.js LTS (4.4.x) to publish packages.')
-    log.warn('pack', 'See https://github.com/npm/npm/issues/5082 for details and current status.')
-  }
 
   log.verbose('tarball', tarball)
   log.verbose('folder', folder)

--- a/node_modules/fstream/.travis.yml
+++ b/node_modules/fstream/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - iojs
-  - 0.12
-  - 0.10
-  - 0.8
+  - "6"
+  - "4"
+  - "0.10"
+  - "0.12"
 before_install:
   - "npm config set spin false"
   - "npm install -g npm/npm"

--- a/node_modules/fstream/lib/collect.js
+++ b/node_modules/fstream/lib/collect.js
@@ -3,6 +3,8 @@ module.exports = collect
 function collect (stream) {
   if (stream._collected) return
 
+  if (stream._paused) return stream.on('resume', collect.bind(null, stream))
+
   stream._collected = true
   stream.pause()
 

--- a/node_modules/fstream/package.json
+++ b/node_modules/fstream/package.json
@@ -1,19 +1,62 @@
 {
+  "_args": [
+    [
+      {
+        "raw": "fstream@~1.0.10",
+        "scope": null,
+        "escapedName": "fstream",
+        "name": "fstream",
+        "rawSpec": "~1.0.10",
+        "spec": ">=1.0.10 <1.1.0",
+        "type": "range"
+      },
+      "/Users/ogd/Documents/projects/npm/npm"
+    ]
+  ],
+  "_from": "fstream@>=1.0.10 <1.1.0",
+  "_id": "fstream@1.0.10",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/fstream",
+  "_nodeVersion": "4.4.5",
+  "_npmOperationalInternal": {
+    "host": "packages-16-east.internal.npmjs.com",
+    "tmp": "tmp/fstream-1.0.10.tgz_1466189553883_0.3062701092567295"
+  },
+  "_npmUser": {
+    "name": "othiym23",
+    "email": "ogd@aoaioxxysz.net"
+  },
+  "_npmVersion": "3.10.0",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "fstream@~1.0.10",
+    "scope": null,
+    "escapedName": "fstream",
+    "name": "fstream",
+    "rawSpec": "~1.0.10",
+    "spec": ">=1.0.10 <1.1.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/",
+    "/fstream-npm/fstream-ignore",
+    "/node-gyp",
+    "/tar"
+  ],
+  "_resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+  "_shasum": "604e8a92fe26ffd9f6fae30399d4984e1ab22822",
+  "_shrinkwrap": null,
+  "_spec": "fstream@~1.0.10",
+  "_where": "/Users/ogd/Documents/projects/npm/npm",
   "author": {
     "name": "Isaac Z. Schlueter",
     "email": "i@izs.me",
     "url": "http://blog.izs.me/"
   },
-  "name": "fstream",
-  "description": "Advanced file system stream things",
-  "version": "1.0.8",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/isaacs/fstream.git"
-  },
-  "main": "fstream.js",
-  "engines": {
-    "node": ">=0.6"
+  "bugs": {
+    "url": "https://github.com/npm/fstream/issues"
   },
   "dependencies": {
     "graceful-fs": "^4.1.2",
@@ -21,32 +64,23 @@
     "mkdirp": ">=0.5 0",
     "rimraf": "2"
   },
+  "description": "Advanced file system stream things",
   "devDependencies": {
     "standard": "^4.0.0",
     "tap": "^1.2.0"
   },
-  "scripts": {
-    "test": "standard && tap examples/*.js"
-  },
-  "license": "ISC",
-  "gitHead": "d9f81146c50e687f1df04c1a0e7e4c173eb3dae2",
-  "bugs": {
-    "url": "https://github.com/isaacs/fstream/issues"
-  },
-  "homepage": "https://github.com/isaacs/fstream#readme",
-  "_id": "fstream@1.0.8",
-  "_shasum": "7e8d7a73abb3647ef36e4b8a15ca801dba03d038",
-  "_from": "fstream@>=1.0.8 <1.1.0",
-  "_npmVersion": "2.14.3",
-  "_nodeVersion": "2.2.2",
-  "_npmUser": {
-    "name": "zkat",
-    "email": "kat@sykosomatic.org"
-  },
+  "directories": {},
   "dist": {
-    "shasum": "7e8d7a73abb3647ef36e4b8a15ca801dba03d038",
-    "tarball": "http://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+    "shasum": "604e8a92fe26ffd9f6fae30399d4984e1ab22822",
+    "tarball": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
   },
+  "engines": {
+    "node": ">=0.6"
+  },
+  "gitHead": "24fabdec32e334dd3b130d77b38c010e3119b102",
+  "homepage": "https://github.com/npm/fstream#readme",
+  "license": "ISC",
+  "main": "fstream.js",
   "maintainers": [
     {
       "name": "iarna",
@@ -65,7 +99,15 @@
       "email": "kat@sykosomatic.org"
     }
   ],
-  "directories": {},
-  "_resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-  "readme": "ERROR: No README data found!"
+  "name": "fstream",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/fstream.git"
+  },
+  "scripts": {
+    "test": "standard && tap examples/*.js"
+  },
+  "version": "1.0.10"
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "editor": "~1.0.0",
     "fs-vacuum": "~1.2.9",
     "fs-write-stream-atomic": "~1.0.8",
-    "fstream": "~1.0.8",
+    "fstream": "~1.0.10",
     "fstream-npm": "~1.1.0",
     "glob": "~7.0.4",
     "graceful-fs": "~4.1.4",

--- a/test/tap/full-warning-messages.js
+++ b/test/tap/full-warning-messages.js
@@ -3,7 +3,6 @@ var test = require('tap').test
 var path = require('path')
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
-var semver = require('semver')
 var fs = require('graceful-fs')
 var common = require('../common-tap')
 
@@ -94,12 +93,7 @@ test('tree-style', function (t) {
     t.match(stdout, /modA@1.0.0/, 'modA got installed')
     t.notMatch(stdout, /modB/, 'modB not installed')
     var stderrlines = stderr.trim().split(/\n/)
-    // https://github.com/npm/npm/pull/13077
-    if (semver.gte(process.version, '6.0.0')) {
-      t.is(stderrlines.length, 5)
-    } else {
-      t.is(stderrlines.length, 2, 'two lines of warnings')
-    }
+    t.is(stderrlines.length, 2, 'two lines of warnings')
     t.match(stderr, /Skipping failed optional dependency/, 'expected optional failure warning')
     t.match(stderr, /Not compatible with your operating system or architecture/, 'reason for optional failure')
     exists(t, modJoin(base, 'modA'), 'module A')

--- a/test/tap/pack-scoped.js
+++ b/test/tap/pack-scoped.js
@@ -5,7 +5,6 @@ var fs = require('graceful-fs')
 var join = require('path').join
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
-var semver = require('semver')
 
 var pkg = join(__dirname, 'scoped_package')
 var manifest = join(pkg, 'package.json')
@@ -67,12 +66,7 @@ test('test', function (t) {
   }, function (err, code, stdout, stderr) {
     t.ifErr(err, 'npm pack finished without error')
     t.equal(code, 0, 'npm pack exited ok')
-    // https://github.com/npm/npm/pull/13077
-    if (semver.gte(process.version, '6.0.0')) {
-      t.is(stderr.trim().split(/\n/).length, 3)
-    } else {
-      t.notOk(stderr, 'got stderr data: ' + JSON.stringify('' + stderr))
-    }
+    t.notOk(stderr, 'got stderr data: ' + JSON.stringify('' + stderr))
     stdout = stdout.trim()
     var regex = new RegExp('scope-generic-package-90000.100001.5.tgz', 'ig')
     t.ok(stdout.match(regex), 'found package')

--- a/test/tap/prepublish.js
+++ b/test/tap/prepublish.js
@@ -5,7 +5,6 @@ var fs = require('graceful-fs')
 var join = require('path').join
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
-var semver = require('semver')
 
 var pkg = join(__dirname, 'prepublish_package')
 var tmp = join(pkg, 'tmp')
@@ -60,12 +59,7 @@ test('test', function (t) {
     t.equal(code, 0, 'pack finished successfully')
     t.ifErr(err, 'pack finished successfully')
 
-    // https://github.com/npm/npm/pull/13077
-    if (semver.gte(process.version, '6.0.0')) {
-      t.is(stderr.trim().split(/\n/).length, 3)
-    } else {
-      t.notOk(stderr, 'got stderr data: ' + JSON.stringify('' + stderr))
-    }
+    t.notOk(stderr, 'got stderr data:' + JSON.stringify('' + stderr))
     var c = stdout.trim()
     var regex = new RegExp('' +
       '> npm-test-prepublish@1.2.5 prepublish [^\\r\\n]+\\r?\\n' +


### PR DESCRIPTION
This probably fixes 5082 enough to justify the removal of the warning, but it needs a complete green CI run and a bunch more poking before we can call it good. I've cleaned up the CI Node.js version matrix as part of this change because we want to do it anyway, and because I want to ensure that Travis and AppVeyor are testing the same things.

I'll create a separate PR for `npm@lts` due to the need to revert a different commit.

**r**: @iarna 
**r**: @zkat 
