### PR TITLE
Docs: Remove note about prepublish not being run

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -70,11 +70,6 @@ allow users to avoid the confusing behavior of existing npm versions and only
 run on `npm publish` (for instance, running the tests one last time to ensure
 they're in good shape).
 
-**IMPORTANT:** As of `npm@5`, `prepublish` will _only_ be run for `npm
-publish`.  This will make its behavior identical to `prepublishOnly`, so
-`npm@6` or later may drop support for the use of `prepublishOnly`, and then
-maybe we can all forget this embarrassing thing ever happened.
-
 See <https://github.com/npm/npm/issues/10074> for a much lengthier
 justification, with further reading, for this change.
 


### PR DESCRIPTION
See #16685

Removing the following note from the [docs](https://docs.npmjs.com/misc/scripts) as the described change is not actually correct.
> IMPORTANT: As of npm@5, prepublish will only be run for npm publish. This will make its behavior identical to prepublishOnly, so npm@6 or later may drop support for the use of prepublishOnly, and then maybe we can all forget this embarrassing thing ever happened.

Follows the change in https://github.com/npm/npm/pull/16918.