### PR TITLE
shrinkwrap: lean on from field for better forward-compat

### DIFF
--- a/lib/install/realize-shrinkwrap-specifier.js
+++ b/lib/install/realize-shrinkwrap-specifier.js
@@ -5,13 +5,16 @@ module.exports = function (name, sw, where) {
   try {
     if (sw.version && sw.integrity) {
       return npa.resolve(name, sw.version, where)
+    } else if (sw.from) {
+      const spec = npa(sw.from, where)
+      if (spec.registry && sw.version) {
+        return npa.resolve(name, sw.version, where)
+      } else if (!sw.resolved) {
+        return spec
+      }
     }
     if (sw.resolved) {
       return npa.resolve(name, sw.resolved, where)
-    }
-    if (sw.from) {
-      var spec = npa(sw.from, where)
-      if (!spec.registry) return spec
     }
   } catch (_) { }
   return npa.resolve(name, sw.version, where)


### PR DESCRIPTION
This patch, I think, will finally make most folks' shrinkwrap upgrade experience work out: right now, if you have a legacy shrinkwrap, it treats the `resolved` field (with the package tarball) as the version. This means everyone ends up with `"version": "https://registry.npmjs.org....1.2.3.tgz"`.

This patch should fix that.