### PR TITLE
Fix CWD while running shrinkwrap lifecycle scripts

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -35,12 +35,11 @@ function shrinkwrap (args, silent, cb) {
     log.warn('shrinkwrap', "doesn't take positional args")
   }
 
-  var dir = path.resolve(npm.dir, '..')
   var packagePath = path.join(npm.localPrefix, 'package.json')
   var dev = !!npm.config.get('dev') || /^dev(elopment)?$/.test(npm.config.get('also'))
 
   readPackageJson(packagePath, iferr(cb, function (pkg) {
-    createShrinkwrap(dir, pkg, dev, silent, cb)
+    createShrinkwrap(npm.localPrefix, pkg, dev, silent, cb)
   }))
 }
 

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -47,14 +47,14 @@ function shrinkwrap (args, silent, cb) {
 module.exports.createShrinkwrap = createShrinkwrap
 
 function createShrinkwrap (dir, pkg, dev, silent, cb) {
-  lifecycle(pkg, 'preshrinkwrap', function () {
+  lifecycle(pkg, 'preshrinkwrap', dir, function () {
     readPackageTree(dir, andRecalculateMetadata(iferr(cb, function (tree) {
       var pkginfo = treeToShrinkwrap(tree, dev)
 
       chain([
-        [lifecycle, tree.package, 'shrinkwrap'],
+        [lifecycle, tree.package, 'shrinkwrap', dir],
         [shrinkwrap_, pkginfo, silent],
-        [lifecycle, tree.package, 'postshrinkwrap']
+        [lifecycle, tree.package, 'postshrinkwrap', dir]
       ], iferr(cb, function (data) {
         cb(null, data[0])
       }))

--- a/test/tap/shrinkwrap-lifecycle-cwd.js
+++ b/test/tap/shrinkwrap-lifecycle-cwd.js
@@ -1,0 +1,90 @@
+'use strict'
+var path = require('path')
+var test = require('tap').test
+var mr = require('npm-registry-mock')
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+var extend = Object.assign || require('util')._extend
+var common = require('../common-tap.js')
+
+var basedir = path.join(__dirname, path.basename(__filename, '.js'))
+var testdir = path.join(basedir, 'testdir')
+var cachedir = path.join(basedir, 'cache')
+var globaldir = path.join(basedir, 'global')
+var tmpdir = path.join(basedir, 'tmp')
+var escapeArg = require('../../lib/utils/escape-arg.js')
+
+var conf = {
+  cwd: testdir,
+  env: extend({
+    npm_config_cache: cachedir,
+    npm_config_tmp: tmpdir,
+    npm_config_prefix: globaldir,
+    npm_config_registry: common.registry,
+    npm_config_loglevel: 'warn'
+  }, process.env)
+}
+
+var server
+var fixture = new Tacks(Dir({
+  cache: Dir(),
+  global: Dir(),
+  tmp: Dir(),
+  testdir: Dir({
+    node_modules: Dir({}),
+    'package.json': File({
+      name: '13252',
+      version: '1.0.0',
+      scripts: {
+        // add this to the end of the command to preserve the debug log:
+        // || mv npm-debug.log real-debug.log
+        // removed for windows compat reasons
+        abc: escapeArg(common.nodeBin) + ' ' + escapeArg(common.bin) + ' shrinkwrap',
+        shrinkwrap: escapeArg(common.nodeBin) + ' scripts/shrinkwrap.js'
+      }
+    }),
+    scripts: Dir({
+      'shrinkwrap.js': File(
+        'console.log("OK " + process.cwd())'
+      )
+    })
+  })
+}))
+
+function setup () {
+  cleanup()
+  fixture.create(basedir)
+}
+
+function cleanup () {
+  fixture.remove(basedir)
+}
+
+test('setup', function (t) {
+  setup()
+  mr({port: common.port, throwOnUnmatched: true}, function (err, s) {
+    if (err) throw err
+    server = s
+    t.done()
+  })
+})
+
+test('shrinkwrap-lifecycle-cwd', function (t) {
+  common.npm(['run', 'abc'], conf, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'command ran ok')
+    t.comment(stdout.trim())
+    t.comment(stderr.trim())
+    t.match(stdout.trim(), 'OK ' + testdir, 'got output from lifecycle script')
+    t.is(stderr.trim().length, 0, 'no errors')
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  server.close()
+  cleanup()
+  t.done()
+})
+


### PR DESCRIPTION
Previously if you ran a shrinkwrap from another lifecycle script AND `node_modules` existed (and if you're running `npm shrinkwrap` it probably should) then `npm` would run the shrinkwrap lifecycle from the `node_modules` folder instead of the package folder.

Fixes: #13252
