### PR TITLE
fix: we were not populating version # in new search results

### DIFF
--- a/lib/search/format-package-stream.js
+++ b/lib/search/format-package-stream.js
@@ -150,8 +150,6 @@ function highlightSearchTerms (str, terms) {
 
 function normalizePackage (data, opts) {
   opts = opts || {}
-  var version = Object.keys(data.versions || {})[0] || []
-  if (data.version) version = data.version
   return {
     name: data.name,
     description: opts.description ? data.description : '',
@@ -163,7 +161,7 @@ function normalizePackage (data, opts) {
     : typeof data.keywords === 'string'
     ? data.keywords.replace(/[,\s]+/, ' ')
     : '',
-    version: version,
+    version: data.version,
     date: data.date &&
           (data.date.toISOString() // remove time
             .split('T').join(' ')

--- a/lib/search/format-package-stream.js
+++ b/lib/search/format-package-stream.js
@@ -150,6 +150,8 @@ function highlightSearchTerms (str, terms) {
 
 function normalizePackage (data, opts) {
   opts = opts || {}
+  var version = Object.keys(data.versions || {})[0] || []
+  if (data.version) version = data.version
   return {
     name: data.name,
     description: opts.description ? data.description : '',
@@ -161,7 +163,7 @@ function normalizePackage (data, opts) {
     : typeof data.keywords === 'string'
     ? data.keywords.replace(/[,\s]+/, ' ')
     : '',
-    version: Object.keys(data.versions || {})[0] || [],
+    version: version,
     date: data.date &&
           (data.date.toISOString() // remove time
             .split('T').join(' ')

--- a/test/tap/search.js
+++ b/test/tap/search.js
@@ -130,7 +130,7 @@ test('can switch to tab separated mode', function (t) {
     '--cache', CACHE_DIR
   ], {}, function (err, code, stdout, stderr) {
     if (err) throw err
-    t.equal(stdout, 'cool\t\t\tprehistoric\t\t\nfoo\tthis has tabs\t\tprehistoric\t\t\n', 'correct output, including replacing tabs in descriptions')
+    t.equal(stdout, 'cool\t\t\tprehistoric\t1.0.0\t\nfoo\tthis has tabs\t\tprehistoric\t2.0.0\t\n', 'correct output, including replacing tabs in descriptions')
     t.equal(stderr, '', 'no error output')
     t.equal(code, 0, 'search gives 0 error code even if no matches')
     t.done()


### PR DESCRIPTION
the new `/-/v1/search` API returns the version number on the key `.version`, we were accidentally not populating this in the UI.