### PR TITLE
test: fix async version in update-symlink.js

### DIFF
--- a/test/tap/update-symlink.js
+++ b/test/tap/update-symlink.js
@@ -61,7 +61,7 @@ test('when update is called linked packages should be excluded', function (t) {
   mr({ port: common.port }, function (er, s) {
     common.npm(['update'], OPTS, function (err, c, out, stderr) {
       t.ifError(err)
-      t.has(out, /async@1.5.2/, 'updated ok')
+      t.has(out, /async@2.0.1/, 'updated ok')
       t.doesNotHave(stderr, /ERR!/, 'no errors in stderr')
       s.close()
       t.end()


### PR DESCRIPTION
A hardcoded value included in `test/update-symlink.js` is no
longer accurate and is causing test failures. This commit
updates the value in order to see a green test suite.

It seems a bit fragile that an update to a module could break
the test suite, is there something I am missing? If there is
a way to modify this to be less fragile please let me know.
