### PR TITLE
run-script: Add option to ignore the current node executable for PATH

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -42,7 +42,8 @@ instead of `"scripts": {"test": "node_modules/.bin/tap test/\*.js"}` to run your
 
 `npm run` sets the `NODE` environment variable to the `node` executable with
 which `npm` is executed. Also, the directory within which it resides is added to the
-`PATH`, if the `node` executable is not in the `PATH`.
+`PATH`, if the `node` executable is not in the `PATH`. This behaviour can be
+overridden by running `npm` with the `--scripts-prepend-node-path` flag.
 
 If you try to run a script without having a `node_modules` directory and it fails,
 you will be given a warning to run `npm install`, just in case you've forgotten.

--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -41,9 +41,11 @@ you should write:
 instead of `"scripts": {"test": "node_modules/.bin/tap test/\*.js"}` to run your tests.
 
 `npm run` sets the `NODE` environment variable to the `node` executable with
-which `npm` is executed. Also, the directory within which it resides is added to the
-`PATH`, if the `node` executable is not in the `PATH`. This behaviour can be
-overridden by running `npm` with the `--scripts-prepend-node-path` flag.
+which `npm` is executed. Also, if the `--scripts-prepend-node-path` is passed,
+the directory within which `node` resides is added to the
+`PATH`. If `--scripts-prepend-node-path=auto` is passed (which has been the
+default in `npm` v3), this is only performed when that `node` executable is
+not found in the `PATH`.
 
 If you try to run a script without having a `node_modules` directory and it fails,
 you will be given a warning to run `npm install`, just in case you've forgotten.

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -811,14 +811,18 @@ of packages specified according to the pattern `@organization/package`.
 ### scripts-prepend-node-path
 
 * Default: "auto"
-* Type: Boolean or `"auto"`
+* Type: Boolean, `"auto"` or `"warn-only"`
 
 If set to `true`, add the directory in which the current `node` executable
 resides to the `PATH` environment variable when running scripts,
 even if that means that `npm` will invoke a different `node` executable than
 the one which it is running.
 
-If set to `false`, never do that.
+If set to `false`, never modify `PATH` with that.
+
+If set to `"warn-only"`, never modify `PATH` but print a warning if `npm` thinks
+that you may want to run it with `true`, e.g. because the `node` executable
+in the `PATH` is not the one `npm` was invoked with.
 
 If set to `auto`, only add that directory to the `PATH` environment variable
 if the `node` executable with which `npm` was invoked and the one that is found

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -808,6 +808,22 @@ in to a private registry for the first time:
 will cause `@organization` to be mapped to the registry for future installation
 of packages specified according to the pattern `@organization/package`.
 
+### scripts-prepend-node-path
+
+* Default: "auto"
+* Type: Boolean or `"auto"`
+
+If set to `true`, add the directory in which the current `node` executable
+resides to the `PATH` environment variable when running scripts,
+even if that means that `npm` will invoke a different `node` executable than
+the one which it is running.
+
+If set to `false`, never do that.
+
+If set to `auto`, only add that directory to the `PATH` environment variable
+if the `node` executable with which `npm` was invoked and the one that is found
+first on the `PATH` are different.
+
 ### searchopts
 
 * Default: ""

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -810,7 +810,7 @@ of packages specified according to the pattern `@organization/package`.
 
 ### scripts-prepend-node-path
 
