### PR TITLE
test: handle the order of the cli args for windows

### DIFF
--- a/test/tap/bitbucket-https-url-with-creds-package.js
+++ b/test/tap/bitbucket-https-url-with-creds-package.js
@@ -34,10 +34,10 @@ test('bitbucket-https-url-with-creds-package', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/bitbucket-https-url-with-creds.js
+++ b/test/tap/bitbucket-https-url-with-creds.js
@@ -31,10 +31,10 @@ test('bitbucket-https-url-with-creds', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/bitbucket-shortcut-package.js
+++ b/test/tap/bitbucket-shortcut-package.js
@@ -35,10 +35,10 @@ test('bitbucket-shortcut', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/bitbucket-shortcut.js
+++ b/test/tap/bitbucket-shortcut.js
@@ -32,10 +32,10 @@ test('bitbucket-shortcut', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gist-short-shortcut-package.js
+++ b/test/tap/gist-short-shortcut-package.js
@@ -35,10 +35,10 @@ test('gist-short-shortcut-package', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gist-short-shortcut.js
+++ b/test/tap/gist-short-shortcut.js
@@ -32,10 +32,10 @@ test('gist-shortcut', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gist-shortcut-package.js
+++ b/test/tap/gist-shortcut-package.js
@@ -35,10 +35,10 @@ test('gist-shortcut-package', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gist-shortcut.js
+++ b/test/tap/gist-shortcut.js
@@ -32,10 +32,10 @@ test('gist-shortcut', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/git-races.js
+++ b/test/tap/git-races.js
@@ -60,9 +60,12 @@ function cleanup () {
 var npm = requireInject.installGlobally('../../lib/npm.js', {
   'child_process': {
     'execFile': function (cmd, args, options, cb) {
+      // on win 32, the following prefix is added in utils/git.js
+      // $ git -c core.longpaths=true clone
+      var i = process.platform === 'win32' ? 2 : 0
       // If it's a clone we swap any requests for any of the urls we're mocking
       // with the path to the bare repo
-      if (args[0] === 'clone') {
+      if (args[i] === 'clone') {
         var m2 = args.length - 2
         var m1 = args.length - 1
         if (testrepos[args[m2]]) {
@@ -72,7 +75,7 @@ var npm = requireInject.installGlobally('../../lib/npm.js', {
         execFile(cmd, args, options, cb)
       // here, we intercept npm validating the remote origin url on one of the
       // clones we've done previously and return the original url that was requested
-      } else if (args[0] === 'config' && args[1] === '--get' && args[2] === 'remote.origin.url') {
+      } else if (args[i] === 'config' && args[i + 1] === '--get' && args[i + 2] === 'remote.origin.url') {
         process.nextTick(function () {
           cb(null, testurls[options.cwd], '')
         })

--- a/test/tap/github-shortcut-package.js
+++ b/test/tap/github-shortcut-package.js
@@ -35,10 +35,10 @@ test('github-shortcut-package', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gitlab-shortcut-package.js
+++ b/test/tap/gitlab-shortcut-package.js
@@ -34,10 +34,10 @@ test('gitlab-shortcut-package', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }

--- a/test/tap/gitlab-shortcut.js
+++ b/test/tap/gitlab-shortcut.js
@@ -31,10 +31,10 @@ test('gitlab-shortcut', function (t) {
     'child_process': {
       'execFile': function (cmd, args, options, cb) {
         process.nextTick(function () {
-          if (args[0] !== 'clone') return cb(null, '', '')
+          if (args.indexOf('clone') === -1) return cb(null, '', '')
           var cloneUrl = cloneUrls.shift()
           if (cloneUrl) {
-            t.is(args[3], cloneUrl[0], cloneUrl[1])
+            t.is(args[args.length - 2], cloneUrl[0], cloneUrl[1])
           } else {
             t.fail('too many attempts to clone')
           }


### PR DESCRIPTION
Hello!

I've fixed the ci error on Appveyor. Some of the test code are depending on the order of the command line arguments in the git command, and it doesn't work on Windows since prefixes are added in `lib/utils/git.js`, like the following:

```
$ git -c core.longpaths=true clone
```

For the test cases related to bitbucket, github and gitlab, I used the same solution with [github-shortcut-package.js](https://github.com/npm/npm/blob/8fa75cd0313e3cea8459f89b79208461e54b033b/test/tap/github-shortcut-package.js#L34-L49) which doesn't depend on the order of the command line arguments. For the other case, I've added an index number into it: [git-race.js](https://github.com/watilde/npm/blob/e58b4b308f38acbbe3ed1f8e6f73e01a47308888/test/tap/git-races.js#L63-L84).
