### PR TITLE
Add shasum to shrinkwrap for use during install

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -84,9 +84,9 @@ var cachedPackageRoot = require('./cache/cached-package-root.js')
 var mapToRegistry = require('./utils/map-to-registry.js')
 var output = require('./utils/output.js')
 
-cache.usage = 'npm cache add <tarball file>' +
+cache.usage = 'npm cache add <tarball file> [shasum]' +
               '\nnpm cache add <folder>' +
-              '\nnpm cache add <tarball url>' +
+              '\nnpm cache add <tarball url> [shasum]' +
               '\nnpm cache add <git url>' +
               '\nnpm cache add <name>@<version>' +
               '\nnpm cache ls [<path>]' +
@@ -225,16 +225,22 @@ function clean (args, cb) {
 // npm cache add <tarball>
 // npm cache add <folder>
 cache.add = function (pkg, ver, where, scrub, cb) {
+  addWithShaCheck(pkg, ver, where, scrub, null, cb)
+}
+
+cache.addWithShaCheck = addWithShaCheck
+
+function addWithShaCheck (pkg, ver, where, scrub, shasum, cb) {
   assert(typeof pkg === 'string', 'must include name of package to install')
   assert(typeof cb === 'function', 'must include callback')
 
   if (scrub) {
     return clean([], function (er) {
       if (er) return cb(er)
-      add([pkg, ver], where, cb)
+      add([pkg, ver, shasum], where, cb)
     })
   }
-  return add([pkg, ver], where, cb)
+  add([pkg, ver, shasum], where, cb)
 }
 
 var adding = 0
@@ -250,20 +256,26 @@ function add (args, where, cb) {
   // that just a single argument.
 
   var usage = 'Usage:\n' +
-              '    npm cache add <tarball-url>\n' +
+              '    npm cache add <tarball-url> [shasum]\n' +
               '    npm cache add <pkg>@<ver>\n' +
               '    npm cache add <tarball>\n' +
               '    npm cache add <folder>\n'
-  var spec
-
+  var spec, shasum
   log.silly('cache add', 'args', args)
 
   if (args[1] === undefined) args[1] = null
-
+  if (args.length === 3) {
+    shasum = args[2]
+  } else {
+    if (args[0].indexOf('@') && args[1] !== null) {
+      shasum = args[1]
+      args[1] = null
+    }
+  }
   // at this point the args length must ==2
   if (args[1] !== null) {
     spec = args[0] + '@' + args[1]
-  } else if (args.length === 2) {
+  } else {
     spec = args[0]
   }
 
@@ -288,8 +300,7 @@ function add (args, where, cb) {
         // get auth, if possible
         mapToRegistry(p.raw, npm.config, function (err, uri, auth) {
           if (err) return cb(err)
-
-          addRemoteTarball(p.spec, { name: p.name }, null, auth, cb)
+          addRemoteTarball(p.spec, { name: p.name }, shasum, auth, cb)
         })
         break
       case 'git':

--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -89,7 +89,7 @@ var annotateMetadata = module.exports.annotateMetadata = function (pkg, requeste
 function fetchOtherPackageData (spec, dep, where, next) {
   validate('SOSF', arguments)
   log.silly('fetchOtherPackageData', spec)
-  cache.add(spec, null, where, false, iferr(next, function (pkg) {
+  cache.addWithShaCheck(spec, null, where, false, dep._shasum, iferr(next, function (pkg) {
     var result = clone(pkg)
     result._inCache = true
     next(null, result)
@@ -185,7 +185,7 @@ function fetchNamedPackageData (dep, next) {
 
 function retryWithCached (pkg, asserter, next) {
   if (!pkg._inCache) {
-    cache.add(pkg._spec, null, pkg._where, false, iferr(next, function (newpkg) {
+    cache.addWithShaCheck(pkg._spec, null, pkg._where, false, pkg._shasum, iferr(next, function (newpkg) {
       Object.keys(newpkg).forEach(function (key) {
         if (key[0] !== '_') return
         pkg[key] = newpkg[key]

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -40,11 +40,13 @@ function inflateShrinkwrap (topPath, tree, swdeps, finishInflating) {
       var child = onDisk[name]
       if (childIsEquivalent(sw, requested, child)) {
         if (!child.fromShrinkwrap) child.fromShrinkwrap = requested.raw
+        child._shasum = sw._shasum
         tree.children.push(child)
         annotateMetadata(child.package, requested, requested.raw, topPath)
         return inflateShrinkwrap(topPath, child, dependencies || {}, next)
       } else {
         var from = sw.from || requested.raw
+        requested._shasum = sw.shasum
         return fetchPackageMetadata(requested, topPath, iferr(next, andAddShrinkwrap(from, dependencies, next)))
       }
     }

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -84,6 +84,12 @@ function treeToShrinkwrap (tree, dev) {
   return pkginfo
 }
 
+const TYPES_WITH_DETERMINISTIC_SHAS = ['latest', 'version', 'range', 'tag', 'local']
+
+function shouldIncludeShaSumForPackage (pkg) {
+  return pkg._requested && TYPES_WITH_DETERMINISTIC_SHAS.indexOf(pkg._requested.type) !== -1
+}
+
 function shrinkwrapDeps (dev, problems, deps, tree, seen) {
   validate('BAOO', [dev, problems, deps, tree])
   if (!seen) seen = {}
@@ -109,6 +115,9 @@ function shrinkwrapDeps (dev, problems, deps, tree, seen) {
     pkginfo.version = child.package.version
     pkginfo.from = child.package._from
     pkginfo.resolved = child.package._resolved
+    if (shouldIncludeShaSumForPackage(child.package)) {
+      pkginfo.shasum = child.package._shasum
+    }
     if (dev && childIsOnlyDev) pkginfo.dev = true
     if (isOptional(child)) pkginfo.optional = true
     if (isExtraneous(child)) {

--- a/test/tap/shrinkwrap-dev-dependency.js
+++ b/test/tap/shrinkwrap-dev-dependency.js
@@ -23,12 +23,14 @@ var desired = {
     request: {
       version: '0.9.0',
       from: 'request@0.9.0',
-      resolved: common.registry + '/request/-/request-0.9.0.tgz'
+      resolved: common.registry + '/request/-/request-0.9.0.tgz',
+      shasum: '1049f59a6f46588e6d030921fbb84ca2f0c2714e'
     },
     underscore: {
       version: '1.3.1',
       from: 'underscore@1.3.1',
-      resolved: common.registry + '/underscore/-/underscore-1.3.1.tgz'
+      resolved: common.registry + '/underscore/-/underscore-1.3.1.tgz',
+      shasum: '6cb8aad0e77eb5dbbfb54b22bcd8697309cf9641'
     }
   }
 }

--- a/test/tap/shrinkwrap-optional-dependency.js
+++ b/test/tap/shrinkwrap-optional-dependency.js
@@ -64,7 +64,8 @@ var desired = {
     'test-package': {
       version: '0.0.0',
       from: 'test-package@0.0.0',
-      resolved: common.registry + '/test-package/-/test-package-0.0.0.tgz'
+      resolved: common.registry + '/test-package/-/test-package-0.0.0.tgz',
+      shasum: 'b0d32b6c45c259c578ba2003762b205131bdfbd1'
     }
   }
 }

--- a/test/tap/shrinkwrap-optional-property.js
+++ b/test/tap/shrinkwrap-optional-property.js
@@ -54,12 +54,14 @@ var desired = {
     'test-package': {
       version: '0.0.0',
       from: 'test-package@0.0.0',
-      resolved: common.registry + '/test-package/-/test-package-0.0.0.tgz'
+      resolved: common.registry + '/test-package/-/test-package-0.0.0.tgz',
+      shasum: 'b0d32b6c45c259c578ba2003762b205131bdfbd1'
     },
     'underscore': {
       version: '1.3.3',
       from: 'underscore@1.3.3',
       resolved: 'http://localhost:1337/underscore/-/underscore-1.3.3.tgz',
+      shasum: '47ac53683daf832bfa952e1774417da47817ae42',
       optional: true
     }
   }

--- a/test/tap/shrinkwrap-prod-dependency-also.js
+++ b/test/tap/shrinkwrap-prod-dependency-also.js
@@ -67,13 +67,15 @@ var desired = {
     request: {
       version: '0.9.0',
       from: 'request@0.9.0',
-      resolved: common.registry + '/request/-/request-0.9.0.tgz'
+      resolved: common.registry + '/request/-/request-0.9.0.tgz',
+      shasum: '1049f59a6f46588e6d030921fbb84ca2f0c2714e'
     },
     underscore: {
       dev: true,
       version: '1.5.1',
       from: 'underscore@1.5.1',
-      resolved: common.registry + '/underscore/-/underscore-1.5.1.tgz'
+      resolved: common.registry + '/underscore/-/underscore-1.5.1.tgz',
+      shasum: 'd2bde817d176ffade894ab71458e682a14b86dc9'
     }
   }
 }

--- a/test/tap/shrinkwrap-prod-dependency.js
+++ b/test/tap/shrinkwrap-prod-dependency.js
@@ -47,13 +47,15 @@ var desired = {
     request: {
       version: '0.9.0',
       from: 'request@0.9.0',
-      resolved: common.registry + '/request/-/request-0.9.0.tgz'
+      resolved: common.registry + '/request/-/request-0.9.0.tgz',
+      shasum: '1049f59a6f46588e6d030921fbb84ca2f0c2714e'
     },
     underscore: {
       dev: true,
       version: '1.5.1',
       from: 'underscore@1.5.1',
-      resolved: common.registry + '/underscore/-/underscore-1.5.1.tgz'
+      resolved: common.registry + '/underscore/-/underscore-1.5.1.tgz',
+      shasum: 'd2bde817d176ffade894ab71458e682a14b86dc9'
     }
   }
 }

--- a/test/tap/shrinkwrap-shared-dev-dependency.js
+++ b/test/tap/shrinkwrap-shared-dev-dependency.js
@@ -47,12 +47,14 @@ var desired = {
       version: '0.0.0',
       from: 'test-package-with-one-dep@0.0.0',
       resolved: common.registry +
-        '/test-package-with-one-dep/-/test-package-with-one-dep-0.0.0.tgz'
+        '/test-package-with-one-dep/-/test-package-with-one-dep-0.0.0.tgz',
+      shasum: '256c1596dbac2b23d12268dab5a802bb2e365ac8'
     },
     'test-package': {
       version: '0.0.0',
       from: 'test-package@0.0.0',
-      resolved: common.registry + '/test-package/-/test-package-0.0.0.tgz'
+      resolved: common.registry + '/test-package/-/test-package-0.0.0.tgz',
+      shasum: 'b0d32b6c45c259c578ba2003762b205131bdfbd1'
     }
   }
 }


### PR DESCRIPTION
Extend the cache add command to optionally accept a SHA to validate
against when adding a package by URL.

NB: This PR does not implement any code which attempts to perform any cache lookups using the package's shasum. The only changes is to shrinkwrap generation and inflation.

This means that an error will occur when running an npm install if the
downloaded package's checksum is different to that in the shrinkwrap

e.g.

![image](https://cloud.githubusercontent.com/assets/1167425/19131203/69bd2518-8b46-11e6-91d9-78d0bc7b6e7d.png)

TODO:
- [ ] tests
