### PR TITLE
doc: fix readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 npm(1) -- a JavaScript package manager
 ==============================
+
 [![Build Status](https://img.shields.io/travis/npm/npm/latest.svg)](https://travis-ci.org/npm/npm)
+
 ## SYNOPSIS
 
 This is just enough info to get you up and running.


### PR DESCRIPTION
> Fixes #15629

Added newlines around build status line to fix a formatting error that caused the readme to display incorrectly on npmjs.org.

A difference in markdown rendering rules between npm and github is the cause (marky-markdown vs whatever github is using).

## bad formatting

![screen shot 2017-01-31 at 11 20 13 am](https://cloud.githubusercontent.com/assets/427322/22480930/00f01392-e7a8-11e6-9d82-c091fffdd0ac.png)

> see https://www.npmjs.com/package/npm