-* Default: "auto"
+* Default: "warn-only"
 * Type: Boolean, `"auto"` or `"warn-only"`
 
 If set to `true`, add the directory in which the current `node` executable

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -301,7 +301,7 @@ exports.types = {
   'save-optional': Boolean,
   'save-prefix': String,
   scope: String,
-  'scripts-prepend-node-path': [false, true, 'auto'],
+  'scripts-prepend-node-path': [false, true, 'auto', 'warn-only'],
   searchopts: String,
   searchexclude: [null, String],
   searchsort: [

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -193,7 +193,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'save-optional': false,
     'save-prefix': '^',
     scope: '',
-    'scripts-prepend-node-path': 'auto',
+    'scripts-prepend-node-path': 'warn-only',
     searchopts: '',
     searchexclude: null,
     searchsort: 'name',

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -193,6 +193,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'save-optional': false,
     'save-prefix': '^',
     scope: '',
+    'scripts-prepend-node-path': 'auto',
     searchopts: '',
     searchexclude: null,
     searchsort: 'name',
@@ -300,6 +301,7 @@ exports.types = {
   'save-optional': Boolean,
   'save-prefix': String,
   scope: String,
+  'scripts-prepend-node-path': [false, true, 'auto'],
   searchopts: String,
   searchexclude: [null, String],
   searchsort: [

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -146,13 +146,29 @@ function shouldPrependCurrentNodeDirToPATH () {
   if (cfgsetting === false) return false
   if (cfgsetting === true) return true
 
+  var isDifferentNodeInPath
+
   var isWindows = process.platform === 'win32'
+  var foundExecPath = '(none)'
   try {
-    var foundExecPath = which.sync(path.basename(process.execPath), {pathExt: isWindows ? ';' : ':'})
-    return process.execPath.toUpperCase() !== foundExecPath.toUpperCase()
+    foundExecPath = which.sync(path.basename(process.execPath), {pathExt: isWindows ? ';' : ':'})
+    isDifferentNodeInPath = process.execPath.toUpperCase() !== foundExecPath.toUpperCase()
   } catch (e) {
-    return true
+    isDifferentNodeInPath = true
   }
+
+  if (cfgsetting === 'warn-only') {
+    if (isDifferentNodeInPath && !shouldPrependCurrentNodeDirToPATH.hasWarned) {
+      log.warn('lifecycle', 'The node binary used for scripts is', foundExecPath,
+                            'but npm uses', process.execPath,
+                            'itself. You may want to take a look at npm’s --scripts-prepend-node-path option.')
+      shouldPrependCurrentNodeDirToPATH.hasWarned = true
+    }
+
+    return false
+  }
+
+  return isDifferentNodeInPath
 }
 
 function validWd (d, cb) {

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -142,6 +142,10 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
 }
 
 function shouldPrependCurrentNodeDirToPATH () {
+  var cfgsetting = npm.config.get('scripts-prepend-node-path')
+  if (cfgsetting === false) return false
+  if (cfgsetting === true) return true
+
   var isWindows = process.platform === 'win32'
   try {
     var foundExecPath = which.sync(path.basename(process.execPath), {pathExt: isWindows ? ';' : ':'})

--- a/test/tap/lifecycle-path.js
+++ b/test/tap/lifecycle-path.js
@@ -43,6 +43,14 @@ test('make sure the path is correct, with directory of current node but ignored 
   checkPath(true, true, t)
 })
 
+test('make sure the path is correct, without directory of current node and automatic detection', function (t) {
+  checkPath(false, 'auto', t)
+})
+
+test('make sure the path is correct, with directory of current node and automatic detection', function (t) {
+  checkPath(true, 'auto', t)
+})
+
 function checkPath (withDirOfCurrentNode, prependNodePathSetting, t) {
   var newPATH = PATH
   var currentNodeExecPath = process.execPath
@@ -95,7 +103,7 @@ function checkPath (withDirOfCurrentNode, prependNodePathSetting, t) {
     // used by the child process, as the coverage tooling may set the
     // --scripts-prepend-node-path option on its own.
     var realPrependNodePathSetting = stdout.filter(function (line) {
-      return line.match(/npm_config_scripts_prepend_node_path=true/)
+      return line.match(/npm_config_scripts_prepend_node_path=(true|auto)/)
     }).length > 0
 
     if (withDirOfCurrentNode && realPrependNodePathSetting) {

--- a/test/tap/lifecycle-path.js
+++ b/test/tap/lifecycle-path.js
@@ -32,14 +32,18 @@ test('setup', function (t) {
 })
 
 test('make sure the path is correct, without directory of current node', function (t) {
-  checkPath(false, t)
+  checkPath(false, false, t)
 })
 
 test('make sure the path is correct, with directory of current node', function (t) {
-  checkPath(true, t)
+  checkPath(true, false, t)
 })
 
-function checkPath (withDirOfCurrentNode, t) {
+test('make sure the path is correct, with directory of current node but ignored node path', function (t) {
+  checkPath(true, true, t)
+})
+
+function checkPath (withDirOfCurrentNode, prependNodePathSetting, t) {
   var newPATH = PATH
   var currentNodeExecPath = process.execPath
   if (withDirOfCurrentNode) {
@@ -57,7 +61,8 @@ function checkPath (withDirOfCurrentNode, t) {
     cwd: pkg,
     nodeExecPath: currentNodeExecPath,
     env: {
-      PATH: newPATH
+      PATH: newPATH,
+      npm_config_scripts_prepend_node_path: prependNodePathSetting
     },
     stdio: [ 0, 'pipe', 2 ]
   }, function (er, code, stdout) {
@@ -84,7 +89,7 @@ function checkPath (withDirOfCurrentNode, t) {
     // get the ones we tacked on, then the system-specific requirements
     var expectedPaths = ['{{ROOT}}/bin/node-gyp-bin',
                          '{{ROOT}}/test/tap/lifecycle-path/node_modules/.bin']
-    if (withDirOfCurrentNode) {
+    if (withDirOfCurrentNode && !withIgnoreNodePath) {
       expectedPaths.push('{{ROOT}}/test/tap/lifecycle-path/node-bin')
     }
     var expect = expectedPaths.concat(newPATH.split(pathSplit)).map(function (p) {

--- a/test/tap/lifecycle-path.js
+++ b/test/tap/lifecycle-path.js
@@ -120,7 +120,7 @@ function checkPath (withDirOfCurrentNode, prependNodePathSetting, t) {
       if (withDirOfCurrentNode) {
         t.match(stderr, new RegExp(
           'npm WARN lifecycle The node binary used for scripts is \\(none\\) ' +
-          'but npm uses .*/test/tap/lifecycle-path/node-bin/my_bundled_node ' +
+          'but npm uses .*test.tap.lifecycle-path.node-bin.my_bundled_node(.exe)? ' +
           'itself.'
         ))
       } else {


### PR DESCRIPTION
I know a lot of time has already been spent arguing about this topic, but I still think this is the right thing to do and I at least want to propose it. No hard feelings if you decide to turn this PR down on principle!

Also, ping @isaacs on whether he’d accept a patch like https://github.com/addaleax/spawn-wrap/commit/e4294c0ded9705752bc13f391fa55b7f77ab330b that could, in the long run, replace all other npm-specific hacks that needed to be built into `spawn-wrap` in the past few months.

---

Add a `--scripts-ignore-node-path` option that makes `npm` assume its behaviour from prior to v3.7.0, namely not adding the directory of the current `node` executable to the `PATH`, even if that means that `npm` will invoke a different `node` executable than the one which it is running.

This is a non-invasive solution to some of the problems described in https://github.com/npm/npm/issues/12318. It should not come with any drawbacks for npm’s side, as it shifts the responsibility of making sure that the `PATH` variable contains everything it should to whoever invoked npm with `--scripts-ignore-node-path`.

While https://github.com/npm/npm/pull/12968 may have addressed some of the problems described there, it does not help in the case that the `PATH` has explicitly been overridden with the intention of having a different `node` executed (This is the case for `spawn-wrap`).
