### PR TITLE
Fix interpreter command to /usr/bin/nodejs

### DIFF
--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 ;(function () { // wrapper in case we're in module_context mode
   // windows: running "npm blah" in this folder will invoke WSH, not node.
   /*global WScript*/

--- a/changelogs/CHANGELOG-2.md
+++ b/changelogs/CHANGELOG-2.md
@@ -35,7 +35,7 @@ next main development version.
   ([@rvagg](https://github.com/rvagg))
 * [`e81b4f1`](https://github.com/npm/npm/commit/e81b4f1d18a4d79b7af8342747f2ed7dc3e84f0a)
   [#12438](https://github.com/npm/npm/issues/12438)
-  Remind folks to use `#!/usr/bin/env node` in their `bin` scripts to make files
+  Remind folks to use `#!/usr/bin/nodejs` in their `bin` scripts to make files
   executable directly.
   ([@mxstbr](https://github.com/mxstbr))
 * [`f89789f`](https://github.com/npm/npm/commit/f89789f43d65bfc74f64f15a99356841377e1af3)

--- a/changelogs/CHANGELOG-3.md
+++ b/changelogs/CHANGELOG-3.md
@@ -316,7 +316,7 @@ inconsistencies.
   ([@mdjasper](https://github.com/mdjasper))
 * [`b352a84`](https://github.com/npm/npm/commit/b352a84c2c7ad15e9c669af75f65cdaa964f86c0)
   [#12438](https://github.com/npm/npm/issues/12438)
-  Remind folks to use `#!/usr/bin/env node` in their `bin` scripts to make files
+  Remind folks to use `#!/usr/bin/nodejs` in their `bin` scripts to make files
   executable directly.
   ([@mxstbr](https://github.com/mxstbr))
 * [`b82fd83`](https://github.com/npm/npm/commit/b82fd838edbfff5d2833a62f6d8ae8ea2df5a1f2)

--- a/cli.js
+++ b/cli.js
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 require('./bin/npm-cli.js')

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -249,7 +249,7 @@ would be the same as this:
     , "bin" : { "my-program" : "./path/to/program" } }
 
 Please make sure that your file(s) referenced in `bin` starts with
-`#!/usr/bin/env node`, otherwise the scripts are started without the node
+`#!/usr/bin/nodejs`, otherwise the scripts are started without the node
 executable!
 
 ## man

--- a/node_modules/JSONStream/index.js
+++ b/node_modules/JSONStream/index.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#! /usr/bin/nodejs
 
 'use strict'
 

--- a/node_modules/cmd-shim/test/00-setup.js
+++ b/node_modules/cmd-shim/test/00-setup.js
@@ -6,8 +6,8 @@ var fixtures = path.resolve(__dirname, 'fixtures')
 
 var froms = {
   'from.exe': 'exe',
-  'from.env': '#!/usr/bin/env node\nconsole.log(/hi/)\n',
-  'from.env.args': '#!/usr/bin/env node --expose_gc\ngc()\n',
+  'from.env': '#!/usr/bin/nodejs\nconsole.log(/hi/)\n',
+  'from.env.args': '#!/usr/bin/nodejs --expose_gc\ngc()\n',
   'from.sh': '#!/usr/bin/sh\necho hi\n',
   'from.sh.args': '#!/usr/bin/sh -x\necho hi\n'
 }

--- a/node_modules/mkdirp/bin/cmd.js
+++ b/node_modules/mkdirp/bin/cmd.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 var mkdirp = require('../');
 var minimist = require('minimist');

--- a/node_modules/node-gyp/bin/node-gyp.js
+++ b/node_modules/node-gyp/bin/node-gyp.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 /**
  * Set the title.

--- a/node_modules/node-gyp/node_modules/nopt/bin/nopt.js
+++ b/node_modules/node-gyp/node_modules/nopt/bin/nopt.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 var nopt = require("../lib/nopt")
   , path = require("path")
   , types = { num: Number

--- a/node_modules/node-gyp/node_modules/nopt/examples/my-program.js
+++ b/node_modules/node-gyp/node_modules/nopt/examples/my-program.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 //process.env.DEBUG_NOPT = 1
 

--- a/node_modules/nopt/bin/nopt.js
+++ b/node_modules/nopt/bin/nopt.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 var nopt = require("../lib/nopt")
   , path = require("path")
   , types = { num: Number

--- a/node_modules/nopt/examples/my-program.js
+++ b/node_modules/nopt/examples/my-program.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 //process.env.DEBUG_NOPT = 1
 

--- a/node_modules/opener/opener.js
+++ b/node_modules/opener/opener.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 "use strict";
 

--- a/node_modules/read-cmd-shim/test/integration.js
+++ b/node_modules/read-cmd-shim/test/integration.js
@@ -14,7 +14,7 @@ var testShimCmd = testShim + '.cmd'
 test('setup', function (t) {
   rimraf.sync(workDir)
   fs.mkdirSync(workDir)
-  fs.writeFileSync(testShbang + '.js', '#!/usr/bin/env node\ntrue')
+  fs.writeFileSync(testShbang + '.js', '#!/usr/bin/nodejs\ntrue')
   cmdShim(__filename, testShim, function (er) {
     t.error(er)
     cmdShim(testShbang + '.js', testShbang, function (er) {

--- a/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/info
+++ b/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/info
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 'use strict';
 

--- a/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-conv
+++ b/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-conv
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 // -*- mode: js -*-
 // vim: set filetype=javascript :
 // Copyright 2015 Joyent, Inc.  All rights reserved.

--- a/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-sign
+++ b/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-sign
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 // -*- mode: js -*-
 // vim: set filetype=javascript :
 // Copyright 2015 Joyent, Inc.  All rights reserved.

--- a/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-verify
+++ b/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-verify
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 // -*- mode: js -*-
 // vim: set filetype=javascript :
 // Copyright 2015 Joyent, Inc.  All rights reserved.

--- a/node_modules/rimraf/bin.js
+++ b/node_modules/rimraf/bin.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 var rimraf = require('./')
 

--- a/node_modules/semver/bin/semver
+++ b/node_modules/semver/bin/semver
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 // Standalone semver comparison program.
 // Exits successfully and prints matching version(s) if
 // any supplied version is valid and passes all tests.

--- a/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/index.js
+++ b/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/index.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#! /usr/bin/nodejs
 var cc   = require('./lib/utils')
 var join = require('path').join
 var deepExtend = require('deep-extend')

--- a/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/index.js
+++ b/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/index.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#! /usr/bin/nodejs
 var cc   = require('./lib/utils')
 var join = require('path').join
 var deepExtend = require('deep-extend')

--- a/node_modules/uuid/bin/uuid
+++ b/node_modules/uuid/bin/uuid
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 var path = require('path');
 var uuid = require(path.join(__dirname, '..'));

--- a/node_modules/which/bin/which
+++ b/node_modules/which/bin/which
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 var which = require("../")
 if (process.argv.length < 3)
   usage()

--- a/scripts/index-build.js
+++ b/scripts/index-build.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 var fs = require('fs')
 var path = require('path')
 var root = path.resolve(__dirname, '..')

--- a/scripts/maketest
+++ b/scripts/maketest
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 'use strict'
 var loadFromDir = require('tacks/load-from-dir.js')
 

--- a/scripts/relocate.sh
+++ b/scripts/relocate.sh
@@ -15,7 +15,7 @@ tmp="$cli".tmp
 
 node="$1"
 if [ "x$node" = "x" ]; then
-  node="/usr/bin/env node"
+  node="/usr/bin/nodejs"
 fi
 node="#!$node"
 

--- a/test/tap/config-edit.js
+++ b/test/tap/config-edit.js
@@ -9,7 +9,7 @@ var common = require('../common-tap.js')
 var pkg = path.resolve(__dirname, 'npm-global-edit')
 
 var editorSrc = function () { /*
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 var fs = require('fs')
 if (fs.existsSync(process.argv[2])) {
   console.log('success')

--- a/test/tap/gently-rm-cmdshims.js
+++ b/test/tap/gently-rm-cmdshims.js
@@ -17,7 +17,7 @@ var example_json = {
   }
 }
 var example_bin =
-  '#!/usr/bin/env node\n' +
+  '#!/usr/bin/nodejs\n' +
   'true\n'
 
 // NOTE: if this were actually produced on windows it would be \ not / of

--- a/test/tap/install-link-scripts.js
+++ b/test/tap/install-link-scripts.js
@@ -29,7 +29,7 @@ var dependency = {
 }
 
 var foo = function () { /*
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 console.log('hey sup')
 */ }.toString().split('\n').slice(1, -1).join('\n')

--- a/test/tap/install-scoped-link.js
+++ b/test/tap/install-scoped-link.js
@@ -18,7 +18,7 @@ var modules = path.join(work, 'node_modules')
 
 var EXEC_OPTS = { cwd: work }
 
-var world = '#!/usr/bin/env node\nconsole.log("hello blrbld")\n'
+var world = '#!/usr/bin/nodejs\nconsole.log("hello blrbld")\n'
 
 var json = {
   name: '@scoped/package',

--- a/test/tap/legacy-array-bin.js
+++ b/test/tap/legacy-array-bin.js
@@ -15,7 +15,7 @@ var fixture = new Tacks(
   Dir({
     bin: Dir({
       'array-bin': File(
-        '#!/usr/bin/env node\n' +
+        '#!/usr/bin/nodejs\n' +
         "console.log('test ran ok')\n"
       )
     }),

--- a/test/tap/legacy-dir-bin.js
+++ b/test/tap/legacy-dir-bin.js
@@ -15,7 +15,7 @@ var fixture = new Tacks(
   Dir({
     bin: Dir({
       'dir-bin': File(
-        '#!/usr/bin/env node\n' +
+        '#!/usr/bin/nodejs\n' +
         "console.log('test ran ok')\n"
       )
     }),

--- a/test/tap/prepublish-only.js
+++ b/test/tap/prepublish-only.js
@@ -39,7 +39,7 @@ var fixture = new Tacks(Dir({
   ].join('\n') + '\n'),
   helper: Dir({
     'script.js': File([
-      '#!/usr/bin/env node\n',
+      '#!/usr/bin/nodejs\n',
       'console.log("ok")\n'
     ].join('\n') + '\n'
     ),

--- a/test/tap/scripts-whitespace-windows.js
+++ b/test/tap/scripts-whitespace-windows.js
@@ -38,7 +38,7 @@ var dependency = {
 var extend = Object.assign || require('util')._extend
 
 var foo = function () { /*
-#!/usr/bin/env node
+#!/usr/bin/nodejs
 
 if (process.argv.length === 8)
   console.log('npm-test-fine')


### PR DESCRIPTION
The command name 'node' is very ambiguous conflicts with other packages
(eg. AX25 tools). Therefore distros have to rename it. The obvious
consensus is calling it 'nodejs'.