### PR TITLE
run-script: __catchall handler

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -62,20 +62,21 @@ function runScript (args, cb) {
   })
 }
 
+var cmdList = [
+  'publish',
+  'install',
+  'uninstall',
+  'test',
+  'stop',
+  'start',
+  'restart',
+  'version'
+].reduce(function (l, p) {
+  return l.concat(['pre' + p, p, 'post' + p])
+}, [])
+
 function list (cb) {
   var json = path.join(npm.localPrefix, 'package.json')
-  var cmdList = [
-    'publish',
-    'install',
-    'uninstall',
-    'test',
-    'stop',
-    'start',
-    'restart',
-    'version'
-  ].reduce(function (l, p) {
-    return l.concat(['pre' + p, p, 'post' + p])
-  }, [])
   return readJson(json, function (er, d) {
     if (er && er.code !== 'ENOENT' && er.code !== 'ENOTDIR') return cb(er)
     if (er) d = {}
@@ -127,6 +128,7 @@ function run (pkg, wd, cmd, args, cb) {
   if (!pkg.scripts) pkg.scripts = {}
 
   var cmds
+  var catchAll = false
   if (cmd === 'restart' && !pkg.scripts.restart) {
     cmds = [
       'prestop', 'stop', 'poststop',
@@ -147,6 +149,8 @@ function run (pkg, wd, cmd, args, cb) {
         }
       } else if (npm.config.get('if-present')) {
         return cb(null)
+      } else if (pkg.scripts['__catchall'] && cmdList.indexOf(cmd) === -1) {
+        catchAll = true
       } else {
         return cb(new Error('missing script: ' + cmd))
       }
@@ -155,7 +159,18 @@ function run (pkg, wd, cmd, args, cb) {
   }
 
   if (!cmd.match(/^(pre|post)/)) {
-    cmds = ['pre' + cmd].concat(cmds).concat('post' + cmd)
+    if (catchAll) {
+      // only run pre|post hooks for __catchall when they are explicitly defined
+      // in the scripts section
+      if (pkg.scripts['pre' + cmd]) {
+        cmds = ['pre' + cmd].concat(cmds)
+      }
+      if (pkg.scripts['post' + cmd]) {
+        cmds = cmds.concat('post' + cmd)
+      }
+    } else {
+      cmds = ['pre' + cmd].concat(cmds).concat('post' + cmd)
+    }
   }
 
   log.verbose('run-script', cmds)
@@ -163,11 +178,19 @@ function run (pkg, wd, cmd, args, cb) {
     // pass cli arguments after -- to script.
     if (pkg.scripts[c] && c === cmd) {
       pkg.scripts[c] = pkg.scripts[c] + joinArgs(args)
+    } else if (catchAll && c === cmd) {
+      // pass script name as well as arguments when defering to __catchall
+      pkg.scripts[c] = pkg.scripts['__catchall'] + joinArgs([c].concat(args))
     }
 
     // when running scripts explicitly, assume that they're trusted.
     return [lifecycle, pkg, c, wd, true]
-  }), cb)
+  }), function (err) {
+    if (err && catchAll && err.stage === cmd) {
+      return cb(new Error('script "' + err.stage + '" errored when passed to catchall script "' + pkg.scripts['__catchall'] + '"'))
+    }
+    return cb.apply(null, arguments)
+  })
 }
 
 // join arguments after '--' and pass them to script,


### PR DESCRIPTION
People want to use `npm run-script` as a simple task runner. Most of the time, a dedicated task runner is overkill, or simply just not nice to work with. Tools like Grunt, Gulp, and Broccoli all define their own structures and require you to install plugins to solve even the most trivial tasks like running eslint. GNU Make is currently one of the best alternatives, as it integrates nicely with CLI tools, which most of the tools we integrate with exports anyway.

The downside to GNU Make is that it needs to be installed before you can run the targets and it is not as portable as a pure javascript solution.
## The proposal

Introduce a new special cased script in the scripts block called `__catchall`, which will be called when the script that was asked for did not exist.

``` json
{
  "name": "some-package",
  "version": "1.0.0",
  "scripts": {
    "__catchall": "node scripts.js"
  }
}
```

``` js
console.log('process.argv', process.argv);
```

```
$ npm run build

> some-package@1.0.0 build /.../some-package
> node scripts.js

process.argv [ 'node', '/.../some-package/scripts.js', 'build' ]
```

This will allow people to implement any script resolution algorithm that they desire, while keeping the impact on npm itself minimal.

It is called slightly different than other scripts, as the name of the script is to the list of arguments (notice the third item in the argv array). This will, among other things, allow you to use e.g. Gulp through `__catchall` instead of requiring a globally installed version:

``` json
{
  "name": "some-package",
  "version": "1.0.0",
  "scripts": { "__catchall": "gulp" },
  "devDependencies": { "gulp": "*" }
}
```

```
$ npm run build

> some-package@1.0.0 build /.../some-package
> gulp build
...
```

