### PR TITLE
addRemoteTarball: extract package metadata without writing to disk

### DIFF
--- a/lib/cache/add-local-tarball.js
+++ b/lib/cache/add-local-tarball.js
@@ -14,8 +14,6 @@ var chownr = require('chownr')
 var inflight = require('inflight')
 var once = require('once')
 var writeStreamAtomic = require('fs-write-stream-atomic')
-var tempFilename = require('../utils/temp-filename.js')
-var rimraf = require('rimraf')
 var packageId = require('../utils/package-id.js')
 
 module.exports = addLocalTarball
@@ -109,33 +107,30 @@ function addTmpTarball (tgz, pkgData, shasum, cb) {
   // NOTE: we might not have any clue what we think it is, for example if the
   // user just did `npm install ./foo.tgz`
 
-  var target = tempFilename('unpack')
   getCacheStat(function (er, cs) {
     if (er) return cb(er)
 
     log.verbose('addTmpTarball', 'validating metadata from', tgz)
-    tar.unpack(tgz, target, null, null, cs.uid, cs.gid, function (unpackEr, data) {
-      // cleanup the extracted package and move on with the metadata
-      rimraf(target, function () {
-        if (unpackEr) return cb(unpackEr)
-        // check that this is what we expected.
-        if (!data.name) {
-          return cb(new Error('No name provided'))
-        } else if (pkgData.name && data.name !== pkgData.name) {
-          return cb(new Error('Invalid Package: expected ' + pkgData.name +
-                              ' but found ' + data.name))
-        }
+    tar.getPackageMetadata(tgz, function (unpackEr, data) {
+      log.silly('getPackageMetadata', tgz)
+      if (unpackEr) return cb(unpackEr)
+      // check that this is what we expected.
+      if (!data.name) {
+        return cb(new Error('No name provided'))
+      } else if (pkgData.name && data.name !== pkgData.name) {
+        return cb(new Error('Invalid Package: expected ' + pkgData.name +
+                            ' but found ' + data.name))
+      }
 
-        if (!data.version) {
-          return cb(new Error('No version provided'))
-        } else if (pkgData.version && data.version !== pkgData.version) {
-          return cb(new Error('Invalid Package: expected ' +
-                              packageId(pkgData) +
-                              ' but found ' + packageId(data)))
-        }
+      if (!data.version) {
+        return cb(new Error('No version provided'))
+      } else if (pkgData.version && data.version !== pkgData.version) {
+        return cb(new Error('Invalid Package: expected ' +
+                            packageId(pkgData) +
+                            ' but found ' + packageId(data)))
+      }
 
-        addTmpTarball_(tgz, data, shasum, cb)
-      })
+      addTmpTarball_(tgz, data, shasum, cb)
     })
   })
 }

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -255,6 +255,39 @@ function unpack_ (tarball, unpackTarget, dMode, fMode, uid, gid, cb) {
   })
 }
 
+exports.getPackageMetadata = function getPackageMetadata (tarball, cb) {
+  log.silly('getPackageMetadata', tarball)
+  var fst = fs.createReadStream(tarball)
+
+  var found = false
+  var unzip = zlib.Unzip()
+  var untar = tar.Parse()
+  fst.pipe(unzip)
+    .on('error', function (er) {
+      if (er) log.error('tar.getPackageMetadata', 'unzip error ' + tarball)
+      cb(er)
+    })
+    .pipe(untar)
+    .on('entry', function (entry) {
+      if (!entry.props.path.match(/^[^\/]+\/package.json$/)) {
+        return
+      }
+      var content = ''
+      found = true
+      entry.on('data', function (data) {
+        content += data.toString()
+      })
+      entry.on('end', function () {
+        fst.close()
+        cb(null, JSON.parse(content))
+      })
+      entry.resume()
+    })
+    .on('end', function () {
+      if (!found) cb(null, null)
+    })
+}
+
 function gunzTarPerm (tarball, target, dMode, fMode, uid, gid, cb_) {
   if (!dMode) dMode = npm.modes.exec
   if (!fMode) fMode = npm.modes.file


### PR DESCRIPTION
One of the slowest parts of installing from a shrinkwrap is that `addLocalTarball` must validate the contents before it's added to the package cache ([here](https://github.com/npm/npm/blob/master/lib/cache/add-local-tarball.js#L105-L141)).

How much validation do we need? If it is enough simply to extract the `package.json` file and check the name, then we could stop extracting after `package.json` is extracted - since the tarballs are optimised to include this file first. We can also extract directly to memory to avoid the disk I/O.

I tried implementing this to see what the effect would be:

Timing on `master` for an application with a lot of dependencies on an SSD:

`node ~/src/npm/bin/npm-cli.js install --ignore-scripts  89.43s user 32.43s system 133% cpu 1:30.97 total`

timing on this branch:

`node ~/src/npm/bin/npm-cli.js install --ignore-scripts  63.44s user 19.56s system 128% cpu 1:04.34 total`

While a 30% speed-up is significant, there are _implicit_ validations that occur with the current method.
1. The whole file is extracted so we can be sure it's a valid tarball.
2. Loading the package metadata is more than just loading the JSON data (the README is inlined, etc.)
