### PR TITLE
Don't crash when node.requiredBy is missing.

### DIFF
--- a/lib/install/is-dev.js
+++ b/lib/install/is-dev.js
@@ -20,7 +20,7 @@ function andIsDev (name) {
 }
 
 exports.isDev = function (node) {
-  return node.requiredBy.some(andIsDev(moduleName(node)))
+  return node.requiredBy && node.requiredBy.some(andIsDev(moduleName(node)))
 }
 
 function andIsOnlyDev (name) {

--- a/lib/install/mutate-into-logical-tree.js
+++ b/lib/install/mutate-into-logical-tree.js
@@ -38,7 +38,7 @@ var mutateIntoLogicalTree = module.exports = function (tree) {
 
   Object.keys(flat).sort().forEach(function (flatname) {
     var node = flat[flatname]
-    if (!node.requiredBy.length) return
+    if (!(node.requiredBy && node.requiredBy.length)) return
 
     if (node.parent) {
       // If a node is a cycle that never reaches the root of the logical


### PR DESCRIPTION
This fix works for us in that we're unblocked and can use the newer npm on our old codebase with some probably malformed packages.

``` sh
$ ls -lh node_modules
...
lrwxrwxrwx  1 creationix admins   19 Jul 28 20:09 thrift -> thrift-performance/
drwxrwsr-x  5 creationix admins 4.0K Jul 28 20:31 thrift-performance
...
```

node_modules/thrift-performance/package.json:

``` json
{
  "name": "thrift-performance",
  "description": "node-thrift",
  "version": "0.6.0dev5",
  "author": "Wade Simmons <wade@wades.im>",
  "directories" : { "lib" : "./lib/thrift" },
  "main": "./lib/thrift",
  "engines": { "node": ">= 0.2.4" },
  "dependencies": {
    "node-int64": "0.2.x"
  }
}
```

There may be a better way to handle this edge case, but this patch at least prevents the crash and reports something.
