### PR TITLE
tar: ignore *.orig files

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -203,6 +203,7 @@ Conversely, some files are always ignored:
 * `.npmrc`
 * `node_modules`
 * `config.gypi`
+* `*.orig`
 
 ## main
 

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -102,7 +102,8 @@ BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
       entry === '.npmrc' ||
       entry.match(/^\..*\.swp$/) ||
       entry === '.DS_Store' ||
-      entry.match(/^\._/)
+      entry.match(/^\._/) ||
+      entry.match(/^.*\.orig$/)
     ) {
     return false
   }

--- a/test/tap/files-and-ignores.js
+++ b/test/tap/files-and-ignores.js
@@ -404,7 +404,8 @@ test('certain files ignored unconditionally', function (t) {
           '.npmrc',
           '.foo.swp',
           '.DS_Store',
-          '._ohno'
+          '._ohno',
+          'foo.orig'
         ]
       }),
       '.git': Dir({foo: File('')}),
@@ -421,7 +422,8 @@ test('certain files ignored unconditionally', function (t) {
       '.foo.swp': File(''),
       '.DS_Store': Dir({foo: File('')}),
       '._ohno': File(''),
-      '._ohnoes': Dir({noes: File('')})
+      '._ohnoes': Dir({noes: File('')}),
+      'foo.orig': File('')
     })
   )
   withFixture(t, fixture, function (done) {
@@ -440,6 +442,7 @@ test('certain files ignored unconditionally', function (t) {
     t.notOk(fileExists('.DS_Store'), '.DS_Store not included')
     t.notOk(fileExists('._ohno'), '._ohno not included')
     t.notOk(fileExists('._ohnoes'), '._ohnoes not included')
+    t.notOk(fileExists('foo.orig'), 'foo.orig not included')
     done()
   })
 })


### PR DESCRIPTION
This PR ignores causes `*.orig` files to explicitly be ignored upon `npm publish`.  Docs & tests updated accordingly.  

Original issue: mochajs/mocha#2446.

In Git, when performing a merge, the original file(s) with conflict markers can be saved as `file.orig`.  Git's default behavior is to create them ([reference](https://git-scm.com/docs/git-config)).

Then, unless:
- a `.npmignore` contains `*.orig`, or
- an npm user is careful to remove these files before publishing, or
- a Git user disables this behavior via `git config mergetool.keepBackup false` (and thus the files are never created),

any of these untracked files present in a working copy will be published upon `npm publish`.  

Since it's often desirable to published untracked files, there's no issue with `npm publish`'s behavior _per se_--but I cannot think of a use case for publishing an `.orig` file.
