### PR TITLE
shrinkwrap: guard against hard-to-find bug

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -31,7 +31,7 @@ function inflateShrinkwrap (topPath, tree, swdeps, finishInflating) {
   // already on disk. If it DOES have dev dependencies then ONLY those in the
   // shrinkwrap will be included.
   var swHasDev = Object.keys(swdeps).some(function (name) { return swdeps[name].dev })
-  tree.children = swHasDev ? [] : tree.children.filter(function (child) {
+  tree.children = (swHasDev || !tree.package.devDependencies) ? [] : tree.children.filter(function (child) {
     return tree.package.devDependencies[moduleName(child)]
   })
 

--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -53,6 +53,7 @@ function saveShrinkwrap (tree, next) {
     var shrinkwrapHasAnyDevOnlyDeps = tree.requires.some(function (dep) {
       var name = moduleName(dep)
       return isDevDep(tree, name) &&
+             shrinkwrap.dependencies &&
              shrinkwrap.dependencies[name] != null
     })
 


### PR DESCRIPTION
This is a quick guard that should take care of https://github.com/npm/npm/issues/14427. Unfortunately, I don't know how to reproduce this. There's a mystery place in the current architecture where that property becomes `undefined` even though it should _really_ always be assigned. We can't really merge this until we have a failing test for it :(