### PR TITLE
metrics: Don't launch if we're runnning from a sender process

### DIFF
--- a/lib/utils/metrics.js
+++ b/lib/utils/metrics.js
@@ -9,17 +9,22 @@ var path = require('path')
 var npm = require('../npm.js')
 var uuid = require('uuid')
 
+var inMetrics = false
+
 function startMetrics () {
+  if (inMetrics) return
   // loaded on demand to avoid any recursive deps when `./metrics-launch` requires us.
   var metricsLaunch = require('./metrics-launch.js')
   npm.metricsProcess = metricsLaunch()
 }
 
 function stopMetrics () {
+  if (inMetrics) return
   if (npm.metricsProcess) npm.metricsProcess.kill('SIGKILL')
 }
 
 function saveMetrics (itWorked) {
+  if (inMetrics) return
   // If the metrics reporter hasn't managed to PUT yet then kill it so that it doesn't
   // step on our updating the anonymous-cli-metrics json
   stopMetrics()
@@ -52,6 +57,7 @@ function saveMetrics (itWorked) {
 }
 
 function sendMetrics (metricsFile, metricsRegistry) {
+  inMetrics = true
   var cliMetrics = JSON.parse(fs.readFileSync(metricsFile))
   npm.load({}, function (err) {
     if (err) return


### PR DESCRIPTION
This saves our users from having almost launcher processes that are forever launching their own children before going away. As it is, once one of these has started it's very difficult to kill them short of rebooting. =/