### PR TITLE
completion: handle colons (e.g. in script names) correctly

### DIFF
--- a/lib/utils/completion.sh
+++ b/lib/utils/completion.sh
@@ -11,7 +11,7 @@ if type complete &>/dev/null; then
   _npm_completion () {
     local words cword
     if type _get_comp_words_by_ref &>/dev/null; then
-      _get_comp_words_by_ref -n = -n @ -w words -i cword
+      _get_comp_words_by_ref -n = -n @ -n : -w words -i cword
     else
       cword="$COMP_CWORD"
       words=("${COMP_WORDS[@]}")
@@ -24,6 +24,9 @@ if type complete &>/dev/null; then
                            npm completion -- "${words[@]}" \
                            2>/dev/null)) || return $?
     IFS="$si"
+    if type __ltrim_colon_completions &>/dev/null; then
+      __ltrim_colon_completions "${words[cword]}"
+    fi
   }
   complete -o default -F _npm_completion npm
 elif type compdef &>/dev/null; then


### PR DESCRIPTION
As this problem mentioned a few times on the internet including npm's very own Github issues. I thought I'd propose a fix.

Based on this answer: http://stackoverflow.com/questions/2805412/bash-completion-for-maven-escapes-colon/12495727#12495727

Does not modify `COMP_WORDBREAKS`. Uses `__ltrim_colon_completions`

Fixes #11696

P.S. There's also a possibility to implement a solution that does not rely on `_get_comp_words_by_ref` or `__ltrim_colon_completions`. For example, like this: http://willcode4beer.com/tips.jsp?set=tabMaven