### PR TITLE
lifecycle: move ignore-scripts handling to actual place of use

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -51,10 +51,6 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
   log.info('lifecycle', logid(pkg, stage), pkg._id)
   if (!pkg.scripts) pkg.scripts = {}
 
-  if (npm.config.get('ignore-scripts')) {
-    log.info('lifecycle', logid(pkg, stage), 'ignored because ignore-scripts is set to true', pkg._id)
-    pkg.scripts = {}
-  }
   if (stage === 'prepublish' && npm.config.get('ignore-prepublish')) {
     log.info('lifecycle', logid(pkg, stage), 'ignored because ignore-prepublish is set to true', pkg._id)
     delete pkg.scripts.prepublish
@@ -116,7 +112,10 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
 
   var packageLifecycle = pkg.scripts && pkg.scripts.hasOwnProperty(stage)
 
-  if (packageLifecycle) {
+  if (npm.config.get('ignore-scripts')) {
+    log.info('lifecycle', logid(pkg, stage), 'ignored because ignore-scripts is set to true', pkg._id)
+    packageLifecycle = false
+  } else if (packageLifecycle) {
     // define this here so it's available to all scripts.
     env.npm_lifecycle_script = pkg.scripts[stage]
   } else {


### PR DESCRIPTION
Instead of overriding `pkg.scripts` when `ignore-scripts` is in
effect, test the option when actually determining whether there is a
script to invoke. Otherwise, published packages will not contain
the proper `scripts:` fields when `ignore-scripts` is `true`.

Fixes: https://github.com/npm/npm/issues/16243

If you have any pointers for writing a test for this, I’d love to look into that. :)