### PR TITLE
Document `sign-git-tag` in npm-version(1)'s 'configuration' section

### DIFF
--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -85,6 +85,15 @@ and tag up to the server, and deletes the `build/temp` directory.
 
 Commit and tag the version change.
 
+### sign-git-tag
+
+* Default: false
+* Type: Boolean
+
+Pass the `-s` flag to git to sign the tag.
+
+Note that you must have a default GPG key set up in your git config for this to work properly.
+
 ## SEE ALSO
 
 * npm-init(1)


### PR DESCRIPTION
Basically what the title says - `sign-git-tag` is mentioned further up, but not included in the "configuration" section.