### PR TITLE
Makefile: dont call destructive 'uninstall' on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ dev: install
 link: uninstall
 	node cli.js link -f
 
-clean: markedclean marked-manclean doc-clean uninstall
+clean: markedclean marked-manclean doc-clean
 	rm -rf npmrc
 	node cli.js cache clean
 


### PR DESCRIPTION
The 'clean' rule calls 'uninstall', which attemts ***destructive***
operation in the host system and fails if run as unprivileged user.

nekrad@orion:~/src/packaging/pkg/npm.git$ make clean
rm -rf node_modules/marked node_modules/.bin/marked .building_marked
rm -rf node_modules/marked-man node_modules/.bin/marked-man .building_marked-man
rm -rf
.building_marked
.building_marked-man
html/doc
man
nodejs cli.js rm npm -g -f
npm WARN using --force I sure hope you know what you are doing.
npm ERR! path /usr/lib/nodejs/nodejs-7.9/lib
npm ERR! code EACCES
npm ERR! errno -13
npm ERR! syscall mkdir
npm ERR! Error: EACCES: permission denied, mkdir '/usr/lib/nodejs/nodejs-7.9/lib'
npm ERR! { Error: EACCES: permission denied, mkdir '/usr/lib/nodejs/nodejs-7.9/lib'
npm ERR! errno: -13,
npm ERR! code: 'EACCES',
npm ERR! syscall: 'mkdir',
npm ERR! path: '/usr/lib/nodejs/nodejs-7.9/lib' }
npm ERR!
npm ERR! Please try running this command again as root/Administrator.

npm ERR! A complete log of this run can be found in:
npm ERR! /home/nekrad/.npm/_logs/2017-05-05T13_08_46_485Z-debug.log
make: *** [uninstall] Error 243