### PR TITLE
install as if this is fresh and there is no node modules yet

### DIFF
--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -46,6 +46,7 @@ var affordances = {
 // these are filenames in .
 var cmdList = [
   'install',
+  'install-as-if-this-is-fresh-and-there-is-no-node_modules-yet',
   'install-test',
   'uninstall',
   'cache',

--- a/lib/install-as-if-this-is-fresh-and-there-is-no-node_modules-yet.js
+++ b/lib/install-as-if-this-is-fresh-and-there-is-no-node_modules-yet.js
@@ -1,0 +1,66 @@
+module.exports = freshinstall
+
+freshinstall.usage = 'npm install-as-if-this-is-fresh-and-there-is-no-node_modules-yet [<pkg>...]'
+
+var path = require('path')
+var validate = require('aproba')
+var log = require('npmlog')
+var npm = require('./npm.js')
+var Installer = require('./install.js').Installer
+var inherits = require('inherits')
+
+freshinstall.completion = npm.commands.install.completion
+
+function freshinstall (where, args, cb) {
+  if (!cb) {
+    cb = args
+    args = where
+    where = null
+  }
+  var globalTop = path.resolve(npm.globalDir, '..')
+  if (!where) {
+    where = npm.config.get('global')
+          ? globalTop
+          : npm.prefix
+  }
+  validate('SAF', [where, args, cb])
+  // the /path/to/node_modules/..
+  var dryrun = !!npm.config.get('dry-run')
+
+  if (npm.config.get('dev')) {
+    log.warn('install', 'Usage of the `--dev` option is deprecated. Use `--only=dev` instead.')
+  }
+
+  if (where === globalTop && !args.length) {
+    args = ['.']
+  }
+  args = args.filter(function (a) {
+    return path.resolve(a) !== npm.prefix
+  })
+
+  new FreshInstaller(where, dryrun, args).run(cb)
+}
+
+function FreshInstaller (where, dryrun, args) {
+  Installer.apply(this, arguments)
+}
+
+inherits(FreshInstaller, Installer)
+
+FreshInstaller.prototype.cloneCurrentTreeToIdealTree = function (cb) {
+  validate('F', arguments)
+  log.silly('install', 'cloneCurrentTreeToIdealTree')
+  this.idealTree = {
+    package: this.currentTree.package,
+    path: this.currentTree.path,
+    realpath: this.currentTree.realpath,
+    children: [],
+    requires: [],
+    missingDeps: {},
+    missingDevDeps: {},
+    requiredBy: [],
+    error: this.currentTree.error,
+    warnings: []
+  }
+  cb()
+}

--- a/lib/install-as-if-this-is-fresh-and-there-is-no-node_modules-yet.js
+++ b/lib/install-as-if-this-is-fresh-and-there-is-no-node_modules-yet.js
@@ -60,7 +60,8 @@ FreshInstaller.prototype.cloneCurrentTreeToIdealTree = function (cb) {
     missingDevDeps: {},
     requiredBy: [],
     error: this.currentTree.error,
-    warnings: []
+    warnings: [],
+    isTop: true
   }
   cb()
 }

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -15,6 +15,8 @@ var semver = require('semver')
 var color = require('ansicolors')
 var npa = require('npm-package-arg')
 var iferr = require('iferr')
+var sortedObject = require('sorted-object')
+var extend = Object.assign || require('util')._extend
 var npm = require('./npm.js')
 var mutateIntoLogicalTree = require('./install/mutate-into-logical-tree.js')
 var recalculateMetadata = require('./install/deps.js').recalculateMetadata
@@ -76,8 +78,8 @@ var lsFromTree = ls.fromTree = function (dir, physicalTree, args, silent, cb) {
 
   pruneNestedExtraneous(data)
   filterByEnv(data)
-  var bfs = filterFound(bfsify(data), args)
-  var lite = getLite(bfs)
+  var unlooped = filterFound(unloop(data), args)
+  var lite = getLite(unlooped)
 
   if (silent) return cb(null, data, lite)
 
@@ -86,7 +88,7 @@ var lsFromTree = ls.fromTree = function (dir, physicalTree, args, silent, cb) {
   var out
   if (json) {
     var seen = []
-    var d = long ? bfs : lite
+    var d = long ? unlooped : lite
     // the raw data can be circular
     out = JSON.stringify(d, function (k, o) {
       if (typeof o === 'object') {
@@ -96,9 +98,9 @@ var lsFromTree = ls.fromTree = function (dir, physicalTree, args, silent, cb) {
       return o
     }, 2)
   } else if (npm.config.get('parseable')) {
-    out = makeParseable(bfs, long, dir)
+    out = makeParseable(unlooped, long, dir)
   } else if (data) {
-    out = makeArchy(bfs, long, dir)
+    out = makeArchy(unlooped, long, dir)
   }
   output(out)
 
@@ -247,18 +249,10 @@ function getLite (data, noname, depth) {
   return lite
 }
 
-function bfsify (root) {
-  // walk over the data, and turn it from this:
-  // +-- a
-  // |   `-- b
-  // |       `-- a (truncated)
-  // `--b (truncated)
-  // into this:
-  // +-- a
-  // `-- b
-  // which looks nicer
+function unloop (root) {
   var queue = [root]
-  var seen = [root]
+  var seen = {}
+  seen[root.path] = true
 
   while (queue.length) {
     var current = queue.shift()
@@ -266,17 +260,14 @@ function bfsify (root) {
     Object.keys(deps).forEach(function (d) {
       var dep = deps[d]
       if (dep.missing) return
-      if (inList(seen, dep)) {
-        if (npm.config.get('parseable') || !npm.config.get('long')) {
-          delete deps[d]
-          return
-        } else {
-          dep = deps[d] = Object.create(dep)
-          dep.dependencies = {}
-        }
+      if (dep.path && seen[dep.path]) {
+        dep = deps[d] = extend({}, dep)
+        dep.dependencies = {}
+        dep._deduped = path.relative(root.path, dep.path).replace(/node_modules\//g, '')
+        return
       }
+      seen[dep.path] = true
       queue.push(dep)
-      seen.push(dep)
     })
   }
 
@@ -285,18 +276,23 @@ function bfsify (root) {
 
 function filterFound (root, args) {
   if (!args.length) return root
-  var deps = root.dependencies
-  if (deps) {
-    Object.keys(deps).forEach(function (depName) {
-      var dep = filterFound(deps[depName], args)
-      if (dep.peerMissing) return
+  if (!root.dependencies) return root
 
-      // see if this one itself matches
-      var found = false
-      for (var ii = 0; !found && ii < args.length; ii++) {
+  // Mark all deps
+  var toMark = [root]
+  while (toMark.length) {
+    var markPkg = toMark.shift()
+    var markDeps = markPkg.dependencies
+    if (!markDeps) continue
+    Object.keys(markDeps).forEach(function (depName) {
+      var dep = markDeps[depName]
+      if (dep.peerMissing) return
+      dep._parent = markPkg
+      for (var ii = 0; ii < args.length; ii++) {
         var argName = args[ii][0]
         var argVersion = args[ii][1]
         var argRaw = args[ii][2]
+        var found
         if (depName === argName && argVersion) {
           found = semver.satisfies(dep.version, argVersion, true)
         } else if (depName === argName) {
@@ -305,16 +301,33 @@ function filterFound (root, args) {
         } else if (dep.path === argRaw) {
           found = true
         }
+        if (found) {
+          dep._found = 'explicit'
+          var parent = dep._parent
+          while (parent && !parent._found && !parent._deduped) {
+            parent._found = 'implicit'
+            parent = parent._parent
+          }
+          break
+        }
       }
-      // included explicitly
-      if (found) dep._found = true
-      // included because a child was included
-      if (dep._found && !root._found) root._found = 1
-      // not included
-      if (!dep._found) delete deps[depName]
+      toMark.push(dep)
     })
   }
-  if (!root._found) root._found = false
+  var toTrim = [root]
+  while (toTrim.length) {
+    var trimPkg = toTrim.shift()
+    var trimDeps = trimPkg.dependencies
+    if (!trimDeps) continue
+    trimPkg.dependencies = {}
+    Object.keys(trimDeps).forEach(function (name) {
+      var dep = trimDeps[name]
+      if (!dep._found) return
+      if (dep._found === 'implicit' && dep._deduped) return
+      trimPkg.dependencies[name] = dep
+      toTrim.push(dep)
+    })
+  }
   return root
 }
 
@@ -345,7 +358,7 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
   var out = {}
   // the top level is a bit special.
   out.label = data._id || ''
-  if (data._found === true && data._id) {
+  if (data._found === 'explicit' && data._id) {
     if (npm.color) {
       out.label = color.bgBlack(color.yellow(out.label.trim())) + ' '
     } else {
@@ -353,6 +366,14 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
     }
   }
   if (data.link) out.label += ' -> ' + data.link
+
+  if (data._deduped) {
+    if (npm.color) {
+      out.label += ' ' + color.brightBlack('deduped')
+    } else {
+      out.label += ' deduped'
+    }
+  }
 
   if (data.invalid) {
     if (data.realName !== data.name) out.label += ' (' + data.realName + ')'
@@ -369,6 +390,7 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
 
   if (data.peerMissing) {
     var peerMissing = 'UNMET PEER DEPENDENCY'
+
     if (npm.color) peerMissing = color.bgBlack(color.red(peerMissing))
     out.label = peerMissing + ' ' + out.label
   }
@@ -415,7 +437,7 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
       .sort(alphasort).filter(function (d) {
         return !isCruft(data.dependencies[d])
       }).map(function (d) {
-        return makeArchy_(data.dependencies[d], long, dir, depth + 1, data, d)
+        return makeArchy_(sortedObject(data.dependencies[d]), long, dir, depth + 1, data, d)
       })
   }
 
@@ -444,19 +466,20 @@ function getExtras (data) {
 }
 
 function makeParseable (data, long, dir, depth, parent, d) {
+  if (data._deduped) return []
   depth = depth || 0
   if (depth > npm.config.get('depth')) return [ makeParseable_(data, long, dir, depth, parent, d) ]
   return [ makeParseable_(data, long, dir, depth, parent, d) ]
-  .concat(Object.keys(data.dependencies || {})
-    .sort(alphasort).map(function (d) {
-      return makeParseable(data.dependencies[d], long, dir, depth + 1, data, d)
-    }))
-  .filter(function (x) { return x })
-  .join('\n')
+    .concat(Object.keys(data.dependencies || {})
+      .sort(alphasort).map(function (d) {
+        return makeParseable(data.dependencies[d], long, dir, depth + 1, data, d)
+      }))
+    .filter(function (x) { return x })
+    .join('\n')
 }
 
 function makeParseable_ (data, long, dir, depth, parent, d) {
-  if (data.hasOwnProperty('_found') && data._found !== true) return ''
+  if (data.hasOwnProperty('_found') && data._found !== 'explicit') return ''
 
   if (data.missing) {
     if (depth < npm.config.get('depth')) {

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -357,7 +357,7 @@ function shouldUpdate (args, tree, dep, has, req, depth, pkgpath, cb, type) {
         }
       }
 
-      if (curr.version !== wanted) {
+      if (!curr || curr.version !== wanted) {
         doIt(wanted, latest)
       } else {
         skip()

--- a/test/tap/extraneous-dep-cycle-ls-ok.js
+++ b/test/tap/extraneous-dep-cycle-ls-ok.js
@@ -54,7 +54,8 @@ test('setup', function (t) {
 
 var expected = pkg + '\n' +
                '└─┬ moduleA@1.0.0\n' +
-               '  └── moduleB@1.0.0\n\n'
+               '  └─┬ moduleB@1.0.0\n' +
+               '    └── moduleA@1.0.0 deduped\n\n'
 
 test('extraneous-dep-cycle', function (t) {
   common.npm(['ls', '--unicode=true'], {cwd: pkg}, function (er, code, stdout, stderr) {

--- a/test/tap/git-races.js
+++ b/test/tap/git-races.js
@@ -162,7 +162,8 @@ function setup (cb) {
 var oneTree = [
   'npm-git-test@1.0.0', [
     ['dummy-npm-bar@4.0.0', [
-      ['dummy-npm-foo@3.0.0', []]
+      ['dummy-npm-foo@3.0.0', []],
+      ['dummy-npm-buzz@3.0.0', []]
     ]],
     ['dummy-npm-buzz@3.0.0', []],
     ['dummy-npm-foo@4.0.0', [
@@ -199,17 +200,19 @@ test('setup', function (t) {
 })
 
 test('correct versions are installed for git dependency', function (t) {
-  t.plan(3)
   t.comment('test for https://github.com/npm/npm/issues/7202')
   npm.commands.install([], function (er) {
     t.ifError(er, 'installed OK')
     npm.commands.ls([], true, function (er, result) {
       t.ifError(er, 'ls OK')
       var simplified = toSimple(result)
-      t.ok(
-        deepEqual(simplified, oneTree) || deepEqual(simplified, otherTree),
-        'install tree is correct'
-      )
+      if (deepEqual(simplified, oneTree) || deepEqual(simplified, otherTree)) {
+        t.pass('install tree is correct')
+      } else {
+        t.isDeeply(simplified, oneTree, 'oneTree matches')
+        t.isDeeply(simplified, otherTree, 'otherTree matches')
+      }
+      t.done()
     })
   })
 })


### PR DESCRIPTION
This is a version of `npm install` that will always check the registry for updates to all of your direct and transitive dependencies. It's kind of like `npm update` at all depth levels.

Before this could land it would need to have either a better name or get it folded into a command line option. Possibly we might replace `npm update` and `npm outdated` with this.