### PR TITLE
npm-config list -l option documented

### DIFF
--- a/doc/cli/npm-config.md
+++ b/doc/cli/npm-config.md
@@ -6,7 +6,7 @@ npm-config(1) -- Manage the npm configuration files
     npm config set <key> <value> [-g|--global]
     npm config get <key>
     npm config delete <key>
-    npm config list
+    npm config list [-l]
     npm config edit
     npm get <key>
     npm set <key> <value> [-g|--global]
@@ -48,7 +48,7 @@ Echo the config value to stdout.
 
     npm config list
 
-Show all the config settings.
+Show all the config settings. Use `-l` to also show defaults.
 
 ### delete
 


### PR DESCRIPTION
`-l` option of `npm config list` documented.

Previously it was only mentioned in output of `npm config list`:

    ; "npm config ls -l" to show all defaults.