### PR TITLE
Makefile: fix doc build tools dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,16 @@ doc-clean:
     html/doc \
     man
 
+## build-time tools for the documentation
+build-doc-tools := node_modules/.bin/marked \
+                   node_modules/.bin/marked-man
+
 # use `npm install marked-man` for this to work.
-man/man1/npm-README.1: README.md scripts/doc-build.sh package.json
+man/man1/npm-README.1: README.md scripts/doc-build.sh package.json $(build-doc-tools)
 	@[ -d man/man1 ] || mkdir -p man/man1
 	scripts/doc-build.sh $< $@
 
-man/man1/%.1: doc/cli/%.md scripts/doc-build.sh package.json
+man/man1/%.1: doc/cli/%.md scripts/doc-build.sh package.json $(build-doc-tools)
 	@[ -d man/man1 ] || mkdir -p man/man1
 	scripts/doc-build.sh $< $@
 
@@ -102,26 +106,26 @@ man/man5/npm-json.5: man/man5/package.json.5
 man/man5/npm-global.5: man/man5/npm-folders.5
 	cp $< $@
 
-man/man5/%.5: doc/files/%.md scripts/doc-build.sh package.json
+man/man5/%.5: doc/files/%.md scripts/doc-build.sh package.json $(build-doc-tools)
 	@[ -d man/man5 ] || mkdir -p man/man5
 	scripts/doc-build.sh $< $@
 
-doc/misc/npm-index.md: scripts/index-build.js package.json
+doc/misc/npm-index.md: scripts/index-build.js package.json $(build-doc-tools)
 	node scripts/index-build.js > $@
 
-html/doc/index.html: doc/misc/npm-index.md $(html_docdeps)
+html/doc/index.html: doc/misc/npm-index.md $(html_docdeps) $(build-doc-tools)
 	@[ -d html/doc ] || mkdir -p html/doc
 	scripts/doc-build.sh $< $@
 
-man/man7/%.7: doc/misc/%.md scripts/doc-build.sh package.json
+man/man7/%.7: doc/misc/%.md scripts/doc-build.sh package.json $(build-doc-tools)
 	@[ -d man/man7 ] || mkdir -p man/man7
 	scripts/doc-build.sh $< $@
 
-html/doc/README.html: README.md $(html_docdeps)
+html/doc/README.html: README.md $(html_docdeps) $(build-doc-tools)
 	@[ -d html/doc ] || mkdir -p html/doc
 	scripts/doc-build.sh $< $@
 
-html/doc/cli/%.html: doc/cli/%.md $(html_docdeps)
+html/doc/cli/%.html: doc/cli/%.md $(html_docdeps) $(build-doc-tools)
 	@[ -d html/doc/cli ] || mkdir -p html/doc/cli
 	scripts/doc-build.sh $< $@
 
@@ -131,11 +135,11 @@ html/doc/files/npm-json.html: html/doc/files/package.json.html
 html/doc/files/npm-global.html: html/doc/files/npm-folders.html
 	cp $< $@
 
-html/doc/files/%.html: doc/files/%.md $(html_docdeps)
+html/doc/files/%.html: doc/files/%.md $(html_docdeps) $(build-doc-tools)
 	@[ -d html/doc/files ] || mkdir -p html/doc/files
 	scripts/doc-build.sh $< $@
 
-html/doc/misc/%.html: doc/misc/%.md $(html_docdeps)
+html/doc/misc/%.html: doc/misc/%.md $(html_docdeps) $(build-doc-tools)
 	@[ -d html/doc/misc ] || mkdir -p html/doc/misc
 	scripts/doc-build.sh $< $@
 

--- a/scripts/doc-build.sh
+++ b/scripts/doc-build.sh
@@ -6,58 +6,6 @@ fi
 set -o errexit
 set -o pipefail
 
-if ! [ -x node_modules/.bin/marked-man ]; then
-  ps=0
-  if [ -f .building_marked-man ]; then
-    pid=$(cat .building_marked-man)
-    ps=$(ps -p $pid | grep $pid | wc -l) || true
-  fi
-
-  if [ -f .building_marked-man ] && [ $ps != 0 ]; then
-    while [ -f .building_marked-man ]; do
-      sleep 1
-    done
-  else
-    # a race to see which make process will be the one to install marked-man
-    echo $$ > .building_marked-man
-    sleep 1
-    if [ $(cat .building_marked-man) == $$ ]; then
-      make node_modules/.bin/marked-man
-      rm .building_marked-man
-    else
-      while [ -f .building_marked-man ]; do
-        sleep 1
-      done
-    fi
-  fi
-fi
-
-if ! [ -x node_modules/.bin/marked ]; then
-  ps=0
-  if [ -f .building_marked ]; then
-    pid=$(cat .building_marked)
-    ps=$(ps -p $pid | grep $pid | wc -l) || true
-  fi
-
-  if [ -f .building_marked ] && [ $ps != 0 ]; then
-    while [ -f .building_marked ]; do
-      sleep 1
-    done
-  else
-    # a race to see which make process will be the one to install marked
-    echo $$ > .building_marked
-    sleep 1
-    if [ $(cat .building_marked) == $$ ]; then
-      make node_modules/.bin/marked
-      rm .building_marked
-    else
-      while [ -f .building_marked ]; do
-        sleep 1
-      done
-    fi
-  fi
-fi
-
 src=$1
 dest=$2
 name=$(basename ${src%.*})


### PR DESCRIPTION
The build tools for the documentation need to be built/installed
before the documents, even with parallel builds.

Make has a simple mechanism which was made exactly for that:
target dependencies.