### PR TITLE
Update .npmrc documentation

### DIFF
--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -41,6 +41,15 @@ sensitive credentials, they must be readable and writable _only_ by your user
 account (i.e. must have a mode of `0600`), otherwise they _will be ignored by
 npm!_
 
+#### Comments
+
+Because lines in an npm config file follow the `key = value` pattern, lines may be effectivly commmented-out by placing any character at the beginning of the line (creating a `key` which is not recoginized, or used). Common comment characters are `;`, `#`, or `//`.
+
+For example:
+
+    ; Set a new registry for a scoped package
+    @myscope:registry=https://mycustomregistry.example.org
+
 ### Per-project config file
 
 When working locally in a project, a `.npmrc` file in the root of the

--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -43,10 +43,11 @@ npm!_
 
 #### Comments
 
-Because lines in an npm config file follow the `key = value` pattern, lines may be effectivly commmented-out by placing any character at the beginning of the line (creating a `key` which is not recoginized, or used). Common comment characters are `;`, `#`, or `//`.
+Lines in `.npmrc` files are interpreted as comments when they begin with a `;` or `#` character. `.npmrc` files are parsed by [npm/ini](https://github.com/npm/ini), which specifies this comment syntax.
 
 For example:
 
+    # last modified: 01 Jan 2016
     ; Set a new registry for a scoped package
     @myscope:registry=https://mycustomregistry.example.org
 


### PR DESCRIPTION
I found that information about commenting lines in a `.npmrc` file was lacking from the official documentation. I've updated the doc to reflect currently supported ways to commenting lines in the npm config file as found through reading other sources and through experimentation with different ways of adding comments.
