### PR TITLE
returning the searchResults as a string in the callback

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -71,9 +71,11 @@ function search (args, cb) {
     parseable: npm.config.get('parseable'),
     color: npm.color
   })
+  var searchResults = '';
   outputStream.on('data', function (chunk) {
     if (!anyOutput) { anyOutput = true }
     output(chunk.toString('utf8'))
+	searchResults += chunk.toString('utf8')
   })
 
   log.silly('search', 'searching packages')
@@ -84,7 +86,7 @@ function search (args, cb) {
     }
     log.silly('search', 'search completed')
     log.clearProgress()
-    cb(null, {})
+    cb(null, searchResults)
   })
 }
 


### PR DESCRIPTION
With this change, the callback would return a string instead an empty object (see Issues: #15933  )
The string is the same that is outputted to the console.
I took a look into the tests, but it seems there are no tests for the commands API at all. 
If needed I can create one. 

