### PR TITLE
Remove slow assertion from module-name util

### DIFF
--- a/lib/utils/module-name.js
+++ b/lib/utils/module-name.js
@@ -1,6 +1,5 @@
 'use strict'
 var path = require('path')
-var validate = require('aproba')
 
 module.exports = moduleName
 module.exports.test = {}
@@ -22,7 +21,6 @@ function isNotEmpty (str) {
 
 var unknown = 0
 function moduleName (tree) {
-  validate('O', arguments)
   var pkg = tree.package || tree
   if (isNotEmpty(pkg.name)) return pkg.name
   var pkgName = pathToPackageName(tree.path)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.6.1",
+  "version": "5.0.0",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [


### PR DESCRIPTION
Was playing around and profiling the new npm5 release and it's still a drop sluggish in cases where it could be much faster (like when it already has package-lock.json). I can provide benchmarks if necessary to get this landed, just point me in the right direction. In my tests, it speeds up install by approx 25%!

The assertion appears to just be an abundance of caution, as I checked all call sites and it seems like an object is guaranteed in each of those cases. Let me know your thoughts, thanks for considering the patch and thanks for everything you all do!

P.S. Excuse the `patch-1` branch. I tested this on my computer but am recreating the pr on my phone!