### PR TITLE
feat: add "npm org" command

### DIFF
--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -32,6 +32,7 @@ var affordances = {
   'login': 'adduser',
   'add-user': 'adduser',
   'author': 'owner',
+  'ogr': 'org',
   'home': 'docs',
   'issues': 'bugs',
   'info': 'view',
@@ -71,6 +72,7 @@ var cmdList = [
   'owner',
   'access',
   'team',
+  'org',
   'deprecate',
   'shrinkwrap',
 

--- a/lib/org.js
+++ b/lib/org.js
@@ -1,0 +1,55 @@
+'use strict'
+
+var mapToRegistry = require('./utils/map-to-registry.js')
+var npm = require('./npm')
+var output = require('./utils/output.js')
+
+module.exports = org
+
+org.subcommands = ['set', 'rm', 'add']
+
+org.usage =
+  'npm org set orgname username [developer | admin | owner]\n' +
+  'npm org add orgname username [developer | admin | owner]\n' +
+  'npm org rm orgname username\n' +
+  'npm org ls orgname'
+
+org.completion = function (opts, cb) {
+  var argv = opts.conf.argv.remain
+  if (argv.length === 2) {
+    return cb(null, org.subcommands)
+  }
+  switch (argv[2]) {
+    case 'ls':
+    case 'add':
+    case 'rm':
+    case 'set':
+      return cb(null, [])
+    default:
+      return cb(new Error(argv[2] + ' not recognized'))
+  }
+}
+
+function org (args, cb) {
+  // Entities are in the format <scope>:<org>
+  var cmd = args.shift()
+  var orgname = args.shift()
+  var username = args.shift()
+  var role = args.shift()
+  return mapToRegistry('/', npm.config, function (err, uri, auth) {
+    if (err) { return cb(err) }
+    try {
+      return npm.registry.org(cmd, uri, {
+        auth: auth,
+        role: role,
+        org: orgname,
+        user: username
+      }, function (err, data) {
+        !err && data && output(JSON.stringify(data, undefined, 2))
+        cb(err, data)
+      })
+    } catch (e) {
+      cb(e.message + '\n\nUsage:\n' + org.usage)
+    }
+  })
+}

--- a/node_modules/npm-registry-client/index.js
+++ b/node_modules/npm-registry-client/index.js
@@ -60,6 +60,7 @@ function RegClient (config) {
   client.get = require('./lib/get')
   client.initialize = require('./lib/initialize')
   client.logout = require('./lib/logout')
+  client.org = require('./lib/org')
   client.ping = require('./lib/ping')
   client.publish = require('./lib/publish')
   client.request = require('./lib/request')

--- a/node_modules/npm-registry-client/package.json
+++ b/node_modules/npm-registry-client/package.json
@@ -2,53 +2,53 @@
   "_args": [
     [
       {
-        "raw": "npm-registry-client@8.1.1",
+        "raw": "npm-registry-client@8.2.0",
         "scope": null,
         "escapedName": "npm-registry-client",
         "name": "npm-registry-client",
-        "rawSpec": "8.1.1",
-        "spec": "8.1.1",
+        "rawSpec": "8.2.0",
+        "spec": "8.2.0",
         "type": "version"
       },
-      "/Users/rebecca/code/npm"
+      "/Users/chris/projects/npm/cli"
     ]
   ],
-  "_from": "npm-registry-client@8.1.1",
-  "_id": "npm-registry-client@8.1.1",
+  "_from": "npm-registry-client@8.2.0",
+  "_id": "npm-registry-client@8.2.0",
   "_inCache": true,
   "_location": "/npm-registry-client",
-  "_nodeVersion": "7.7.4",
+  "_nodeVersion": "7.9.0",
   "_npmOperationalInternal": {
-    "host": "packages-18-east.internal.npmjs.com",
-    "tmp": "tmp/npm-registry-client-8.1.1.tgz_1492135290715_0.17790596769191325"
+    "host": "packages-12-west.internal.npmjs.com",
+    "tmp": "tmp/npm-registry-client-8.2.0.tgz_1493170417055_0.22317605768330395"
   },
   "_npmUser": {
-    "name": "iarna",
-    "email": "me@re-becca.org"
+    "name": "zkat",
+    "email": "kat@sykosomatic.org"
   },
-  "_npmVersion": "4.5.0",
+  "_npmVersion": "4.6.1",
   "_phantomChildren": {
     "inherits": "2.0.3",
-    "readable-stream": "2.2.6"
+    "readable-stream": "2.2.9"
   },
   "_requested": {
-    "raw": "npm-registry-client@8.1.1",
+    "raw": "npm-registry-client@8.2.0",
     "scope": null,
     "escapedName": "npm-registry-client",
     "name": "npm-registry-client",
-    "rawSpec": "8.1.1",
-    "spec": "8.1.1",
+    "rawSpec": "8.2.0",
+    "spec": "8.2.0",
     "type": "version"
   },
   "_requiredBy": [
     "#USER",
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.1.1.tgz",
-  "_shasum": "831476455423ca0a265c6ffdb6100fcc042b36cf",
+  "_resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.2.0.tgz",
+  "_shasum": "39067d3c086db0ff8fa7cf444e9d4a785a9c07f6",
   "_shrinkwrap": null,
-  "_spec": "npm-registry-client@8.1.1",
-  "_where": "/Users/rebecca/code/npm",
+  "_spec": "npm-registry-client@8.2.0",
+  "_where": "/Users/chris/projects/npm/cli",
   "author": {
     "name": "Isaac Z. Schlueter",
     "email": "i@izs.me",
@@ -81,14 +81,14 @@
   },
   "directories": {},
   "dist": {
-    "shasum": "831476455423ca0a265c6ffdb6100fcc042b36cf",
-    "tarball": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.1.1.tgz"
+    "shasum": "39067d3c086db0ff8fa7cf444e9d4a785a9c07f6",
+    "tarball": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.2.0.tgz"
   },
   "files": [
     "lib",
     "index.js"
   ],
-  "gitHead": "81afb2ce59d82c2a1179211d8c1bc789c9f6128c",
+  "gitHead": "53c15d996ceaa39e36453c499f32adaebbba97b9",
   "homepage": "https://github.com/npm/npm-registry-client#readme",
   "license": "ISC",
   "main": "index.js",
@@ -102,13 +102,12 @@
   "optionalDependencies": {
     "npmlog": "2 || ^3.1.0 || ^4.0.0"
   },
-  "readme": "# npm-registry-client\n\nThe code that npm uses to talk to the registry.\n\nIt handles all the caching and HTTP calls.\n\n## Usage\n\n```javascript\nvar RegClient = require('npm-registry-client')\nvar client = new RegClient(config)\nvar uri = \"https://registry.npmjs.org/npm\"\nvar params = {timeout: 1000}\n\nclient.get(uri, params, function (error, data, raw, res) {\n  // error is an error if there was a problem.\n  // data is the parsed data object\n  // raw is the json string\n  // res is the response from couch\n})\n```\n\n# Registry URLs\n\nThe registry calls take either a full URL pointing to a resource in the\nregistry, or a base URL for the registry as a whole (including the registry\npath – but be sure to terminate the path with `/`). `http` and `https` URLs are\nthe only ones supported.\n\n## Using the client\n\nEvery call to the client follows the same pattern:\n\n* `uri` {String} The *fully-qualified* URI of the registry API method being\n  invoked.\n* `params` {Object} Per-request parameters.\n* `callback` {Function} Callback to be invoked when the call is complete.\n\n### Credentials\n\nMany requests to the registry can be authenticated, and require credentials\nfor authorization. These credentials always look the same:\n\n* `username` {String}\n* `password` {String}\n* `email` {String}\n* `alwaysAuth` {Boolean} Whether calls to the target registry are always\n  authed.\n\n**or**\n\n* `token` {String}\n* `alwaysAuth` {Boolean} Whether calls to the target registry are always\n  authed.\n\n## Requests\n\nAs of `npm-registry-client@8`, all requests are made with an `Accept` header\nof `application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*`.\n\nThis enables filtered document responses to requests for package metadata.\nYou know that you got a filtered response if the mime type is set to\n`application/vnd.npm.install-v1+json` and not `application/json`.\n\nThis filtering substantially reduces the over all data size.  For example\nfor `https://registry.npmjs.org/npm`, the compressed metadata goes from\n410kB to 21kB.\n\n## API\n\n### client.access(uri, params, cb)\n\n* `uri` {String} Registry URL for the package's access API endpoint.\n  Looks like `/-/package/<package name>/access`.\n* `params` {Object} Object containing per-request properties.\n  * `access` {String} New access level for the package. Can be either\n    `public` or `restricted`. Registry will raise an error if trying\n    to change the access level of an unscoped package.\n  * `auth` {Credentials}\n\nSet the access level for scoped packages. For now, there are only two\naccess levels: \"public\" and \"restricted\".\n\n### client.adduser(uri, params, cb)\n\n* `uri` {String} Base registry URL.\n* `params` {Object} Object containing per-request properties.\n  * `auth` {Credentials}\n* `cb` {Function}\n  * `error` {Error | null}\n  * `data` {Object} the parsed data object\n  * `raw` {String} the json\n  * `res` {Response Object} response from couch\n\nAdd a user account to the registry, or verify the credentials.\n\n### client.deprecate(uri, params, cb)\n\n* `uri` {String} Full registry URI for the deprecated package.\n* `params` {Object} Object containing per-request properties.\n  * `version` {String} Semver version range.\n  * `message` {String} The message to use as a deprecation warning.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nDeprecate a version of a package in the registry.\n\n### client.distTags.fetch(uri, params, cb)\n\n* `uri` {String} Base URL for the registry.\n* `params` {Object} Object containing per-request properties.\n  * `package` {String} Name of the package.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nFetch all of the `dist-tags` for the named package.\n\n### client.distTags.add(uri, params, cb)\n\n* `uri` {String} Base URL for the registry.\n* `params` {Object} Object containing per-request properties.\n  * `package` {String} Name of the package.\n  * `distTag` {String} Name of the new `dist-tag`.\n  * `version` {String} Exact version to be mapped to the `dist-tag`.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nAdd (or replace) a single dist-tag onto the named package.\n\n### client.distTags.set(uri, params, cb)\n\n* `uri` {String} Base URL for the registry.\n* `params` {Object} Object containing per-request properties.\n  * `package` {String} Name of the package.\n  * `distTags` {Object} Object containing a map from tag names to package\n     versions.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nSet all of the `dist-tags` for the named package at once, creating any\n`dist-tags` that do not already exist. Any `dist-tags` not included in the\n`distTags` map will be removed.\n\n### client.distTags.update(uri, params, cb)\n\n* `uri` {String} Base URL for the registry.\n* `params` {Object} Object containing per-request properties.\n  * `package` {String} Name of the package.\n  * `distTags` {Object} Object containing a map from tag names to package\n     versions.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nUpdate the values of multiple `dist-tags`, creating any `dist-tags` that do\nnot already exist. Any pre-existing `dist-tags` not included in the `distTags`\nmap will be left alone.\n\n### client.distTags.rm(uri, params, cb)\n\n* `uri` {String} Base URL for the registry.\n* `params` {Object} Object containing per-request properties.\n  * `package` {String} Name of the package.\n  * `distTag` {String} Name of the new `dist-tag`.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nRemove a single `dist-tag` from the named package.\n\n### client.get(uri, params, cb)\n\n* `uri` {String} The complete registry URI to fetch\n* `params` {Object} Object containing per-request properties.\n  * `timeout` {Number} Duration before the request times out. Optional\n    (default: never).\n  * `follow` {Boolean} Follow 302/301 responses. Optional (default: true).\n  * `staleOk` {Boolean} If there's cached data available, then return that to\n    the callback quickly, and update the cache the background. Optional\n    (default: false).\n  * `auth` {Credentials} Optional.\n  * `fullMetadata` {Boolean} If true, don't attempt to fetch filtered\n    (\"corgi\") registry metadata.  (default: false)\n* `cb` {Function}\n\nFetches data from the registry via a GET request, saving it in the cache folder\nwith the ETag or the \"Last Modified\" timestamp.\n\n### client.publish(uri, params, cb)\n\n* `uri` {String} The registry URI for the package to publish.\n* `params` {Object} Object containing per-request properties.\n  * `metadata` {Object} Package metadata.\n  * `access` {String} Access for the package. Can be `public` or `restricted` (no default).\n  * `body` {Stream} Stream of the package body / tarball.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nPublish a package to the registry.\n\nNote that this does not create the tarball from a folder.\n\n### client.sendAnonymousCLIMetrics(uri, params, cb)\n\n- `uri` {String} Base URL for the registry.\n- `params` {Object} Object containing per-request properties.\n  - `metricId` {String} A uuid unique to this dataset.\n  - `metrics` {Object} The metrics to share with the registry, with the following properties:\n    - `from` {Date} When the first data in this report was collected.\n    - `to` {Date} When the last data in this report was collected. Usually right now.\n    - `successfulInstalls` {Number} The number of successful installs in this period.\n    - `failedInstalls` {Number} The number of installs that ended in error in this period.\n- `cb` {Function}\n\nPUT a metrics object to the `/-/npm/anon-metrics/v1/` endpoint on the registry.\n\n### client.star(uri, params, cb)\n\n* `uri` {String} The complete registry URI for the package to star.\n* `params` {Object} Object containing per-request properties.\n  * `starred` {Boolean} True to star the package, false to unstar it. Optional\n    (default: false).\n  * `auth` {Credentials}\n* `cb` {Function}\n\nStar or unstar a package.\n\nNote that the user does not have to be the package owner to star or unstar a\npackage, though other writes do require that the user be the package owner.\n\n### client.stars(uri, params, cb)\n\n* `uri` {String} The base URL for the registry.\n* `params` {Object} Object containing per-request properties.\n  * `username` {String} Name of user to fetch starred packages for. Optional\n    (default: user in `auth`).\n  * `auth` {Credentials} Optional (required if `username` is omitted).\n* `cb` {Function}\n\nView your own or another user's starred packages.\n\n### client.tag(uri, params, cb)\n\n* `uri` {String} The complete registry URI to tag\n* `params` {Object} Object containing per-request properties.\n  * `version` {String} Version to tag.\n  * `tag` {String} Tag name to apply.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nMark a version in the `dist-tags` hash, so that `pkg@tag` will fetch the\nspecified version.\n\n### client.unpublish(uri, params, cb)\n\n* `uri` {String} The complete registry URI of the package to unpublish.\n* `params` {Object} Object containing per-request properties.\n  * `version` {String} version to unpublish. Optional – omit to unpublish all\n    versions.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nRemove a version of a package (or all versions) from the registry.  When the\nlast version us unpublished, the entire document is removed from the database.\n\n### client.whoami(uri, params, cb)\n\n* `uri` {String} The base registry for the URI.\n* `params` {Object} Object containing per-request properties.\n  * `auth` {Credentials}\n* `cb` {Function}\n\nSimple call to see who the registry thinks you are. Especially useful with\ntoken-based auth.\n\n\n## PLUMBING\n\nThe below are primarily intended for use by the rest of the API, or by the npm\ncaching logic directly.\n\n### client.request(uri, params, cb)\n\n* `uri` {String} URI pointing to the resource to request.\n* `params` {Object} Object containing per-request properties.\n  * `method` {String} HTTP method. Optional (default: \"GET\").\n  * `body` {Stream | Buffer | String | Object} The request body.  Objects\n    that are not Buffers or Streams are encoded as JSON. Optional – body\n    only used for write operations.\n  * `etag` {String} The cached ETag. Optional.\n  * `lastModified` {String} The cached Last-Modified timestamp. Optional.\n  * `follow` {Boolean} Follow 302/301 responses. Optional (default: true).\n  * `streaming` {Boolean} Stream the request body as it comes, handling error\n    responses in a non-streaming way.\n  * `auth` {Credentials} Optional.\n* `cb` {Function}\n  * `error` {Error | null}\n  * `data` {Object} the parsed data object\n  * `raw` {String} the json\n  * `res` {Response Object} response from couch\n\nMake a generic request to the registry. All the other methods are wrappers\naround `client.request`.\n\n### client.fetch(uri, params, cb)\n\n* `uri` {String} The complete registry URI to upload to\n* `params` {Object} Object containing per-request properties.\n  * `headers` {Stream} HTTP headers to be included with the request. Optional.\n  * `auth` {Credentials} Optional.\n* `cb` {Function}\n\nFetch a package from a URL, with auth set appropriately if included. Used to\ncache remote tarballs as well as request package tarballs from the registry.\n\n# Configuration\n\nThe client uses its own configuration, which is just passed in as a simple\nnested object. The following are the supported values (with their defaults, if\nany):\n\n* `proxy.http` {URL} The URL to proxy HTTP requests through.\n* `proxy.https` {URL} The URL to proxy HTTPS requests through. Defaults to be\n  the same as `proxy.http` if unset.\n* `proxy.localAddress` {IP} The local address to use on multi-homed systems.\n* `ssl.ca` {String} Certificate signing authority certificates to trust.\n* `ssl.certificate` {String} Client certificate (PEM encoded). Enable access\n  to servers that require client certificates.\n* `ssl.key` {String} Private key (PEM encoded) for client certificate.\n* `ssl.strict` {Boolean} Whether or not to be strict with SSL certificates.\n  Default = `true`\n* `retry.count` {Number} Number of times to retry on GET failures. Default = 2.\n* `retry.factor` {Number} `factor` setting for `node-retry`. Default = 10.\n* `retry.minTimeout` {Number} `minTimeout` setting for `node-retry`.\n  Default = 10000 (10 seconds)\n* `retry.maxTimeout` {Number} `maxTimeout` setting for `node-retry`.\n  Default = 60000 (60 seconds)\n* `userAgent` {String} User agent header to send. Default =\n  `\"node/{process.version}\"`\n* `log` {Object} The logger to use.  Defaults to `require(\"npmlog\")` if\n  that works, otherwise logs are disabled.\n* `defaultTag` {String} The default tag to use when publishing new packages.\n  Default = `\"latest\"`\n* `couchToken` {Object} A token for use with\n  [couch-login](https://npmjs.org/package/couch-login).\n* `sessionToken` {String} A random identifier for this set of client requests.\n  Default = 8 random hexadecimal bytes.\n* `maxSockets` {Number} The maximum number of connections that will be open per\n  origin (unique combination of protocol:host:port). Passed to the\n  [httpAgent](https://nodejs.org/api/http.html#http_agent_maxsockets).\n  Default = 50\n* `isFromCI` {Boolean} Identify to severs if this request is coming from CI (for statistics purposes).\n  Default = detected from environment– primarily this is done by looking for\n  the CI environment variable to be set to `true`.  Also accepted are the\n  existence of the `JENKINS_URL`, `bamboo.buildKey` and `TDDIUM` environment\n  variables.\n* `scope` {String} The scope of the project this command is being run for. This is the\n  top level npm module in which a command was run.\n  Default = none\n",
-  "readmeFilename": "README.md",
+  "readme": "ERROR: No README data found!",
   "repository": {
     "url": "git+https://github.com/npm/npm-registry-client.git"
   },
   "scripts": {
     "test": "standard && tap test/*.js"
   },
-  "version": "8.1.1"
+  "version": "8.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "npm-cache-filename": "~1.0.2",
     "npm-install-checks": "~3.0.0",
     "npm-package-arg": "~4.2.1",
-    "npm-registry-client": "~8.1.1",
+    "npm-registry-client": "~8.2.0",
     "npm-user-validate": "~0.1.5",
     "npmlog": "~4.0.2",
     "once": "~1.4.0",

--- a/test/tap/org.js
+++ b/test/tap/org.js
@@ -1,0 +1,130 @@
+'use strict'
+
+var mr = require('npm-registry-mock')
+
+var test = require('tap').test
+var common = require('../common-tap.js')
+
+var server
+
+test('setup', function (t) {
+  mr({port: common.port}, function (err, s) {
+    t.ifError(err, 'registry mocked successfully')
+    server = s
+    t.end()
+  })
+})
+
+const names = ['add', 'set']
+const roles = ['developer', 'admin', 'owner']
+
+names.forEach(function (name) {
+  test('org ' + name + ' [orgname] [username]: defaults to developer', function (t) {
+    const membershipData = {
+      org: {
+        name: 'myorg',
+        size: 1
+      },
+      user: 'myuser',
+      role: 'developer'
+    }
+    server.put('/-/org/myorg/user', JSON.stringify({
+      user: 'myuser'
+    })).reply(200, membershipData)
+    common.npm([
+      'org', 'add', 'myorg', 'myuser',
+      '--registry', common.registry,
+      '--loglevel', 'silent'
+    ], {}, function (err, code, stdout, stderr) {
+      t.ifError(err, 'npm org')
+
+      t.equal(code, 0, 'exited OK')
+      t.equal(stderr, '', 'no error output')
+
+      t.same(JSON.parse(stdout), membershipData)
+      t.end()
+    })
+  })
+
+  roles.forEach(function (role) {
+    test('org ' + name + ' [orgname] [username]: accepts role ' + role, function (t) {
+      const membershipData = {
+        org: {
+          name: 'myorg',
+          size: 1
+        },
+        user: 'myuser',
+        role: role
+      }
+      server.put('/-/org/myorg/user', JSON.stringify({
+        user: 'myuser'
+      })).reply(200, membershipData)
+      common.npm([
+        'org', name, 'myorg', 'myuser',
+        '--registry', common.registry,
+        '--loglevel', 'silent'
+      ], {}, function (err, code, stdout, stderr) {
+        t.ifError(err, 'npm org')
+
+        t.equal(code, 0, 'exited OK')
+        t.equal(stderr, '', 'no error output')
+
+        t.same(JSON.parse(stdout), membershipData)
+        t.end()
+      })
+    })
+  })
+})
+
+test('org rm [orgname] [username]', function (t) {
+  const membershipData = {
+    org: {
+      name: 'myorg',
+      size: 1
+    },
+    user: 'myuser'
+  }
+  server.delete('/-/org/myorg/user', JSON.stringify({
+    user: 'myuser'
+  })).reply(204, membershipData)
+  common.npm([
+    'org', 'rm', 'myorg', 'myuser',
+    '--registry', common.registry,
+    '--loglevel', 'silent'
+  ], {}, function (err, code, stdout, stderr) {
+    t.ifError(err, 'npm org')
+
+    t.equal(code, 0, 'exited OK')
+    t.equal(stderr, '', 'no error output')
+    t.equal(stdout, '', 'no output')
+    t.end()
+  })
+})
+
+test('org ls [orgname]', function (t) {
+  const membershipData = {
+    username: 'admin',
+    username2: 'foo'
+  }
+  server.get('/-/org/myorg/user')
+    .reply(200, membershipData)
+  common.npm([
+    'org', 'ls', 'myorg',
+    '--registry', common.registry,
+    '--loglevel', 'silent'
+  ], {}, function (err, code, stdout, stderr) {
+    t.ifError(err, 'npm org')
+    t.equal(code, 0, 'exited OK')
+    t.equal(stderr, '', 'no error output')
+    t.same(JSON.parse(stdout), membershipData, 'outputs members')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  t.pass('cleaned up')
+  server.done()
+  server.close()
+  t.end()
+})
+


### PR DESCRIPTION
This adds support for adding, removing, and listing org memberships from the command line!

```
$ npm org add npmcorp chrisdickinson admin
$ npm org set npmcorp chrisdickinson developer
$ npm org rm npmcorp chrisdickinson
$ npm org ls npmcorp
```