### PR TITLE
config: change apply to call

### DIFF
--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -208,7 +208,7 @@ inherits(Conf, CC)
 function Conf (base) {
   if (!(this instanceof Conf)) return new Conf(base)
 
-  CC.apply(this)
+  CC.call(this)
 
   if (base) {
     if (base instanceof Conf) {


### PR DESCRIPTION
Since it doesn't have to apply an array of arguments, we change `apply` to more performant `call`.