### PR TITLE
gitignore: ignore npm-debug.log*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.swp
-npm-debug.log
+npm-debug.log*
 .nyc_output/
 /test/bin
 /test/output.log


### PR DESCRIPTION
Since `npm-debug.log` sometimes has numbers, we can use `*` which is same pattern with the `Node.gitignore`:
+ https://github.com/github/gitignore/blob/master/Node.gitignore#L4