### PR TITLE
Move execution of top level lifecycle scripts to install instead of postinstall

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -259,9 +259,9 @@ Installer.prototype.run = function (cb) {
     [this, this.debugActions, 'decomposeActions', 'todo'])
   if (!this.dryrun) {
     installSteps.push(
-      [this.newTracker(log, 'runTopLevelLifecycles', 2)],
-      [this, this.runTopLevelLifecycles],
-      [this, this.finishTracker, 'runTopLevelLifecycles'],
+      [this.newTracker(log, 'runPreinstallTopLevelLifecycles', 2)],
+      [this, this.runPreinstallTopLevelLifecycles],
+      [this, this.finishTracker, 'runPreinstallTopLevelLifecycles'],
 
       [this.newTracker(log, 'executeActions', 8)],
       [this, this.executeActions],
@@ -272,8 +272,11 @@ Installer.prototype.run = function (cb) {
       [this.newTracker(log, 'rollbackFailedOptional', 1)],
       [this, this.rollbackFailedOptional, staging, this.todo],
       [this, this.finishTracker, 'rollbackFailedOptional'],
-      [this, this.commit, staging, this.todo])
+      [this, this.commit, staging, this.todo],
 
+      [this.newTracker(log, 'runPostinstallTopLevelLifecycles', 2)],
+      [this, this.runPostinstallTopLevelLifecycles],
+      [this, this.finishTracker, 'runPostinstallTopLevelLifecycles'])
     if (getSaveType(this.args)) {
       postInstallSteps.push(
         [this, this.saveToDependencies])
@@ -521,29 +524,45 @@ Installer.prototype.commit = function (staging, actionsToRun, cb) {
   }, cb)
 }
 
