### PR TITLE
install: print spec for each requested package

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -741,6 +741,9 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
     }
   })
   var report = ''
+  if (added && this.args.length) {
+    report += this.args.map((p) => p.name + '@' + p.version).join('\n') + '\n'
+  }
   var actions = []
   if (added) actions.push('added ' + packages(added))
   if (removed) actions.push('removed ' + packages(removed))


### PR DESCRIPTION
For every package that is given as an argument to install, print the
name and version that was actually installed.

Resolves #16897