### PR TITLE
Warn if running `npm build` without args and with a build script

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -43,14 +43,19 @@ function build (args, global, didPre, didRB, cb) {
     global = npm.config.get('global')
   }
 
-  // it'd be nice to asyncMap these, but actually, doing them
-  // in parallel generally munges up the output from node-waf
-  var builder = build_(global, didPre, didRB)
-  chain(args.map(function (arg) {
-    return function (cb) {
-      builder(arg, cb)
+  readJson(path.resolve(npm.localPrefix, 'package.json'), function (er, pkg) {
+    if (!args.length && pkg && pkg.scripts && pkg.scripts.build) {
+      log.warn('build', '`npm build` called with no arguments. Did you mean to `npm run-script build`?')
     }
-  }), cb)
+    // it'd be nice to asyncMap these, but actually, doing them
+    // in parallel generally munges up the output from node-waf
+    var builder = build_(global, didPre, didRB)
+    chain(args.map(function (arg) {
+      return function (cb) {
+        builder(arg, cb)
+      }
+    }), cb)
+  })
 }
 
 function build_ (global, didPre, didRB) {


### PR DESCRIPTION
If a user mistakenly shorthands `npm build` for `npm run build` then they currently get no output or information since `npm build` without arguments is a no-op.

If `npm build` is called without arguments when a `build` script is defined in the package.json `scripts` section then output a warning message to indicate this.

See https://github.com/npm/npm/issues/3927