### PR TITLE
Fix afterUser() function to get root npm dir

### DIFF
--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -151,14 +151,14 @@ function load_ (builtin, rc, cli, cb) {
     // Eg, `npm config get globalconfig --prefix ~/local` should
     // return `~/local/etc/npmrc`
     // annoying humans and their expectations!
-    var rootdir = path.resolve(__dirname, '../..', '')
-    if (rootdir) {
-      var etc = path.resolve(root, 'etc')
+    conf.set('prefix', path.resolve(__dirname, '../..', ''))
+    if (conf.get('prefix')) {
+      var etc = path.resolve(conf.get('prefix'), 'etc')
       mkdirp(etc, function () {
         defaults.globalconfig = path.resolve(etc, 'npmrc')
         defaults.globalignorefile = path.resolve(etc, 'npmignore')
+        afterUserContinuation()
       })
-      afterUserContinuation()
     } else {
       afterUserContinuation()
     }

--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -151,13 +151,14 @@ function load_ (builtin, rc, cli, cb) {
     // Eg, `npm config get globalconfig --prefix ~/local` should
     // return `~/local/etc/npmrc`
     // annoying humans and their expectations!
-    if (conf.get('prefix')) {
-      var etc = path.resolve(conf.get('prefix'), 'etc')
+    var rootdir = path.resolve(__dirname, '../..', '')
+    if (rootdir) {
+      var etc = path.resolve(root, 'etc')
       mkdirp(etc, function () {
         defaults.globalconfig = path.resolve(etc, 'npmrc')
         defaults.globalignorefile = path.resolve(etc, 'npmignore')
-        afterUserContinuation()
       })
+      afterUserContinuation()
     } else {
       afterUserContinuation()
     }


### PR DESCRIPTION
The directory in afterUser() can not be obtained by conf.get('prefix'), as it must necessarily be the root directory npm, or it will not proceed with loadExtras, line 241 `// Without prefix, nothing will ever work`

My problem was that conf.get('prefix') was getting a bug directory and I could not run any command npm! See my problem: 

http://stackoverflow.com/questions/39540427/npm-commands-not-work
