### PR TITLE
Clarify the behavior of the `files` array

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -170,12 +170,15 @@ npm also sets a top-level "maintainers" field with your npm user info.
 
 The "files" field is an array of files to include in your project.  If
 you name a folder in the array, then it will also include the files
-inside that folder. (Unless they would be ignored by another rule.)
+inside that folder. (Unless they would be ignored by another rule in this section.)
 
-You can also provide a ".npmignore" file in the root of your package or
-in subdirectories, which will keep files from being included, even
-if they would be picked up by the files array.  The `.npmignore` file
-works just like a `.gitignore`.
+You can also provide a `.npmignore` file in the root of your package or
+in subdirectories, which will keep files from being included. The `.npmignore` 
+file works just like a `.gitignore`. If there is a `.gitignore` 
+file, and `.npmignore` is missing, `.gitignore`'s contents will be used instead.
+
+Files included with the "package.json#files" field _cannot_ be excluded through
+`.npmignore` or `.gitignore`.
 
 Certain files are always included, regardless of settings:
 


### PR DESCRIPTION
The `files` documentation is a bit confusing (and actually incorrect with respect to current `files` vs `.npmignore` behavior, so I hope this clarifies it.