### PR TITLE
Add certificate authority config to pacoteOpts

### DIFF
--- a/lib/config/pacote.js
+++ b/lib/config/pacote.js
@@ -17,9 +17,12 @@ function pacoteOpts (moreOpts) {
   const ownerStats = calculateOwner()
   const opts = {
     cache: path.join(npm.config.get('cache'), '_cacache'),
+    ca: npm.config.get('ca'),
+    cert: npm.config.get('cert'),
     defaultTag: npm.config.get('tag'),
     dirPacker: pack.packGitDep,
     hashAlgorithm: 'sha1',
+    key: npm.config.get('key'),
     localAddress: npm.config.get('local-address'),
     log: log,
     maxAge: npm.config.get('cache-min'),


### PR DESCRIPTION
Custom certificate config (e.g. via `npm config set cafile`) isn't making their way into `make-fetch-happen`, this appears to be an `npm@5` regression.

See the discussion here: https://github.com/npm/npm/issues/16868