### PR TITLE
Update issue_template.md to reference macOS

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -21,7 +21,7 @@
  - `npm -v` prints:
  - `node -v` prints:
  - `npm config get registry` prints:
- - Windows, OS X, or Linux?:
+ - Windows, OS X/macOS, or Linux?:
  - Network issues:
    - Geographic location where npm was run:
    - [ ] I use a proxy to connect to the npm registry.


### PR DESCRIPTION
As of 10.12 OS X has been renamed to macOS. This PR updates the GitHub issue template to reference both OS X and macOS.
