### PR TITLE
Document package-lock.json never being allowed in tarballs

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -204,6 +204,7 @@ Conversely, some files are always ignored:
 * `node_modules`
 * `config.gypi`
 * `*.orig`
+* `package-lock.json` (use shrinkwrap instead)
 
 ## main
 


### PR DESCRIPTION
See [lib/utils/tar.js#L106-L107](https://github.com/npm/npm/blob/v5.0.0/lib/utils/tar.js#L106-L107).