### PR TITLE
drop support for Nodes 0.10, 0.12, and 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,18 @@ language: node_js
 matrix:
   include:
     # LTS is our most important target
-    - node_js: "4"
+    - node_js: "6"
       # DEPLOY_VERSION is used to set the couchapp setup mode for test/tap/registry.js
       # only gather coverage info for LTS
       env: DEPLOY_VERSION=testing COVERALLS_REPO_TOKEN="$COVERALLS_OPTIONAL_TOKEN"
       script:
         - "node . run tap-cover -- \"test/tap/*.js\""
         - "unset COVERALLS_REPO_TOKEN ; node . run tap -- \"test/slow/*.js\" \"test/broken-under-*/*.js\""
-    # next LTS and master is next most important
-    - node_js: "6"
+    # previous LTS is next most important
+    - node_js: "4"
       env: DEPLOY_VERSION=testing
-    # still in LTS maintenance until fall 2016 (also still in wide use)
-    - node_js: "0.10"
-      env: DEPLOY_VERSION=testing
-    # will be unsupported as soon as 6 becomes LTS and 7 released
-    - node_js: "5"
-      env: DEPLOY_VERSION=testing
-    # technically in LTS / distros, unbeloved
-    - node_js: "0.12"
+    # then master
+    - node_js: "7"
       env: DEPLOY_VERSION=testing
 before_install:
   # required by test/tap/registry.js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,11 @@
 environment:
   matrix:
     # LTS is our most important target
-    - nodejs_version: "4"
-    # next LTS and master is next most important
     - nodejs_version: "6"
-    # still in LTS maintenance until fall 2016
-    # (also still in wide use)
-    - nodejs_version: "0.10"
-    # will be unsupported as soon as 6 becomes LTS and 7 released
+    # previous LTS is next most important
+    - nodejs_version: "4"
+    # then master
     - nodejs_version: "5"
-    # technically in LTS / distros, unbeloved
-    - nodejs_version: "0.12"
   COVERALLS_REPO_TOKEN:
     secure: XdC0aySefK0HLh1GNk6aKrzZPbCfPQLyA4mYtFGEp4DrTuZA/iuCUS0LDqFYO8JQ
 platform:

--- a/lib/utils/unsupported.js
+++ b/lib/utils/unsupported.js
@@ -1,6 +1,6 @@
 'use strict'
 var semver = require('semver')
-var supportedNode = '0.10 || 0.12 || >= 4'
+var supportedNode = '>= 4'
 var knownBroken = '>=0.1 <=0.7'
 
 var checkVersion = exports.checkVersion = function (version) {

--- a/test/tap/unsupported.js
+++ b/test/tap/unsupported.js
@@ -3,7 +3,7 @@ var test = require('tap').test
 var unsupported = require('../../lib/utils/unsupported.js')
 
 var versions = [
-//            broken  unsupported
+  //          broken unsupported
   ['v0.1.103', true, true],
   ['v0.2.0', true, true],
   ['v0.3.5', true, true],
@@ -13,9 +13,9 @@ var versions = [
   ['v0.7.8', true, true],
   ['v0.8.28', false, true],
   ['v0.9.6', false, true],
-  ['v0.10.48', false, false],
+  ['v0.10.48', false, true],
   ['v0.11.16', false, true],
-  ['v0.12.9', false, false],
+  ['v0.12.9', false, true],
   ['v1.0.1', false, true],
   ['v1.6.0', false, true],
   ['v2.3.1', false, true],


### PR DESCRIPTION
We still 💖 u, Node.js 0.10, but we gotta keep up with the times. This is _not_ a license to go wild with ES6isms. npm still _works_ (most of the time) back to 0.8, and that's in large part because of the project's conservatism about sticking to plain ES5 in both its own code base and its npm-controlled dependencies. Dependencies not under the team's control are already hard-deprecating 0.10, though, and the build matrix already leads to long Travis times.

This patch also adds Node 7 to the CI matrix, but build should overall be significantly faster because there are, overall, two fewer versions to test.