### PR TITLE
save: stop using url.format for relative local dep paths

### DIFF
--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -167,11 +167,7 @@ function computeVersionSpec (child) {
         pathname: requested.spec
       })
     } else {
-      return url.format({
-        protocol: 'file',
-        slashes: false,
-        pathname: relativePath
-      })
+      return 'file:' + relativePath
     }
   } else if (requested.type === 'hosted') {
     return requested.spec

--- a/test/tap/install-save-local.js
+++ b/test/tap/install-save-local.js
@@ -61,6 +61,35 @@ test('\'npm install --save ../local/path\' should save to package.json', functio
   )
 })
 
+test('\'npm install --save local/path\' should save to package.json', function (t) {
+  setup()
+  common.npm(
+    [
+      '--loglevel', 'silent',
+      '--save',
+      'install', 'package-local-dependency'
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'npm install ran without issue')
+      t.notOk(code, 'npm install exited with code 0')
+
+      var dependencyPackageJson = path.join(
+        pkg, 'node_modules', 'package-local-dependency', 'package.json'
+      )
+      t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
+
+      var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+      t.is(Object.keys(pkgJson.dependencies).length, 1, 'only one dep')
+      t.ok(
+        /file:package-local-dependency$/.test(pkgJson.dependencies['package-local-dependency']),
+        'local package saved correctly'
+      )
+      t.end()
+    }
+  )
+})
+
 test('\'npm install --save-dev ../local/path\' should save to package.json', function (t) {
   setup()
   common.npm(
@@ -83,6 +112,35 @@ test('\'npm install --save-dev ../local/path\' should save to package.json', fun
       t.is(Object.keys(pkgJson.devDependencies).length, 1, 'only one dep')
       t.ok(
         /file:.*?[/\\]package-local-dev-dependency$/.test(pkgJson.devDependencies['package-local-dev-dependency']),
+        'local package saved correctly'
+      )
+
+      t.end()
+    }
+  )
+})
+test('\'npm install --save-dev local/path\' should save to package.json', function (t) {
+  setup()
+  common.npm(
+    [
+      '--loglevel', 'silent',
+      '--save-dev',
+      'install', 'package-local-dev-dependency'
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'npm install ran without issue')
+      t.notOk(code, 'npm install exited with code 0')
+
+      var dependencyPackageJson = path.resolve(
+        pkg, 'node_modules', 'package-local-dev-dependency', 'package.json'
+      )
+      t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
+
+      var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+      t.is(Object.keys(pkgJson.devDependencies).length, 1, 'only one dep')
+      t.ok(
+        /file:package-local-dev-dependency$/.test(pkgJson.devDependencies['package-local-dev-dependency']),
         'local package saved correctly'
       )
 
@@ -122,5 +180,16 @@ function setup () {
     JSON.stringify(localDevDependency, null, 2)
   )
 
+  mkdirp.sync(path.join(pkg, 'package-local-dependency'))
+  fs.writeFileSync(
+    path.join(pkg, 'package-local-dependency', 'package.json'),
+    JSON.stringify(localDependency, null, 2)
+  )
+
+  mkdirp.sync(path.join(pkg, 'package-local-dev-dependency'))
+  fs.writeFileSync(
+    path.join(pkg, 'package-local-dev-dependency', 'package.json'),
+    JSON.stringify(localDevDependency, null, 2)
+  )
   process.chdir(pkg)
 }


### PR DESCRIPTION
`node@7` [introduced an issue](https://github.com/nodejs/node/issues/9521) with file URIs that broke the way npm was expecting them to be parsed. Turns out we don't really need to be doing any parsing in this particular case. I've added tests to verify things, too.

Fixes: #15097