### PR TITLE
Do not overwrite TMPDIR

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -2,6 +2,7 @@ exports = module.exports = lifecycle
 exports.cmd = cmd
 exports.makeEnv = makeEnv
 exports._incorrectWorkingDirectory = _incorrectWorkingDirectory
+exports._getTemporaryDirectory = _getTemporaryDirectory
 
 var log = require('npmlog')
 var spawn = require('./spawn')
@@ -75,16 +76,36 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
     env.npm_node_execpath = env.NODE = env.NODE || process.execPath
     env.npm_execpath = require.main.filename
 
-    // 'nobody' typically doesn't have permission to write to /tmp
-    // even if it's never used, sh freaks out.
-    if (!npm.config.get('unsafe-perm')) env.TMPDIR = wd
+    _getTemporaryDirectory(wd, process.env, function (er, tmpdir) {
+      if (er) return cb(er)
 
-    lifecycle_(pkg, stage, wd, env, unsafe, failOk, cb)
+      env.TMPDIR = tmpdir
+      lifecycle_(pkg, stage, wd, env, unsafe, failOk, cb)
+    })
   })
 }
 
 function _incorrectWorkingDirectory (wd, pkg) {
   return wd.lastIndexOf(pkg.name) !== wd.length - pkg.name.length
+}
+
+function _getTemporaryDirectory (wd, env, cb) {
+  if (_isWritable(env.TMPDIR)) return cb(null, env.TMPDIR)
+
+  // 'nobody' typically doesn't have permission to write to /tmp
+  // even if it's never used, sh freaks out.
+  if (_isWritable(wd)) return cb(null, wd)
+
+  cb(new Error('Cannot find writable TMPDIR, please set TMPDIR to something writable'))
+}
+
+function _isWritable (dir) {
+  try {
+    fs.accessSync(dir, fs.W_OK)
+    return true
+  } catch (e) {
+    return false
+  }
 }
 
 function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {

--- a/test/tap/lifecycle.js
+++ b/test/tap/lifecycle.js
@@ -42,3 +42,30 @@ test('lifecycle : rejects wd for ', function (t) {
     t.end()
   })
 })
+
+test('lifecycle : accepts TMPDIR that is writable', function (t) {
+  var wd = '/opt/my-time/node_modules/time'
+
+  lifecycle._getTemporaryDirectory(wd, process.env, function (er, tmpdir) {
+    t.equal(tmpdir, process.env.TMPDIR)
+    t.end()
+  })
+})
+
+test('lifecycle : uses wd if TMPDIR is not writable', function (t) {
+  var wd = process.cwd()
+
+  lifecycle._getTemporaryDirectory(wd, {TMPDIR: '/probably/not/writable'}, function (er, tmpdir) {
+    t.equal(tmpdir, wd)
+    t.end()
+  })
+})
+
+test('lifecycle : errors if neither TMPDIR or wd are writable', function (t) {
+  var wd = '/probably/not/writable/either'
+
+  lifecycle._getTemporaryDirectory(wd, {TMPDIR: '/probably/not/writable'}, function (er, tmpdir) {
+    t.ok(er, 'non-writable-directories tmpdir should produce an error')
+    t.end()
+  })
+})


### PR DESCRIPTION
Fixes #13325 

Maybe a check for 'nobody' would be more appropriate, I don't know, but this existing behavior is surprising and causes mysterious/confusing problems. 
