### PR TITLE
doc: we do NOT check npmrc permissions

### DIFF
--- a/doc/files/npmrc.md
+++ b/doc/files/npmrc.md
@@ -36,11 +36,6 @@ example:
     key[] = "first value"
     key[] = "second value"
 
-**NOTE:** Because local (per-project or per-user) `.npmrc` files can contain
-sensitive credentials, they must be readable and writable _only_ by your user
-account (i.e. must have a mode of `0600`), otherwise they _will be ignored by
-npm!_
-
 #### Comments
 
 Lines in `.npmrc` files are interpreted as comments when they begin with a `;` or `#` character. `.npmrc` files are parsed by [npm/ini](https://github.com/npm/ini), which specifies this comment syntax.


### PR DESCRIPTION
These docs slipped into the codebase without any code. If this was ever true, it's not now.