### PR TITLE
utils: remove `lib/utils/rename.js`

### DIFF
--- a/lib/utils/rename.js
+++ b/lib/utils/rename.js
@@ -1,9 +1,0 @@
-/*
-
-This is a stub file to ensure that the following hack doesn't break. This can be removed w/ npm@5.
-
-# Fix bug https://github.com/npm/npm/issues/9863
-RUN cd $(npm root -g)/npm \
-  && npm install fs-extra \
-  && sed -i -e s/graceful-fs/fs-extra/ -e s/fs\.rename/fs.move/ ./lib/utils/rename.js
-*/


### PR DESCRIPTION
It was used as a stub file to not break a monkey patching hack, but it's no longer required. It's removed with npm@5.

Fixes: npm#15965