### PR TITLE
Change `npm_config_node_gyp` to use shell script on Windows

### DIFF
--- a/bin/node-gyp-bin/node-gyp.cmd
+++ b/bin/node-gyp-bin/node-gyp.cmd
@@ -1,5 +1,5 @@
 if not defined npm_config_node_gyp (
   node "%~dp0\..\..\node_modules\node-gyp\bin\node-gyp.js" %*
 ) else (
-  node "%npm_config_node_gyp%" %*
+  "%npm_config_node_gyp%" %*
 )


### PR DESCRIPTION
On non-Windows platforms, custom node-gyp can be used by npm by
`export npm_config_node_gyp=$(which node-gyp)`. But on Windows,
the implementation expected the real js script of node-gyp rather
than the shell script. So you have to set the environment to
`path\to\global\node_modules\node-gyp\bin\node-gyp.js`. This patch
changed the launch script of node-gyp by invoking the script set
to `npm_config_node_gyp` directly instead of invoking as node script.

Fixed #14543