### PR TITLE
Disable progress bar for `npm edit` and `npm config edit`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -106,6 +106,7 @@ function edit (cb) {
         data,
         function (er) {
           if (er) return cb(er)
+          log.disableProgress()
           editor(f, { editor: e }, cb)
         }
       )

--- a/lib/edit.js
+++ b/lib/edit.js
@@ -6,6 +6,7 @@ edit.usage = 'npm edit <pkg>[@<version>]'
 
 edit.completion = require('./utils/completion/installed-shallow.js')
 
+var log = require('npmlog')
 var npm = require('./npm.js')
 var path = require('path')
 var fs = require('graceful-fs')
@@ -26,6 +27,7 @@ function edit (args, cb) {
   var f = path.resolve(npm.dir, p)
   fs.lstat(f, function (er) {
     if (er) return cb(er)
+    log.disableProgress()
     editor(f, { editor: e }, function (er) {
       if (er) return cb(er)
       npm.commands.rebuild(args, cb)


### PR DESCRIPTION
Fixes https://github.com/npm/npm/issues/13290 and the similar issue. In v3.10.x, the progress bar is shown inside editor during `npm config edit` and `npm edit`. This kind of issues are fixed by just disabling it: https://github.com/npm/npm/pull/13117, so I added a line into the files.

Thanks!
