### PR TITLE
outdated: exitcode != 0 on outdated dependencies

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -111,7 +111,12 @@ function outdated (args, silent, cb) {
         }
         output(table(outTable, tableOpts))
       }
-      cb(null, list.map(function (item) { return [item[0].parent.path].concat(item.slice(1, 7)) }))
+      var msg = [
+        'The outdated dependencies were found. Please make sure',
+        'the versions in node_module, or look over package.json',
+        'to use the most suitable semver range.'
+      ].join('\n')
+      cb(msg, list.map(function (item) { return [item[0].parent.path].concat(item.slice(1, 7)) }))
     })
   }))
 }

--- a/test/tap/outdated-color.js
+++ b/test/tap/outdated-color.js
@@ -56,8 +56,8 @@ test('does not use ansi styling', function (t) {
       ],
     EXEC_OPTS,
     function (err, code, stdout) {
-      t.ifError(err)
-      t.notOk(code, 'npm outdated exited with code 0')
+      t.ifError(err, 'npm outdated ran with a error message')
+      t.is(code, 1, 'npm outdated exited with code 1')
       t.ok(stdout, stdout.length)
       t.ok(!hasControlCodes(stdout))
       s.close()

--- a/test/tap/outdated-depth-deep.js
+++ b/test/tap/outdated-depth-deep.js
@@ -71,8 +71,8 @@ test('outdated depth deep (9999)', function (t) {
 
   function thenValidateOutput (err, code, stdout, stderr) {
     if (err) throw err
-    t.is(code, 0, 'outdated completed successfully')
-    t.is('', stderr, 'no error output')
+    t.ifError(err, 'npm outdated ran with a error message')
+    t.is(code, 1, 'npm outdated exited with code 1')
     t.match(
       stdout,
       /underscore.*1\.3\.1.*1\.3\.1.*1\.5\.1.*whatever\n/g,

--- a/test/tap/outdated-depth-integer.js
+++ b/test/tap/outdated-depth-integer.js
@@ -62,7 +62,7 @@ test('outdated depth integer', function (t) {
       npm.install('request@0.9.0', function (er) {
         if (er) throw new Error(er)
         npm.outdated(function (err, d) {
-          if (err) throw new Error(err)
+          t.ok(err, 'npm outdated ran with a error message')
           t.deepEqual(d, expected)
           s.close()
           t.end()

--- a/test/tap/outdated-depth.js
+++ b/test/tap/outdated-depth.js
@@ -54,7 +54,7 @@ test('outdated depth zero', function (t) {
         npm.install('.', function (er) {
           if (er) throw new Error(er)
           npm.outdated(function (err, d) {
-            if (err) throw new Error(err)
+            t.ok(err, 'npm outdated ran with a error message')
             t.deepEqual(d[0], expected)
             s.close()
             t.end()

--- a/test/tap/outdated-json.js
+++ b/test/tap/outdated-json.js
@@ -79,8 +79,8 @@ test('it should log json data', function (t) {
     ],
     EXEC_OPTS,
     function (err, code, stdout) {
-      t.ifError(err, 'npm outdated ran without issue')
-      t.notOk(code, 'npm outdated ran without raising error code')
+      t.ifError(err, 'npm outdated ran with a error message')
+      t.is(code, 1, 'npm outdated exited with code 1')
       var out
       t.doesNotThrow(function () {
         out = JSON.parse(stdout)

--- a/test/tap/outdated-local.js
+++ b/test/tap/outdated-local.js
@@ -115,7 +115,7 @@ test('outdated support local modules', function (t) {
           t.ifError(err, 'install success')
           bumpLocalModules()
           npm.outdated(function (er, d) {
-            t.ifError(er, 'outdated success')
+            t.ifError(err, 'npm outdated ran with a error message')
             t.ok(verify(d, [
               [
                 path.resolve(__dirname, 'outdated-local'),

--- a/test/tap/outdated-long.js
+++ b/test/tap/outdated-long.js
@@ -75,8 +75,7 @@ test('it should not throw', function (t) {
           t.ifError(err, 'install success')
           npm.config.set('long', true)
           npm.outdated(function (er, d) {
-            t.ifError(er, 'outdated success')
-
+            t.ifError(err, 'npm outdated ran with a error message')
             console.log = originalLog
 
             t.same(output, expOut)

--- a/test/tap/outdated-private.js
+++ b/test/tap/outdated-private.js
@@ -66,7 +66,7 @@ test('outdated ignores private modules', function (t) {
           t.ifError(err, 'install success')
           bumpLocalPrivate()
           npm.outdated(function (er, d) {
-            t.ifError(er, 'outdated success')
+            t.ifError(err, 'npm outdated ran with a error message')
             t.deepEqual(d, [[
               path.resolve(__dirname, 'outdated-private'),
               'underscore',

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -103,7 +103,7 @@ test('it should not throw', function (t) {
             output.push.apply(output, arguments)
           }
           npm.outdated(function (er, d) {
-            t.ifError(er, 'outdated success')
+            t.ifError(err, 'npm outdated ran with a error message')
             output = output.map(function (x) { return x.replace(/\r/g, '') })
             console.log = originalLog
 


### PR DESCRIPTION
Fixes: #5999.

This update is a breaking change requested a long time ago. When outdated dependencies exist in a project, the command displays a helpful error message and then finish the action with `exit 1`. To ignore the error and keep the previous behavior, it's possible via passing `--silent` option.
