### PR TITLE
Use https-proxy config for spawned processes

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -295,6 +295,13 @@
           umask: umask
         }
 
+        if (config.get('proxy') && !process.env['HTTP_PROXY']){
+          process.env['HTTP_PROXY'] = config.get('proxy')
+        }
+        if (config.get('https-proxy') && !process.env['HTTPS_PROXY']){
+          process.env['HTTPS_PROXY'] = config.get('https-proxy')
+        }
+
         var gp = Object.getOwnPropertyDescriptor(config, 'globalPrefix')
         Object.defineProperty(npm, 'globalPrefix', gp)
 


### PR DESCRIPTION
Prefill HTTPS_PROXY and HTTP_PROXY from https-proxy and proxy if not yet set.
This avoids issues if you are behind a proxy while using 
 - curl (like during webdriver-manager update) 
 - git+https, see #3559

I took a look at all those require('child_process') for execFile/spawn/exec and found that setting process.env['HTTPS_PROXY'] is a easy way to catch all externally launched programs. 
Ìn case HTTPS_PROXY is already set should we issue some kind of warning? 