### PR TITLE
On SIGINT, ensure process stays alive until spawned child_process exits.

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -282,6 +282,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
     procError(er)
   })
   process.once('SIGTERM', procKill)
+  process.once('SIGINT', procInterupt)
 
   function procError (er) {
     if (er) {
@@ -302,10 +303,19 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
       er.pkgname = pkg.name
     }
     process.removeListener('SIGTERM', procKill)
+    process.removeListener('SIGTERM', procInterupt)
+    process.removeListener('SIGINT', procKill)
     return cb(er)
   }
   function procKill () {
     proc.kill()
+  }
+  function procInterupt () {
+    proc.kill('SIGINT')
+    proc.on('exit', function () {
+      process.exit()
+    })
+    process.once('SIGINT', procKill)
   }
 }
 


### PR DESCRIPTION
Currently npm run scripts can get caught in a strange state where the child process is still operating but the parent process has returned control to the shell.

This PR aims to solve two uses cases:
1. It waits to exit until the child async SIGINT handlers have completed.
2. It allows the second SIGINT call to kill the process.