### PR TITLE
Update example to show feature branch reference

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -467,7 +467,8 @@ included.  For example:
       "version": "0.0.0",
       "dependencies": {
         "express": "visionmedia/express",
-        "mocha": "visionmedia/mocha#4727d357ea"
+        "mocha": "visionmedia/mocha#4727d357ea",
+        "module": "user/repo#feature\/branch"
       }
     }
 


### PR DESCRIPTION
When manually adding a dependency reference to a github branch with the pattern feature/[branchName](same for bugfix, etc) npm fails with a forward slash, you need a backslash to escape this and everything works fine. Updated the documentation to reflect this.