-Installer.prototype.runTopLevelLifecycles = function (cb) {
+Installer.prototype.runPreinstallTopLevelLifecycles = function (cb) {
   validate('F', arguments)
   if (this.failing) return cb()
-  log.silly('install', 'runTopLevelLifecycles')
+  log.silly('install', 'runPreinstallTopLevelLifecycles')
   var steps = []
-  var trackLifecycle = this.progress.runTopLevelLifecycles
+  var trackPreinstallLifecycle = this.progress.runPreinstallTopLevelLifecycles
   if (!this.topLevelLifecycles) {
-    trackLifecycle.finish()
+    trackPreinstallLifecycle.finish()
     return cb()
   }
 
   steps.push(
-    [doOneAction, 'preinstall', this.idealTree.path, this.idealTree, trackLifecycle.newGroup('preinstall:.')],
-    [doOneAction, 'build', this.idealTree.path, this.idealTree, trackLifecycle.newGroup('build:.')],
-    [doOneAction, 'install', this.idealTree.path, this.idealTree, trackLifecycle.newGroup('install:.')],
-    [doOneAction, 'postinstall', this.idealTree.path, this.idealTree, trackLifecycle.newGroup('postinstall:.')])
+    [doOneAction, 'preinstall', this.idealTree.path, this.idealTree, trackPreinstallLifecycle.newGroup('preinstall:.')]
+  )
+  chain(steps, cb)
+}
+
+Installer.prototype.runPostinstallTopLevelLifecycles = function (cb) {
+  validate('F', arguments)
+  if (this.failing) return cb()
+  log.silly('install', 'runPostinstallTopLevelLifecycles')
+  var steps = []
+  var trackPostinstallLifecycle = this.progress.runPostinstallTopLevelLifecycles
+  if (!this.topLevelLifecycles) {
+    trackPostinstallLifecycle.finish()
+    return cb()
+  }
+
+  steps.push(
+    [doOneAction, 'build', this.idealTree.path, this.idealTree, trackPostinstallLifecycle.newGroup('build:.')],
+    [doOneAction, 'install', this.idealTree.path, this.idealTree, trackPostinstallLifecycle.newGroup('install:.')],
+    [doOneAction, 'postinstall', this.idealTree.path, this.idealTree, trackPostinstallLifecycle.newGroup('postinstall:.')])
   if (this.npat) {
     steps.push(
-      [doOneAction, 'test', this.idealTree.path, this.idealTree, trackLifecycle.newGroup('npat:.')])
+      [doOneAction, 'test', this.idealTree.path, this.idealTree, trackPostinstallLifecycle.newGroup('npat:.')])
   }
   if (this.dev) {
     steps.push(
-      [doOneAction, 'prepublish', this.idealTree.path, this.idealTree, trackLifecycle.newGroup('prepublish')])
+      [doOneAction, 'prepublish', this.idealTree.path, this.idealTree, trackPostinstallLifecycle.newGroup('prepublish')])
   }
   chain(steps, cb)
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -261,17 +261,17 @@ Installer.prototype.run = function (cb) {
     installSteps.push(
       [this.newTracker(log, 'executeActions', 8)],
       [this, this.executeActions],
-      [this, this.finishTracker, 'executeActions'])
+      [this, this.finishTracker, 'executeActions'],
+      [this.newTracker(log, 'runTopLevelLifecycles', 2)],
+      [this, this.runTopLevelLifecycles],
+      [this, this.finishTracker, 'runTopLevelLifecycles'])
     var node_modules = path.resolve(this.where, 'node_modules')
     var staging = path.resolve(node_modules, '.staging')
     postInstallSteps.push(
       [this.newTracker(log, 'rollbackFailedOptional', 1)],
       [this, this.rollbackFailedOptional, staging, this.todo],
       [this, this.finishTracker, 'rollbackFailedOptional'],
-      [this, this.commit, staging, this.todo],
-      [this.newTracker(log, 'runTopLevelLifecycles', 2)],
-      [this, this.runTopLevelLifecycles],
-      [this, this.finishTracker, 'runTopLevelLifecycles'])
+      [this, this.commit, staging, this.todo])
 
     if (getSaveType(this.args)) {
       postInstallSteps.push(

--- a/lib/install.js
+++ b/lib/install.js
@@ -259,12 +259,13 @@ Installer.prototype.run = function (cb) {
     [this, this.debugActions, 'decomposeActions', 'todo'])
   if (!this.dryrun) {
     installSteps.push(
-      [this.newTracker(log, 'executeActions', 8)],
-      [this, this.executeActions],
-      [this, this.finishTracker, 'executeActions'],
       [this.newTracker(log, 'runTopLevelLifecycles', 2)],
       [this, this.runTopLevelLifecycles],
-      [this, this.finishTracker, 'runTopLevelLifecycles'])
+      [this, this.finishTracker, 'runTopLevelLifecycles'],
+
+      [this.newTracker(log, 'executeActions', 8)],
+      [this, this.executeActions],
+      [this, this.finishTracker, 'executeActions'])
     var node_modules = path.resolve(this.where, 'node_modules')
     var staging = path.resolve(node_modules, '.staging')
     postInstallSteps.push(

--- a/test/tap/lifecycle-order.js
+++ b/test/tap/lifecycle-order.js
@@ -1,0 +1,65 @@
+var fs = require('graceful-fs')
+var path = require('path')
+var spawn = require('child_process').spawn
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var node = process.execPath
+var npm = require.resolve('../../bin/npm-cli.js')
+
+var pkg = path.resolve(__dirname, 'lifecycle-order')
+
+var json = {
+  name: 'lifecycle-order',
+  version: '1.0.0',
+  scripts: {
+    preinstall: 'node -e "var fs = require(\'fs\'); fs.openSync(\'preinstall-step\', \'w+\'); if (fs.existsSync(\'node_modules\')) { throw \'node_modules exists on preinstall\' }"',
+    install: 'node -e "var fs = require(\'fs\'); if (fs.existsSync(\'preinstall-step\')) { fs.openSync(\'install-step\', \'w+\') } else { throw \'Out of order\' }"',
+    postinstall: 'node -e "var fs = require(\'fs\'); if (fs.existsSync(\'install-step\')) { fs.openSync(\'postinstall-step\', \'w+\') } else { throw \'Out of order\' }"'
+  }
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+
+  process.chdir(pkg)
+  t.end()
+})
+
+test('lifecycle scripts execute in the proper order', function (t) {
+  var child = spawn(node, [npm, 'install'], {
+    cwd: pkg
+  })
+
+  // Ensure files exist for lifecycle runs
+  // If code is 1 and/or all three files do not exist
+  // Then lifecycle scripts are not executed in proper order
+  child.on('close', function (code, signal) {
+    t.equal(code, 0);
+
+    // All three files should exist
+    t.equal(fs.existsSync(path.join(pkg, 'preinstall-step')), true)
+    t.equal(fs.existsSync(path.join(pkg, 'install-step')), true)
+    t.equal(fs.existsSync(path.join(pkg, 'postinstall-step')), true)
+
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}

--- a/test/tap/lifecycle-order.js
+++ b/test/tap/lifecycle-order.js
@@ -43,7 +43,7 @@ test('lifecycle scripts execute in the proper order', function (t) {
   // If code is 1 and/or all three files do not exist
   // Then lifecycle scripts are not executed in proper order
   child.on('close', function (code, signal) {
-    t.equal(code, 0);
+    t.equal(code, 0)
 
     // All three files should exist
     t.equal(fs.existsSync(path.join(pkg, 'preinstall-step')), true)


### PR DESCRIPTION
This appears to fix https://github.com/npm/npm/issues/10379

Could use some further testing.
