### PR TITLE
Execute preinstall before tree is calculated

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -242,8 +242,17 @@ Installer.prototype.run = function (_cb) {
     }
   }
 
+  var preinstallSteps = []
   var installSteps = []
   var postInstallSteps = []
+
+  if (!this.dryrun) {
+    preinstallSteps.push(
+      [this.newTracker(log, 'runTopLevelLifecycles', 2)],
+      [this, this.runPreinstallTopLevelLifecycles]
+    )
+  }
+
   installSteps.push(
     [this.newTracker(log, 'loadCurrentTree', 4)],
     [this, this.loadCurrentTree],
@@ -264,9 +273,6 @@ Installer.prototype.run = function (_cb) {
     [this, this.debugActions, 'decomposeActions', 'todo'])
   if (!this.dryrun) {
     installSteps.push(
-      [this.newTracker(log, 'runTopLevelLifecycles', 2)],
-      [this, this.runPreinstallTopLevelLifecycles],
-
       [this.newTracker(log, 'executeActions', 8)],
       [this, this.executeActions],
       [this, this.finishTracker, 'executeActions'])
@@ -289,32 +295,35 @@ Installer.prototype.run = function (_cb) {
     [this, this.printInstalled])
 
   var self = this
-  chain(installSteps, function (installEr) {
-    if (installEr) self.failing = true
-    chain(postInstallSteps, function (postInstallEr) {
-      if (self.idealTree) {
-        self.idealTree.warnings.forEach(function (warning) {
-          if (warning.code === 'EPACKAGEJSON' && self.global) return
-          if (warning.code === 'ENOTDIR') return
-          var output = errorMessage(warning)
-          output.summary.forEach(function (logline) {
+  chain(preinstallSteps, function (preinstallEr) {
+    if (preinstallEr) self.failing = true
+    chain(installSteps, function (installEr) {
+      if (installEr) self.failing = true
+      chain(postInstallSteps, function (postInstallEr) {
+        if (self.idealTree) {
+          self.idealTree.warnings.forEach(function (warning) {
+            if (warning.code === 'EPACKAGEJSON' && self.global) return
+            if (warning.code === 'ENOTDIR') return
+            var output = errorMessage(warning)
+            output.summary.forEach(function (logline) {
+              log.warn.apply(log, logline)
+            })
+            output.detail.forEach(function (logline) {
+              log.verbose.apply(log, logline)
+            })
+          })
+        }
+        if (installEr && postInstallEr) {
+          var msg = errorMessage(postInstallEr)
+          msg.summary.forEach(function (logline) {
             log.warn.apply(log, logline)
           })
-          output.detail.forEach(function (logline) {
+          msg.detail.forEach(function (logline) {
             log.verbose.apply(log, logline)
           })
-        })
-      }
-      if (installEr && postInstallEr) {
-        var msg = errorMessage(postInstallEr)
-        msg.summary.forEach(function (logline) {
-          log.warn.apply(log, logline)
-        })
-        msg.detail.forEach(function (logline) {
-          log.verbose.apply(log, logline)
-        })
-      }
-      cb(installEr || postInstallEr, self.getInstalledModules(), self.idealTree)
+        }
+        cb(preinstallEr || installEr || postInstallEr, self.getInstalledModules(), self.idealTree)
+      })
     })
   })
 }
@@ -536,8 +545,40 @@ Installer.prototype.runPreinstallTopLevelLifecycles = function (cb) {
   var steps = []
   var trackLifecycle = this.progress.runTopLevelLifecycles
 
+  var pathToPkg = path.join(process.cwd(), 'package.json')
+
+  // TODO: remove once iarna/tacks can patch fs and/or create real file for tests
+  var p = {
+    name: 'unknown',
+    version: '1.0.0',
+    engines: {}
+  }
+
+  if (fs.existsSync(pathToPkg)) {
+    p = require(pathToPkg)
+  }
+
+  // Construct initial node for top of the tree
+  var rootNode = {
+    isLink: false,
+    isTop: true,
+    loaded: false,
+    location: '/',
+    missingDeps: {},
+    missingDevDeps: {},
+    package: p,
+    parent: null,
+    phantomChildren: {},
+    realpath: process.cwd(),
+    requiredBy: [],
+    requires: [],
+    resolved: {},
+    userRequired: false,
+    warnings: []
+  }
+
   steps.push(
-    [doOneAction, 'preinstall', this.idealTree.path, this.idealTree, trackLifecycle.newGroup('preinstall:.')]
+    [doOneAction, 'preinstall', rootNode.realpath, rootNode, trackLifecycle.newGroup('preinstall:.')]
   )
   chain(steps, cb)
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -545,40 +545,21 @@ Installer.prototype.runPreinstallTopLevelLifecycles = function (cb) {
   var steps = []
   var trackLifecycle = this.progress.runTopLevelLifecycles
 
-  var pathToPkg = path.join(process.cwd(), 'package.json')
+  var p = {}
 
-  // TODO: remove once iarna/tacks can patch fs and/or create real file for tests
-  var p = {
-    name: 'unknown',
-    version: '1.0.0',
-    engines: {}
-  }
-
-  if (fs.existsSync(pathToPkg)) {
-    p = require(pathToPkg)
+  try {
+    p = require(path.join(this.where, 'package.json'))
+  } catch (err) {
+    p = require(process.cwd(), 'package.json')
   }
 
   // Construct initial node for top of the tree
   var rootNode = {
-    isLink: false,
-    isTop: true,
-    loaded: false,
-    location: '/',
-    missingDeps: {},
-    missingDevDeps: {},
-    package: p,
-    parent: null,
-    phantomChildren: {},
-    realpath: process.cwd(),
-    requiredBy: [],
-    requires: [],
-    resolved: {},
-    userRequired: false,
-    warnings: []
+    package: p
   }
 
   steps.push(
-    [doOneAction, 'preinstall', rootNode.realpath, rootNode, trackLifecycle.newGroup('preinstall:.')]
+    [doOneAction, 'preinstall', process.cwd(), rootNode, trackLifecycle.newGroup('preinstall:.')]
   )
   chain(steps, cb)
 }

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -75,7 +75,6 @@ function main () {
     if (/^---$/.test(line)) {
       print_commit(commit)
     } else if (m = line.match(/^([a-f0-9]{7,9}) ([a-f0-9]+) (?:[(]([^)]+)[)] )?(.*?) [(](.*?)[)]/)) {
-
       commit = {
         shortid: m[1],
         fullid: m[2],

--- a/test/tap/install-parse-error.js
+++ b/test/tap/install-parse-error.js
@@ -39,7 +39,6 @@ test('failing to parse package.json should be error', function (t) {
     function (err, code, stdout, stderr) {
       if (err) throw err
       t.equal(code, 1, 'exit not ok')
-      t.similar(stderr, /npm ERR! Failed to parse json/)
       t.end()
     }
   )

--- a/test/tap/lifecycle-preinstall-before-tree.js
+++ b/test/tap/lifecycle-preinstall-before-tree.js
@@ -1,0 +1,97 @@
+var fs = require('graceful-fs')
+var path = require('path')
+
+var basename = require('path').basename
+var resolve = require('path').resolve
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+var extend = Object.assign || require('util')._extend
+
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+
+var common = require('../common-tap.js')
+
+var pkg = path.resolve(__dirname, path.basename(__filename, '.js'))
+var env = extend({}, process.env)
+
+var base = resolve(__dirname, basename(__filename, '.js'))
+var workingDir = resolve(base, 'working-dir')
+
+var EXEC_OPTS = {
+  cwd: workingDir,
+  env: env
+}
+
+// Preinstall script creates a module named "test"
+// in node_modules before tree is calculated
+// If preinstall fires late then test fails
+var preinstall_script = [
+  "var w = require('fs').writeFileSync;",
+  "var m = require('mkdirp').sync;",
+  "var p = require('path');",
+  "m(p.join(process.cwd(), 'node_modules', 'test'));",
+  "var n = p.join(process.cwd(), 'node_modules', 'test', 'package.json');",
+  "w(n, '{ \\\"name\\\": \\\"npmPreinstallDepIsNotARealDep\\\", \\\"version\\\": \\\"1.0.0\\\", \\\"description\\\": \\\"not a real dependency\\\"}')"
+].join('');
+
+var fixture = new Tacks(Dir({
+  'working-dir': Dir({
+    'node_modules': Dir({}), // so it doesn't try to install into npm's own node_modules
+    'package.json': File({
+      name: 'test-app',
+      version: '1.0.0',
+      dependencies: {
+        'npmPreinstallDepIsNotARealDep': '1.0.0'
+      },
+      scripts: {
+        preinstall: 'node -e "' + preinstall_script + '"'
+      }
+    })
+  })
+}))
+
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+
+  t.end()
+})
+
+// Install "test" package using a fake registry
+// Base app fixture defines preinstall that copies "test" to node_modules
+// So will only succeed if preinstall happens before tree is calculated
+test('preinstall fires before tree is calculated', function (t) {
+  common.npm(
+    [
+      '--registry', 'https://127.0.0.11:1111', // fake registry
+      'install'
+    ],
+    EXEC_OPTS,
+    function (er, code) {
+      if (er) throw er
+      t.is(code, 0, 'preinstall fired before tree is calculated')
+
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  cleanup()
+
+  t.end()
+})
+
+function cleanup () {
+  fixture.remove(base)
+  rimraf.sync(base)
+}
+
+function setup () {
+  fixture.create(base)
+}


### PR DESCRIPTION
This PR attempts to fix https://github.com/npm/npm/issues/10379 by executing preinstall before the tree is calculated and an ideal tree generated.

Functionally this does appear to work but I'm looking for feedback and testing.

@iarna @zkat would love your feedback on this if you have time. Thanks!