### PR TITLE
fix(pacote): Generate and pass npm-session header value to pacote

### DIFF
--- a/lib/config/pacote.js
+++ b/lib/config/pacote.js
@@ -2,12 +2,16 @@
 
 const Buffer = require('safe-buffer').Buffer
 
+const crypto = require("crypto")
 const npm = require('../npm')
 const log = require('npmlog')
 let pack
 const path = require('path')
 
 let effectiveOwner
+
+const npmSession = crypto.randomBytes(8).toString('hex')
+log.verbose('npm-session', npmSession)
 
 module.exports = pacoteOpts
 function pacoteOpts (moreOpts) {
@@ -24,6 +28,7 @@ function pacoteOpts (moreOpts) {
     log: log,
     maxAge: npm.config.get('cache-min'),
     maxSockets: npm.config.get('maxsockets'),
+    npmSession: npmSession,
     offline: npm.config.get('offline'),
     preferOffline: npm.config.get('prefer-offline') || npm.config.get('cache-min') > 9999,
     preferOnline: npm.config.get('prefer-online') || npm.config.get('cache-max') <= 0,


### PR DESCRIPTION
Partially fixes #16889 along with https://github.com/zkat/pacote/pull/98