### PR TITLE
adds an alias for `rum` -> `run`

### DIFF
--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -41,7 +41,8 @@ var affordances = {
   'unlink': 'uninstall',
   'remove': 'uninstall',
   'rm': 'uninstall',
-  'r': 'uninstall'
+  'r': 'uninstall',
+  'rum': 'run'
 }
 
 // these are filenames in .


### PR DESCRIPTION
Because I got one of those fancy ergonomic split keyboards and i cannot be the only one who keeps typing `npm rum`. especially since the last letter in npm makes for a nice pattern with rum.






.




.




.



[Edited by @zkat: unacceptable content]
<details>
```javascript
'npm'.toUpperCase() 
```
</details>