### PR TITLE
doc: npm link will link bin of project.

### DIFF
--- a/doc/cli/npm-link.md
+++ b/doc/cli/npm-link.md
@@ -14,7 +14,8 @@ Package linking is a two-step process.
 
 First, `npm link` in a package folder will create a symlink in the global folder
 `{prefix}/lib/node_modules/<package>` that links to the package where the `npm
-link` command was executed. (see `npm-config(7)` for the value of `prefix`).
+link` command was executed. (see `npm-config(7)` for the value of `prefix`). It
+will also link any bins in the package to `{prefix}/bin/{name}`.
 
 Next, in some other location, `npm link package-name` will create a
 symbolic link from globally-installed `package-name` to `node_modules/`


### PR DESCRIPTION
This documents the fact that `npm link` will link the files specified in the `bin` field of `package.json` to `{prefix}/bin/{name}`.
