### PR TITLE
Fixes #13973 #14030

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -273,15 +273,17 @@ function printData (data, name, cb) {
     })
   })
 
-  if (msgJson.length && Object.keys(msgJson[0]).length === 1) {
-    var k = Object.keys(msgJson[0])[0]
-    msgJson = msgJson.map(function (m) { return m[k] })
-  }
+  if (npm.config.get('json')) {
+    if (msgJson.length && Object.keys(msgJson[0]).length === 1) {
+      var k = Object.keys(msgJson[0])[0]
+      msgJson = msgJson.map(function (m) { return m[k] })
+    }
 
-  if (!msg) {
-    msg = JSON.stringify(msgJson[0], null, 2) + '\n'
-  } else if (msgJson.length > 1) {
-    msg = JSON.stringify(msgJson, null, 2) + '\n'
+    if (msgJson.length === 1) {
+      msg = JSON.stringify(msgJson[0], null, 2) + '\n'
+    } else if (msgJson.length > 1) {
+      msg = JSON.stringify(msgJson, null, 2) + '\n'
+    }
   }
 
   // preserve output symmetry by adding a whitespace-only line at the end if

--- a/test/tap/view.js
+++ b/test/tap/view.js
@@ -277,6 +277,27 @@ test('npm view <package name>@<semver range> versions', function (t) {
   })
 })
 
+test('npm view <package name>@<semver range> version --json', function (t) {
+  mr({ port: common.port, plugin: plugin }, function (er, s) {
+    common.npm([
+      'view',
+      'underscore@~1.5.0',
+      'version',
+      '--json',
+      '--registry=' + common.registry
+    ], { cwd: t2dir }, function (err, code, stdout) {
+      t.ifError(err, 'view command finished successfully')
+      t.equal(code, 0, 'exit ok')
+      t.equal(stdout.trim(), JSON.stringify([
+        '1.5.0',
+        '1.5.1'
+      ], null, 2), 'should have three versions')
+      s.close()
+      t.end()
+    })
+  })
+})
+
 test('npm view <package name> --json', function (t) {
   t.plan(3)
   mr({ port: common.port, plugin: plugin }, function (er, s) {
@@ -297,6 +318,39 @@ test('npm view <package name> --json', function (t) {
       } catch (er) {
         t.fail('Unable to parse JSON')
       }
+    })
+  })
+})
+
+test('npm view <package name>@<invalid version>', function (t) {
+  mr({ port: common.port, plugin: plugin }, function (er, s) {
+    common.npm([
+      'view',
+      'underscore@12345',
+      '--registry=' + common.registry
+    ], { cwd: t2dir }, function (err, code, stdout) {
+      t.ifError(err, 'view command finished successfully')
+      t.equal(code, 0, 'exit ok')
+      t.equal(stdout.trim(), '', 'should return empty')
+      s.close()
+      t.end()
+    })
+  })
+})
+
+test('npm view <package name>@<invalid version> --json', function (t) {
+  mr({ port: common.port, plugin: plugin }, function (er, s) {
+    common.npm([
+      'view',
+      'underscore@12345',
+      '--json',
+      '--registry=' + common.registry
+    ], { cwd: t2dir }, function (err, code, stdout) {
+      t.ifError(err, 'view command finished successfully')
+      t.equal(code, 0, 'exit ok')
+      t.equal(stdout.trim(), '', 'should return empty')
+      s.close()
+      t.end()
     })
   })
 })


### PR DESCRIPTION
This makes `npm show` for an unpublished version print empty string, regardless of whether `--json` is passed. As a (intentional) side effect of making it return empty string for `--json`, it fixes #14030.

Empty string for `--json` might be the wrong thing, but it's what npm2 did, and it seemed weird at first blush for `--json` to print `undefined`, since I don't think that's valid JSON. 

Approach: wrap some stuff towards the end of `printData` in a `--json` check, since it doesn't seem like it should apply if we're not printing JSON. The check for `if (!msg)` was what was ultimately causing the `undefined` to be printed, and it seems like we should be going into that branch (line 283 in the patch) if we have no `msgJson` data to begin with.

LMK if there's anything I can clean up here (or if I'm way off base). Thanks!
# 

Commits
13973: npm show w/ undefined version prints 'undefined'
14030: npm show --json w/ semver range prints single result
