### PR TITLE
git: Use shallow clones making some installs faster

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -179,6 +179,9 @@ after packing it up into a tarball (b).
     If the repository makes use of submodules, those submodules will
     be cloned as well.
 
+    If you set the "git-shallow-clone" config, the clone will be shallow with
+    depth 1, unless `<commit-ish>` is a SHA.
+
     The following git environment variables are recognized by npm and will be added
     to the environment when running git:
 

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -364,6 +364,14 @@ The command to use for git commands.  If git is installed on the
 computer, but is not in the `PATH`, then set this to the full path to
 the git binary.
 
+### git-shallow-clone
+
+* Default: `false`
+* Type: Boolean
+
+Use shallow clone when fetching git repositories.  This will only fetch the
+newest commit, making clones faster.  Only supported with Git 1.9+.
+
 ### git-tag-version
 
 * Default: `true`

--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -201,8 +201,11 @@ function mirrorRemote (from, cloneURL, treeish, cachedRemote, silent, cb) {
       '--mirror',
       cloneURL, cachedRemote
     ]
+    if (npm.config.get('git-shallow-clone')) {
+      args.splice(1, 0, '--depth=1')
+    }
     git.whichAndExec(
-      ['clone', '--template=' + templates, '--mirror', cloneURL, cachedRemote],
+      args,
       { cwd: cachedRemote, env: gitEnv() },
       function (er, stdout, stderr) {
         if (er) {
@@ -216,7 +219,7 @@ function mirrorRemote (from, cloneURL, treeish, cachedRemote, silent, cb) {
           return cb(er)
         }
         log.verbose('mirrorRemote', from, 'git clone ' + cloneURL, stdout.trim())
-        setPermissions(from, cloneURL, treeish, cachedRemote, cb)
+        updateRemote(from, cloneURL, treeish, cachedRemote, cb)
       }
     )
   })
