### PR TITLE
Run cache/add-local's install prune and pack in a child process

### DIFF
--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -23,13 +23,9 @@
 
   var path = require('path')
   var npm = require('../lib/npm.js')
-  var npmconf = require('../lib/config/core.js')
   var errorHandler = require('../lib/utils/error-handler.js')
 
-  var configDefs = npmconf.defs
-  var shorthands = configDefs.shorthands
-  var types = configDefs.types
-  var nopt = require('nopt')
+  var buildConf = require('../lib/utils/build-conf.js')
 
   // if npm is called as "npmg" or "npm_g", then
   // run in global mode.
@@ -39,7 +35,7 @@
 
   log.verbose('cli', process.argv)
 
-  var conf = nopt(types, shorthands)
+  var conf = buildConf()
   npm.argv = conf.argv.remain
   if (npm.deref(npm.argv[0])) npm.command = npm.argv.shift()
   else conf.usage = true

--- a/lib/cache/add-local-fork.js
+++ b/lib/cache/add-local-fork.js
@@ -30,8 +30,15 @@ process.once('message', function onMessage (message) {
   }
 
   function cb (er) {
+    var error = undefined
+    if (er instanceof Error && er.stack) {
+      error = er.stack + '\n From fork child, ' +
+        String(er.message).replace(/\n/g, '\n ')
+    } else if (er) {
+      error = String(er)
+    }
     process.send({
-      error: er
+      error: error
     })
     setTimeout(function () {
       process.exit(0)

--- a/lib/cache/add-local-fork.js
+++ b/lib/cache/add-local-fork.js
@@ -1,0 +1,40 @@
+var log = require('npmlog')
+var iferr = require('iferr')
+
+process.once('message', function onMessage (message) {
+  var tgz = message.tgz
+  var p = message.p
+
+  var npm = require('../npm.js')
+  var buildConf = require('../utils/build-conf.js')
+  npm.load(buildConf(), iferr(cb, thenInstall))
+
+  function thenInstall () {
+    var install = require('../install.js')
+    install([], iferr(cb, thenPrune))
+  }
+
+  function thenPrune () {
+    var prune = require('../prune.js')
+    prune([], iferr(cb, thenPack))
+  }
+
+  function thenPack () {
+    var tar = require('../utils/tar.js')
+    tar.pack(tgz, p, undefined, function (er) {
+      if (er) {
+        log.error('addLocalDirectory', 'Could not pack', p, 'to', tgz)
+      }
+      cb(er)
+    })
+  }
+
+  function cb (er) {
+    process.send({
+      error: er
+    })
+    setTimeout(function () {
+      process.exit(0)
+    })
+  }
+})

--- a/lib/cache/add-local.js
+++ b/lib/cache/add-local.js
@@ -6,15 +6,13 @@ var pathIsInside = require('path-is-inside')
 var readJson = require('read-package-json')
 var log = require('npmlog')
 var npm = require('../npm.js')
-var tar = require('../utils/tar.js')
 var deprCheck = require('../utils/depr-check.js')
 var getCacheStat = require('./get-stat.js')
 var cachedPackageRoot = require('./cached-package-root.js')
 var addLocalTarball = require('./add-local-tarball.js')
 var sha = require('sha')
 var inflight = require('inflight')
-var lifecycle = require('../utils/lifecycle.js')
-var iferr = require('iferr')
+var fork = require('child_process').fork
 
 module.exports = addLocal
 
@@ -54,7 +52,7 @@ function addLocalDirectory (p, pkgData, shasum, cb) {
   // tar it to the proper place, and add the cache tar
   if (pathIsInside(p, npm.cache)) {
     return cb(new Error(
-    'Adding a cache directory to the cache will make the world implode.'
+      'Adding a cache directory to the cache will make the world implode.'
     ))
   }
 
@@ -74,7 +72,7 @@ function addLocalDirectory (p, pkgData, shasum, cb) {
     } else if (pkgData.version && pkgData.version !== data.version) {
       return cb(new Error(
         'Invalid package: expected ' + pkgData.name + '@' + pkgData.version +
-          ' but found ' + data.name + '@' + data.version
+        ' but found ' + data.name + '@' + data.version
       ))
     }
 
@@ -92,25 +90,37 @@ function addLocalDirectory (p, pkgData, shasum, cb) {
     getCacheStat(function (er, cs) {
       mkdir(path.dirname(pj), function (er, made) {
         if (er) return wrapped(er)
-        var doPrePublish = !pathIsInside(p, npm.tmp)
-        if (doPrePublish) {
-          lifecycle(data, 'prepublish', p, iferr(wrapped, thenPack))
-        } else {
-          thenPack()
+
+        var child = fork(require.resolve('./add-local-fork.js'), [], {
+          cwd: p
+        })
+        child.on('error', onChildError)
+        child.on('message', onChildMessage)
+        child.send({
+          tgz: tgz,
+          p: p
+        })
+
+        function onChildError (er) {
+          childCallback(er)
         }
-        function thenPack () {
-          tar.pack(tgz, p, data, function (er) {
-            if (er) {
-              log.error('addLocalDirectory', 'Could not pack', p, 'to', tgz)
-              return wrapped(er)
-            }
 
-            if (!cs || isNaN(cs.uid) || isNaN(cs.gid)) return wrapped()
+        function onChildMessage (message) {
+          childCallback(message.error)
+        }
 
-            chownr(made || tgz, cs.uid, cs.gid, function (er) {
-              if (er && er.code === 'ENOENT') return wrapped()
-              wrapped(er)
-            })
+        function childCallback (er) {
+          child.removeListener('error', onChildError)
+          child.removeListener('message', onChildMessage)
+          if (er) {
+            return wrapped(er)
+          }
+
+          if (!cs || isNaN(cs.uid) || isNaN(cs.gid)) return wrapped()
+
+          chownr(made || tgz, cs.uid, cs.gid, function (er) {
+            if (er && er.code === 'ENOENT') return wrapped()
+            wrapped(er)
           })
         }
       })

--- a/lib/cache/add-local.js
+++ b/lib/cache/add-local.js
@@ -106,7 +106,7 @@ function addLocalDirectory (p, pkgData, shasum, cb) {
         }
 
         function onChildMessage (message) {
-          childCallback(message.error)
+          childCallback(message.error ? new Error(message.error) : undefined)
         }
 
         function childCallback (er) {

--- a/lib/utils/build-conf.js
+++ b/lib/utils/build-conf.js
@@ -1,0 +1,10 @@
+module.exports = function () {
+  var npmconf = require('../config/core.js')
+
+  var configDefs = npmconf.defs
+  var shorthands = configDefs.shorthands
+  var types = configDefs.types
+  var nopt = require('nopt')
+
+  return nopt(types, shorthands)
+}


### PR DESCRIPTION
This PR make `add-local` tasks "install, prune, pack" to be run in a child process.

This PR should probably not be merged as it is now, a few questions remain.

The changes are heavily inspired by #8725. It should be a good step to build modules from git/local without polluting node_modules in global and/or production mode (see #3055).

I've tested it (inspired by #7040) with the following files:
- `./package.json`
  
  ```
  {
    "name": "npm-issue-local-dependency-prepublish",
    "version": "0.0.0",
    "dependencies": {
      "local-pkg": "file:local-pkg"
    }
  }
  ```
- `./local-pkg/package.json`
  
  ```
  {
    "name": "local-pkg",
    "version": "1.0.0",
    "scripts": {
      "prepublish": "npm config get cache-lock-retries > npmconfig && tap --version > tapversion"
    },
    "devDependencies": {
      "tap": "^0.4.13"
    }
  }
  ```
- `./local-pkg/.npmrc`
  
  ```
  cache-lock-retries = 9
  ```

I've tested with `../npm/bin/npm-cli.js i` and `../npm/bin/npm-cli.js i --production` and `../npm/bin/npm-cli.js -g i`. Also a test with `"git+file:///f/Dev/some-module#master"` (on Windows)

The benefits of this implementation: don't have unwanted arguments when running install/prune/pack (in fact it'll be easy to chose what arguments and env variables to transmit), also take into consideration any .npmrc in the built module

Remaining questions:
- What arguments should be forwarded to the child process?
- What environment variables should be forwarded to the child process?
- How to configure if install or prune should be executed?
  It may make sense not to execute them for a local directory, and to be able to configure that in the .npmrc
- Add some test / doc in the PR?

Hope this will help, waiting for feedbacks.
