### PR TITLE
deps: ignore npa.resolve error from parsing peerDeps

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -625,7 +625,10 @@ var validatePeerDeps = exports.validatePeerDeps = function (tree, onInvalid) {
   if (!tree.package.peerDependencies) return
   Object.keys(tree.package.peerDependencies).forEach(function (pkgname) {
     var version = tree.package.peerDependencies[pkgname]
-    var match = findRequirement(tree.parent || tree, pkgname, npa.resolve(pkgname, version))
+    try {
+      var spec = npa.resolve(pkgname, version)
+    } catch (e) {}
+    var match = spec && findRequirement(tree.parent || tree, pkgname, spec)
     if (!match) onInvalid(tree, pkgname, version)
   })
 }


### PR DESCRIPTION
This emulates npm@4's behavior of simply marking the peerDep
as invalid, instead of crashing.

Fixes: #16981