### PR TITLE
script: fix lint error

### DIFF
--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -75,7 +75,6 @@ function main () {
     if (/^---$/.test(line)) {
       print_commit(commit)
     } else if (m = line.match(/^([a-f0-9]{7,9}) ([a-f0-9]+) (?:[(]([^)]+)[)] )?(.*?) [(](.*?)[)]/)) {
-
       commit = {
         shortid: m[1],
         fullid: m[2],


### PR DESCRIPTION
Fix the following error in latest branch:
```
$ ./node_modules/.bin/standard
standard: Use JavaScript Standard Style (http://standardjs.com)
  /Users/watilde/Development/npm/scripts/changelog.js:77:101: Block must not be padded by blank lines.
```