### PR TITLE
Issue #13113: Docs: link to `npm-tag` from cli docs on tag is 404

### DIFF
--- a/doc/cli/npm-tag.md
+++ b/doc/cli/npm-tag.md
@@ -57,5 +57,5 @@ that do not begin with a number or the letter `v`.
 * npm-registry(7)
 * npm-config(1)
 * npm-config(7)
-* npm-tag(3)
+* npm-dist-tag(1)
 * npmrc(5)


### PR DESCRIPTION
User @SimenB found a broken link. I think that the `npm-tag(3)` should actually be `npm-dist-tag(1)` in the see also section to link to the non-deprecated command.
