### PR TITLE
15% speed up: avoid building environment for empty lifecycle scripts

### DIFF
--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -60,6 +60,8 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
     delete pkg.scripts.prepublish
   }
 
+  if (!pkg.scripts[stage]) return cb()
+
   validWd(wd || path.resolve(npm.dir, pkg.name), function (er, wd) {
     if (er) return cb(er)
 


### PR DESCRIPTION
Hello npm friends! Thanks again for everything you do! My second contribution to npm perf is alas, another one-liner. In my tests, this saves about 3 seconds on a run where 1800 modules are being installed, which is roughly 10-15% of the run.

It avoids building environment variables and checking working directories for non existent lifecycle scripts.

Please let me know if you have any questions.