### PR TITLE
Respect PREFIX and DESTDIR in combination

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -97,11 +97,11 @@ Object.defineProperty(exports, 'defaults', {get: function () {
   } else {
     // /usr/local/bin/node --> prefix=/usr/local
     globalPrefix = path.dirname(path.dirname(process.execPath))
+  }
 
-    // destdir only is respected on Unix
-    if (process.env.DESTDIR) {
-      globalPrefix = path.join(process.env.DESTDIR, globalPrefix)
-    }
+  // destdir only is respected on Unix
+  if (process.platform !== 'win32' && process.env.DESTDIR) {
+    globalPrefix = path.join(process.env.DESTDIR, globalPrefix)
   }
 
   defaults = {


### PR DESCRIPTION
Convention dictates that these two variables should be usable in
combination. Fixes #15517.