### PR TITLE
deps: use relaxed semver range matching for compatibility

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -74,7 +74,7 @@ function doesChildVersionMatch (child, requested, requestor) {
     return false
   }
   try {
-    return semver.satisfies(child.package.version, requested.fetchSpec)
+    return semver.satisfies(child.package.version, requested.fetchSpec, true)
   } catch (e) {
     return false
   }


### PR DESCRIPTION
It seems like, somehow, we were using relaxed semver range matching before. This enables that again, which fixes at least two current issues, possibly others, having to do with people putting the most amazing garbage in their `package.json`.

Fixes: #16925
Fixes: #16931