### PR TITLE
Update CLI docs regarding npm cache clear/clean

### DIFF
--- a/doc/cli/npm-cache.md
+++ b/doc/cli/npm-cache.md
@@ -14,7 +14,7 @@ npm-cache(1) -- Manipulates packages cache
 
 ## DESCRIPTION
 
-Used to add, list, or clear the npm cache folder.
+Used to add, list, or clean the npm cache folder.
 
 * add:
   Add the specified package to the local cache.  This command is primarily
@@ -29,7 +29,7 @@ Used to add, list, or clear the npm cache folder.
 * clean:
   Delete data out of the cache folder.  If an argument is provided, then
   it specifies a subpath to delete.  If no argument is provided, then
-  the entire cache is cleared.
+  the entire cache is cleaned.
 
 ## DETAILS
 


### PR DESCRIPTION
It looks to be that `npm cache clear` is being deprecated in favor of `npm cache clean` so adjusting the docs to represent that (if that is in fact what is happening).

Or if both are going to continue to remain then I could make the docs more verbose to reflect that so that the community knows.