### PR TITLE
Replace http: URL in npm-shrinkwrap with https:

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1590,7 +1590,7 @@
         "are-we-there-yet": {
           "version": "1.1.2",
           "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-          "resolved": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
           "dependencies": {
             "delegates": {
               "version": "1.0.0",


### PR DESCRIPTION
Per http://blog.npmjs.org/post/154400916805/avoid-http-urls-in-shrinkwrap-files.

This is affecting me because I'm using [wintersmith](https://www.npmjs.com/package/wintersmith), which pulls in npm as a dependency.