### PR TITLE
prune: stop creating `package-lock.json`

### DIFF
--- a/lib/prune.js
+++ b/lib/prune.js
@@ -5,6 +5,7 @@ module.exports.Pruner = Pruner
 
 prune.usage = 'npm prune [[<@scope>/]<pkg>...] [--production]'
 
+var path = require('path')
 var npm = require('./npm.js')
 var log = require('npmlog')
 var util = require('util')
@@ -16,12 +17,16 @@ var removeDeps = require('./install/deps.js').removeDeps
 var loadExtraneous = require('./install/deps.js').loadExtraneous
 var chain = require('slide').chain
 var computeMetadata = require('./install/deps.js').computeMetadata
+var exists = require('./install/exists.js')
 
 prune.completion = require('./utils/completion/installed-deep.js')
 
 function prune (args, cb) {
-  var dryrun = !!npm.config.get('dry-run')
-  new Pruner('.', dryrun, args).run(cb)
+  exists(path.join(npm.localPrefix, 'package-lock.json'), function (e) {
+    if (e) npm.config.set('save', false)
+    var dryrun = !!npm.config.get('dry-run')
+    new Pruner('.', dryrun, args).run(cb)
+  })
 }
 
 function Pruner (where, dryrun, args) {


### PR DESCRIPTION
A package-lock.json file was created when `npm prune` is executed, and it deleted the existed dependencies/devDependencies. `npm prune` shouldn not touch `package-lock.json` from the first.

related issues:
+ https://github.com/npm/npm/issues/17061
+ https://github.com/npm/npm/issues/17068