### PR TITLE
shrinkwrap: fix optional deps check

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -311,14 +311,16 @@ function andForEachChild (load, next) {
   }
 }
 
-function isDepOptional (tree, name) {
+function isDepOptional (tree, name, pkg) {
+  if (pkg.package && pkg.package._optional) return true
   if (!tree.package.optionalDependencies) return false
   if (tree.package.optionalDependencies[name] != null) return true
   return false
 }
 
 var failedDependency = exports.failedDependency = function (tree, name_pkg) {
-  var name, pkg
+  var name
+  var pkg = {}
   if (typeof name_pkg === 'string') {
     name = name_pkg
   } else {
@@ -327,7 +329,7 @@ var failedDependency = exports.failedDependency = function (tree, name_pkg) {
   }
   tree.children = tree.children.filter(noModuleNameMatches(name))
 
-  if (isDepOptional(tree, name)) {
+  if (isDepOptional(tree, name, pkg)) {
     return false
   }
 

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -45,14 +45,16 @@ function inflateShrinkwrap (topPath, tree, swdeps, finishInflating) {
         return inflateShrinkwrap(topPath, child, dependencies || {}, next)
       } else {
         var from = sw.from || requested.raw
-        return fetchPackageMetadata(requested, topPath, iferr(next, andAddShrinkwrap(from, dependencies, next)))
+        var optional = sw.optional
+        return fetchPackageMetadata(requested, topPath, iferr(next, andAddShrinkwrap(from, optional, dependencies, next)))
       }
     }
   }
 
-  function andAddShrinkwrap (from, dependencies, next) {
+  function andAddShrinkwrap (from, optional, dependencies, next) {
     return function (pkg) {
       pkg._from = from
+      pkg._optional = optional
       addShrinkwrap(pkg, iferr(next, andAddBundled(pkg, dependencies, next)))
     }
   }

--- a/test/tap/shrinkwrap-optional-platform.js
+++ b/test/tap/shrinkwrap-optional-platform.js
@@ -33,9 +33,18 @@ var fixture = new Tacks(Dir({
       'package.json': File({
         name: 'mod1',
         version: '1.0.0',
-        scripts: {
-
+        scripts: {},
+        'optionalDependencies': {
+          'mod2': 'file:../mod2'
         },
+        os: ['nosuchos']
+      })
+    }),
+    mod2: Dir({
+      'package.json': File({
+        name: 'mod2',
+        version: '1.0.0',
+        scripts: {},
         os: ['nosuchos']
       })
     }),
@@ -47,6 +56,12 @@ var fixture = new Tacks(Dir({
           version: '1.0.0',
           from: 'mod1',
           resolved: 'file:mod1',
+          optional: true
+        },
+        mod2: {
+          version: '1.0.0',
+          from: 'mod2',
+          resolved: 'file:mod2',
           optional: true
         }
       }
@@ -93,4 +108,3 @@ test('cleanup', function (t) {
   cleanup()
   t.done()
 })
-


### PR DESCRIPTION
Fixes https://github.com/npm/npm/issues/14042. From the last release, `npm-shrinkwrap.json` has been updated to tell us the deps is optional or not, but instal-check in `install/action.js` still has been checking the deps could be installable or not even the deps has `optional: true`.

I've updated `inflate-shrinkwrap.js` to pass the property of the optional to `action.js` and  `isInstallable` should be skipped if the deps is optional. I will add a test and write more detail into the commit message later. Thanks!
