### PR TITLE
ci: reintroduce 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ matrix:
     # then master
     - node_js: "7"
       env: DEPLOY_VERSION=testing
+    # then 0.12, which is still in maintenance mode until the end of 2016 I guess?
+    # https://github.com/nodejs/LTS#lts-schedule
+    - node_js: "0.12"
+      env: DEPLOY_VERSION=testing
 before_install:
   # required by test/tap/registry.js
   - "mkdir -p /var/run/couchdb"

--- a/lib/utils/unsupported.js
+++ b/lib/utils/unsupported.js
@@ -1,6 +1,6 @@
 'use strict'
 var semver = require('semver')
-var supportedNode = '>= 4'
+var supportedNode = '0.12 || >= 4'
 var knownBroken = '>=0.1 <=0.7'
 
 var checkVersion = exports.checkVersion = function (version) {

--- a/test/tap/unsupported.js
+++ b/test/tap/unsupported.js
@@ -15,7 +15,7 @@ var versions = [
   ['v0.9.6', false, true],
   ['v0.10.48', false, true],
   ['v0.11.16', false, true],
-  ['v0.12.9', false, true],
+  ['v0.12.9', false, false],
   ['v1.0.1', false, true],
   ['v1.6.0', false, true],
   ['v2.3.1', false, true],


### PR DESCRIPTION
I genuinely thought it went out of maintenance mode with 0.10, and removing it from the test matrix was therefore both premature and an oversight. My apologies.