### PR TITLE
error-handler: write an empty string and wait for callback to wait fo…

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -135,7 +135,9 @@ function exit (code, noLog) {
     // for whatever reason gets thrown away, instead of leaving the CLI open
     //
     // Commands that expect long-running actions should just delay `cb()`
-    process.exit(code)
+    process.stdout.write('', () => {
+      process.exit(code)
+    })
   }
 }
 


### PR DESCRIPTION
…r output

I think this'll catch any remaining bits where we were exiting the npm process before stdout was flushed. I could do the same thing for stderr but I feel like that's... not as important?