### PR TITLE
Resolve git dependencies with semver ranges

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -174,7 +174,12 @@ after packing it up into a tarball (b).
 
     `<protocol>` is one of `git`, `git+ssh`, `git+http`, `git+https`,
     or `git+file`.
-    If no `<commit-ish>` is specified, then `master` is used.
+    If no `<commit-ish>` is specified, then `master` is used. A  semver range
+    may be used in place of a `<commit-ish>` to resolve against git tags. In
+    order to differentiate between a `<commit-ish>` and a range, the range must
+    be prefixed by `semver:`. For example:
+
+        git://github.com/user/project.git#semver:^1.0.0
 
     If the repository makes use of submodules, those submodules will
     be cloned as well.

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -459,7 +459,13 @@ Git urls can be of the form:
     git+https://user@hostname/project/blah.git#commit-ish
 
 The `commit-ish` can be any tag, sha, or branch which can be supplied as
-an argument to `git checkout`.  The default is `master`.
+an argument to `git checkout`. The default is `master`.
+
+In addition, a semver range may be used to resolve against git tags. In order to
+differentiate between a `commit-ish` and a range, the range must be prefixed by
+`semver:`. For example:
+
+    git://github.com/user/project.git#semver:^1.0.0
 
 ## GitHub URLs
 

--- a/lib/cache/add-remote-git.js
+++ b/lib/cache/add-remote-git.js
@@ -12,6 +12,7 @@ var mkdir = require('mkdirp')
 var normalizeGitUrl = require('normalize-git-url')
 var npa = require('npm-package-arg')
 var realizePackageSpecifier = require('realize-package-specifier')
+var semver = require('semver')
 var uniqueFilename = require('unique-filename')
 
 var addLocal = require('./add-local.js')
@@ -33,6 +34,8 @@ var VALID_VARIABLES = [
   'GIT_SSL_CAINFO',
   'GIT_SSL_NO_VERIFY'
 ]
