### PR TITLE
doc: update the GitHub URL examples

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -471,8 +471,8 @@ included.  For example:
       "name": "foo",
       "version": "0.0.0",
       "dependencies": {
-        "express": "visionmedia/express",
-        "mocha": "visionmedia/mocha#4727d357ea",
+        "express": "expressjs/express",
+        "mocha": "mochajs/mocha#4727d357ea",
         "module": "user/repo#feature\/branch"
       }
     }


### PR DESCRIPTION
This updates the two GitHub URL examples that used to be projects under the `visionmedia` organization and uses the current URLs for those projects.