### PR TITLE
inflate-bundled: Initialize nodes from bundled dependencies

### DIFF
--- a/lib/install/inflate-bundled.js
+++ b/lib/install/inflate-bundled.js
@@ -1,10 +1,12 @@
 'use strict'
 var validate = require('aproba')
 var childPath = require('../utils/child-path.js')
+var reset = require('./node.js').reset
 
 module.exports = function inflateBundled (parent, children) {
   validate('OA', arguments)
   children.forEach(function (child) {
+    reset(child)
     child.fromBundle = true
     child.parent = parent
     child.path = childPath(parent.path, child)


### PR DESCRIPTION
This solves the root cause of the errors where an attempt to read `node.package.devDependencies` crashes because `devDependencies` is not defined.

Fixes: #14427