### PR TITLE
readme: remove 0.8 from readme as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Much more info available via `npm help` once it's installed.
 
 ## IMPORTANT
 
-**You need node v0.8 or higher to run this program.**
+**You need node v0.10 or higher to run this program.**
 
 To install an old **and unsupported** version of npm that works on node 0.3
 and prior, clone the git repo and dig through the old tags and branches.


### PR DESCRIPTION
v0.8 support was removed since [this commit](https://github.com/npm/npm/commit/d6afd5ffb1b19e5d94aeee666afcb8adaced58db).
