### PR TITLE
Fix error EXDEV: cross-device link not permitted (utils/rename.js)

### DIFF
--- a/lib/utils/rename.js
+++ b/lib/utils/rename.js
@@ -1,16 +1,86 @@
 'use strict'
 var fs = require('graceful-fs')
+var log = require('npmlog')
+var path = require('path')
 var SaveStack = require('./save-stack.js')
 
 module.exports = rename
 
 function rename (from, to, cb) {
   var saved = new SaveStack(rename)
-  fs.rename(from, to, function (er) {
-    if (er) {
-      return cb(saved.completeWith(er))
-    } else {
-      return cb()
+  fs.rename(from, to, function (renameErr) {
+    if (renameErr) {
+      try {
+        copyDir(from, to)
+        rmdir(from)
+      } catch (copyErr) {
+        log.silly('renameFail', 'Could not copy directory %s => %s: %s',
+          from, to, copyErr)
+        try {
+          rmdir(to)
+        } catch (cleanupErr) {
+          log.silly('cleanupFailedCopy', 'Could not cleanup partial copy %s: %s',
+            to, cleanupErr)
+        }
+        return cb(saved.completeWith(renameErr))
+      }
     }
+    return cb()
   })
+}
+
+function mkdir (dir) {
+  // making directory without exception if exists
+  try {
+    fs.mkdirSync(dir, '0755')
+  } catch (e) {
+    if (e.code !== 'EEXIST') {
+      throw e
+    }
+  }
+}
+
+function rmdir (dir) {
+  if (fs.existsSync(dir)) {
+    var list = fs.readdirSync(dir)
+    for (var i = 0; i < list.length; i++) {
+      var filename = path.join(dir, list[i])
+      var stat = fs.statSync(filename)
+
+      if (filename === '.' || filename === '..') {
+        // pass these files
+      } else if (stat.isDirectory()) {
+        // rmdir recursively
+        rmdir(filename)
+      } else {
+        // rm fiilename
+        fs.unlinkSync(filename)
+      }
+    }
+    fs.rmdirSync(dir)
+  } else {
+    log.silly('removeDir', 'Does not exist: %s', dir)
+  }
+}
+
+function copyDir (src, dest) {
+  mkdir(dest)
+  var files = fs.readdirSync(src)
+  for (var i = 0; i < files.length; i++) {
+    var current = fs.lstatSync(path.join(src, files[i]))
+    if (current.isDirectory()) {
+      copyDir(path.join(src, files[i]), path.join(dest, files[i]))
+    } else if (current.isSymbolicLink()) {
+      var symlink = fs.readlinkSync(path.join(src, files[i]))
+      fs.symlinkSync(symlink, path.join(dest, files[i]))
+    } else {
+      copy(path.join(src, files[i]), path.join(dest, files[i]))
+    }
+  }
+}
+
+function copy (src, dest) {
+  var oldFile = fs.createReadStream(src)
+  var newFile = fs.createWriteStream(dest)
+  oldFile.pipe(newFile)
 }


### PR DESCRIPTION
Fixes issue #9863

Copy and delete when `rename` fails.
A common problem when a node module is mounted on a different mount point, as in common Docker build caching mechanisms.

---

Edit:
In reference to PR #10805 -- the copy/remove action in this PR acts as a fallback that only occurs when `rename` fails, so only causes slowdown when absolutely necessary to fix the problem.
