### PR TITLE
Null check to prevent npm install from throwing in some cases.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -648,7 +648,7 @@ Installer.prototype.normalizeTree = function (log, cb) {
   log.silly('install', 'normalizeTree')
   recalculateMetadata(this.currentTree, log, iferr(cb, function (tree) {
     tree.children.forEach(function (child) {
-      if (child.requiredBy.length === 0) {
+      if (!child.requiredBy || child.requiredBy.length === 0) {
         child.existing = true
       }
     })

--- a/lib/install/copy-tree.js
+++ b/lib/install/copy-tree.js
@@ -18,7 +18,7 @@ function copyTree (tree, cache) {
 
 function copyModuleList (tree, key, cache) {
   var newList = []
-  let list = tree[key]
+  var list = tree[key]
 
   if (list) {
     list.forEach(function (child) {

--- a/lib/install/copy-tree.js
+++ b/lib/install/copy-tree.js
@@ -18,8 +18,13 @@ function copyTree (tree, cache) {
 
 function copyModuleList (tree, key, cache) {
   var newList = []
-  tree[key].forEach(function (child) {
-    newList.push(copyTree(child, cache))
-  })
+  let list = tree[key]
+
+  if (list) {
+    list.forEach(function (child) {
+      newList.push(copyTree(child, cache))
+    })
+  }
+
   tree[key] = newList
 }


### PR DESCRIPTION
This adds a simple null check to cases that are hit by `npm install` where a child package doesn't have requiredBy array populated.

Addresses issue: https://github.com/npm/npm/issues/14166
