### PR TITLE
lifecycle: split node_module path parts properly

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -89,7 +89,7 @@ function _incorrectWorkingDirectory (wd, pkg) {
 
 function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
   var pathArr = []
-  var p = wd.split('node_modules')
+  var p = wd.split(/[\\\/]node_modules[\\\/]/)
   var acc = path.resolve(p.shift())
 
   p.forEach(function (pp) {

--- a/test/tap/node-modules-path-munge.js
+++ b/test/tap/node-modules-path-munge.js
@@ -1,0 +1,39 @@
+var common = require('../common-tap.js')
+var t = require('tap')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var path = require('path')
+var dir = path.join(__dirname, 'my_node_modules')
+var script = process.platform === 'win32' ? 'echo %PATH%' : 'echo $PATH'
+
+t.test('setup', function (t) {
+  rimraf.sync(dir)
+  mkdirp.sync(dir)
+  fs.writeFileSync(dir + '/package.json', JSON.stringify({
+    name: 'my_node_modules',
+    version: '1.2.3',
+    scripts: {
+      test: script
+    }
+  }))
+  t.end()
+})
+
+t.test('verify PATH is munged right', function (t) {
+  common.npm(['test'], { cwd: dir }, function (err, code, stdout, stderr) {
+    if (err) {
+      throw err
+    }
+    t.equal(code, 0, 'exit ok')
+    t.notOk(stderr, 'should have no stderr')
+    var expect = path.resolve(dir, 'node_modules', '.bin').toLowerCase()
+    t.contains(stdout.toLowerCase(), expect)
+    t.end()
+  })
+})
+
+t.test('cleanup', function (t) {
+  rimraf.sync(dir)
+  t.end()
+})


### PR DESCRIPTION
In lifecycle scripts, any `node_modules/.bin` existing in the heirarchy
should be turned into an entry in the PATH environment variable.
However, prior to this commit, it was splitting based on the string
`node_modules`, rather than restricting it to only path portions like
`/node_modules/` or `\node_modules\`.  So, a path containing an entry
like `my_node_modules` would be improperly split.

Fix #13456
