### PR TITLE
Add shasum to shrinkwrap for use during install

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -225,16 +225,22 @@ function clean (args, cb) {
 // npm cache add <tarball>
 // npm cache add <folder>
 cache.add = function (pkg, ver, where, scrub, cb) {
+  addWithShaCheck(pkg, ver, where, scrub, null, cb)
+}
+
+cache.addWithShaCheck = addWithShaCheck
+
+function addWithShaCheck (pkg, ver, where, scrub, shasum, cb) {
   assert(typeof pkg === 'string', 'must include name of package to install')
   assert(typeof cb === 'function', 'must include callback')
 
   if (scrub) {
     return clean([], function (er) {
       if (er) return cb(er)
-      add([pkg, ver], where, cb)
+      add([pkg, ver, shasum], where, cb)
     })
   }
-  return add([pkg, ver], where, cb)
+  add([pkg, ver, shasum], where, cb)
 }
 
 var adding = 0
@@ -250,20 +256,26 @@ function add (args, where, cb) {
   // that just a single argument.
 
   var usage = 'Usage:\n' +
-              '    npm cache add <tarball-url>\n' +
+              '    npm cache add <tarball-url> [shasum]\n' +
               '    npm cache add <pkg>@<ver>\n' +
               '    npm cache add <tarball>\n' +
               '    npm cache add <folder>\n'
-  var spec
-
+  var spec, shasum
   log.silly('cache add', 'args', args)
 
   if (args[1] === undefined) args[1] = null
-
+  if (args.length === 3) {
+    shasum = args[2]
+  } else {
+    if (args[0].indexOf('@') && args[1] !== null) {
+      shasum = args[1]
+      args[1] = null
+    }
+  }
   // at this point the args length must ==2
   if (args[1] !== null) {
     spec = args[0] + '@' + args[1]
-  } else if (args.length === 2) {
+  } else {
     spec = args[0]
   }
 
@@ -288,8 +300,7 @@ function add (args, where, cb) {
         // get auth, if possible
         mapToRegistry(p.raw, npm.config, function (err, uri, auth) {
           if (err) return cb(err)
-
-          addRemoteTarball(p.spec, { name: p.name }, null, auth, cb)
+          addRemoteTarball(p.spec, { name: p.name }, shasum, auth, cb)
         })
         break
       case 'git':

--- a/lib/cache/add-remote-tarball.js
+++ b/lib/cache/add-remote-tarball.js
@@ -12,6 +12,29 @@ var addLocalTarball = require('./add-local-tarball.js')
 var cacheFile = require('npm-cache-filename')
 var rimraf = require('rimraf')
 var pulseTillDone = require('../utils/pulse-till-done.js')
+var fs = require('graceful-fs')
+
+function findInCache (pkgData, shasum, cb) {
+  if (!pkgData.name || !shasum) return cb()
+
+  var packageVersionsPath = path.resolve(npm.cache, pkgData.name)
+  try {
+    var versionPaths = fs.readdirSync(packageVersionsPath)
+
+    for (var i = 0; i < versionPaths.length; i++) {
+      var versionPath = path.resolve(packageVersionsPath, versionPaths[i])
+      var pkgJson = path.join(versionPath, 'package', 'package.json')
+      var versionData = JSON.parse(fs.readFileSync(pkgJson, 'utf-8'))
+      if (shasum === versionData._shasum) {
+        var pkgtgz = path.join(versionPath, 'package.tgz')
+        return cb(null, pkgtgz, versionData)
+      }
+    }
+  } catch (e) {
+    if (e.code !== 'ENOENT') return cb(e)
+  }
+  cb()
+}
 
 module.exports = addRemoteTarball
 
@@ -32,25 +55,33 @@ function addRemoteTarball (u, pkgData, shasum, auth, cb_) {
   if (!cb_) return log.verbose('addRemoteTarball', u, 'already in flight; waiting')
   log.verbose('addRemoteTarball', u, 'not in flight; adding')
 
-  // XXX Fetch direct to cache location, store tarballs under
-  // ${cache}/registry.npmjs.org/pkg/-/pkg-1.2.3.tgz
-  var tmp = cacheFile(npm.tmp, u)
+  findInCache(pkgData, shasum, function (err, cachedTarballPath, pkgData) {
+    if (err) return cb(err)
+    if (cachedTarballPath) {
+      log.silly('addRemoteTarball', u, 'found in cache', cachedTarballPath)
+      return addLocalTarball(cachedTarballPath, pkgData, shasum, cb)
+    }
 
-  function next (er, resp, shasum) {
-    if (er) return cb(er)
-    addLocalTarball(tmp, pkgData, shasum, cleanup)
-  }
-  function cleanup (er, data) {
-    if (er) return cb(er)
-    rimraf(tmp, function () {
-      cb(er, data)
+    // XXX Fetch direct to cache location, store tarballs under
+    // ${cache}/registry.npmjs.org/pkg/-/pkg-1.2.3.tgz
+    var tmp = cacheFile(npm.tmp, u)
+
+    function next (er, resp, shasum) {
+      if (er) return cb(er)
+      addLocalTarball(tmp, pkgData, shasum, cleanup)
+    }
+    function cleanup (er, data) {
+      if (er) return cb(er)
+      rimraf(tmp, function () {
+        cb(er, data)
+      })
+    }
+
+    log.verbose('addRemoteTarball', [u, shasum])
+    mkdir(path.dirname(tmp), function (er) {
+      if (er) return cb(er)
+      addRemoteTarball_(u, tmp, shasum, auth, next)
     })
-  }
-
-  log.verbose('addRemoteTarball', [u, shasum])
-  mkdir(path.dirname(tmp), function (er) {
-    if (er) return cb(er)
-    addRemoteTarball_(u, tmp, shasum, auth, next)
   })
 }
 

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -89,7 +89,7 @@ var annotateMetadata = module.exports.annotateMetadata = function (pkg, requeste
 function fetchOtherPackageData (spec, dep, where, next) {
   validate('SOSF', arguments)
   log.silly('fetchOtherPackageData', spec)
-  cache.add(spec, null, where, false, iferr(next, function (pkg) {
+  cache.addWithShaCheck(spec, null, where, false, dep._shasum, iferr(next, function (pkg) {
     var result = clone(pkg)
     result._inCache = true
     next(null, result)
@@ -184,7 +184,7 @@ function fetchNamedPackageData (dep, next) {
 
 function retryWithCached (pkg, asserter, next) {
   if (!pkg._inCache) {
-    cache.add(pkg._spec, null, pkg._where, false, iferr(next, function (newpkg) {
+    cache.addWithShaCheck(pkg._spec, null, pkg._where, false, pkg._shasum, iferr(next, function (newpkg) {
       Object.keys(newpkg).forEach(function (key) {
         if (key[0] !== '_') return
         pkg[key] = newpkg[key]

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -40,11 +40,13 @@ function inflateShrinkwrap (topPath, tree, swdeps, finishInflating) {
                     (!isRegistrySpecifier(requested) && child.package._from === sw.from) ||
                     child.package.version === sw.version)) {
         if (!child.fromShrinkwrap) child.fromShrinkwrap = requested.raw
+        child._shasum = sw._shasum
         tree.children.push(child)
         annotateMetadata(child.package, requested, requested.raw, topPath)
         return inflateShrinkwrap(topPath, child, dependencies || {}, next)
       } else {
         var from = sw.from || requested.raw
+        requested._shasum = sw.shasum
         return fetchPackageMetadata(requested, topPath, iferr(next, andAddShrinkwrap(from, dependencies, next)))
       }
     }

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -106,6 +106,7 @@ function shrinkwrapDeps (dev, problems, deps, tree, seen) {
     pkginfo.version = child.package.version
     pkginfo.from = child.package._from
     pkginfo.resolved = child.package._resolved
+    pkginfo.shasum = child.package._shasum
     if (isExtraneous(child)) {
       problems.push('extraneous: ' + child.package._id + ' ' + child.path)
     }


### PR DESCRIPTION
Optionally including a shasum when adding a package via a URL also allow us to look up packages in the local cache, and validate when adding packages to the cache using only a URL, e.g.

``` bash
npm cache add https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz 7c1d16d679a1bbe59ca02cacecfb011e201f5a1f
```

``` bash
npm cache add https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz 789
pm ERR! Darwin 15.5.0
npm ERR! argv "/Users/adam/.nvm/versions/node/v5.10.1/bin/node" "/Users/adam/src/npm/bin/npm-cli.js" "cache" "add" "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz" "789"
npm ERR! node v5.10.1
npm ERR! npm  v3.10.6

npm ERR! shasum check failed for /var/folders/g7/8qlj4bk90lg637c449yjg6mr0000gq/T/npm-19243-30cdcc1b/registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz
npm ERR! Expected: 789
npm ERR! Actual:   7c1d16d679a1bbe59ca02cacecfb011e201f5a1f
npm ERR! From:     https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     .../npm-debug.log

```

This speeds up shrinkwrap installs quite a lot when the package is locally cached because the package's contents don't have to be validated if the shasum matches the one that's supplied from the shrinkwrap. It also gives us more confidence that the contents of the packages that we are installing are exactly as we expect.

e.g.

``` bash
time node ~/src/npm/bin/npm-cli.js install --ignore-scripts
node ~/src/npm/bin/npm-cli.js install --ignore-scripts  88.82s user 32.35s system 132% cpu 1:31.50 total

node ~/src/npm/bin/npm-cli.js shrinkwrap --dev
rm -rf node_modules

time node ~/src/npm/bin/npm-cli.js install --ignore-scripts
node ~/src/npm/bin/npm-cli.js install --ignore-scripts  55.17s user 15.99s system 125% cpu 56.762 total
```

This PR is illustrative. There are no tests. The cache lookup is synchronous, and could be improved by keeping a `sha => directory` index in the cache somewhere. I'm sure there are also better ways to pass the shasum around.
