### PR TITLE
Added sanitation of the maintainers field.

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -98,13 +98,11 @@ function filter (data, args, notArgs) {
 }
 
 function stripData (data) {
-  
   // Sanitize the maintainers field to ensure that NPM repositories (Artifactory) that
   // does not sanitize this won't break the search functionality.
-  if (typeof data.maintainers === "string") {
-    data.maintainers = [data.maintainers];
+  if (typeof data.maintainers === 'string') {
+    data.maintainers = [data.maintainers]
   }
-  
   return {
     name: data.name,
     description: npm.config.get('description') ? data.description : '',

--- a/lib/search.js
+++ b/lib/search.js
@@ -98,6 +98,13 @@ function filter (data, args, notArgs) {
 }
 
 function stripData (data) {
+  
+  // Sanitize the maintainers field to ensure that NPM repositories (Artifactory) that
+  // does not sanitize this won't break the search functionality.
+  if (typeof data.maintainers === "string") {
+    data.maintainers = [data.maintainers];
+  }
+  
   return {
     name: data.name,
     description: npm.config.get('description') ? data.description : '',


### PR DESCRIPTION
Some (at least Artifactory) doesn't sanitize non-conforming package.json content, and serves it back verbatim. There exists many? packages where the maintainers property is a string instead of an array. This pollutes the NPM cache (when using Artifactory) and breaks the search.js/stripData() function where it tries to do a map over the maintainers property (or an empty array).
