### PR TITLE
Move when rename fails (fix EXDEV docker issues)

### DIFF
--- a/lib/utils/rename.js
+++ b/lib/utils/rename.js
@@ -6,85 +6,177 @@ var SaveStack = require('./save-stack.js')
 
 module.exports = rename
 
-/**
- * Rename or move a single directory.
- */
-function rename (src, dest, cb) {
+function rename (from, to, cb) {
   var saved = new SaveStack(rename)
-  try {
-    renameOrCopy(src, dest)
-    try {
-      removeFile(src)
-    } catch (_) {
-      // XXX: Cleanup failures don't throw exception
-    }
-  } catch (renameErr) {
-    return cb(saved.completeWith(renameErr))
-  }
-  return cb()
-}
 
-function removeFile (filename) {
-  var exists = false
-  try {
-    fs.accessSync(filename)
-    exists = true
-  } catch (_) {}
+  var basePath = process.cwd()
+  var currentPath = path.resolve(basePath, from)
+  var targetPath = path.resolve(basePath, to)
 
-  if (exists) {
-    rimraf.sync(filename)
-  }
-}
+  var hadErr = false
 
-function copyDir (src, dest) {
-  var filenames = fs.readdirSync(src)
-  fs.mkdirSync(dest)
+  var started = 1 // Unlike ncp we always start with 1 (the top-level rename)
+  var finished = 0
+  var running = 0
+  var limit = 512
 
-  for (var i = 0; i < filenames.length; i++) {
-    renameOrCopy(path.join(src, filenames[i]), path.join(dest, filenames[i]))
-  }
-}
-
-function copyFile (src, dest) {
-  var oldFile = fs.createReadStream(src)
-  var newFile = fs.createWriteStream(dest)
-  oldFile.pipe(newFile)
-}
-
-function copyLink (src, dest) {
-  var symlink = fs.readlinkSync(src)
-  fs.symlinkSync(symlink, dest)
-}
-
-function syncPermissions (srcStats, dest) {
-  var destFD = fs.openSync(dest, 'r+')
-
-  fs.fchownSync(destFD, srcStats.uid, srcStats.gid)
-  fs.fchmodSync(destFD, srcStats.mode)
-  fs.futimesSync(destFD, srcStats.atime, srcStats.mtime)
-
-  fs.closeSync(destFD)
-}
-
-function renameOrCopy (src, dest) {
-  try {
-    fs.renameSync(src, dest)
-  } catch (renameErr) {
-    var srcStats
-    try {
-      removeFile(dest)
-      srcStats = fs.lstatSync(src)
-    } catch (_) {
-      throw renameErr
+  // First, try a 'standard' rename on the top-level directory
+  fs.rename(currentPath, targetPath, function (renameErr) {
+    if (!renameErr) {
+      return cb(null)
     }
 
-    if (srcStats.isDirectory()) {
-      copyDir(src, dest)
-    } else if (srcStats.isSymbolicLink()) {
-      copyLink(src, dest)
-    } else {
-      copyFile(src, dest)
+    if (renameErr.code !== 'EXDEV' && renameErr.code !== 'EPERM') {
+      return cb(saved.completeWith(renameErr))
     }
-    syncPermissions(srcStats, dest)
+
+    getStats(currentPath)
+  })
+
+  function startRenameOrCopy (source) {
+    if (hadErr) return
+
+    var target = source.replace(currentPath, targetPath)
+    started++
+
+    // Always try to rename first
+    fs.rename(source, target, function (err) {
+      if (!err) {
+        return doneOne(true)
+      }
+
+      return getStats(source)
+    })
+  }
+
+  function getStats (source) {
+    if (running >= limit) {
+      return setImmediate(function () {
+        getStats(source)
+      })
+    }
+    running++
+
+    fs.lstat(source, function (err, stats) {
+      if (err) return onError(err)
+      // We need to get the mode from the stats object and preserve it.
+      var item = {
+        name: source,
+        mode: stats.mode,
+        mtime: stats.mtime, // modified time
+        atime: stats.atime, // access time
+        stats: stats // temporary
+      }
+
+      if (stats.isDirectory()) {
+        return onDir(item)
+      } else if (stats.isFile()) {
+        return onFile(item)
+      } else if (stats.isSymbolicLink()) {
+        // Symlinks don't really need to know about the mode.
+        return onLink(source)
+      }
+    })
+  }
+
+  function onFile (file) {
+    var target = file.name.replace(currentPath, targetPath)
+    copyFile(file, target)
+  }
+
+  function copyFile (file, target) {
+    var readStream = fs.createReadStream(file.name)
+    var writeStream = fs.createWriteStream(target, { mode: file.mode })
+
+    readStream.on('error', onError)
+    writeStream.on('error', onError)
+
+    writeStream.on('open', function () {
+      readStream.pipe(writeStream)
+    })
+
+    writeStream.once('finish', function () {
+      setFilePermissions(file, target)
+    })
+  }
+
+  function setFilePermissions (file, target) {
+    fs.chmod(target, file.mode, function (err) {
+      if (err) return onError(err)
+
+      fs.open(path, 'r+', function (err, fd) {
+        if (err) return onError(err)
+
+        fs.futimes(fd, file.atime, file.mtime, function (futimesErr) {
+          fs.close(fd, function (closeErr) {
+            if (futimesErr) return onError(futimesErr)
+            if (closeErr) return onError(closeErr)
+            return doneOne()
+          })
+        })
+      })
+    })
+  }
+
+  function onDir (dir) {
+    var target = dir.name.replace(currentPath, targetPath)
+    return mkDir(dir, target)
+  }
+
+  function mkDir (dir, target) {
+    fs.mkdir(target, dir.mode, function (err) {
+      if (err) return onError(err)
+      // despite setting mode in fs.mkdir, doesn't seem to work
+      // so we set it here.
+      fs.chmod(target, dir.mode, function (err) {
+        if (err) return onError(err)
+        copyDir(dir.name)
+      })
+    })
+  }
+
+  function copyDir (dir) {
+    fs.readdir(dir, function (err, items) {
+      if (err) return onError(err)
+      items.forEach(function (item) {
+        startRenameOrCopy(path.join(dir, item))
+      })
+      return doneOne()
+    })
+  }
+
+  function onLink (link) {
+    var target = link.replace(currentPath, targetPath)
+    fs.readlink(link, function (err, resolvedPath) {
+      if (err) return onError(err)
+      makeLink(resolvedPath, target)
+    })
+  }
+
+  function makeLink (linkPath, target) {
+    fs.symlink(linkPath, target, function (err) {
+      if (err) return onError(err)
+      return doneOne()
+    })
+  }
+
+  function onError (err) {
+    if (!hadErr) {
+      hadErr = true // Only call the callback once
+      return cb(saved.finishWith(err))
+    }
+  }
+
+  function doneOne (skipped) {
+    if (!skipped) running--
+    finished++
+
+    if ((started === finished) && (running === 0) && (!hadErr)) {
+      rimraf(currentPath, { disableGlob: true }, function (err) {
+        // xxx: Should this be ignored?
+        if (err) onError(err)
+        cb(null)
+      })
+    }
   }
 }

--- a/lib/utils/rename.js
+++ b/lib/utils/rename.js
@@ -1,16 +1,90 @@
 'use strict'
 var fs = require('graceful-fs')
+var path = require('path')
+var rimraf = require('rimraf')
 var SaveStack = require('./save-stack.js')
 
 module.exports = rename
 
-function rename (from, to, cb) {
+/**
+ * Rename or move a single directory.
+ */
+function rename (src, dest, cb) {
   var saved = new SaveStack(rename)
-  fs.rename(from, to, function (er) {
-    if (er) {
-      return cb(saved.completeWith(er))
-    } else {
-      return cb()
+  try {
+    renameOrCopy(src, dest)
+    try {
+      removeFile(src)
+    } catch (_) {
+      // XXX: Cleanup failures don't throw exception
     }
-  })
+  } catch (renameErr) {
+    return cb(saved.completeWith(renameErr))
+  }
+  return cb()
+}
+
+function removeFile (filename) {
+  var exists = false
+  try {
+    fs.accessSync(filename)
+    exists = true
+  } catch (_) {}
+
+  if (exists) {
+    rimraf.sync(filename)
+  }
+}
+
+function copyDir (src, dest) {
+  var filenames = fs.readdirSync(src)
+  fs.mkdirSync(dest)
+
+  for (var i = 0; i < filenames.length; i++) {
+    renameOrCopy(path.join(src, filenames[i]), path.join(dest, filenames[i]))
+  }
+}
+
+function copyFile (src, dest) {
+  var oldFile = fs.createReadStream(src)
+  var newFile = fs.createWriteStream(dest)
+  oldFile.pipe(newFile)
+}
+
+function copyLink (src, dest) {
+  var symlink = fs.readlinkSync(src)
+  fs.symlinkSync(symlink, dest)
+}
+
+function syncPermissions (srcStats, dest) {
+  var destFD = fs.openSync(dest, 'r+')
+
+  fs.fchownSync(destFD, srcStats.uid, srcStats.gid)
+  fs.fchmodSync(destFD, srcStats.mode)
+  fs.futimesSync(destFD, srcStats.atime, srcStats.mtime)
+
+  fs.closeSync(destFD)
+}
+
+function renameOrCopy (src, dest) {
+  try {
+    fs.renameSync(src, dest)
+  } catch (renameErr) {
+    var srcStats
+    try {
+      removeFile(dest)
+      srcStats = fs.lstatSync(src)
+    } catch (_) {
+      throw renameErr
+    }
+
+    if (srcStats.isDirectory()) {
+      copyDir(src, dest)
+    } else if (srcStats.isSymbolicLink()) {
+      copyLink(src, dest)
+    } else {
+      copyFile(src, dest)
+    }
+    syncPermissions(srcStats, dest)
+  }
 }

--- a/lib/utils/rename.js
+++ b/lib/utils/rename.js
@@ -1,7 +1,7 @@
 'use strict'
 var fs = require('graceful-fs')
 var path = require('path')
-var rimraf = require('rimraf')
+var gentlyRm = require('./gently-rm')
 var SaveStack = require('./save-stack.js')
 
 module.exports = rename
@@ -172,7 +172,7 @@ function rename (from, to, cb) {
     finished++
 
     if ((started === finished) && (running === 0) && (!hadErr)) {
-      rimraf(currentPath, { disableGlob: true }, function (err) {
+      gentlyRm(currentPath, false, function (err) {
         // xxx: Should this be ignored?
         if (err) onError(err)
         cb(null)


### PR DESCRIPTION
Fixes issue: https://github.com/npm/npm/issues/9863

Currently, the npm 'rename' function is a thin wrapper around the `rename(2)` syscall. However, rename isn't guaranteed to be implemented by all filesystems, and can cause issues when running inside docker containers.

This patch changes the behavior of the 'rename' function to behave more like the traditional unix `mv` command, falling back to recursively copying and deleting files if renaming them isn't possible.

I based my work on https://github.com/npm/npm/pull/13257 and I've tried to take into account the feedback on this PR:
- Use a recursive strategy, trying to make use of 'rename' for as much of the work as possible (making it slower across-devices, but faster on AUFS for Docker).
- Preserve most important file attributes when copying.
- Testing - I don't think there are any valuable test cases that can be written for this functionality, as the only way to actually test it would be to setup a copy across filesystems, which is very system-dependent.
