### PR TITLE
feat: allow custom shell for run-script

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -271,13 +271,6 @@ It is _not_ the path to a certificate file (and there is no "certfile" option).
 If false, never shows colors.  If `"always"` then always shows colors.
 If true, then only prints color codes for tty file descriptors.
 
-### command-shell
-
-* Default: `null`
-* Type: path
-
-The shell to use for scripts run with the `npm run` command.
-
 ### depth
 
 * Default: Infinity
@@ -838,6 +831,13 @@ in to a private registry for the first time:
 `npm login --scope=@organization --registry=registry.organization.com`, which
 will cause `@organization` to be mapped to the registry for future installation
 of packages specified according to the pattern `@organization/package`.
+
+### script-shell
+
+* Default: `null`
+* Type: path
+
+The shell to use for scripts run with the `npm run` command.
 
 ### scripts-prepend-node-path
 

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -271,6 +271,13 @@ It is _not_ the path to a certificate file (and there is no "certfile" option).
 If false, never shows colors.  If `"always"` then always shows colors.
 If true, then only prints color codes for tty file descriptors.
 
+### command-shell
+
+* Default: `null`
+* Type: path
+
+The shell to use for scripts run with the `npm run` command.
+
 ### depth
 
 * Default: Infinity

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -129,9 +129,6 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     cert: null,
 
     color: true,
-
-    'command-shell': null,
-
     depth: Infinity,
     description: true,
     dev: false,
@@ -200,6 +197,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'save-optional': false,
     'save-prefix': '^',
     scope: '',
+    'script-shell': null,
     'scripts-prepend-node-path': 'warn-only',
     searchopts: '',
     searchexclude: null,
@@ -254,7 +252,6 @@ exports.types = {
   'cache-min': Number,
   cert: [null, String],
   color: ['always', Boolean],
-  'command-shell': [null, String],
   depth: Number,
   description: Boolean,
   dev: Boolean,
@@ -318,6 +315,7 @@ exports.types = {
   'save-optional': Boolean,
   'save-prefix': String,
   scope: String,
+  'script-shell': [null, String],
   'scripts-prepend-node-path': [false, true, 'auto', 'warn-only'],
   searchopts: String,
   searchexclude: [null, String],

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -129,6 +129,9 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     cert: null,
 
     color: true,
+
+    'command-shell': null,
+
     depth: Infinity,
     description: true,
     dev: false,
@@ -251,6 +254,7 @@ exports.types = {
   'cache-min': Number,
   cert: [null, String],
   color: ['always', Boolean],
+  'command-shell': [null, String],
   depth: Number,
   description: Boolean,
   dev: Boolean,

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -258,7 +258,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
   var sh = 'sh'
   var shFlag = '-c'
 
-  var customShell = npm.config.get('command-shell')
+  var customShell = npm.config.get('script-shell')
 
   if (customShell) {
     sh = customShell

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -258,7 +258,11 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
   var sh = 'sh'
   var shFlag = '-c'
 
-  if (process.platform === 'win32') {
+  var customShell = npm.config.get('command-shell')
+
+  if (customShell) {
+    sh = customShell
+  } else if (process.platform === 'win32') {
     sh = process.env.comspec || 'cmd'
     shFlag = '/d /s /c'
     conf.windowsVerbatimArguments = true

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -75,11 +75,11 @@ var exitCode = {
   }
 }
 
-var tcshOnly = {
+var shell = {
   name: 'scripted',
   version: '1.2.3',
   scripts: {
-    'start': 'setenv foo 1 && echo $foo'
+    'start': 'echo foo'
   }
 }
 
@@ -316,23 +316,10 @@ test('npm run-script no-params (direct only)', function (t) {
   })
 })
 
-test('npm run-script invalid bash command', function (t) {
-    writeMetadata(tcshOnly)
-
-    common.npm(['run-script', 'start'], opts, function (err, code, stdout, stderr) {
-        t.ifError(err, 'ran command that works in tcsh but not bash without crashing')
-        t.equal(code, 1, 'npm exited with error code')
-        t.match(stderr,
-            new RegExp('setenv: command not found'),
-            'missing setenv command printed to stderr')
-        t.end()
-    })
-})
-
 test('npm run-script command-shell config', function (t) {
-    writeMetadata(tcshOnly)
+    writeMetadata(shell)
 
-    common.npm(['run-script', 'start', '--command-shell', '/bin/tcsh'], opts, testOutput.bind(null, t, '1'))
+    common.npm(['run-script', 'start', '--command-shell', 'echo'], opts, testOutput.bind(null, t, '-c echo foo'))
 })
 
 test('npm run-script no-params (direct only)', function (t) {

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -316,10 +316,10 @@ test('npm run-script no-params (direct only)', function (t) {
   })
 })
 
-test('npm run-script command-shell config', function (t) {
+test('npm run-script script-shell config', function (t) {
     writeMetadata(shell)
 
-    common.npm(['run-script', 'start', '--command-shell', 'echo'], opts, testOutput.bind(null, t, '-c echo foo'))
+    common.npm(['run-script', 'start', '--script-shell', 'echo'], opts, testOutput.bind(null, t, '-c echo foo'))
 })
 
 test('npm run-script no-params (direct only)', function (t) {

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -75,6 +75,14 @@ var exitCode = {
   }
 }
 
+var tcshOnly = {
+  name: 'scripted',
+  version: '1.2.3',
+  scripts: {
+    'start': 'setenv foo 1 && echo $foo'
+  }
+}
+
 function testOutput (t, command, er, code, stdout, stderr) {
   var lines
 
@@ -306,6 +314,25 @@ test('npm run-script no-params (direct only)', function (t) {
     t.equal(stdout, expected, 'got expected output')
     t.end()
   })
+})
+
+test('npm run-script invalid bash command', function (t) {
+    writeMetadata(tcshOnly)
+
+    common.npm(['run-script', 'start'], opts, function (err, code, stdout, stderr) {
+        t.ifError(err, 'ran command that works in tcsh but not bash without crashing')
+        t.equal(code, 1, 'npm exited with error code')
+        t.match(stderr,
+            new RegExp('setenv: command not found'),
+            'missing setenv command printed to stderr')
+        t.end()
+    })
+})
+
+test('npm run-script command-shell config', function (t) {
+    writeMetadata(tcshOnly)
+
+    common.npm(['run-script', 'start', '--command-shell', '/bin/tcsh'], opts, testOutput.bind(null, t, '1'))
 })
 
 test('npm run-script no-params (direct only)', function (t) {


### PR DESCRIPTION
Addresses https://github.com/npm/npm/issues/6543

Maybe I'm under-thinking the problem, but this seems to work for me. I can set
`command-shell = C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
or
`command-shell = C:\Windows\System32\bash.exe`
in my `.npmrc` and it just works.

~I'm guessing tests would go in https://github.com/npm/npm/blob/latest/test/tap/run-script.js, but I'd be interested to hear thoughts on the approach before I go that far.~
