### PR TITLE
Resolve local args relative to cwd

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -310,7 +310,7 @@ Installer.prototype.run = function (cb) {
 
 Installer.prototype.loadArgMetadata = function (next) {
   var self = this
-  getAllMetadata(this.args, this.currentTree, iferr(next, function (args) {
+  getAllMetadata(this.args, this.currentTree, process.cwd(), iferr(next, function (args) {
     self.args = args
     next()
   }))

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -212,12 +212,12 @@ function getShrinkwrap (tree, name) {
   return tree.package._shrinkwrap && tree.package._shrinkwrap.dependencies && tree.package._shrinkwrap.dependencies[name]
 }
 
-exports.getAllMetadata = function (args, tree, next) {
+exports.getAllMetadata = function (args, tree, where, next) {
   asyncMap(args, function (spec, done) {
     if (tree && spec.lastIndexOf('@') <= 0) {
       var sw = getShrinkwrap(tree, spec)
       if (sw) {
-        // FIXME: This is duplicated in inflate-shrinkwrap and should be factoed
+        // FIXME: This is duplicated in inflate-shrinkwrap and should be factored
         // into a shared function
         spec = sw.resolved
              ? spec + '@' + sw.resolved
@@ -231,7 +231,7 @@ exports.getAllMetadata = function (args, tree, next) {
         }
       }
     }
-    fetchPackageMetadata(spec, packageRelativePath(tree), done)
+    fetchPackageMetadata(spec, where, done)
   }, next)
 }
 

--- a/test/tap/local-args-relative-to-cwd.js
+++ b/test/tap/local-args-relative-to-cwd.js
@@ -1,0 +1,65 @@
+'use strict'
+var fs = require('graceful-fs')
+var path = require('path')
+var test = require('tap').test
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+var common = require('../common-tap.js')
+var testdir = path.join(__dirname, path.basename(__filename, '.js'))
+
+var fixture = new Tacks(
+  Dir({
+    example: Dir({
+    }),
+    mod1: Dir({
+      'package.json': File({
+        name: 'mod1',
+        version: '1.0.0'
+      })
+    }),
+    node_modules: Dir({
+    })
+  })
+)
+
+function setup () {
+  fixture.create(testdir)
+}
+
+function cleanup () {
+  fixture.remove(testdir)
+}
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+  t.end()
+})
+
+function exists (file) {
+  try {
+    fs.statSync(file)
+    return true
+  } catch (ex) {
+    return false
+  }
+}
+
+test('local-args-relative-to-cwd', function (t) {
+  var instdir = path.join(testdir, 'example')
+  var config = ['--loglevel=error']
+  common.npm(config.concat(['install', '../mod1']), {cwd: instdir}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.comment(stdout.trim())
+    t.comment(stderr.trim())
+    t.is(code, 0, 'install ran ok')
+    t.ok(exists(path.join(testdir, 'node_modules', 'mod1')), 'mod1 installed')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
When you run `npm install ../relative/path/to/module` it should be resolving that relative to your current directory.

This fixes a bug in npm@3 where it would resolve it relative to your package root, so if you were in a subdirectory it would mysteriously fail.
