### PR TITLE
inflate-shrinkwrap: fix installing with --no-shrinkwrap

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -19,12 +19,12 @@ module.exports = function (tree, swdeps, opts, finishInflating) {
     fetchPackageMetadata = BB.promisify(require('../fetch-package-metadata.js'))
     addBundled = BB.promisify(fetchPackageMetadata.addBundled)
   }
-  if (!npm.config.get('shrinkwrap') || !npm.config.get('package-lock')) {
-    return finishInflating()
-  }
   if (arguments.length === 3) {
     finishInflating = opts
     opts = {}
+  }
+  if (!npm.config.get('shrinkwrap') || !npm.config.get('package-lock')) {
+    return finishInflating()
   }
   tree.loaded = true
   return inflateShrinkwrap(tree.path, tree, swdeps, opts).then(


### PR DESCRIPTION
https://github.com/npm/npm/commit/5599538eff233f7cbf128d70bbe34997bf7e7dd3 changed the arity of `inflateShrinkwrap`, but placed the arity check after the `--no-shrinkwrap` guard. 

[This caller](https://github.com/npm/npm/blob/39495d07b9a66c88621e8a2ad07739ee98b70a56/lib/install/deps.js#L615) still calls it with a function as the third argument, so `npm --no-shrinkwrap install` can fail. For example, `nsp` has an `npm-shrinkwrap.json`, and trying to install it with npm 5 fails accordingly:

```
$ npm --no-shrinkwrap install nsp
Unhandled rejection TypeError: finishInflating is not a function
    at module.exports (/Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/lib/install/inflate-shrinkwrap.js:23:12)
    at /Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/lib/install/deps.js:615:16
    at /Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/node_modules/iferr/index.js:13:50
    at addBundled (/Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/lib/fetch-package-metadata.js:93:78)
    at /Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/lib/install/deps.js:587:5
    at /Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/node_modules/iferr/index.js:13:50
    at checkPlatform (/Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/node_modules/npm-install-checks/index.js:53:10)
    at thenWarnEngineIssues (/Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/lib/install/validate-args.js:41:5)
    at /Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/node_modules/iferr/index.js:13:50
    at checkEngine (/Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/node_modules/npm-install-checks/index.js:10:20)
    at module.exports.isInstallable (/Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/lib/install/validate-args.js:38:3)
    at resolveWithNewModule (/Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/lib/install/deps.js:586:10)
    at /Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/lib/install/deps.js:225:5
    at /Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/node_modules/slide/lib/async-map.js:52:35
    at Array.forEach (native)
    at /Users/jnagel/.nvm/versions/node/v6.10.3/lib/node_modules/npm/node_modules/slide/lib/async-map.js:52:11
npm ERR! cb() never called!
```

This patch moves the arity check before the `--no-shrinkwrap` guard.