### PR TITLE
keep md files ascii

### DIFF
--- a/doc/cli/npm-ls.md
+++ b/doc/cli/npm-ls.md
@@ -18,8 +18,8 @@ nested packages will *also* show the paths to the specified packages.
 For example, running `npm ls promzard` in npm's source tree will show:
 
     npm@@VERSION@ /path/to/npm
-    └─┬ init-package-json@0.0.4
-      └── promzard@0.1.5
+    |-- init-package-json@0.0.4
+      |-- promzard@0.1.5
 
 It will print out extraneous, missing, and invalid packages.
 

--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -560,8 +560,8 @@ This ensures your package `tea-latte` can be installed *along* with the second
 major version of the host package `tea` only. `npm install tea-latte` could
 possibly yield the following dependency graph:
 
-    ├── tea-latte@1.3.5
-    └── tea@2.2.0
+    |-- tea-latte@1.3.5
+    `-- tea@2.2.0
 
 **NOTE: npm versions 1 and 2 will automatically install `peerDependencies` if
 they are not explicitly depended upon higher in the dependency tree. In the


### PR DESCRIPTION
It is simpler to generate documentation if only ascii is needed,
otherwise `ronn` requires to install some UTF8 locale.