### PR TITLE
Add .npmignore to always ignored files

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -200,6 +200,7 @@ Conversely, some files are always ignored:
 * `.DS_Store`
 * `._*`
 * `npm-debug.log`
+* `.npmignore`
 * `.npmrc`
 * `node_modules`
 * `config.gypi`

--- a/doc/misc/npm-developers.md
+++ b/doc/misc/npm-developers.md
@@ -120,6 +120,7 @@ need to add them to `.npmignore` explicitly:
 * `.DS_Store`
 * `.git`
 * `.hg`
+* `.npmignore`
 * `.npmrc`
 * `.lock-wscript`
 * `.svn`

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -99,6 +99,7 @@ BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
       (this.parent && this.parent.packageRoot && this.basename === 'build' &&
        entry === 'config.gypi') ||
       entry === 'npm-debug.log' ||
+      entry === '.npmignore' ||
       entry === '.npmrc' ||
       entry.match(/^\..*\.swp$/) ||
       entry === '.DS_Store' ||

--- a/test/tap/files-and-ignores.js
+++ b/test/tap/files-and-ignores.js
@@ -325,25 +325,6 @@ test('includes files regardless of emptiness', function (t) {
   })
 })
 
-test('.npmignore itself gets included', function (t) {
-  var fixture = new Tacks(
-    Dir({
-      'package.json': File({
-        name: 'npm-test-files',
-        version: '1.2.5',
-        files: [
-          '.npmignore'
-        ]
-      }),
-      '.npmignore': File('')
-    })
-  )
-  withFixture(t, fixture, function (done) {
-    t.ok(fileExists('.npmignore'), '.npmignore included')
-    done()
-  })
-})
-
 test('include default files when missing files spec', function (t) {
   var fixture = new Tacks(
     Dir({
@@ -401,6 +382,7 @@ test('certain files ignored unconditionally', function (t) {
           '.wafpickle-50',
           'build/config.gypi',
           'npm-debug.log',
+          '.npmignore',
           '.npmrc',
           '.foo.swp',
           '.DS_Store',
@@ -418,6 +400,7 @@ test('certain files ignored unconditionally', function (t) {
       '.wafpickle-50': File(''),
       'build': Dir({'config.gypi': File('')}),
       'npm-debug.log': File(''),
+      '.npmignore': File(''),
       '.npmrc': File(''),
       '.foo.swp': File(''),
       '.DS_Store': Dir({foo: File('')}),
@@ -437,6 +420,7 @@ test('certain files ignored unconditionally', function (t) {
     t.notOk(fileExists('.wafpickle-50'), '.wafpickle-50 not included')
     t.notOk(fileExists('build/config.gypi'), 'build/config.gypi not included')
     t.notOk(fileExists('npm-debug.log'), 'npm-debug.log not included')
+    t.notOk(fileExists('.npmignore'), '.npmignore not included')
     t.notOk(fileExists('.npmrc'), '.npmrc not included')
     t.notOk(fileExists('.foo.swp'), '.foo.swp not included')
     t.notOk(fileExists('.DS_Store'), '.DS_Store not included')

--- a/test/tap/git-npmignore.js
+++ b/test/tap/git-npmignore.js
@@ -48,8 +48,7 @@ var modules = resolve(testdir, 'node_modules')
 var installed = resolve(modules, 'gitch')
 var expected = [
   'a.js',
-  'package.json',
-  '.npmignore'
+  'package.json'
 ].sort()
 
 var NPM_OPTS = { cwd: testdir }


### PR DESCRIPTION
Many packages unintentionally publish `.npmignore` to npm. For example, looking at the dependencies of `npm` package alone, almost half of them include `.npmignore`:

```
npm init -f
npm install npm --save
npm list | wc -l
     267
find node_modules -name ".npmignore" | wc -l
      98
```

However, by definition, `.npmignore` is unnecessary once the package has been published to npm. Removing it from published packages would speed up npm installs everywhere. But asking all package authors to ignore it manually is almost an impossible task.

npm already ignores certain files (e.g. `.npmrc`) by default. Let's add `.npmignore` to this list of ignores, and make lots of future releases smaller.
