### PR TITLE
Fix self-reference in package-lock.json docs

### DIFF
--- a/doc/files/package-lock.json.md
+++ b/doc/files/package-lock.json.md
@@ -127,5 +127,6 @@ The dependencies of this dependency, exactly as at the top level.
 ## SEE ALSO
 
 * npm-shrinkwrap(1)
+* npm-shrinkwrap.json(5)
 * package.json(5)
 * npm-install(1)

--- a/doc/files/package-lock.json.md
+++ b/doc/files/package-lock.json.md
@@ -127,6 +127,5 @@ The dependencies of this dependency, exactly as at the top level.
 ## SEE ALSO
 
 * npm-shrinkwrap(1)
-* package-lock.json(5)
 * package.json(5)
 * npm-install(1)


### PR DESCRIPTION
The "see also" section in the [package-lock.json manpage](https://docs.npmjs.com/files/package-lock.json) links to itself.