### PR TITLE
npm install --prefix bug fix

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -213,7 +213,7 @@ function Installer (where, dryrun, args) {
   this.prod = !/^dev(elopment)?$/.test(npm.config.get('only'))
   this.rollback = npm.config.get('rollback')
   this.link = npm.config.get('link')
-  this.global = this.where === path.resolve(npm.globalDir, '..')
+  this.global = this.where === path.resolve(npm.globalDir, '..') && this.where !== npm.config.get('prefix')
 }
 Installer.prototype = {}
 


### PR DESCRIPTION
set always as global when run command like npm install --prefix [path]

https://github.com/npm/npm/issues/15692 issue fixed.