### PR TITLE
Make fake package `@test/whoops` packagable in test `gently-rm-overeager`

### DIFF
--- a/test/tap/gently-rm-overeager.js
+++ b/test/tap/gently-rm-overeager.js
@@ -15,9 +15,18 @@ var fixture = {
   name: '@test/whoops',
   version: '1.0.0',
   scripts: {
-    postinstall: 'echo \'nope\' && exit 1'
+    postinstall: 'echo \'nope\' && node failinstall.js'
   }
 }
+
+var failscript = [
+  '#!/usr/bin/env node',
+  '"use strict"',
+  'var path = require("path")',
+  'var test = "node_modules" + path.sep + "@test" + path.sep + "whoops"',
+  'console.log(__dirname, test)',
+  'process.exit(__dirname.indexOf(test)>=0 ? 1 : 0)'
+].join('\n')
 
 test('setup', function (t) {
   cleanup()
@@ -56,4 +65,5 @@ function setup () {
   mkdirp.sync(resolve(pkg, 'node_modules'))
   mkdirp.sync(dep)
   fs.writeFileSync(resolve(dep, 'package.json'), JSON.stringify(fixture))
+  fs.writeFileSync(resolve(dep, 'failinstall.js'), failscript)
 }


### PR DESCRIPTION
Discovered while working on #13316

In the test `gently-rm-overeager.js`, the package `@test/whoops` is expected to fail in postinstall when installed as a dependency.
Currently it also fails when installed for development, packaging or publishing. (That's why the test fails on my other PR)

This PR changes the test so that the package `@test/whoops` is packageable/publishable, but still fails when installed as a dependency.

By the way, when I was trying to figure out how this test works, I had cases where the `node_modules` or `node_modules/.bin` where not removed (rollback) after the installation of `@test/whoops` failed. Don't know if it was me messing with the code or an actual issue.
