### PR TITLE
Fixed crash during 'npm i' or 'npm u' on win32 when repo URL is too l…

### DIFF
--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -117,7 +117,16 @@ function tryClone (from, combinedURL, silent, cb) {
   var treeish = normalized.branch
 
   // ensure that similarly-named remotes don't collide
-  var cachedRemote = uniqueFilename(remotes, combinedURL.replace(/[^a-zA-Z0-9]+/g, '-'), cloneURL)
+  //
+  // on win32 we should limit dirname due to 260-character path length
+  var dirPrefix = combinedURL.replace(/[^a-zA-Z0-9]+/g, '-')
+  var cachedRemote
+  if (process.platform === 'win32') {
+    dirPrefix = dirPrefix.slice(0, 30)
+    cachedRemote = uniqueFilename(remotes, dirPrefix, combinedURL)
+  } else {
+    cachedRemote = uniqueFilename(remotes, dirPrefix, cloneURL)
+  }
   var repoID = path.relative(remotes, cachedRemote)
   cachedRemote = path.join(remotes, repoID)
 


### PR DESCRIPTION
Fixed crash during 'npm i' or 'npm u' on win32 when repo URL is too long.
