### PR TITLE
fix(git): git repos with prepare scripts always install with dev flag

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -163,6 +163,8 @@ function packGitDep (manifest, dir) {
       const child = cp.spawn(process.env.NODE || process.execPath, [
         require.main.filename,
         'install',
+        '--dev',
+        '--prod',
         '--ignore-prepublish',
         '--no-progress',
         '--no-save'


### PR DESCRIPTION
Force devDependencies to always install with --dev flag in case NODE_ENV is production

Related: #16533
Closes #17059 