### PR TITLE
docs: update troubleshooting links

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -40,10 +40,10 @@
     before submitting your issue.
 
     - Please check if there's a solution in the troubleshooting wiki:
-      https://github.com/npm/npm/blob/master/TROUBLESHOOTING.md
+      https://github.com/npm/npm/blob/latest/TROUBLESHOOTING.md
 
     - Also ensure that your new issue conforms to npm's contribution guidelines:
-      https://github.com/npm/npm/blob/master/CONTRIBUTING.md
+      https://github.com/npm/npm/blob/latest/CONTRIBUTING.md
 
     - Participation in this open source project is subject to the npm Code of Conduct:
       https://www.npmjs.com/policies/conduct

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -40,10 +40,10 @@
     before submitting your issue.
 
     - Please check if there's a solution in the troubleshooting wiki:
-      https://github.com/npm/npm/wiki/Troubleshooting
+      https://github.com/npm/npm/blob/master/TROUBLESHOOTING.md
 
     - Also ensure that your new issue conforms to npm's contribution guidelines:
-      https://github.com/npm/npm/wiki/Contributing-Guidelines
+      https://github.com/npm/npm/blob/master/CONTRIBUTING.md
 
     - Participation in this open source project is subject to the npm Code of Conduct:
       https://www.npmjs.com/policies/conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ This includes anyone who may show up to the npm/npm repo with issues, PRs, comme
 * Comment on issues when they have a reference to the answer.
 * If community members aren't sure they are correct and don't have a reference to the answer, please leave the issue and try another one.
 * Defer to collaborators and npm employees for answers.
-* Make sure to search for the troubleshooting doc and search on the issue tracker for similar issues before opening a new one.
+* Make sure to search for [the troubleshooting doc](./TROUBLESHOOTING.md) and search on the issue tracker for similar issues before opening a new one.
 * Any users with urgent support needs are welcome to email support@npmjs.com, and our dedicated support team will be happy to help.
 
 PLEASE don't @ collaborators or npm employees on issues. The CLI team is small, and has many outstanding commitments to fulfill.
@@ -61,7 +61,7 @@ Collaborators who become inactive for 3 months or longer may have their collabor
 * If they've responded to an issue, it becomes their responsibility to see it to resolution.
 * Close issues if there's no response within a month.
 * Defer to fellow Collaborators & npm employees for answers (Again, please don't @ collaborators or npm employees, thank you!)
-* Make sure to search for the troubleshooting doc and search on the issue tracker for similar issues before opening a new one.
+* Make sure to search for [the troubleshooting doc](./TROUBLESHOOTING.md) and search on the issue tracker for similar issues before opening a new one.
 
 ### npm, Inc Employees
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ experience if you run a recent version of npm. To upgrade, either use [Microsoft
 upgrade tool](https://github.com/felixrieseberg/npm-windows-upgrade),
 [download a new version of Node](https://nodejs.org/en/download/),
 or follow the Windows upgrade instructions in the
-[npm Troubleshooting Guide](https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows).
+[npm Troubleshooting Guide](./TROUBLESHOOTING.md).
 
 If that's not fancy enough for you, then you can fetch the code with
 git, and mess with it directly.


### PR DESCRIPTION
 Following up for https://github.com/npm/npm/pull/15756. I updated the troubleshooting and the contribution guideline links in docs.