### PR TITLE
Add support for long option to view output

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -259,7 +259,22 @@ function printData (data, name, cb) {
         if (npm.config.get('json')) {
           msgJson[msgJson.length - 1][f] = d
         } else {
-          d = util.inspect(d, false, 5, npm.color)
+          if (npm.config.get('long')) {
+            d = util.inspect(d, {
+              showHidden: false,
+              depth: 5,
+              colors: npm.color,
+              customInspect: true,
+              showProxy: false,
+              maxArrayLength: null
+            })
+          } else {
+            d = util.inspect(d, {
+              showHidden: false,
+              depth: 5,
+              colors: npm.color
+            })
+          }
         }
       } else if (typeof d === 'string' && npm.config.get('json')) {
         d = JSON.stringify(d)


### PR DESCRIPTION
This PR adds support for the "--long" option for view output.
Issue was filed here: https://github.com/npm/npm/issues/16590
Without the option the behavior is exactly the same as before. With the long option the array output will not be truncated (and in my use case, all versions will be shown).