### PR TITLE
Created Warning Message for Duplicate Deps and Test for Issue: 6725

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -451,3 +451,4 @@ Dmitry Litvinchenko <karaliti@gmail.com>
 chocolateboy <chocolate@cpan.org>
 Henry Zhu <hi@henryzoo.com>
 Nate Goldman <ungoldman@gmail.com>
+Ted Yavuzkurt <hello@TedY.io>

--- a/lib/install/validate-tree.js
+++ b/lib/install/validate-tree.js
@@ -26,7 +26,8 @@ module.exports = function (idealTree, log, next) {
       ], done)
     }],
     [thenValidateAllPeerDeps, idealTree],
-    [thenCheckTop, idealTree]
+    [thenCheckTop, idealTree],
+    [thenCheckDuplicateDeps, idealTree]
   ], andFinishTracker(log, next))
 }
 
@@ -73,5 +74,31 @@ function thenCheckTop (idealTree, next) {
     warnObj.code = 'ENODEPRE'
     idealTree.warnings.push(warnObj)
   }
+
+  next()
+}
+
+// check if dependencies are duplicated between dependencies and
+// dev-dependencies. Issue warning if so.
+function thenCheckDuplicateDeps (idealTree, next) {
+  var shorterDepsList = idealTree.package.devDependencies
+  var longerDepsList = idealTree.package.dependencies
+  // might be undefined -- skip if so
+  if (!(idealTree.package.devDependencies === undefined || idealTree.package.dependencies === undefined)) {
+    // speed optimization --> iterate through shorter dependencies list
+    if (idealTree.package.dependencies.length < idealTree.package.devDependencies.length) {
+      shorterDepsList = idealTree.package.devDependencies
+      longerDepsList = idealTree.package.dependencies
+    }
+
+    for (var pkg in shorterDepsList) {
+      if (pkg in longerDepsList) {
+        var warnObj = new Error('The package ' + pkg + ' is included as both a dev and production dependency.')
+        warnObj.code = 'EDUPLICATEDEP'
+        idealTree.warnings.push(warnObj)
+      }
+    }
+  }
+
   next()
 }

--- a/test/tap/install-duplicate-deps-warning.js
+++ b/test/tap/install-duplicate-deps-warning.js
@@ -1,0 +1,72 @@
+var fs = require('graceful-fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+var npm = npm = require('../../')
+
+var pkg = path.resolve(__dirname, 'dev-dep-duplicate')
+
+var json = {
+  author: 'Anders Janmyr',
+  name: 'dev-dep-duplicate',
+  version: '0.0.0',
+  dependencies: {
+    underscore: '1.5.1'
+  },
+  devDependencies: {
+    underscore: '1.3.1'
+  }
+}
+
+test('setup', function (t) {
+  t.comment('test for https://github.com/npm/npm/issues/6725')
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
+  console.dir(pkg)
+  t.end()
+})
+
+test('npm install with duplicate dependencies, different versions', function (t) {
+  t.plan(1)
+  mr({ port: common.port }, function (er, s) {
+    var opts = {
+      cache: path.resolve(pkg, 'cache'),
+      registry: common.registry
+    }
+
+    npm.load(opts, function (err) {
+      if (err) return t.fail(err)
+
+      npm.install('.', function (err, additions, result) {
+        if (err) return t.fail(err)
+
+        var invalid = result.warnings.filter(function (warning) { return warning.code === 'EDUPLICATEDEP' })
+        t.is(invalid.length, 1, 'got a warning (EDUPLICATEDEP) for duplicate dev/production dependencies')
+
+        s.close()
+        t.end()
+      })
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
Original Issue: https://github.com/npm/npm/issues/6725

Decisions I made:

- Chose a pretty vanilla warning message. Can change if suggestions are made
- I opted to have it warn if dependencies are same version or different versions

Instead of including in `thenCheckTop` as @iarna  suggested, I opted to factor the duplicate checking to a separate function. I thought this kept things a little cleaner.

Wrote test as well. I could unit test the function in particular but I think this test verifies that it's properly created the warning.