+
+var SEMVER_REGEX = /^semver:(.*)$/
 
 module.exports = addRemoteGit
 function addRemoteGit (uri, _cb) {
@@ -114,7 +117,9 @@ function tryClone (from, combinedURL, silent, cb) {
 
   var normalized = normalizeGitUrl(combinedURL)
   var cloneURL = normalized.url
-  var treeish = normalized.branch
+  // semver ranges can contain special characters which are escaped when the
+  // the url is normalized
+  var treeish = decodeURIComponent(normalized.branch)
 
   // ensure that similarly-named remotes don't collide
   var cachedRemote = uniqueFilename(remotes, combinedURL.replace(/[^a-zA-Z0-9]+/g, '-'), cloneURL)
@@ -269,13 +274,50 @@ function updateRemote (from, cloneURL, treeish, cachedRemote, cb) {
   )
 }
 
+function resolveHead (from, cloneURL, treeish, cachedRemote, cb) {
+  var match = SEMVER_REGEX.exec(treeish)
+  if (match) {
+    resolveSemverRange(from, cloneURL, match[1], cachedRemote, cb)
+  } else {
+    resolveTreeish(from, cloneURL, treeish, cachedRemote, cb)
+  }
+}
+
+// resolve a semver range with the max satisfying git tag
+function resolveSemverRange (from, cloneURL, semverRange, cachedRemote, cb) {
+  log.verbose('resolveSemverRange', from, 'semver range:', semverRange)
+  if (!semver.validRange(semverRange)) {
+    return cb(new Error(semverRange + ' is not a valid semver range'))
+  }
+  git.whichAndExec(
+    ['tag', '--list'],
+    { cwd: cachedRemote, env: gitEnv() },
+    function (er, stdout, stderr) {
+      if (er) {
+        log.error('git tag:', stderr)
+        return cb(er)
+      }
+
+      var tags = stdout.trim().split('\n')
+      tags = tags.filter(semver.valid)
+      var resolvedVersion = semver.maxSatisfying(tags, semverRange)
+      if (!resolvedVersion) {
+        return cb(new Error('unable to find satisfying git tag for semver range: ' + semverRange))
+      }
+      log.silly('resolveSemverRange', from, 'resolved version:', resolvedVersion)
+
+      resolveTreeish(from, cloneURL, resolvedVersion, cachedRemote, cb)
+    }
+  )
+}
+
 // branches and tags are both symbolic labels that can be attached to different
 // commits, so resolve the commit-ish to the current actual treeish the label
 // corresponds to
 //
 // important for shrinkwrap
-function resolveHead (from, cloneURL, treeish, cachedRemote, cb) {
-  log.verbose('resolveHead', from, 'original treeish:', treeish)
+function resolveTreeish (from, cloneURL, treeish, cachedRemote, cb) {
+  log.verbose('resolveTreeish', from, 'original treeish:', treeish)
   var args = ['rev-list', '-n1', treeish]
   git.whichAndExec(
     args,
@@ -287,7 +329,7 @@ function resolveHead (from, cloneURL, treeish, cachedRemote, cb) {
       }
 
       var resolvedTreeish = stdout.trim()
-      log.silly('resolveHead', from, 'resolved treeish:', resolvedTreeish)
+      log.silly('resolveTreeish', from, 'resolved treeish:', resolvedTreeish)
 
       var resolvedURL = getResolved(cloneURL, resolvedTreeish)
       if (!resolvedURL) {
@@ -296,11 +338,11 @@ function resolveHead (from, cloneURL, treeish, cachedRemote, cb) {
             cloneURL + ' is in a form npm can\'t handle'
         ))
       }
-      log.verbose('resolveHead', from, 'resolved Git URL:', resolvedURL)
+      log.verbose('resolveTreeish', from, 'resolved Git URL:', resolvedURL)
 
       // generate a unique filename
       var tmpdir = path.join(tempFilename('git-cache'), resolvedTreeish)
-      log.silly('resolveHead', 'Git working directory:', tmpdir)
+      log.silly('resolveTreeish', 'Git working directory:', tmpdir)
 
       mkdir(tmpdir, function (er) {
         if (er) return cb(er)

--- a/test/tap/add-remote-git-semver.js
+++ b/test/tap/add-remote-git-semver.js
@@ -1,0 +1,250 @@
+var fs = require('fs')
+var resolve = require('path').resolve
+
+var osenv = require('osenv')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var npm = require('../../lib/npm.js')
+var common = require('../common-tap.js')
+
+var pkg = resolve(__dirname, 'add-remote-git-semver')
+var pkgDeps = resolve(pkg, 'node_modules')
+var repo = resolve(__dirname, 'add-remote-git-semver-repo')
+
+var daemon
+var daemonPID
+var git
+
+var writeParentPkg = function (commitish) {
+  var pjParent = JSON.stringify({
+    name: 'parent',
+    version: '1.2.3',
+    dependencies: {
+      child: 'git://localhost:1234/child.git#' + commitish
+    }
+  }, null, 2) + '\n'
+  fs.writeFileSync(resolve(pkg, 'package.json'), pjParent)
+}
+
+var pjChildVersions = ['1.0.0', '1.0.1', '1.0.3', '1.1.0', '1.1.5', '2.0.0']
+var createChildPkg = function (version) {
+  return JSON.stringify({
+    name: 'child',
+    version: version
+  }, null, 2) + '\n'
+}
+
+test('setup', function (t) {
+  bootstrap()
+  setup(function (er, r) {
+    t.ifError(er, 'git started up successfully')
+
+    if (!er) {
+      daemon = r[r.length - 2]
+      daemonPID = r[r.length - 1]
+    }
+
+    t.end()
+  })
+})
+
+test('install exact version tag', function (t) {
+  process.chdir(pkg)
+  writeParentPkg('v2.0.0')
+  npm.commands.install('.', [], function (er, result) {
+    t.ifError(er, 'npm installed exact version tag')
+    t.equal(result.length, 1)
+    t.equal(result[0][0], 'child@2.0.0')
+
+    cleanup(pkgDeps)
+    t.end()
+  })
+})
+
+test('install latest tag', function (t) {
+  process.chdir(pkg)
+  writeParentPkg('latest')
+  npm.commands.install('.', [], function (er, result) {
+    t.ifError(er, 'npm installed `latest` tag')
+    t.equal(result.length, 1)
+    t.equal(result[0][0], 'child@2.0.0')
+
+    cleanup(pkgDeps)
+    t.end()
+  })
+})
+
+test('install semver exact version', function (t) {
+  process.chdir(pkg)
+  writeParentPkg('semver:2.0.0')
+  npm.commands.install('.', [], function (er, result) {
+    t.ifError(er, 'npm installed exact semver version')
+    t.equal(result.length, 1)
+    t.equal(result[0][0], 'child@2.0.0')
+
+    cleanup(pkgDeps)
+    t.end()
+  })
+})
+
+test('install semver range ^', function (t) {
+  process.chdir(pkg)
+  writeParentPkg('semver:^1.0.0')
+  npm.commands.install('.', [], function (er, result) {
+    t.ifError(er, 'npm installed semver range with `^`')
+    t.equal(result.length, 1)
+    t.equal(result[0][0], 'child@1.1.5')
+
+    cleanup(pkgDeps)
+    t.end()
+  })
+})
+
+test('install semver range ~', function (t) {
+  process.chdir(pkg)
+  writeParentPkg('semver:~1.0.0')
+  npm.commands.install('.', [], function (er, result) {
+    t.ifError(er, 'npm installed semver range with `~`')
+    t.equal(result.length, 1)
+    t.equal(result[0][0], 'child@1.0.3')
+
+    cleanup(pkgDeps)
+    t.end()
+  })
+})
+
+test('latest tag is an invalid semver range', function (t) {
+  process.chdir(pkg)
+  writeParentPkg('semver:latest')
+  npm.commands.install('.', [], function (er, result) {
+    t.equal(er.message, 'latest is not a valid semver range')
+    t.equal(result.length, 0)
+
+    cleanup(pkgDeps)
+    t.end()
+  })
+})
+
+test('invalid semver range', function (t) {
+  process.chdir(pkg)
+  writeParentPkg('semver:not-a-valid-range')
+  npm.commands.install('.', [], function (er, result) {
+    t.equal(er.message, 'not-a-valid-range is not a valid semver range')
+    t.equal(result.length, 0)
+
+    cleanup(pkgDeps)
+    t.end()
+  })
+})
+
+test('no satisfying tag found', function (t) {
+  process.chdir(pkg)
+  writeParentPkg('semver:5.x.x')
+  npm.commands.install('.', [], function (er, result) {
+    t.equal(er.message, 'unable to find satisfying git tag for semver range: 5.x.x')
+    t.equal(result.length, 0)
+
+    cleanup(pkgDeps)
+    t.end()
+  })
+})
+
+test('clean', function (t) {
+  daemon.on('close', function () {
+    cleanup(repo)
+    cleanup(pkg)
+    t.end()
+  })
+  process.kill(daemonPID)
+})
+
+function bootstrap () {
+  cleanup(repo)
+  cleanup(pkg)
+  mkdirp.sync(pkg)
+}
+
+function setup (cb) {
+  mkdirp.sync(repo)
+  fs.writeFileSync(resolve(repo, 'package.json'), createChildPkg('0.0.0'))
+  npm.load({ registry: common.registry, loglevel: 'silent' }, function () {
+    git = require('../../lib/utils/git.js')
+
+    function startDaemon (cb) {
+      // start git server
+      var d = git.spawn(
+        [
+          'daemon',
+          '--verbose',
+          '--listen=localhost',
+          '--export-all',
+          '--base-path=.',
+          '--reuseaddr',
+          '--port=1234'
+        ],
+        {
+          cwd: pkg,
+          env: process.env,
+          stdio: ['pipe', 'pipe', 'pipe']
+        }
+      )
+      d.stderr.on('data', childFinder)
+
+      function childFinder (c) {
+        var cpid = c.toString().match(/^\[(\d+)\]/)
+        if (cpid[1]) {
+          this.removeListener('data', childFinder)
+          cb(null, [d, cpid[1]])
+        }
+      }
+    }
+
+    var commands = []
+    // write package.json files and tag each version
+    pjChildVersions.forEach(function (version) {
+      commands.push(
+        [
+          fs, 'writeFile',
+          resolve(repo, 'package.json'), createChildPkg(version)
+        ],
+        git.chainableExec(
+          ['add', 'package.json'],
+          { cwd: repo, env: process.env }
+        ),
+        git.chainableExec(
+          ['commit', '-m', 'up version to ' + version],
+          { cwd: repo, env: process.env }
+        ),
+        git.chainableExec(
+          ['tag', 'v' + version],
+          { cwd: repo, env: process.env }
+        )
+      )
+    })
+
+    commands.push(
+      // non semver-valid tag should be handled
+      git.chainableExec(
+        ['tag', 'latest'],
+        { cwd: repo, env: process.env }
+      ),
+      git.chainableExec(
+        ['clone', '--bare', repo, 'child.git'],
+        { cwd: pkg, env: process.env }
+      ),
+      startDaemon
+    )
+
+    common.makeGitRepo({
+      path: repo,
+      commands: commands
+    }, cb)
+  })
+}
+
+function cleanup (path) {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(path)
+}


### PR DESCRIPTION
Fixes: https://github.com/npm/npm/issues/3328

This would allow git dependencies to use semver ranges for the `commit-ish`, which will be compared against semver-valid git tags.

For example take a project with the following tags:

```bash
$ git tag --list
next
v1.2.0
v1.1.0
v1.0.1
```

Then we can require it as a dependency as so (or using any of the other allowed syntax for git):
```json
"dependencies": {
  "project": "git://github.com/user/project.git#^1.0.0"
}
```

1. The `^1.0.0` will be recognized as a semver range by `semver.validRange()`.
2. The resolver will then attempt to resolve the range against all *valid* semver tags.
In this case `next` would be filtered out, as it is not a valid semver tag, as determined by `semver.valid()`.
3. Using `semver.maxSatisfying()` the range will resolve to `v1.2.0`.

Let me know if you think this is the right direction for this feature and I'll add more tests to thoroughly check the behavior.