### PR TITLE
Rewrite how arguments are passed to actions

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -502,9 +502,10 @@ Installer.prototype.rollbackFailedOptional = function (staging, actionsToRun, cb
   }).filter(function (pkg) {
     return pkg.failed && pkg.rollback
   })
+  var top = this.currentTree.path
   asyncMap(failed, function (pkg, next) {
     asyncMap(pkg.rollback, function (rollback, done) {
-      rollback(staging, pkg, done)
+      rollback(top, staging, pkg, done)
     }, next)
   }, cb)
 }

--- a/lib/install/action/build.js
+++ b/lib/install/action/build.js
@@ -4,7 +4,7 @@ var build = require('../../build.js')
 var npm = require('../../npm.js')
 var packageId = require('../../utils/package-id.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
+module.exports = function (staging, pkg, log, next) {
   log.silly('build', packageId(pkg))
   chain([
     [build.linkStuff, pkg.package, pkg.path, npm.config.get('global'), true],

--- a/lib/install/action/fetch.js
+++ b/lib/install/action/fetch.js
@@ -3,7 +3,7 @@
 // var packageId = require('../../utils/package-id.js')
 // var moduleName = require('../../utils/module-name.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
+module.exports = function (staging, pkg, log, next) {
   next()
 /*
 // FIXME: Unnecessary as long as we have to have the tarball to resolve all deps, which
@@ -24,6 +24,6 @@ module.exports = function (top, buildpath, pkg, log, next) {
       name = pkg.package._requested.raw
   }
   log.silly('fetch', packageId(pkg))
-  cache.add(name, version, top, false, next)
+  cache.add(name, version, pkg.parent.path, false, next)
 */
 }

--- a/lib/install/action/finalize.js
+++ b/lib/install/action/finalize.js
@@ -6,9 +6,12 @@ var mkdirp = require('mkdirp')
 var asyncMap = require('slide').asyncMap
 var rename = require('../../utils/rename.js')
 var gentlyRm = require('../../utils/gently-rm')
+var moduleStagingPath = require('../module-staging-path.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
+module.exports = function (staging, pkg, log, next) {
   log.silly('finalize', pkg.path)
+
+  var extractedTo = moduleStagingPath(staging, pkg)
 
   var delpath = path.join(path.dirname(pkg.path), '.' + path.basename(pkg.path) + '.DELETE')
 
@@ -23,7 +26,7 @@ module.exports = function (top, buildpath, pkg, log, next) {
 
   function destStatted (doesNotExist) {
     if (doesNotExist) {
-      rename(buildpath, pkg.path, whenMoved)
+      rename(extractedTo, pkg.path, whenMoved)
     } else {
       moveAway()
     }
@@ -41,7 +44,7 @@ module.exports = function (top, buildpath, pkg, log, next) {
 
   function whenOldMovedAway (renameEr) {
     if (renameEr) return next(renameEr)
-    rename(buildpath, pkg.path, whenConflictMoved)
+    rename(extractedTo, pkg.path, whenConflictMoved)
   }
 
   function whenConflictMoved (renameEr) {

--- a/lib/install/action/finalize.js
+++ b/lib/install/action/finalize.js
@@ -5,6 +5,7 @@ var fs = require('graceful-fs')
 var mkdirp = require('mkdirp')
 var asyncMap = require('slide').asyncMap
 var rename = require('../../utils/rename.js')
+var gentlyRm = require('../../utils/gently-rm')
 
 module.exports = function (top, buildpath, pkg, log, next) {
   log.silly('finalize', pkg.path)
@@ -77,15 +78,5 @@ module.exports = function (top, buildpath, pkg, log, next) {
 }
 
 module.exports.rollback = function (top, staging, pkg, next) {
-  rimraf(pkg.path, function () {
-    removeEmptyParents(pkg.path)
-  })
-  function removeEmptyParents (pkgdir) {
-    if (path.relative(top, pkgdir)[0] === '.') return next()
-    fs.rmdir(pkgdir, function (er) {
-      // FIXME: Make sure windows does what we want here
-      if (er && er.code !== 'ENOENT') return next()
-      removeEmptyParents(path.resolve(pkgdir, '..'))
-    })
-  }
+  gentlyRm(pkg.path, false, top, next)
 }

--- a/lib/install/action/finalize.js
+++ b/lib/install/action/finalize.js
@@ -76,8 +76,7 @@ module.exports = function (top, buildpath, pkg, log, next) {
   }
 }
 
-module.exports.rollback = function (buildpath, pkg, next) {
-  var top = path.resolve(buildpath, '..')
+module.exports.rollback = function (top, staging, pkg, next) {
   rimraf(pkg.path, function () {
     removeEmptyParents(pkg.path)
   })

--- a/lib/install/action/global-install.js
+++ b/lib/install/action/global-install.js
@@ -4,7 +4,7 @@ var npm = require('../../npm.js')
 var Installer = require('../../install.js').Installer
 var packageId = require('../../utils/package-id.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
+module.exports = function (staging, pkg, log, next) {
   log.silly('global-install', packageId(pkg))
   var globalRoot = path.resolve(npm.globalDir, '..')
   npm.config.set('global', true)

--- a/lib/install/action/global-link.js
+++ b/lib/install/action/global-link.js
@@ -2,7 +2,7 @@
 var npm = require('../../npm.js')
 var packageId = require('../../utils/package-id.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
+module.exports = function (staging, pkg, log, next) {
   log.silly('global-link', packageId(pkg))
   npm.link(pkg.package.name, next)
 }

--- a/lib/install/action/install.js
+++ b/lib/install/action/install.js
@@ -2,7 +2,7 @@
 var lifecycle = require('../../utils/lifecycle.js')
 var packageId = require('../../utils/package-id.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
-  log.silly('install', packageId(pkg), buildpath)
+module.exports = function (staging, pkg, log, next) {
+  log.silly('install', packageId(pkg))
   lifecycle(pkg.package, 'install', pkg.path, false, false, next)
 }

--- a/lib/install/action/move.js
+++ b/lib/install/action/move.js
@@ -16,7 +16,7 @@ var rename = require('../../utils/rename.js')
   folders.
 */
 
-module.exports = function (top, buildpath, pkg, log, next) {
+module.exports = function (staging, pkg, log, next) {
   log.silly('move', pkg.fromPath, pkg.path)
   chain([
     [lifecycle, pkg.package, 'preuninstall', pkg.fromPath, false, true],

--- a/lib/install/action/postinstall.js
+++ b/lib/install/action/postinstall.js
@@ -2,7 +2,7 @@
 var lifecycle = require('../../utils/lifecycle.js')
 var packageId = require('../../utils/package-id.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
-  log.silly('postinstall', packageId(pkg), buildpath)
+module.exports = function (staging, pkg, log, next) {
+  log.silly('postinstall', packageId(pkg))
   lifecycle(pkg.package, 'postinstall', pkg.path, false, false, next)
 }

--- a/lib/install/action/preinstall.js
+++ b/lib/install/action/preinstall.js
@@ -1,8 +1,9 @@
 'use strict'
 var lifecycle = require('../../utils/lifecycle.js')
 var packageId = require('../../utils/package-id.js')
+var moduleStagingPath = require('../module-staging-path.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
-  log.silly('preinstall', packageId(pkg), buildpath)
-  lifecycle(pkg.package, 'preinstall', buildpath, false, false, next)
+module.exports = function (staging, pkg, log, next) {
+  log.silly('preinstall', packageId(pkg))
+  lifecycle(pkg.package, 'preinstall', moduleStagingPath(staging, pkg), false, false, next)
 }

--- a/lib/install/action/prepare.js
+++ b/lib/install/action/prepare.js
@@ -3,9 +3,10 @@ var chain = require('slide').chain
 var lifecycle = require('../../utils/lifecycle.js')
 var packageId = require('../../utils/package-id.js')
 var prepublishWarning = require('../../utils/warn-deprecated.js')('prepublish-on-install')
+var moduleStagingPath = require('../module-staging-path.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
-  log.silly('prepublish', packageId(pkg), buildpath)
+module.exports = function (staging, pkg, log, next) {
+  log.silly('prepublish', packageId(pkg))
   // TODO: for `npm@5`, change the behavior and remove this warning.
   // see https://github.com/npm/npm/issues/10074 for details
   if (pkg.package && pkg.package.scripts && pkg.package.scripts.prepublish) {
@@ -15,6 +16,7 @@ module.exports = function (top, buildpath, pkg, log, next) {
       'See the deprecation note in `npm help scripts` for more information.'
     ])
   }
+  var buildpath = moduleStagingPath(staging, pkg)
   chain(
     [
       [lifecycle, pkg.package, 'prepublish', buildpath, false, false],

--- a/lib/install/action/remove.js
+++ b/lib/install/action/remove.js
@@ -10,7 +10,7 @@ var rename = require('../../utils/rename.js')
 
 // This is weird because we want to remove the module but not it's node_modules folder
 // allowing for this allows us to not worry about the order of operations
-module.exports = function (top, buildpath, pkg, log, next) {
+module.exports = function (staging, pkg, log, next) {
   log.silly('remove', pkg.path)
   if (pkg.target) {
     removeLink(pkg, next)

--- a/lib/install/action/test.js
+++ b/lib/install/action/test.js
@@ -2,7 +2,7 @@
 var lifecycle = require('../../utils/lifecycle.js')
 var packageId = require('../../utils/package-id.js')
 
-module.exports = function (top, buildpath, pkg, log, next) {
-  log.silly('test', packageId(pkg), buildpath)
-  lifecycle(pkg.package, 'test', buildpath, false, false, next)
+module.exports = function (staging, pkg, log, next) {
+  log.silly('test', packageId(pkg))
+  lifecycle(pkg.package, 'test', pkg.path, false, false, next)
 }

--- a/lib/install/action/update-linked.js
+++ b/lib/install/action/update-linked.js
@@ -1,9 +1,15 @@
 'use strict'
 var path = require('path')
 
-module.exports = function (top, buildpath, pkg, log, next) {
+function getTop (pkg) {
+  if (pkg.target && pkg.target.parent) return getTop(pkg.target.parent)
+  if (pkg.parent) return getTop(pkg.parent)
+  return pkg.path
+}
+
+module.exports = function (staging, pkg, log, next) {
   if (pkg.package.version !== pkg.oldPkg.package.version) {
-    log.warn('update-linked', path.relative(top, pkg.path), 'needs updating to', pkg.package.version,
+    log.warn('update-linked', path.relative(getTop(pkg), pkg.path), 'needs updating to', pkg.package.version,
       'from', pkg.oldPkg.package.version, "but we can't, as it's a symlink")
   }
   next()

--- a/lib/install/actions.js
+++ b/lib/install/actions.js
@@ -1,5 +1,4 @@
 'use strict'
-var path = require('path')
 var validate = require('aproba')
 var chain = require('slide').chain
 var asyncMap = require('slide').asyncMap
@@ -8,7 +7,6 @@ var andFinishTracker = require('./and-finish-tracker.js')
 var andAddParentToErrors = require('./and-add-parent-to-errors.js')
 var failedDependency = require('./deps.js').failedDependency
 var moduleName = require('../utils/module-name.js')
-var buildPath = require('./build-path.js')
 var reportOptionalFailure = require('./report-optional-failure.js')
 var isInstallable = require('./validate-args.js').isInstallable
 
@@ -34,8 +32,9 @@ actions['global-link'] = require('./action/global-link.js')
 
 Object.keys(actions).forEach(function (actionName) {
   var action = actions[actionName]
-  actions[actionName] = function (top, buildpath, pkg, log, next) {
-    validate('SSOOF', arguments)
+  actions[actionName] = function (staging, pkg, log, next) {
+  // top, buildpath, pkg, log
+    validate('SOOF', arguments)
     // refuse to run actions for failed packages
     if (pkg.failed) return next()
     if (action.rollback) {
@@ -58,7 +57,7 @@ Object.keys(actions).forEach(function (actionName) {
       }
     }
     function thenRunAction () {
-      action(top, buildpath, pkg, log, andDone(next))
+      action(staging, pkg, log, andDone(next))
     }
     function andDone (cb) {
       return andFinishTracker(log, andAddParentToErrors(pkg.parent, andHandleOptionalDepErrors(pkg, cb)))
@@ -99,9 +98,7 @@ function prepareAction (staging, log) {
     var cmd = action[0]
     var pkg = action[1]
     if (!actions[cmd]) throw new Error('Unknown decomposed command "' + cmd + '" (is it new?)')
-    var top = path.resolve(staging, '../..')
-    var buildpath = buildPath(staging, pkg)
-    return [actions[cmd], top, buildpath, pkg, log.newGroup(cmd + ':' + moduleName(pkg))]
+    return [actions[cmd], staging, pkg, log.newGroup(cmd + ':' + moduleName(pkg))]
   }
 }
 

--- a/lib/install/module-staging-path.js
+++ b/lib/install/module-staging-path.js
@@ -2,7 +2,7 @@
 var uniqueFilename = require('unique-filename')
 var moduleName = require('../utils/module-name.js')
 
-module.exports = buildPath
-function buildPath (staging, pkg) {
+module.exports = moduleStagingPath
+function moduleStagingPath (staging, pkg) {
   return uniqueFilename(staging, moduleName(pkg), pkg.realpath)
 }

--- a/test/tap/install-actions.js
+++ b/test/tap/install-actions.js
@@ -56,7 +56,7 @@ test('->optdep:a->dep:b', function (t) {
   moduleB.parent = tree
 
   t.plan(3)
-  actions.postinstall('/', '/', moduleA, mockLog, function (er) {
+  actions.postinstall('/', moduleA, mockLog, function (er) {
     t.is(er && er.code, 'ELIFECYCLE', 'Lifecycle failed')
     t.ok(moduleA.failed, 'moduleA (optional dep) is marked failed')
     t.ok(moduleB.failed, 'moduleB (direct dep of moduleA) is marked as failed')
@@ -108,7 +108,7 @@ test('->dep:b,->optdep:a->dep:b', function (t) {
   moduleB.parent = tree
 
   t.plan(3)
-  actions.postinstall('/', '/', moduleA, mockLog, function (er) {
+  actions.postinstall('/', moduleA, mockLog, function (er) {
     t.ok(er && er.code === 'ELIFECYCLE', 'Lifecycle failed')
     t.ok(moduleA.failed, 'moduleA (optional dep) is marked failed')
     t.ok(!moduleB.failed, 'moduleB (direct dep of moduleA) is marked as failed')

--- a/test/tap/install-scoped-with-bundled-dependency.js
+++ b/test/tap/install-scoped-with-bundled-dependency.js
@@ -1,0 +1,84 @@
+'use strict'
+var path = require('path')
+var test = require('tap').test
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+var extend = Object.assign || require('util')._extend
+var common = require('../common-tap.js')
+
+var basedir = path.join(__dirname, path.basename(__filename, '.js'))
+var testdir = path.join(basedir, 'testdir')
+var cachedir = path.join(basedir, 'cache')
+var globaldir = path.join(basedir, 'global')
+var tmpdir = path.join(basedir, 'tmp')
+
+var conf = {
+  cwd: testdir,
+  env: extend({
+    npm_config_cache: cachedir,
+    npm_config_tmp: tmpdir,
+    npm_config_prefix: globaldir,
+    npm_config_registry: common.registry,
+    npm_config_loglevel: 'warn'
+  }, process.env)
+}
+
+var fixture = new Tacks(Dir({
+  cache: Dir(),
+  global: Dir(),
+  tmp: Dir(),
+  testdir: Dir({
+    node_modules: Dir({
+    }),
+    package: Dir({
+      node_modules: Dir({
+        'bundled-dep': Dir({
+          'package.json': File({
+            name: 'bundled-dep',
+            version: '0.0.0'
+          })
+        })
+      }),
+      'package.json': File({
+        name: '@scope/package',
+        version: '0.0.0',
+        dependencies: {
+          'bundled-dep': '*'
+        },
+        bundledDependencies: [
+          'bundled-dep'
+        ]
+      })
+    })
+  })
+}))
+
+function setup () {
+  cleanup()
+  fixture.create(basedir)
+}
+
+function cleanup () {
+  fixture.remove(basedir)
+}
+
+test('setup', function (t) {
+  setup()
+  t.done()
+})
+
+test('install dependencies of bundled dependencies', function (t) {
+  common.npm(['install', './package'], conf, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'command ran ok')
+    t.comment(stdout.trim())
+    t.comment(stderr.trim())
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.done()
+})

--- a/test/tap/uninstall-in-reverse.js
+++ b/test/tap/uninstall-in-reverse.js
@@ -10,7 +10,7 @@ order. That is, they need to go shallow -> deep.
 
 var removed = []
 var npm = requireInject.installGlobally('../../lib/npm.js', {
-  '../../lib/install/action/remove.js': function (top, buildpath, pkg, log, next) {
+  '../../lib/install/action/remove.js': function (staging, pkg, log, next) {
     removed.push(pkg.package.name)
     next()
   }


### PR DESCRIPTION
The arguments passed to actions had been... a bit awkward and we often found ourselves intuiting where the staging directory was, and doing that wrong (see #14311, #13528, #14324). This rejiggers it to pass through the staging folder and only figure out the module specific staging path if it actually needs it.

Also included is a test from #14324 and @NatalieWolfe for one of those cases where the staging path was being miscomputed.