@@ -253,16 +256,29 @@ function setPermissions (from, cloneURL, treeish, cachedRemote, cb) {
 // always fetch the origin, even right after mirroring, because this way
 // permissions will get set correctly
 function updateRemote (from, cloneURL, treeish, cachedRemote, cb) {
+  var args = ['fetch', '-a']
+  if (npm.config.get('git-shallow-clone')) {
+    if (/[a-fA-F0-9]{40}/.test(treeish)) {
+      // most Git remotes don't allow you to reference SHAs, since it can be
+      // expensive, so just fall back to mirroring the full repo.  Git has
+      // special optimizations for this 32 bit MAX_INT number.
+      args.push('--depth=2147483647', '--update-shallow', 'origin')
+    } else {
+      args.push('--depth=1', 'origin', treeish)
+    }
+  } else {
+    args.push('origin')
+  }
   git.whichAndExec(
-    ['fetch', '-a', 'origin'],
+    args,
     { cwd: cachedRemote, env: gitEnv() },
     function (er, stdout, stderr) {
       if (er) {
         var combined = (stdout + '\n' + stderr).trim()
-        log.error('git fetch -a origin (' + cloneURL + ')', combined)
+        log.error('git ' + args.join(' ') + '(' + cloneURL + ')', combined)
         return cb(er)
       }
-      log.verbose('updateRemote', 'git fetch -a origin (' + cloneURL + ')', stdout.trim())
+      log.verbose('updateRemote', 'git ' + args.join(' ') + ' (' + cloneURL + ')', stdout.trim())
 
       setPermissions(from, cloneURL, treeish, cachedRemote, cb)
     }

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -141,6 +141,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'fetch-retry-maxtimeout': 60000,
 
     git: 'git',
+    'git-shallow-clone': false,
     'git-tag-version': true,
 
     global: false,
@@ -251,6 +252,7 @@ exports.types = {
   'fetch-retry-mintimeout': Number,
   'fetch-retry-maxtimeout': Number,
   git: String,
+  'git-shallow-clone': Boolean,
   'git-tag-version': Boolean,
   global: Boolean,
   globalconfig: path,

--- a/test/tap/bitbucket-https-url-with-creds-package.js
+++ b/test/tap/bitbucket-https-url-with-creds-package.js
@@ -37,7 +37,7 @@ test('bitbucket-https-url-with-creds-package', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/bitbucket-https-url-with-creds.js
+++ b/test/tap/bitbucket-https-url-with-creds.js
@@ -34,7 +34,7 @@ test('bitbucket-https-url-with-creds', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/bitbucket-shortcut-package.js
+++ b/test/tap/bitbucket-shortcut-package.js
@@ -38,7 +38,7 @@ test('bitbucket-shortcut', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/bitbucket-shortcut.js
+++ b/test/tap/bitbucket-shortcut.js
@@ -35,7 +35,7 @@ test('bitbucket-shortcut', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gist-short-shortcut-package.js
+++ b/test/tap/gist-short-shortcut-package.js
@@ -38,7 +38,7 @@ test('gist-short-shortcut-package', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gist-short-shortcut.js
+++ b/test/tap/gist-short-shortcut.js
@@ -35,7 +35,7 @@ test('gist-shortcut', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gist-shortcut-package.js
+++ b/test/tap/gist-shortcut-package.js
@@ -38,7 +38,7 @@ test('gist-shortcut-package', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gist-shortcut.js
+++ b/test/tap/gist-shortcut.js
@@ -35,7 +35,7 @@ test('gist-shortcut', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/github-shortcut-package.js
+++ b/test/tap/github-shortcut-package.js
@@ -38,7 +38,7 @@ test('github-shortcut-package', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gitlab-shortcut-package.js
+++ b/test/tap/gitlab-shortcut-package.js
@@ -37,7 +37,7 @@ test('gitlab-shortcut-package', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gitlab-shortcut.js
+++ b/test/tap/gitlab-shortcut.js
@@ -34,7 +34,7 @@ test('gitlab-shortcut', function (t) {
           if (args[0] !== 'clone') return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/install-git-shallow-cloned.js
+++ b/test/tap/install-git-shallow-cloned.js
@@ -1,0 +1,168 @@
+var fs = require('fs')
+var crypto = require('crypto')
+var path = require('path')
+var resolve = path.resolve
+var osenv = require('osenv')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var test = require('tap').test
+var npm = require('../../lib/npm')
+var common = require('../common-tap')
+var chain = require('slide').chain
+
+var pkgPath = resolve(__dirname, 'install-shallow-git')
+var repoPath = resolve(pkgPath, 'gitrepo')
+
+var git
+var gitDaemon
+var gitDaemonPID
+var gitVersion
+
+test('setup', function (t) {
+  setup(function (err, result) {
+    t.ifError(err, 'git started up successfully')
+
+    if (!err) {
+      gitDaemon = result[result.length - 2]
+      gitDaemonPID = result[result.length - 1]
+    }
+
+    t.end()
+  })
+})
+
+test('shallow clone of git repository', function (t) {
+  if (/git version [01]\.[0-8]\./.test(gitVersion)) {
+    console.log('    ok # skip git <1.9 has bad shallow clone support')
+    t.end()
+    return
+  }
+  // Prepare the git repo with a big file removed in the latest commit
+  prepareRepoAndGetRefs(function (refs) {
+    // Install and shallow fetch repo
+    npm.config.set('git-shallow-clone', true)
+    npm.commands.install(['git://localhost:1234/gitrepo'], function (err) {
+      t.ifError(err, 'npm install successful')
+      var cacheSize = getTotalSize(common.npm_config_cache)
+      t.ok(cacheSize > 1024 * 10, 'Git repo size bigger than 10KB')
+      t.ok(cacheSize < 1024 * 512, 'Git repo size less than 512KB')
+      // Install with a SHA as ref, causing us to fetch full repo
+      npm.commands.install(['git://localhost:1234/gitrepo#' + refs[1]], function (err) {
+        t.ifError(err, 'npm install update successful')
+        cacheSize = getTotalSize(common.npm_config_cache)
+        t.ok(cacheSize > 1024 * 512, 'Git repo size bigger than 512KB')
+        t.ok(cacheSize < 20 * 1024 * 1024, 'Git repo size less than 20MB')
+        t.end()
+      })
+    })
+  })
+})
+
+test('clean', function (t) {
+  gitDaemon.on('close', function () {
+    cleanup()
+    t.end()
+  })
+  process.kill(gitDaemonPID)
+})
+
+function setup (cb) {
+  mkdirp.sync(repoPath)
+  // Dummy project only to leave npm package.json alone
+  process.chdir(pkgPath)
+  fs.writeFileSync(resolve(pkgPath, 'package.json'), JSON.stringify({
+    name: 'dummy',
+    version: '0.0.1'
+  }))
+  // Setup gitrepo package
+  fs.writeFileSync(resolve(repoPath, 'package.json'), JSON.stringify({
+    name: 'gitrepo',
+    version: '0.0.1'
+  }))
+  // Setup npm and then git
+  npm.load({
+    registry: common.registry,
+    loglevel: 'silent',
+    save: true // Always install packages with --save
+  }, function () {
+    // It's important to initialize git after npm because it uses config
+    initializeGit(cb)
+  })
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkgPath)
+  rimraf.sync(common['npm_config_cache'])
+}
+
+function prepareRepoAndGetRefs (cb) {
+  var opts = { cwd: repoPath, env: { PATH: process.env.PATH } }
+  chain([
+    [fs.writeFile, path.join(repoPath, 'BIGFILE'), crypto.randomBytes(1024 * 1024)],
+    git.chainableExec(['add', 'BIGFILE'], opts),
+    git.chainableExec(['commit', '-m', 'Add BIGFILE'], opts),
+    git.chainableExec(['rm', 'BIGFILE'], opts),
+    git.chainableExec(['commit', '-m', 'Remove BIGFILE'], opts),
+    git.chainableExec(['log', '--pretty=format:"%H"', '-2'], opts)
+  ], function () {
+    var gitLogStdout = arguments[arguments.length - 1]
+    var refs = gitLogStdout[gitLogStdout.length - 1].split('\n').map(function (ref) {
+      return ref.match(/^"(.+)"$/)[1]
+    })
+    cb(refs)
+  })
+}
+
+function initializeGit (cb) {
+  git = require('../../lib/utils/git')
+  git.whichAndExec(['--version'], {}, function (err, result) {
+    gitVersion = result
+    if (err) {
+      cb(err)
+      return
+    }
+    common.makeGitRepo({
+      path: repoPath,
+      commands: [startGitDaemon]
+    }, cb)
+  })
+}
+
+function startGitDaemon (cb) {
+  var daemon = git.spawn(
+    [
+      'daemon',
+      '--verbose',
+      '--listen=localhost',
+      '--export-all',
+      '--base-path=' + pkgPath, // Path to the dir that contains the repo
+      '--reuseaddr',
+      '--port=1234'
+    ],
+    {
+      cwd: repoPath,
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }
+  )
+  daemon.stderr.on('data', function findChild (c) {
+    var cpid = c.toString().match(/^\[(\d+)\]/)
+    if (cpid[1]) {
+      this.removeListener('data', findChild)
+      cb(null, [daemon, cpid[1]])
+    }
+  })
+}
+
+function getTotalSize (filePath) {
+  var stat = fs.lstatSync(filePath)
+  var size = stat.size
+  if (stat.isDirectory()) {
+    var entries = fs.readdirSync(filePath)
+    for (var i = 0; i < entries.length; i++) {
+      size += getTotalSize(path.join(filePath, entries[i]))
+    }
+  }
+  return size
+}


### PR DESCRIPTION
I noticed that some packages took a lot of time installing.  Some Git repositories have a lot of cruft in them. `npm` sometimes installs from Git repositories, I'd guess this happens a bit more often behind closed doors in companies. Though I guess it's somewhat frowned upon for other reasons thas just speed. Anyway, this change will help me a lot.

By doing a shallow clone, `npm` will get the code that was requested, but without any extra history that probably won't be used anyway.  In some cases this will be a lot faster.
## Example

I did some tests on a big-ish repository and created a hopefully reproducible example:

```
nodetest$ cat package.json
{ "name": "clonetest", "dependencies": {
   "videojs-contrib-hls": "hola/videojs-contrib-hls#v2.2.0-12" } }

nodetest (before)$ time npm install
real    6m9.858s
user    0m25.391s
sys     0m21.009s

nodetest (after)$ time npm install
real    2m24.738s
user    0m14.777s
sys     0m18.674s
```

YMMV based on bandwidth, computer speed etc.  There's also a nice side effect:

```
(before)$ du -hs ~/.npm/_git-remotes/
184M    /home/odin/.npm/_git-remotes/

(after)$ du -hs ~/.npm/_git-remotes/
40M     /home/odin/.npm/_git-remotes/
```
## Information about the pull request (commit body)

> git: Use shallow clones making some installs faster
> 
> This change makes npm require Git 1.9, released February 2014.
> 
> Some git repositories are huge, npm only needs the head of each ref it
> wants to install.  To make sure it can still potentially reuse the
> repository for different branches/tags and also update itself, it will
> always 'git fetch origin <the_ref>' which makes sure that single ref is
> available and the newest version.
> 
> If the ref is a SHA, however, npm will fall back to fetching the entire
> repository again, because we can't know where said SHA is.  Some
> upstream servers allow you to fetch a SHA, but we can't rely on it.
