### PR TITLE
test: don't use undocumented res.writeHeader alias

### DIFF
--- a/test/broken-under-nyc-and-travis/whoami.js
+++ b/test/broken-under-nyc-and-travis/whoami.js
@@ -48,7 +48,7 @@ test('npm whoami with bearer auth', { timeout: 2 * 1000 }, function (t) {
     t.equal(req.url, '/-/whoami')
 
     res.setHeader('content-type', 'application/json')
-    res.writeHeader(200)
+    res.writeHead(200)
     res.end(JSON.stringify({ username: 'wombat' }), 'utf8')
   }
 


### PR DESCRIPTION
`res.writeHeader` is an undocumented alias to `res.writeHead`
It's docs-deprecated in https://github.com/nodejs/node/pull/11355

Refs: https://github.com/nodejs/node/pull/11355

Note: I haven't run tests locally and judging by the folder this resides in I am not sure if this is covered on CI.

---

CI build failure is due to a broken Slack integration:
> Error sending Slack notification: Value cannot be null.
 Parameter name: Either incoming webhook URL or Slack authentication token is required.