### PR TITLE
Fix prune, add tests to demonstrate brokenness in npm 4.1.0+

### DIFF
--- a/lib/prune.js
+++ b/lib/prune.js
@@ -11,7 +11,8 @@ var util = require('util')
 var moduleName = require('./utils/module-name.js')
 var Installer = require('./install.js').Installer
 var isExtraneous = require('./install/is-extraneous.js')
-var isDev = require('./install/is-dev-dep.js')
+var isProdDep = require('./install/is-prod-dep.js')
+var isOptDep = require('./install/is-opt-dep.js')
 var removeDeps = require('./install/deps.js').removeDeps
 var loadExtraneous = require('./install/deps.js').loadExtraneous
 var chain = require('slide').chain
@@ -40,8 +41,13 @@ Pruner.prototype.loadAllDepsIntoIdealTree = function (cb) {
     if (isExtraneous(child)) return true
     if (!excludeDev) return false
     var childName = moduleName(child)
-    var isChildDev = function (parent) { return isDev(parent, childName) }
-    if (child.requiredBy.every(isChildDev)) return true
+    var isDevDep = function (parent) {
+      if (parent.isTop) {
+        return !isProdDep(parent, childName) && !isOptDep(parent, childName)
+      }
+      return parent.requiredBy.every(isDevDep)
+    }
+    return child.requiredBy.every(isDevDep)
   }
   function getModuleName (child) {
     // wrapping because moduleName doesn't like extra args and we're called

--- a/test/tap/prune-dev-dep-cycle.js
+++ b/test/tap/prune-dev-dep-cycle.js
@@ -1,0 +1,79 @@
+'use strict'
+var fs = require('fs')
+var path = require('path')
+var test = require('tap').test
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+var common = require('../common-tap.js')
+var testdir = path.join(__dirname, path.basename(__filename, '.js'))
+
+var fixture = new Tacks(
+  Dir({
+    node_modules: Dir({
+      'a': Dir({
+        'package.json': File({
+          _requested: {
+            rawSpec: 'file:///mods/a'
+          },
+          dependencies: {
+            'b': 'file:///mods/b'
+          },
+          name: 'a',
+          version: '1.0.0'
+        })
+      }),
+      'b': Dir({
+        'package.json': File({
+          _requested: {
+            rawSpec: 'file:///mods/b'
+          },
+          dependencies: {
+            'a': 'file:///mods/a'
+          },
+          name: 'b',
+          version: '1.0.0'
+        })
+      })
+    }),
+    'package.json': File({
+      name: 'test',
+      version: '1.0.0',
+      devDependencies: {
+        'a': 'file:///mods/a'
+      }
+    })
+  })
+)
+
+function setup () {
+  cleanup()
+  fixture.create(testdir)
+}
+
+function cleanup () {
+  fixture.remove(testdir)
+}
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+test('prune cycle in dev deps', function (t) {
+  common.npm(['prune', '--production'], {cwd: testdir}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'prune finished successfully')
+    t.equal(stderr,
+      '- a@1.0.0 node_modules/a\n' +
+      '- b@1.0.0 node_modules/b\n')
+    var dirs = fs.readdirSync(testdir + '/node_modules').sort()
+    t.same(dirs, [])
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})

--- a/test/tap/prune-with-dev-dep-duplicate.js
+++ b/test/tap/prune-with-dev-dep-duplicate.js
@@ -14,12 +14,14 @@ var pkg = path.resolve(__dirname, 'prune')
 var cache = path.resolve(pkg, 'cache')
 
 var json = {
-  name: 'prune-with-only-dev-deps',
+  name: 'prune-with-dev-dep-duplicate',
   description: 'fixture',
   version: '0.0.1',
   main: 'index.js',
+  dependencies: {
+    'test-package': '0.0.0'
+  },
   devDependencies: {
-    'test-package-with-one-dep': '0.0.0',
     'test-package': '0.0.0'
   }
 }
@@ -59,7 +61,7 @@ test('npm install', function (t) {
 
 test('verify installs', function (t) {
   var dirs = fs.readdirSync(pkg + '/node_modules').sort()
-  t.same(dirs, [ 'test-package', 'test-package-with-one-dep' ].sort())
+  t.same(dirs, [ 'test-package' ].sort())
   t.end()
 })
 
@@ -78,7 +80,7 @@ test('npm prune', function (t) {
 
 test('verify installs', function (t) {
   var dirs = fs.readdirSync(pkg + '/node_modules').sort()
-  t.same(dirs, [ 'test-package', 'test-package-with-one-dep' ])
+  t.same(dirs, [ 'test-package' ])
   t.end()
 })
 
@@ -90,16 +92,14 @@ test('npm prune', function (t) {
   ], EXEC_OPTS, function (err, code, stderr) {
     t.ifErr(err, 'prune finished successfully')
     t.notOk(code, 'exit ok')
-    t.equal(stderr,
-      '- test-package@0.0.0 node_modules/test-package\n' +
-      '- test-package-with-one-dep@0.0.0 node_modules/test-package-with-one-dep\n')
+    t.notOk(stderr, 'Should not get data on stderr: ' + stderr)
     t.end()
   })
 })
 
 test('verify installs', function (t) {
   var dirs = fs.readdirSync(pkg + '/node_modules').sort()
-  t.same(dirs, [])
+  t.same(dirs, [ 'test-package' ])
   t.end()
 })
 

--- a/test/tap/prune-with-only-dev-deps.js
+++ b/test/tap/prune-with-only-dev-deps.js
@@ -1,0 +1,131 @@
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap')
+var server
+
+var pkg = path.resolve(__dirname, 'prune')
+var cache = path.resolve(pkg, 'cache')
+
+var json = {
+  name: 'prune-with-only-dev-deps',
+  description: 'fixture',
+  version: '0.0.1',
+  main: 'index.js',
+  devDependencies: {
+    'test-package-with-one-dep': '0.0.0',
+    'test-package': '0.0.0'
+  }
+}
+
+var EXEC_OPTS = {
+  cwd: pkg,
+  npm_config_depth: 'Infinity'
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(cache)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  mr({ port: common.port }, function (er, s) {
+    server = s
+    t.end()
+  })
+})
+
+test('npm install', function (t) {
+  common.npm([
+    'install',
+    '--cache', cache,
+    '--registry', common.registry,
+    '--loglevel', 'silent',
+    '--production', 'false'
+  ], EXEC_OPTS, function (err, code, stdout, stderr) {
+    t.ifErr(err, 'install finished successfully')
+    t.notOk(code, 'exit ok')
+    t.notOk(stderr, 'Should not get data on stderr: ' + stderr)
+    t.end()
+  })
+})
+
+test('npm install test-package', function (t) {
+  common.npm([
+    'install', 'test-package',
+    '--cache', cache,
+    '--registry', common.registry,
+    '--loglevel', 'silent',
+    '--production', 'false'
+  ], EXEC_OPTS, function (err, code, stdout, stderr) {
+    t.ifErr(err, 'install finished successfully')
+    t.notOk(code, 'exit ok')
+    t.notOk(stderr, 'Should not get data on stderr: ' + stderr)
+    t.end()
+  })
+})
+
+test('verify installs', function (t) {
+  var dirs = fs.readdirSync(pkg + '/node_modules').sort()
+  t.same(dirs, [ 'test-package', 'test-package-with-one-dep' ].sort())
+  t.end()
+})
+
+test('npm prune', function (t) {
+  common.npm([
+    'prune',
+    '--loglevel', 'silent',
+    '--production', 'false'
+  ], EXEC_OPTS, function (err, code, stdout, stderr) {
+    t.ifErr(err, 'prune finished successfully')
+    t.notOk(code, 'exit ok')
+    t.notOk(stderr, 'Should not get data on stderr: ' + stderr)
+    t.end()
+  })
+})
+
+test('verify installs', function (t) {
+  var dirs = fs.readdirSync(pkg + '/node_modules').sort()
+  t.same(dirs, [ 'test-package', 'test-package-with-one-dep' ])
+  t.end()
+})
+
+test('npm prune', function (t) {
+  common.npm([
+    'prune',
+    '--loglevel', 'silent',
+    '--production'
+  ], EXEC_OPTS, function (err, code, stderr) {
+    t.ifErr(err, 'prune finished successfully')
+    t.notOk(code, 'exit ok')
+    t.equal(stderr,
+      '- test-package@0.0.0 node_modules/test-package\n' +
+      '- test-package-with-one-dep@0.0.0 node_modules/test-package-with-one-dep\n')
+    t.end()
+  })
+})
+
+test('verify installs', function (t) {
+  var dirs = fs.readdirSync(pkg + '/node_modules').sort()
+  t.same(dirs, [])
+  t.end()
+})
+
+test('cleanup', function (t) {
+  server.close()
+  cleanup()
+  t.pass('cleaned up')
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
This adds two test cases to demonstrate how npm 4.1.0+ (including the latest version) fails to prune in certain cases (likely introduced in #15090). A fix is included, but will need to be reviewed carefully (I'm not sure whether cycle detection or checking `userRequired` is necessary, or if that's already taken care of by `isExtraneous`).

`prune` misbehaving is likely the cause of some of the funny business on display in issues #15727, #15669, #15646.

My interest in this stems from the fact that broken pruning causes [postinstall-build](https://github.com/exogen/postinstall-build) to break on the latest versions of npm ever since 4.1.0.

### The Tests

* Call `npm prune --production` on a module with ONLY these dependencies:

  ```json
  {
    "devDependencies": {
      "test-package-with-one-dep": "0.0.0",
      "test-package": "0.0.0"
    }
  }
  ```

  ...which looks like this before pruning:

  ```console
  ├── test-package@0.0.0
  └─┬ test-package-with-one-dep@0.0.0
    └── test-package@0.0.0  deduped
  ```

  `npm prune --production` SHOULD remove both packages, resulting in an empty `node_modules` tree, but it fails to remove `test-package` (because it's a prod dep of `test-package-with-one-dep`, but that shouldn't matter because `test-package-with-one-dep` itself is a dev dep).

* Call `prune --production` with the same package in both `dependencies` and `devDependencies`. The package SHOULD NOT be removed.

### The Fix

In `--production` mode, packages are now pruned if they are only reachable from dev dependencies (the actual logic is: NOT reachable from prod or opt dependencies).

/cc @iarna 