### PR TITLE
Change default `npm init` license to MIT

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -156,7 +156,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'init-author-email': '',
     'init-author-url': '',
     'init-version': '1.0.0',
-    'init-license': 'ISC',
+    'init-license': 'MIT',
     json: false,
     key: null,
     'legacy-bundling': false,


### PR DESCRIPTION
[See the issue here](https://github.com/npm/npm/issues/15845), this PR is changing the default license from ISC to MIT to match the clear user preferences and make developer's life easier.