### PR TITLE
Reduce 'skipping action' log level from 'warn' to 'verbose'.

### DIFF
--- a/lib/install/filter-invalid-actions.js
+++ b/lib/install/filter-invalid-actions.js
@@ -24,7 +24,7 @@ module.exports = function (top, differences, next) {
     if (pkg.isInLink || (pkg.parent && (pkg.parent.target || pkg.parent.isLink))) {
       // we want to skip warning if this is a child of another module that we're removing
       if (!pkg.parent.removing) {
-        log.warn('skippingAction', 'Module is inside a symlinked module: not running ' +
+        log.verbose('skippingAction', 'Module is inside a symlinked module: not running ' +
           cmd + ' ' + packageId(pkg) + ' ' + path.relative(top, pkg.path))
       }
     } else {


### PR DESCRIPTION
> npm WARN skippingAction Module is inside a symlinked module: not running …

This message is incredibly verbose and not very helpful, as far as I can tell. If a user has symlinked packages into `node_modules` they've very likely done this on purpose. A user certainly does not need a warning for every single sub-dependency of the symlinked dependency i.e. hundreds of lines of non-actionable output.

Closes #9999.

![image](https://cloud.githubusercontent.com/assets/43438/17508064/ac17c838-5e45-11e6-9a43-31c67da2ed31.png)
