### PR TITLE
fetch-package-metadata,add-named: Unify package version selection

### DIFF
--- a/lib/fetch-package-metadata.js
+++ b/lib/fetch-package-metadata.js
@@ -26,6 +26,7 @@ var getCacheStat = require('./cache/get-stat.js')
 var unpack = require('./utils/tar.js').unpack
 var pulseTillDone = require('./utils/pulse-till-done.js')
 var parseJSON = require('./utils/parse-json.js')
+var pickManifestFromRegistryMetadata = require('./utils/pick-manifest-from-registry-metadata.js')
 
 function andLogAndFinish (spec, tracker, done) {
   validate('SF', [spec, done])
@@ -113,7 +114,7 @@ function fetchNamedPackageData (dep, next) {
     } else {
       npm.registry.get(url, {auth: auth}, pulseTillDone('fetchMetadata', iferr(next, pickVersionFromRegistryDocument)))
     }
-    function returnAndAddMetadata (pkg) {
+    function thenAddMetadata (pkg) {
       pkg._from = dep.raw
       pkg._resolved = pkg.dist.tarball
       pkg._shasum = pkg.dist.shasum
@@ -130,35 +131,14 @@ function fetchNamedPackageData (dep, next) {
             'You should delete or re-publish the invalid versions.', pkg.name, invalidVersions.join(', '))
       }
 
-      versions = versions.filter(function (v) { return semver.valid(v) }).sort(semver.rcompare)
+      versions = versions.filter(function (v) { return semver.valid(v) })
 
       if (dep.type === 'tag') {
         var tagVersion = pkg['dist-tags'][dep.spec]
-        if (pkg.versions[tagVersion]) return returnAndAddMetadata(pkg.versions[tagVersion])
+        if (pkg.versions[tagVersion]) return thenAddMetadata(pkg.versions[tagVersion])
       } else {
-        var latestVersion = pkg['dist-tags'][npm.config.get('tag')] || versions[0]
-
-        // Find the the most recent version less than or equal
-        // to latestVersion that satisfies our spec
-        for (var ii = 0; ii < versions.length; ++ii) {
-          if (semver.gt(versions[ii], latestVersion)) continue
-          if (semver.satisfies(versions[ii], dep.spec)) {
-            return returnAndAddMetadata(pkg.versions[versions[ii]])
-          }
-        }
-
-        // Failing that, try finding the most recent version that matches
-        // our spec
-        for (var jj = 0; jj < versions.length; ++jj) {
-          if (semver.satisfies(versions[jj], dep.spec)) {
-            return returnAndAddMetadata(pkg.versions[versions[jj]])
-          }
-        }
-
-        // Failing THAT, if the range was '*' uses latestVersion
-        if (dep.spec === '*') {
-          return returnAndAddMetadata(pkg.versions[latestVersion])
-        }
+        var picked = pickManifestFromRegistryMetadata(dep.spec, npm.config.get('tag'), versions, pkg)
+        if (picked) return thenAddMetadata(picked.manifest)
       }
 
       // We didn't manage to find a compatible version

--- a/lib/utils/pick-manifest-from-registry-metadata.js
+++ b/lib/utils/pick-manifest-from-registry-metadata.js
@@ -1,0 +1,26 @@
+'use strict'
+module.exports = pickManifestFromRegistryMetadata
+
+var log = require('npmlog')
+var semver = require('semver')
+
+function pickManifestFromRegistryMetadata (spec, tag, versions, metadata) {
+  log.silly('pickManifestFromRegistryMetadata', 'spec', spec, 'tag', tag, 'versions', versions)
+
+  // if the tagged version satisfies, then use that.
+  var tagged = metadata['dist-tags'][tag]
+  if (tagged &&
+      metadata.versions[tagged] &&
+      semver.satisfies(tagged, spec, true)) {
+    return {resolvedTo: tag, manifest: metadata.versions[tagged]}
+  }
+  // find the max satisfying version.
+  var ms = semver.maxSatisfying(versions, spec, true)
+  if (ms) {
+    return {resolvedTo: ms, manifest: metadata.versions[ms]}
+  } else if (spec === '*' && versions.length && tagged && metadata.versions[tagged]) {
+    return {resolvedTo: tag, manifest: metadata.versions[tagged]}
+  } else {
+    return
+  }
+}

--- a/test/tap/pick-manifest-from-registry-metadata.js
+++ b/test/tap/pick-manifest-from-registry-metadata.js
@@ -1,0 +1,145 @@
+'use strict'
+var test = require('tap').test
+
+var pickManifest = require('../../lib/utils/pick-manifest-from-registry-metadata.js')
+
+test('basic carat range selection', function (t) {
+  var metadata = {
+    'dist-tags': {
+      'example': '1.1.0'
+    },
+    versions: {
+      '1.0.0': { version: '1.0.0' },
+      '1.0.1': { version: '1.0.1' },
+      '1.0.2': { version: '1.0.2' },
+      '1.1.0': { version: '1.1.0' },
+      '2.0.0': { version: '2.0.0' }
+    }
+  }
+  var versions = Object.keys(metadata.versions)
+  var selected = pickManifest('^1.0.0', 'latest', versions, metadata)
+  t.equal(selected.manifest.version, '1.1.0', 'picked the right manifest using ^')
+  t.equal(selected.resolvedTo, '1.1.0', 'resolved using version match')
+  selected = pickManifest('^1.0.0', 'example', versions, metadata)
+  t.equal(selected.manifest.version, '1.1.0', 'picked the right manifest using ^')
+  t.equal(selected.resolvedTo, 'example', 'resolved using tag')
+  t.end()
+})
+
+test('basic tilde range selection', function (t) {
+  var metadata = {
+    'dist-tags': {
+      'example': '1.1.0'
+    },
+    versions: {
+      '1.0.0': { version: '1.0.0' },
+      '1.0.1': { version: '1.0.1' },
+      '1.0.2': { version: '1.0.2' },
+      '1.1.0': { version: '1.1.0' },
+      '2.0.0': { version: '2.0.0' }
+    }
+  }
+  var versions = Object.keys(metadata.versions)
+  var selected = pickManifest('~1.0.0', 'latest', versions, metadata)
+  t.equal(selected.manifest.version, '1.0.2', 'picked the right manifest using ~')
+  t.equal(selected.resolvedTo, '1.0.2', 'resolved using version match')
+  t.end()
+})
+
+test('basic mathematical range selection', function (t) {
+  var metadata = {
+    'dist-tags': {},
+    versions: {
+      '1.0.0': { version: '1.0.0' },
+      '1.0.1': { version: '1.0.1' },
+      '1.0.2': { version: '1.0.2' },
+      '2.0.0': { version: '2.0.0' }
+    }
+  }
+  var versions = Object.keys(metadata.versions)
+  var selected = pickManifest('>=1.0.0 <2', 'example', versions, metadata)
+  t.equal(selected.manifest.version, '1.0.2', 'picked the right manifest using mathematical range')
+  t.equal(selected.resolvedTo, '1.0.2', 'resolved using version match')
+  t.end()
+})
+
+test('basic version selection', function (t) {
+  var metadata = {
+    'dist-tags': {},
+    versions: {
+      '1.0.0': { version: '1.0.0' },
+      '1.0.1': { version: '1.0.1' },
+      '1.0.2': { version: '1.0.2' },
+      '2.0.0': { version: '2.0.0' }
+    }
+  }
+  var versions = Object.keys(metadata.versions)
+  var selected = pickManifest('1.0.0', 'latest', versions, metadata)
+  t.equal(selected.manifest.version, '1.0.0', 'picked the right manifest using specific version')
+  t.equal(selected.resolvedTo, '1.0.0', 'resolved using version match')
+  t.end()
+})
+
+test('nothing if range does not match anything', function (t) {
+  var metadata = {
+    'dist-tags': {},
+    versions: {
+      '1.0.0': { version: '1.0.0' },
+      '2.0.0': { version: '2.0.0' },
+      '2.0.5': { version: '2.0.5' }
+    }
+  }
+  var versions = Object.keys(metadata.versions)
+  var selected = pickManifest('^2.1.0', 'latest', versions, metadata)
+  t.equal(selected, undefined, 'no manifest matched')
+  t.end()
+})
+
+test('if `defaultTag` matches a given range, use it', function (t) {
+  var metadata = {
+    'dist-tags': {
+      foo: '1.0.1'
+    },
+    versions: {
+      '1.0.0': { version: '1.0.0' },
+      '1.0.1': { version: '1.0.1' },
+      '1.0.2': { version: '1.0.2' },
+      '2.0.0': { version: '2.0.0' }
+    }
+  }
+  var versions = Object.keys(metadata.versions)
+  var selected = pickManifest('^1.0.0', 'foo', versions, metadata)
+  t.equal(selected.manifest.version, '1.0.1', 'picked the version for foo')
+  t.equal(selected.resolvedTo, 'foo', 'resolved using tag')
+
+  selected = pickManifest('^2.0.0', 'foo', versions, metadata)
+  t.equal(selected.manifest.version, '2.0.0', 'no match, no foo')
+  t.equal(selected.resolvedTo, '2.0.0', 'resolved using version match')
+
+  t.end()
+})
+
+test('* ranges use `defaultTag` if no versions match', function (t) {
+  var metadata = {
+    'dist-tags': {
+      beta: '2.0.0-beta.0'
+    },
+    versions: {
+      '1.0.0-pre.0': { version: '1.0.0-pre.0' },
+      '1.0.0-pre.1': { version: '1.0.0-pre.1' },
+      '2.0.0-beta.0': { version: '2.0.0-beta.0' },
+      '2.0.0-beta.1': { version: '2.0.0-beta.1' }
+    }
+  }
+  var versions = Object.keys(metadata.versions)
+  var selected = pickManifest('*', 'beta', versions, metadata)
+  t.equal(selected.manifest.version, '2.0.0-beta.0', 'used defaultTag for all-prerelease splat.')
+  t.equal(selected.resolvedTo, 'beta', 'resolved using tag')
+  t.end()
+})
+
+test('no result if metadata has no versions', function (t) {
+  var selected = pickManifest('^1.0.0', 'latest', [], {'dist-tags': {}, versions: {}})
+  t.equal(selected, undefined, 'no versions, no result')
+  t.end()
+})


### PR DESCRIPTION
Supplants #10662.

Gives us a single source of truth when it comes to selecting which version to use when given a range specifier.
