### PR TITLE
The npm shrinkwrap file needed to have is full path specified.

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -263,7 +263,7 @@ function _commit (version, localData, cb) {
   chain(
     [
       git.chainableExec([ 'add', packagePath ], options),
-      localData.hasShrinkwrap && git.chainableExec([ 'add', 'npm-shrinkwrap.json' ], options),
+      localData.hasShrinkwrap && git.chainableExec([ 'add', path.join(npm.localPrefix, 'npm-shrinkwrap.json') ], options),
       git.chainableExec([ 'commit', '-m', message ], options),
       !localData.existingTag && git.chainableExec([
         'tag',

--- a/test/tap/version-sub-directory-shrinkwrap.js
+++ b/test/tap/version-sub-directory-shrinkwrap.js
@@ -1,0 +1,76 @@
+var common = require('../common-tap.js')
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var npm = require('../../lib/npm.js')
+
+var pkg = path.resolve(__dirname, 'version-sub-directory')
+var subDirectory = path.resolve(pkg, 'sub-directory')
+var packagePath = path.resolve(pkg, 'package.json')
+var shrinkwrapPath = path.resolve(pkg, 'npm-shrinkwrap.json')
+var cache = path.resolve(pkg, 'cache')
+
+var json = { name: 'cat', version: '0.1.2' }
+
+test('npm version <semver> from a subdirectory', function (t) {
+  setup()
+  npmLoad()
+
+  function npmLoad () {
+    npm.load({ cache: cache }, function () {
+      common.makeGitRepo({
+        path: pkg,
+        added: ['package.json', 'npm-shrinkwrap.json']
+      }, version)
+    })
+  }
+
+  function version (er, stdout, stderr) {
+    t.ifError(er, 'git repo initialized without issue')
+    t.notOk(stderr, 'no error output')
+    npm.config.set('sign-git-tag', false)
+    npm.commands.version(['patch'], checkVersion)
+  }
+
+  function checkVersion (er) {
+    var git = require('../../lib/utils/git.js')
+    t.ifError(er, 'version command ran without error')
+    git.whichAndExec(
+      ['log'],
+      { cwd: pkg, env: process.env },
+      checkCommit
+    )
+  }
+
+  function checkCommit (er, log, stderr) {
+    t.ifError(er, 'git log ran without issue')
+    t.notOk(stderr, 'no error output')
+    t.ok(log.match(/0\.1\.3/g), 'commited from subdirectory')
+    t.end()
+  }
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  // windows fix for locked files
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}
+
+function setup () {
+  cleanup()
+  mkdirp.sync(cache)
+  mkdirp.sync(subDirectory)
+  process.chdir(subDirectory)
+  fs.writeFileSync(packagePath, JSON.stringify(json), 'utf8')
+  fs.writeFileSync(shrinkwrapPath, JSON.stringify(json), 'utf8')
+}


### PR DESCRIPTION
fixes issue #14009.  

The problem was that the `git add` of the npm-shrinkwrap.json was failing, since it was looking for it in the wrong directory.  Adding in the actual path to the shrinkwrap file similar to https://github.com/npm/npm/blob/master/lib/version.js#L145 fixes the issue
