### PR TITLE
test: tweaking git-races test to maybe work on appveyor

### DIFF
--- a/test/tap/git-races.js
+++ b/test/tap/git-races.js
@@ -44,7 +44,7 @@ bar#4.0.0 shouldn't have gotten its own copy if buzz, and if it did, it shouldn'
 */
 
 ;['bar', 'foo', 'buzz'].forEach(function (name) {
-  var mockurl = 'ssh://git@github.com/BryanDonovan/dummy-npm-' + name + '.git'
+  var mockurl = 'git://github.com/BryanDonovan/dummy-npm-' + name + '.git'
   var realrepo = path.resolve(wd, 'github-com-BryanDonovan-dummy-npm-' + name + '.git')
   var tgz = path.resolve(fixtures, 'github-com-BryanDonovan-dummy-npm-' + name + '.git.tar.gz')
 


### PR DESCRIPTION
This really shouldn't be going to the network like this
but I would need to take more time to carefully reproduce
this with local repositories.

It's really icky that we're relying on an external git repo
owned by someone else to pull this off.

The actual fix in this patch is just to bypass ssh key errors
that happen in AppVeyor. I'm not sure why Travis doesn't have
this issue, but that's probably because Travis does its own
ssh key business?

**r**: @othiym23 