Most existing task runners will seamlessly integrate this way, without any changes to them, including:
- GNU Make
- [p-s](https://www.npmjs.com/package/p-s) (which at the moment recommends using `npm start` to achieve something similar)
- [scripty](https://www.npmjs.com/package/scripty) (this proposal solves the
  problem of maintaining the scripts object manually for scripty)
## A basic catchall script

The following is one of the simpler ways of implementing a catchall handler, which will allow you to author your scripts as node code.

``` js
// scripts.js
const script = process.argv[2]
const scripts = {
  build: function () {
    // do the build
    console.log('Done!')
  }
};

if (scripts[script]) {
  scripts[script]()
} else {
  console.error('no such script')
  process.exit(1)
}
```

```
$ npm run build

> some-package@1.0.0 build /.../some-package
> node scripts.js

Done!
$ npm run foobar

> some-package@1.0.0 foobar /.../some-package
> node scripts.js

no such script

npm ERR! Linux 4.4.0-31-generic
npm ERR! argv "node" "/.../v0.10.38/bin/npm" "run" "foobar"
npm ERR! node v0.10.38
npm ERR! npm  v3.10.6
npm ERR! script "foobar" errored when passed to catchall script "node scripts.js"
...
```
## Notes on backwards compatibility

To mitigate backwards compatibility concerns not all scripts will be passed on to the catchall handler. Specifically the relevant to core npm scripts, mentioned in the [scripts documentation](https://docs.npmjs.com/misc/scripts).

This will make sure that people will not start relying on the catchall functionality to run code that is required when installing, or other cases that could potentially be a problem for people with older npm clients.

The use case for this feature is mostly development centric. The scripts I have which it would make sense to migrate to a solution based on this will typically handle stuff like building, testing and preparation for publishing.

It is still possible to run the blacklisted script names through the catchall handler, you will just have to explicitly list them in the scripts section, as you would have done without this feature.

``` json
{
  "name": "some-package",
  "version": "1.0.0",
  "scripts": {
    "__catchall": "make",
    "prepublish": "make prepublish"
  }
}
```
## pre and post hooks

When you choose to shell out to a more powerful tool for your task running needs you are likely to handle complex logic and dependencies of your script within that new tool, thus making the pre and post hooks less relevant for scripts ran outside of npm.

When npm shells out to the catchall script, it will thus not call the pre and post versions of that script, unless they are explicitly defined in the scripts object.

``` json
{
  "scripts": { "__catchall": "echo" }
}
```

```
$ npm run build
build
```

``` json
{
  "scripts": {
    "prebuild": "echo prebuild!",
    "__catchall": "echo"
  }
}
```

```
$ npm run build
prebuild!
build
```
## Why not just build a separate task runner?

This solution is as minimal as possible, and basically just allows you to hook in after npm gave up on finding the script to run. So, why is this better than a standalone task runner? What does this proposal provide that wouldn't be handled just as good by a standalone utility?
1. The task runner would need to be installed as a dependency. That is not necessary with this solution.
2. The task runner needs to be installed globally or the user needs to add `node_modules/.bin` to their `$PATH` for it to be available, where `npm run-script` is available already.
3. This solution gets access to the npm environment variables which is also available when you run commands from `npm run-script` or run `npm start`. This means that a task runner based on this proposal could use the [config property](https://docs.npmjs.com/files/package.json#config) in `package.json` instead of introducing another rcfile or dotfile.
## Why use a special cased property in the scripts object?

If the magic property `__catchall` is not desirable, a new package.json property could be introduced, with a name like `scriptsCatchAll` or `scriptResolver`, but otherwise working in the same way. This could make it less obscure and feel less magic.

The argument to keep it as a property on the script object is that it opens a door for people to use it on older versions of npm. If the script name is passed as the first argument (as discussed in the section above) it would allow npm versions 2 and later to use it like so:

```
$ npm run __catchall -- build # npm without __catchall support
$ npm run build # npm with __catchall support
```

It's not beautiful, but it will at least make it usable everywhere.
## Sore Points / Missing Features
### Naming

An alternate name for `__catchall` could be `*`. I'm honestly not sure about it, but I'm leaning towards `*` now. I think that naming was the least interesting part of this proposal, so I decided to submit it as is.
### Script Completion

Currently, if you try to set up `npm run-script` shell completion with this you will get `__catchall` listed as a potential candidate, but not any of the scripts it implement.

I'm not sure how best to support this, if at all, so for now, it is left unanswered. My best idea on the spot is to make a convention that the tool can expose a special command that `npm run-script` will call, which could be used to return the list of available targets.
### Documentation

I did not write any documentation to accompany this pull request, as I would like the proposal validated first.
## Similar Requests:
- https://github.com/npm/npm/issues/12483 (allow script to be a reference to a file)
- https://github.com/npm/npm/issues/11418 (nested objects and arrays @boneskull)
- https://github.com/npm/npm/issues/11284 (allow script to be a reference to a module/file)
- https://github.com/npm/npm/issues/6943 (script entries as arrays that will be auto-concatted)

Thanks to @alexjeffburke and @papandreou for your help with this proposal.
