### PR TITLE
npm version support prerelease identification

### DIFF
--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -3,7 +3,7 @@ npm-version(1) -- Bump a package version
 
 ## SYNOPSIS
 
-    npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
+    npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [prerelease-id] | from-git]
 
     'npm [-v | --version]' to print npm version
     'npm view <pkg> version' to view a package's published version
@@ -16,8 +16,17 @@ data back to `package.json` and, if present, `npm-shrinkwrap.json`.
 
 The `newversion` argument should be a valid semver string, a
 valid second argument to [semver.inc](https://github.com/npm/node-semver#functions) (one of `patch`, `minor`, `major`,
-`prepatch`, `preminor`, `premajor`, `prerelease`), or `from-git`. In the second case,
-the existing version will be incremented by 1 in the specified field.
+`prepatch`, `preminor`, `premajor`, `prerelease`), or `from-git`.
+
+Prerelease Identifiers: `prerelease` second argument accepts a third argument as an additional identifier string argument that will append the value of the string as a prerelease identifier.
+
+```
+$ npm version prerelease beta
+$ 1.2.4-beta.0
+```
+
+In the second case, the existing version will be incremented by 1 in the specified field.
+
 `from-git` will try to read the latest git tag, and use that as the new npm version.
 
 If run in a git repo, it will also create a version commit and tag.

--- a/lib/version.js
+++ b/lib/version.js
@@ -15,7 +15,7 @@ var lifecycle = require('./utils/lifecycle.js')
 var parseJSON = require('./utils/parse-json.js')
 var output = require('./utils/output.js')
 
-version.usage = 'npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]' +
+version.usage = 'npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [preid]| from-git]' +
                 '\n(run in package dir)\n' +
                 "'npm -v' or 'npm --version' to print npm version " +
                 '(' + npm.version + ')\n' +
@@ -28,7 +28,8 @@ function version (args, silent, cb_) {
     cb_ = silent
     silent = false
   }
-  if (args.length > 1) return cb_(version.usage)
+  var hasPrereleaseTag = args[0] === 'prerelease' && args.length < 3
+  if (args.length > 1 && !hasPrereleaseTag) return cb_(version.usage)
 
   readPackage(function (er, data) {
     if (!args.length) return dump(data, cb_)
@@ -41,8 +42,9 @@ function version (args, silent, cb_) {
     if (args[0] === 'from-git') {
       retrieveTagVersion(silent, data, cb_)
     } else {
+      var preid = (args[0] === 'prerelease') ? args[1] : undefined
       var newVersion = semver.valid(args[0])
-      if (!newVersion) newVersion = semver.inc(data.version, args[0])
+      if (!newVersion) newVersion = semver.inc(data.version, args[0], preid)
       if (!newVersion) return cb_(version.usage)
       persistVersion(newVersion, silent, data, cb_)
     }

--- a/test/tap/version-prerelease-tag.js
+++ b/test/tap/version-prerelease-tag.js
@@ -1,0 +1,98 @@
+var common = require('../common-tap.js')
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var npm = require('../../lib/npm.js')
+
+var pkg = path.resolve(__dirname, 'version-from-git')
+var packagePath = path.resolve(pkg, 'package.json')
+var cache = path.resolve(pkg, 'cache')
+
+var json = { name: 'version-prerelease', version: '0.1.2' }
+
+test('npm version preprelease with a prerlease tag fail on extra arguments', function (t) {
+  var expectedVersion = json.version
+  setup()
+
+  npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
+    var version = require('../../lib/version')
+    version(['prerelease', 'alpha', 'extra-arg'], checkManifest)
+  })
+
+  function checkManifest (er) {
+    if (!er) {
+      t.fail('should fail when extra arguments are passed to prerelease.')
+    } else {
+      fs.readFile(path.resolve(pkg, 'package.json'), 'utf8', function (er, data) {
+        t.ifError(er, 'read manifest without error')
+        var manifest = JSON.parse(data)
+        t.equal(manifest.version, expectedVersion, 'package.json version did not update')
+        t.done()
+      })
+    }
+  }
+})
+
+test('npm version preprelease without prerlease tag updates the package.json version', function (t) {
+  var expectedVersion = '0.1.3-0'
+  setup()
+
+  npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
+    var version = require('../../lib/version')
+    version(['prerelease'], checkManifest)
+  })
+
+  function checkManifest (er) {
+    t.ifError(er, 'npm run version ran without error')
+    fs.readFile(path.resolve(pkg, 'package.json'), 'utf8', function (er, data) {
+      t.ifError(er, 'read manifest without error')
+      var manifest = JSON.parse(data)
+      t.equal(manifest.version, expectedVersion, 'updated the package.json version')
+      t.done()
+    })
+  }
+})
+
+test('npm version preprelease with a prerlease tag updates the package.json version', function (t) {
+  var expectedVersion = '0.1.3-alpha.0'
+  setup()
+
+  npm.load({cache: cache, 'sign-git-tag': false, registry: common.registry}, function () {
+    var version = require('../../lib/version')
+    version(['prerelease', 'alpha'], checkManifest)
+  })
+
+  function checkManifest (er) {
+    t.ifError(er, 'npm run version ran without error')
+    fs.readFile(path.resolve(pkg, 'package.json'), 'utf8', function (er, data) {
+      t.ifError(er, 'read manifest without error')
+      var manifest = JSON.parse(data)
+      t.equal(manifest.version, expectedVersion, 'updated the package.json version')
+      t.done()
+    })
+  }
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  // windows fix for locked files
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}
+
+function setup () {
+  cleanup()
+  mkdirp.sync(cache)
+  process.chdir(pkg)
+  fs.writeFileSync(packagePath, JSON.stringify(json), 'utf8')
+}
+


### PR DESCRIPTION
## Prerelease Identifiers:: minor feature

This feature adds `--preid` parameter from https://github.com/npm/node-semver#prerelease-identifiers

According to npm semver documentation, you should be able to add an identifier to prerelease versions such as `beta`, `alpha` or whatever you want. However this feature is not supporter by npm version bumping.

[Read npm semver Docs](https://docs.npmjs.com/misc/semver#prerelease-identifiers)
## Usage

```
npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [preid] | from-git]
```

command:

```
npm version prerelease beta
should increment `0.3.0` to `0.3.1-beta.0`
```

This command only runs if prerelease is specified as its a "prerelease" identifier.
## Pull request Checklist
- [x] Minimal changes.
- [x] Minimal commits, 1 single commit.
- [x] No conflicts.
- [x] Code conforming to the existing conventions and formats. i.e. Please don't reformat whitespace.
- [x] Passing tests in test/tap. Use existing tests as a reference.
- [x] Relevant documentation.
