### PR TITLE
errors: clarifying the ENOSELF error message a bit

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -343,6 +343,10 @@ folder structures that npm creates.
 
 ### Limitations of npm's Install Algorithm
 
+npm will refuse to install any package with an identical name to the
+current package. This can be overridden with the `--force` flag, but in
+most cases can simply be addressed by changing the local package name.
+
 There are some very rare and pathological edge-cases where a cycle can
 cause npm to try to install a never-ending tree of packages.  Here is
 the simplest case:

--- a/lib/install/validate-args.js
+++ b/lib/install/validate-args.js
@@ -50,7 +50,12 @@ function checkSelf (idealTree, pkg, force, next) {
     idealTree.warnings.push(warn)
     next()
   } else {
-    var er = new Error('Refusing to install ' + pkg.name + ' as a dependency of itself')
+    var er = new Error('Refusing to install package with name "' + pkg.name +
+     '" under a package\n' +
+     'also called "' + pkg.name + '". Did you name your project the same\n' +
+     'as the dependency you\'re installing?\n\n' +
+     'For more information, see:\n' +
+     '    <https://docs.npmjs.com/cli/install#limitations-of-npms-install-algorithm>')
     er.code = 'ENOSELF'
     next(er)
   }


### PR DESCRIPTION
This is a tricky error message to word.

It's also an error that normally bites new users.

Perhaps it's worth trying to have a clearer message here.