### PR TITLE
Document that per-user config file isn't hardcoded

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -27,7 +27,7 @@ same.
 The four relevant files are:
 
 * per-project config file (/path/to/my/project/.npmrc)
-* per-user config file (~/.npmrc)
+* per-user config file (${NPM_CONFIG_USERCONFIG:-~/.npmrc})
 * global config file ($PREFIX/etc/npmrc)
 * npm builtin config file (/path/to/npm/npmrc)
 


### PR DESCRIPTION
Document that the per-user config file respects the `$NPM_CONFIG_USERCONFIG` env var, defaulting to ~/.npmrc
