### PR TITLE
docs(npm-scripts): added link to eggheadio video course

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -257,6 +257,11 @@ above.
   there is another option. The only valid use of `install` or `preinstall`
   scripts is for compilation which must be done on the target architecture.
 
+## VIDEO COURSE
+
+To see scripts in action you can watch the free [How to Use npm scripts as Your Build
+Tool](https://egghead.io/courses/how-to-use-npm-scripts-as-your-build-tool) course on [egghead.io](https://egghead.io) by [Elijah Manor](https://twitter.com/elijahmanor).
+
 ## SEE ALSO
 
 * npm-run-script(1)


### PR DESCRIPTION
I've recently made an [egghead.io](https://egghead.io) course on [How to Use npm scripts as Your Build Tool](https://egghead.io/courses/how-to-use-npm-scripts-as-your-build-tool). The course is 52 minutes long and has 21 focused lessons.

Normally these courses start out free, but after about a week or so they get converted to a paid-only offering.

However, I've chatted with egghead.io and they are willing to keep the course **free** if I'm able to get a link to the course from npm's documentation.