### PR TITLE
Don't ham-it-up when expecting JSON

### DIFF
--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -83,7 +83,7 @@
     if (er) return errorHandler(er)
     npm.commands[npm.command](npm.argv, function (err) {
       // https://www.youtube.com/watch?v=7nfPu8qTiQU
-      if (!err && npm.config.get('ham-it-up') && !npm.config.get('json')) {
+      if (!err && npm.config.get('ham-it-up') && !npm.config.get('json') && !npm.config.get('parseable')) {
         output('\n 🎵 I Have the Honour to Be Your Obedient Servant,🎵 ~ npm 📜🖋\n')
       }
       errorHandler.apply(this, arguments)

--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -83,7 +83,7 @@
     if (er) return errorHandler(er)
     npm.commands[npm.command](npm.argv, function (err) {
       // https://www.youtube.com/watch?v=7nfPu8qTiQU
-      if (!err && npm.config.get('ham-it-up')) {
+      if (!err && npm.config.get('ham-it-up') && !npm.config.get('json')) {
         output('\n 🎵 I Have the Honour to Be Your Obedient Servant,🎵 ~ npm 📜🖋\n')
       }
       errorHandler.apply(this, arguments)


### PR DESCRIPTION
I turned on the ham-it-up configuration setting, and then noticed that I received an error when running the npm-windows-upgrade module, because it was trying to parse the JSON from calling `npm view npm versions --json` and didn't know what to do with the easter egg text at the end.

This change disables the ham-it-up text when the json option is present.