### PR TITLE
docs: update supported version number of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Much more info available via `npm help` once it's installed.
 
 ## IMPORTANT
 
-**You need node v0.10 or higher to run this program.**
+**You need node v4 or higher to run this program.**
 
-To install an old **and unsupported** version of npm that works on node 0.3
+To install an old **and unsupported** version of npm that works on node v0.12
 and prior, clone the git repo and dig through the old tags and branches.
 
 **npm is configured to use npm, Inc.'s public package registry at


### PR DESCRIPTION
Since v0.10 is not supported anymore, we can update the important part in readme