### PR TITLE
extractEntry: entry.path ||= entry._header.path; (#1)

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -301,6 +301,7 @@ function gunzTarPerm (tarball, target, dMode, fMode, uid, gid, cb_) {
   }
 
   function extractEntry (entry) {
+    entry.path = entry.path || (entry._header && entry._header.path) || ''
     log.silly('gunzTarPerm', 'extractEntry', entry.path)
     // never create things that are user-unreadable,
     // or dirs that are user-un-listable. Only leads to headaches.


### PR DESCRIPTION
* extractEntry: entry.path ||= entry._header.path;

Windows 10, npm 3.10.8
Linux 3.0.35 arm71 GNU/Linux, npm 2.15.1

Attempting to install a tarball, zipped or not, fails with ENOTDIR. It appears extractEntry entry.path is null for all entries. However, entry._header.path contains the filename. So, to remedy my issue, I simply write entry.path = entry.path || (entry._header && entry._header.path); Perhaps there is a better solution.

Note also? This may have something to do with my tarball? The tarball was created via git on post-receive with git archive master. But I would prefer node handle whatever this issue is properly :)

synopsis:

$npm install <tarball file>
$npm install <tarball url>

...
npm ERR! node ENOTDIR
npm ERR! errno -20
...

$ cat npm-debug.log
....
27 verbose tar unpacking to /tmp/npm-2164-639b1b12/unpack-9ea8b5b96427
28 silly gentlyRm /tmp/npm-2164-639b1b12/unpack-9ea8b5b96427 is being purged
29 verbose gentlyRm don't care about contents; nuking /tmp/npm-2164-639b1b12/un
pack-9ea8b5b96427
30 silly gunzTarPerm modes [ '755', '644' ]
31 silly gunzTarPerm extractEntry
32 silly gunzTarPerm modified mode [ '', 436, 420 ]
33 silly gunzTarPerm extractEntry
34 silly gunzTarPerm modified mode [ '', 436, 420 ]
35 silly gunzTarPerm extractEntry
36 silly gunzTarPerm modified mode [ '', 436, 420 ]
37 verbose stack Error: ENOTDIR: not a directory, open '/tmp/npm-2164-639b1b12/
unpack-9ea8b5b96427/package.json'
37 verbose stack     at Error (native)
...



$ ls -al /tmp/npm-2164-639b1b12/
total 4
drwxr-xr-x    3 root     root            80 Apr 10 23:10 .
drwxrwxrwt   35 root     root           740 Apr 10 23:10 ..
-rw-r--r--    1 root     root           392 Apr 10 08:46 unpack-9ea8b5b96427
drwxr-xr-x    2 root     root            60 Apr 10 23:10 test.example.com

* appending default to empty string