### PR TITLE
shrinkwrap: fix scoped dependency resolution from from

### DIFF
--- a/lib/install/realize-shrinkwrap-specifier.js
+++ b/lib/install/realize-shrinkwrap-specifier.js
@@ -1,6 +1,7 @@
 'use strict'
 var realizePackageSpecifier = require('realize-package-specifier')
 var isRegistrySpecifier = require('./is-registry-specifier.js')
+var url = require('url')
 
 module.exports = function (name, sw, where, cb) {
   function lookup (ver, cb) {
@@ -8,7 +9,7 @@ module.exports = function (name, sw, where, cb) {
   }
   if (sw.resolved) {
     return lookup(sw.resolved, cb)
-  } else if (sw.from) {
+  } else if (sw.from && url.parse(sw.from).protocol) {
     return lookup(sw.from, function (err, spec) {
       if (err || isRegistrySpecifier(spec)) {
         return thenUseVersion()

--- a/test/tap/shrinkwrap-no-resolved.js
+++ b/test/tap/shrinkwrap-no-resolved.js
@@ -1,0 +1,59 @@
+'use strict'
+var test = require('tap').test
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+var path = require('path')
+var common = require('../common-tap.js')
+
+var testdir = path.resolve(__dirname, path.basename(__filename, '.js'))
+
+var fixture = new Tacks(Dir({
+  'package.json': File({
+    name: 'x',
+    version: '1.0.0',
+    dependencies: {
+      '@blarg/foo': 'file://./bfoo',
+      'foo': 'file://./foo'
+    }
+  }),
+  'npm-shrinkwrap.json': File({
+    dependencies: {
+      '@blarg/foo': {
+        version: '1.0.0',
+        from: '@blarg/foo@1.0.0'
+      },
+      'foo': {
+        version: '1.0.0',
+        from: 'foo'
+      }
+    }
+  })
+}))
+
+function setup () {
+  fixture.create(testdir)
+}
+
+function cleanup () {
+  fixture.remove(testdir)
+}
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+  t.end()
+})
+
+test('missing resolved field', function (t) {
+  common.npm(['install'], {registry: 'nope', cwd: testdir}, function (err, code, out, stderr) {
+    t.is(err, null, 'No fatal errors running npm')
+    t.match(stderr, /Not found : @blarg\/foo/, 'tried to look it up in registry')
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
346bba1 broke the way shrinkwrap `from` got parsed.
Because of the way the `lookup` function here is treating
it as a version, the specified was being resolved as a
local package in the current directory.

This brings back the URL check to protect against this case,
which was only happening for scoped packages.

...this is probably not the right solution just yet (might need to look further into `isRegistrySpecifier` here and how it's getting used), and this needs test, so it's WIP.
