### PR TITLE
Disable progress bar for `npm init` & `npm adduser`

### DIFF
--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -6,6 +6,7 @@ var read = require('read')
 var userValidate = require('npm-user-validate')
 var output = require('./utils/output')
 var usage = require('./utils/usage')
+var chain = require('slide').chain
 var crypto
 
 try {
@@ -31,15 +32,13 @@ function adduser (args, cb) {
     e: creds.email || ''
   }
   var u = {}
-  var fns = [readUsername, readPassword, readEmail, save]
 
-  loop()
-  function loop (er) {
-    if (er) return cb(er)
-    var fn = fns.shift()
-    if (fn) return fn(c, u, loop)
-    cb()
-  }
+  chain([
+    [readUsername, c, u],
+    [readPassword, c, u],
+    [readEmail, c, u],
+    [save, c, u]
+  ], cb)
 }
 
 function readUsername (c, u, cb) {

--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -33,6 +33,7 @@ function adduser (args, cb) {
   }
   var u = {}
 
+  log.disableProgress()
   chain([
     [readUsername, c, u],
     [readPassword, c, u],

--- a/lib/init.js
+++ b/lib/init.js
@@ -12,6 +12,7 @@ init.usage = 'npm init [--force|-f|--yes|-y]'
 function init (args, cb) {
   var dir = process.cwd()
   log.pause()
+  log.disableProgress()
   var initFile = npm.config.get('init-module')
   if (!initJson.yes(npm.config)) {
     output([


### PR DESCRIPTION
Displaying the progress bar during interactive commands results in the prompt be stomped.
