### PR TITLE
fix: nyc@7 places files in node_modules/.cache/* that should be excluded

### DIFF
--- a/test/tap/config-meta.js
+++ b/test/tap/config-meta.js
@@ -24,6 +24,7 @@ var exceptions = [
   path.resolve(nm, 'npm-registry-client', 'lib', 'publish.js'),
   path.resolve(nm, 'npm-registry-client', 'lib', 'request.js')
 ]
+var cacheFolder = path.resolve(nm, './.cache')
 
 test('get files', function (t) {
   walk(nm)
@@ -67,7 +68,7 @@ test('get lines', function (t) {
               line: i
             }
           }
-        } else if (exceptions.indexOf(f) === -1) {
+        } else if (exceptions.indexOf(f) === -1 && f.indexOf(cacheFolder) === -1) {
           t.fail('non-string-literal config used in ' + f + ':' + i)
         }
       })


### PR DESCRIPTION
## Background

nyc@7 is a major overhaul, as we move towards merging the nyc and Istanbul projects once and for all:

https://github.com/istanbuljs/nyc/pull/286

tldr; we've completely swapped out the instrumentation internals, so we might bump into a few more hiccups -- please open issues against nyc, and I'll get them fixed ASAP.
## The Problem

nyc caches instrumented source files in `node_modules/.cache`, the cached versions of modules that represent exceptions for the `config-meta.js` test cause problems, e.g., `config.js`.

I'm not sure why this didn't crop up in pre-7.x versions, we've been using this caching approach for quite some time (it might actually be that the instrumentation was silently failing).
## The Solution

Let's just ignore source files that fall inside of `node_modules/.cache`.
