### PR TITLE
quick fix for possibility that `req` is null

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -107,7 +107,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
       return
     }
     var pkginfo = deps[moduleName(child)] = {}
-    var req = child.package._requested || getRequested(child)
+    var req = child.package._requested || getRequested(child) || {}
     if (req.type === 'directory' || req.type === 'file') {
       pkginfo.version = 'file:' + path.relative(top.path, child.package._resolved || req.fetchSpec)
     } else if (!req.registry && !child.fromBundle) {


### PR DESCRIPTION
fixes the bug seen in the following log

i have no idea what caused it

or if this is the correct fix

and i want to leave work instead of triaging this

https://gist.github.com/forivall/249c1966dd8ac335bca4a6177e41132d

i used `npm shrinkwrap --production`. that might be it.