### PR TITLE
Fix map-to-registry test when having custom npm config

### DIFF
--- a/test/fixtures/clean-process-env.js
+++ b/test/fixtures/clean-process-env.js
@@ -1,0 +1,8 @@
+// `npm run tap` dumps a ton of npm_config_* variables in the environment.
+Object.keys(process.env)
+  .filter(function (key) {
+    return /^npm_config_/.test(key)
+  })
+  .forEach(function (key) {
+    delete process.env[key]
+  })

--- a/test/tap/map-to-registry.js
+++ b/test/tap/map-to-registry.js
@@ -1,3 +1,4 @@
+require('../fixtures/clean-process-env.js')
 var test = require('tap').test
 var npm = require('../../')
 


### PR DESCRIPTION
Discovered while working on #13316

When running `npm run tap` something dumps all the npm config in the environment variables, messing with the `map-to-registry.js` test

To reproduce, have a `registry` set in `~/.npmrc`, then run `npm run tap -- test/tap/map-to-registry.js`

This PR fixes the test and provides an utility file in case other tests have the same issue later.
