### PR TITLE
resolve missing build PATH after switch directory to build cache folder

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -91,6 +91,12 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
   var pathArr = []
   var p = wd.split(/[\\\/]node_modules[\\\/]/)
   var acc = path.resolve(p.shift())
+  var oldPwd = env.OLDPWD
+
+  // Consistency in the environment after switch directory to build cache folder ({"prepublishOnly": "npm run build"})
+  if (oldPwd && oldPwd !== wd) {
+    pathArr.unshift(path.join(oldPwd, 'node_modules', '.bin'))
+  }
 
   p.forEach(function (pp) {
     pathArr.unshift(path.join(acc, 'node_modules', '.bin'))

--- a/test/tap/prepublish-only-env.js
+++ b/test/tap/prepublish-only-env.js
@@ -33,7 +33,7 @@ test('setup', function (t) {
     fs.writeFileSync(join(bin, 'test-build'), '#!/usr/bin/env node\nconsole.log(\'ok\')', 'ascii', function (er) {
       if (er) throw er
     })
-    fs.chmodSync(join(bin, 'test-build'), 0755)
+    fs.chmodSync(join(bin, 'test-build'), '755')
     fs.writeFile(join(pkg, 'package.json'), JSON.stringify({
       name: 'npm-test-prepublish-only',
       version: '1.2.5',

--- a/test/tap/prepublish-only-env.js
+++ b/test/tap/prepublish-only-env.js
@@ -1,0 +1,123 @@
+// verify that prepublishOnly runs _only_ on pack and publish
+var common = require('../common-tap')
+var test = require('tap').test
+var fs = require('graceful-fs')
+var join = require('path').join
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var rimraf = require('rimraf')
+
+var pkg = join(__dirname, 'prepublish_env_package')
+var tmp = join(pkg, 'tmp')
+var cache = join(pkg, 'cache')
+var bin = join(pkg, 'node_modules', '.bin')
+
+var server
+
+test('setup', function (t) {
+  var n = 0
+  cleanup()
+  mkdirp(pkg, then())
+  mkdirp(bin, then())
+  mkdirp(cache, then())
+  mkdirp(tmp, then())
+  function then () {
+    n++
+    return function (er) {
+      if (er) throw er
+      if (--n === 0) next()
+    }
+  }
+
+  function next () {
+    fs.writeFileSync(join(bin, 'test-build'), '#!/usr/bin/env node\nconsole.log(\'ok\')', 'ascii', function (er) {
+      if (er) throw er
+    })
+    fs.chmodSync(join(bin, 'test-build'), 0755)
+    fs.writeFile(join(pkg, 'package.json'), JSON.stringify({
+      name: 'npm-test-prepublish-only',
+      version: '1.2.5',
+      scripts: { build: './node_modules/.bin/test-build', prepublishOnly: 'npm run build' }
+    }), 'ascii', function (er) {
+      if (er) throw er
+
+      mr({port: common.port, throwOnUnmatched: true}, function (err, s) {
+        t.ifError(err, 'registry mocked successfully')
+        server = s
+        t.end()
+      })
+    })
+  }
+})
+
+test('test', function (t) {
+  server.filteringRequestBody(function () { return true })
+        .put('/npm-test-prepublish-only', true)
+        .reply(201, {ok: true})
+
+  var env = {
+    'npm_config_cache': cache,
+    'npm_config_tmp': tmp,
+    'npm_config_prefix': pkg,
+    'npm_config_global': 'false'
+  }
+
+  for (var i in process.env) {
+    if (!/^npm_config_/.test(i)) {
+      env[i] = process.env[i]
+    }
+  }
+  env.OLDPWD = pkg
+
+  var configuration = [
+    'progress=false',
+    'registry=' + common.registry,
+    '//localhost:1337/:username=username',
+    '//localhost:1337/:_authToken=deadbeeffeed'
+  ]
+  var configFile = join(pkg, '.npmrc')
+
+  fs.writeFileSync(configFile, configuration.join('\n') + '\n')
+  common.npm(
+    [
+      'publish',
+      '--loglevel', 'warn'
+    ],
+    {
+      cwd: pkg,
+      env: env
+    },
+    function (err, code, stdout, stderr) {
+      t.equal(code, 0, 'pack finished successfully')
+      t.ifErr(err, 'pack finished successfully')
+
+      t.notOk(stderr, 'got stderr data:' + JSON.stringify('' + stderr))
+      var c = stdout.trim()
+      var regex = new RegExp(
+        '> npm-test-prepublish-only@1.2.5 prepublishOnly [^\\r\\n]+\\r?\\n' +
+        '> npm run build\\r?\\n' +
+        '\\r?\\n' +
+        '\\r?\\n' +
+        '> npm-test-prepublish-only@1.2.5 build [^\\r\\n]+\\r?\\n' +
+        '> test-build\\r?\\n' +
+        '\\r?\\n' +
+        'ok\\r?\\n' +
+        '\\+ npm-test-prepublish-only@1.2.5', 'ig'
+      )
+
+      t.match(c, regex)
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  server.close()
+  t.pass('cleaned up')
+  t.end()
+})
+
+function cleanup () {
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
## reproduce the problem:

```sh
$ npm init -y
$ mkdir node_modules/.bin
$ echo "#\!/usr/bin/env node\nconsole.log('output')" > node_modules/.bin/test-build
```

`package.json`

```
{
  "name": "test",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1",
    "build": "test-build",
    "prepublishOnly": "npm run build"
  },
  "keywords": [],
  "author": "",
  "license": "ISC"
}
```

Run `npm run build` with correct outout:

```
❯ npm run build

> test@1.0.0 build /Users/yuji/tmp/test
> test-build
output
```

but, `run npm publish` not found the `test-build` command

```
❯ npm publish

> test@1.0.0 prepublishOnly /Users/yuji/.npm/test/1.0.0/package
> npm run build
```

```
> test@1.0.0 build /Users/yuji/.npm/test/1.0.0/package
> test-build

sh: test-build: command not found

npm ERR! Darwin 16.1.0
npm ERR! argv "/usr/local/Cellar/node/6.8.1/bin/node" "/usr/local/bin/npm" "run" "build"
npm ERR! node v6.8.1
npm ERR! npm  v4.0.1
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! test@1.0.0 build: `test-build`
npm ERR! spawn ENOENT
```

## How to appears

In some cases of lifecycle, we switch directory to build cache folder and lost the `PATH` of `pkg/node_modules/.bin` in environment variable

## How to fixed

I check the `OLDPWD` variable whether equal to `wd`, if not, as a fallback appended to the back of the `wd/node_modules/.bin`

Added a test case [test/tap/prepublish-only-env.js](https://github.com/leecade/npm/blob/781c13b1b38f18bd05f19a59c7151570d3b84c2d/test/tap/prepublish-only-env.js) for the problem.



