### PR TITLE
install: fix hiccup that caused a conflict

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -452,7 +452,9 @@ function addDependency (name, versionSpec, tree, log, done) {
         }
       }))
     } else {
-      resolveWithNewModule(req, tree, log, next)
+      fetchPackageMetadata(req, packageRelativePath(tree), log.newItem('fetchMetadata'), iferr(next, function (pkg) {
+        resolveWithNewModule(pkg, tree, log, next)
+      }))
     }
   }))
 }
@@ -514,11 +516,6 @@ function replaceModule (obj, key, child, matchBy) {
 
 function resolveWithNewModule (pkg, tree, log, next) {
   validate('OOOF', arguments)
-  if (pkg.type) {
-    return fetchPackageMetadata(pkg, packageRelativePath(tree), log.newItem('fetchMetadata'), iferr(next, function (pkg) {
-      resolveWithNewModule(pkg, tree, log, next)
-    }))
-  }
 
   if (!pkg._installable) {
     log.silly('resolveWithNewModule', packageId(pkg), 'checking installable status')

--- a/test/tap/install-property-conflicts.js
+++ b/test/tap/install-property-conflicts.js
@@ -1,0 +1,74 @@
+var fs = require('fs')
+var resolve = require('path').resolve
+
+var osenv = require('osenv')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+
+var pkg = resolve(__dirname, 'install-property-conflicts')
+var target = resolve(pkg, '_target')
+
+var EXEC_OPTS = {
+  cwd: target
+}
+
+var json = {
+  name: 'install-property-conflicts',
+  version: '1.2.3',
+  type: 'nose-boop!'
+}
+
+test('setup', function (t) {
+  setup()
+  t.pass('setup ran')
+  t.end()
+})
+
+test('install package with a `type` property', function (t) {
+  t.comment('issue: https://github.com/npm/npm/issues/11398')
+  common.npm(
+    [
+      'install',
+      '--prefix', target,
+      pkg
+    ],
+    EXEC_OPTS,
+    function (err, code, stdout, stderr) {
+      t.ifError(err, 'npm command ran from test')
+      t.equals(code, 0, 'install exited with success (0)')
+      var installedPkg = resolve(
+        target,
+        'node_modules',
+        'install-property-conflicts',
+        'package.json')
+      t.ok(fs.statSync(installedPkg), 'package installed successfully')
+      t.end()
+    }
+  )
+})
+
+test('clean', function (t) {
+  cleanup()
+  t.pass('cleaned up')
+  t.end()
+})
+
+function setup () {
+  cleanup()
+  mkdirp.sync(pkg)
+  // make sure it installs locally
+  mkdirp.sync(resolve(target, 'node_modules'))
+  fs.writeFileSync(
+    resolve(pkg, 'package.json'),
+    JSON.stringify(json, null, 2) + '\n'
+  )
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+  rimraf.sync(target)
+}


### PR DESCRIPTION
Basically, there was some duck typing in `resolveWithNewModule`
in situations where the function got a `package.json` from `npa`,
rather than the internal request object.

The issue reared its head because of a package that had `type`
in its `package.json`, which confused the duck typing.

Instead, the special case was inlined into (afaict) the only
place where it was actually triggered from.

Fixes: https://github.com/npm/npm/issues/11398
Credit: @zkat
