### PR TITLE
publish: adapt config for publish RegClient

### DIFF
--- a/lib/config/reg-client.js
+++ b/lib/config/reg-client.js
@@ -1,0 +1,29 @@
+'use strict'
+
+module.exports = regClientConfig
+function regClientConfig (npm, log, config) {
+  return {
+    proxy: {
+      http: config.get('proxy'),
+      https: config.get('https-proxy'),
+      localAddress: config.get('local-address')
+    },
+    ssl: {
+      certificate: config.get('cert'),
+      key: config.get('key'),
+      ca: config.get('ca'),
+      strict: config.get('strict-ssl')
+    },
+    retry: {
+      retries: config.get('fetch-retries'),
+      factor: config.get('fetch-retry-factor'),
+      minTimeout: config.get('fetch-retry-mintimeout'),
+      maxTimeout: config.get('fetch-retry-maxtimeout')
+    },
+    userAgent: config.get('user-agent'),
+    log: log,
+    defaultTag: config.get('tag'),
+    maxSockets: config.get('maxsockets'),
+    scope: npm.projectScope
+  }
+}

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -33,6 +33,7 @@
   var rimraf = require('rimraf')
   var lazyProperty = require('lazy-property')
   var parseJSON = require('./utils/parse-json.js')
+  var clientConfig = require('./config/reg-client.js')
   var aliases = require('./config/cmd-list').aliases
   var cmdList = require('./config/cmd-list').cmdList
   var plumbing = require('./config/cmd-list').plumbing
@@ -344,7 +345,7 @@
         lazyProperty(npm, 'registry', function () {
           registryLoaded = true
           var RegClient = require('npm-registry-client')
-          var registry = new RegClient(adaptClientConfig(npm.config))
+          var registry = new RegClient(clientConfig(npm, log, npm.config))
           registry.version = npm.version
           registry.refer = registryRefer
           return registry
@@ -465,33 +466,6 @@
       return pkg.name.slice(0, sep)
     } catch (ex) {
       return ''
-    }
-  }
-
-  function adaptClientConfig (config) {
-    return {
-      proxy: {
-        http: config.get('proxy'),
-        https: config.get('https-proxy'),
-        localAddress: config.get('local-address')
-      },
-      ssl: {
-        certificate: config.get('cert'),
-        key: config.get('key'),
-        ca: config.get('ca'),
-        strict: config.get('strict-ssl')
-      },
-      retry: {
-        retries: config.get('fetch-retries'),
-        factor: config.get('fetch-retry-factor'),
-        minTimeout: config.get('fetch-retry-mintimeout'),
-        maxTimeout: config.get('fetch-retry-maxtimeout')
-      },
-      userAgent: config.get('user-agent'),
-      log: log,
-      defaultTag: config.get('tag'),
-      maxSockets: config.get('maxsockets'),
-      scope: npm.projectScope
     }
   }
 })()

--- a/lib/utils/get-publish-config.js
+++ b/lib/utils/get-publish-config.js
@@ -1,12 +1,16 @@
-var Conf = require('../config/core.js').Conf
-var RegClient = require('npm-registry-client')
-var log = require('npmlog')
+'use strict'
+
+const clientConfig = require('../config/reg-client.js')
+const Conf = require('../config/core.js').Conf
+const log = require('npmlog')
+const npm = require('../npm.js')
+const RegClient = require('npm-registry-client')
 
 module.exports = getPublishConfig
 
 function getPublishConfig (publishConfig, defaultConfig, defaultClient) {
-  var config = defaultConfig
-  var client = defaultClient
+  let config = defaultConfig
+  let client = defaultClient
   log.verbose('getPublishConfig', publishConfig)
   if (publishConfig) {
     config = new Conf(defaultConfig)
@@ -18,7 +22,7 @@ function getPublishConfig (publishConfig, defaultConfig, defaultClient) {
       s[k] = publishConfig[k]
       return s
     }, {}))
-    client = new RegClient(config)
+    client = new RegClient(clientConfig(npm, log, config))
   }
 
   return { config: config, client: client }

--- a/test/tap/publish-config.js
+++ b/test/tap/publish-config.js
@@ -1,36 +1,43 @@
-var common = require('../common-tap.js')
-var test = require('tap').test
-var fs = require('fs')
-var osenv = require('osenv')
-var pkg = process.env.npm_config_tmp || '/tmp'
-pkg += '/npm-test-publish-config'
+'use strict'
+
+const common = require('../common-tap.js')
+const test = require('tap').test
+const fs = require('fs')
+const osenv = require('osenv')
+const pkg = `${process.env.npm_config_tmp || '/tmp'}/npm-test-publish-config`
 
 require('mkdirp').sync(pkg)
 
 fs.writeFileSync(pkg + '/package.json', JSON.stringify({
   name: 'npm-test-publish-config',
   version: '1.2.3',
-  publishConfig: { registry: common.registry }
+  publishConfig: {
+    registry: common.registry
+  }
 }), 'utf8')
 
 fs.writeFileSync(pkg + '/fixture_npmrc',
   '//localhost:1337/:email = fancy@feast.net\n' +
   '//localhost:1337/:username = fancy\n' +
-  '//localhost:1337/:_password = ' + new Buffer('feast').toString('base64') + '\n' +
-  'registry = http://localhost:1337/')
+  '//localhost:1337/:_password = ' + new Buffer('feast').toString('base64'))
 
 test(function (t) {
-  var child
-  t.plan(4)
+  let child
+  t.plan(5)
   require('http').createServer(function (req, res) {
     t.pass('got request on the fakey fake registry')
-    this.close()
-    res.statusCode = 500
-    res.end(JSON.stringify({
-      error: 'sshhh. naptime nao. \\^O^/ <(YAWWWWN!)'
-    }))
-    child.kill('SIGINT')
-  }).listen(common.port, function () {
+    let body = ''
+    req.on('data', (d) => { body += d })
+    req.on('end', () => {
+      this.close()
+      res.statusCode = 500
+      res.end(JSON.stringify({
+        error: 'sshhh. naptime nao. \\^O^/ <(YAWWWWN!)'
+      }))
+      t.match(body, /"beta"/, 'got expected tag')
+      child.kill('SIGINT')
+    })
+  }).listen(common.port, () => {
     t.pass('server is listening')
 
     // don't much care about listening to the child's results
@@ -40,7 +47,7 @@ test(function (t) {
     // itself functions normally.
     //
     // Make sure that we don't sit around waiting for lock files
-    child = common.npm(['publish', '--userconfig=' + pkg + '/fixture_npmrc'], {
+    child = common.npm(['publish', '--userconfig=' + pkg + '/fixture_npmrc', '--tag=beta'], {
       cwd: pkg,
       stdio: 'inherit',
       env: {


### PR DESCRIPTION
Fixes: #16746

There were apparently _two_ places that use `RegClient` directly, and I missed fixing the passed-in config stuff for the one in `get-publish-config`.

This is the last one, so this particular thing shouldn't cause any more issues.