### PR TITLE
Fix wrong symlink direction in link documentation

### DIFF
--- a/doc/cli/npm-link.md
+++ b/doc/cli/npm-link.md
@@ -18,8 +18,8 @@ link` command was executed. (see `npm-config(7)` for the value of `prefix`). It
 will also link any bins in the package to `{prefix}/bin/{name}`.
 
 Next, in some other location, `npm link package-name` will create a
-symbolic link from globally-installed `package-name` to `node_modules/`
-of the current folder.
+symbolic link from `node_modules/` of the current folder
+to globally-installed `package-name`.
 
 Note that `package-name` is taken from `package.json`,
 not from directory name.


### PR DESCRIPTION
In npm-link documentation it is written that after running
```npm-link package-name``` symlink is created from global
folder to node_modules of the current project.

However the symlink is created from node_modules of the current
folder to the global folder, otherwise there would be no
way to achieve linked module. So I swapped the direction
in the documentation.