### PR TITLE
Lock missing dep fixes

### DIFF
--- a/doc/spec/package-lock.md
+++ b/doc/spec/package-lock.md
@@ -36,7 +36,11 @@ property match that environment variable.
 
 ### dependencies
 
-A mapping of package name to dependency object.  Dependency objects have the
+These are the modules installed in the `node_modules`.  Some of these are
+dependencies some of these are transitive dependencies (that is,
+dependencies of our dependencies).
+
+This is a mapping of package name to dependency object.  Dependency objects have the
 following properties:
 
 #### version *(changed)*
@@ -108,9 +112,17 @@ on the current platform.
 This is a record of what specifier was used to originally install this
 package.  This should not be included in new `package-lock.json` files.
 
+#### requires
+
+This is a mapping of module name to version.  This is a list of everything
+this module requires, regardless of where it will be installed.  The version
+should match via normal matching rules a dependency either in our
+`dependencies` or in a level higher than us.
+
 #### dependencies
 
-The dependencies of this dependency, exactly as at the top level.
+Exactly like `dependencies` at the top level, this is a list of modules to
+isntall in the `node_modules` of this module.
 
 ## Generating
 

--- a/doc/spec/package-lock.md
+++ b/doc/spec/package-lock.md
@@ -28,15 +28,6 @@ The version of the package this is a package-lock for. This must match what's in
 An integer version, starting at `1` with the version number of this document
 whose semantics were used when generating this `package-lock.json`.
 
-### packageIntegrity *(new)*
-
-This is a
-[subresource integrity](https://w3c.github.io/webappsec/specs/subresourceintegrity/)
-value created from the `pacakge.json`. No preprocessing of the
-`package.json` should be done.  Subresource integrity strings can be
-produced by modules like
-[`ssri`](https://www.npmjs.com/package/ssri).
-
 ### preserveSymlinks *(new)*
 
 Indicates that the install was done with the environment variable

--- a/lib/install.js
+++ b/lib/install.js
@@ -208,7 +208,6 @@ function Installer (where, dryrun, args) {
   // the only exist when the tree does not match the lockfile
   // this is fine when doing full tree installs/updates but not ok when modifying only
   // a few deps via `npm install` or `npm uninstall`.
-  this.fakeChildren = true
   this.currentTree = null
   this.idealTree = null
   this.differences = []
@@ -325,7 +324,6 @@ Installer.prototype.run = function (_cb) {
 Installer.prototype.loadArgMetadata = function (next) {
   getAllMetadata(this.args, this.currentTree, process.cwd(), iferr(next, (args) => {
     this.args = args
-    if (args.length) this.fakeChildren = false
     next()
   }))
 }
@@ -422,14 +420,14 @@ Installer.prototype.loadAllDepsIntoIdealTree = function (cb) {
   var installNewModules = !!this.args.length
   var steps = []
 
-  const depsToPreload = Object.assign({},
-    this.dev ? this.idealTree.package.devDependencies : {},
-    this.prod ? this.idealTree.package.dependencies : {}
-  )
   if (installNewModules) {
     steps.push([validateArgs, this.idealTree, this.args])
     steps.push([loadRequestedDeps, this.args, this.idealTree, saveDeps, cg.newGroup('loadRequestedDeps')])
   } else {
+    const depsToPreload = Object.assign({},
+      this.dev ? this.idealTree.package.devDependencies : {},
+      this.prod ? this.idealTree.package.dependencies : {}
+    )
     if (this.prod || this.dev) {
       steps.push(
         [prefetchDeps, this.idealTree, depsToPreload, cg.newGroup('prefetchDeps')])
@@ -680,7 +678,7 @@ function isLink (child) {
 Installer.prototype.loadShrinkwrap = function (cb) {
   validate('F', arguments)
   log.silly('install', 'loadShrinkwrap')
-  readShrinkwrap.andInflate(this.idealTree, {fakeChildren: this.fakeChildren}, cb)
+  readShrinkwrap.andInflate(this.idealTree, cb)
 }
 
 Installer.prototype.getInstalledModules = function () {

--- a/lib/install.js
+++ b/lib/install.js
@@ -403,6 +403,7 @@ Installer.prototype.loadIdealTree = function (cb) {
 }
 
 Installer.prototype.pruneIdealTree = function (cb) {
+  if (!this.idealTree) return cb()
   // if our lock file didn't have the requires field and there
   // are any fake children then forgo pruning until we have more info.
   if (!this.idealTree.hasRequiresFromLock && this.idealTree.children.some((n) => n.fakeChild)) return cb()

--- a/lib/install.js
+++ b/lib/install.js
@@ -296,6 +296,7 @@ Installer.prototype.run = function (_cb) {
         // this is necessary as we don't fill in `dependencies` and `devDependencies` in deps loaded from shrinkwrap
         // until after we extract them
         [this, (next) => { computeMetadata(this.idealTree); next() }],
+        [this, this.pruneIdealTree],
         [this, this.saveToDependencies])
     }
   }
@@ -402,8 +403,11 @@ Installer.prototype.loadIdealTree = function (cb) {
 }
 
 Installer.prototype.pruneIdealTree = function (cb) {
+  // if our lock file didn't have the requires field and there
+  // are any fake children then forgo pruning until we have more info.
+  if (!this.idealTree.hasRequiresFromLock && this.idealTree.children.some((n) => n.fakeChild)) return cb()
   var toPrune = this.idealTree.children
-    .filter((n) => !n.fakeChild && isExtraneous(n))
+    .filter(isExtraneous)
     .map((n) => ({name: moduleName(n)}))
   return removeExtraneous(toPrune, this.idealTree, cb)
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -716,7 +716,13 @@ Installer.prototype.printInstalled = function (cb) {
   validate('F', arguments)
   if (this.failing) return cb()
   log.silly('install', 'printInstalled')
-  const diffs = this.differences.concat((this.idealTree.removedChildren || []).map((r) => ['remove', r]))
+  const diffs = this.differences
+  if (this.idealTree.removedChildren) {
+    this.idealTree.removedChildren.forEach((r) => {
+      if (diffs.some((d) => d[0] === 'remove' && d[1].path === r.path)) return
+      diffs.push(['remove', r])
+    })
+  }
   if (npm.config.get('json')) {
     return this.printInstalledForJSON(diffs, cb)
   } else if (npm.config.get('parseable')) {

--- a/lib/install/action/extract.js
+++ b/lib/install/action/extract.js
@@ -69,7 +69,7 @@ function extract (staging, pkg, log) {
     }
     launcher(msg, cb)
   }).then(() => {
-    if (pkg.package.bundleDependencies) {
+    if (pkg.package.bundleDependencies || anyBundled(pkg)) {
       return readBundled(pkg, staging, extractTo)
     }
   }).then(() => {
@@ -77,8 +77,14 @@ function extract (staging, pkg, log) {
   })
 }
 
+function anyBundled (top, pkg) {
+  if (!pkg) pkg = top
+  return pkg.children.some((child) => child.fromBundle === top || anyBundled(top, child))
+}
+
 function readBundled (pkg, staging, extractTo) {
   return BB.map(pkg.children, (child) => {
+    if (!child.fromBundle) return
     if (child.error) {
       throw child.error
     } else {

--- a/lib/install/action/refresh-package-json.js
+++ b/lib/install/action/refresh-package-json.js
@@ -22,6 +22,7 @@ module.exports = function (staging, pkg, log) {
     delete metadata.readmeFilename
 
     pkg.package = metadata
+    pkg.fakeChild = false
   }).catch(() => 'ignore').then(() => {
     const requested = pkg.package._requested || getRequested(pkg)
     if (requested.type !== 'directory') {

--- a/lib/install/action/refresh-package-json.js
+++ b/lib/install/action/refresh-package-json.js
@@ -10,7 +10,7 @@ module.exports = function (staging, pkg, log) {
 
   return readJson(path.join(pkg.path, 'package.json'), false).then((metadata) => {
     Object.keys(pkg.package).forEach(function (key) {
-      if (!isEmpty(pkg.package[key])) {
+      if (key !== 'dependencies' && !isEmpty(pkg.package[key])) {
         metadata[key] = pkg.package[key]
       }
     })

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -37,9 +37,6 @@ var getSaveType = require('./save.js').getSaveType
 var registryTypes = { range: true, version: true }
 
 function doesChildVersionMatch (child, requested, requestor) {
-  // we always consider deps provided by a shrinkwrap as "correct" or else
-  // we'll subvert them if they're intentionally "invalid"
-  if (child.parent === requestor && child.fromShrinkwrap) return true
   // ranges of * ALWAYS count as a match, because when downloading we allow
   // prereleases to match * if there are ONLY prereleases
   if (requested.type === 'range' && requested.fetchSpec === '*') return true
@@ -51,13 +48,9 @@ function doesChildVersionMatch (child, requested, requestor) {
 
   if (!registryTypes[requested.type]) {
     var childReq = child.package._requested
-    if (!childReq && child.package._from) {
-      childReq = npa.resolve(moduleName(child), child.package._from.replace(new RegExp('^' + moduleName(child) + '@'), ''))
-    }
     if (childReq) {
       if (childReq.rawSpec === requested.rawSpec) return true
       if (childReq.type === requested.type && childReq.saveSpec === requested.saveSpec) return true
-      if (childReq.type === requested.type && childReq.spec === requested.saveSpec) return true
     }
     // If _requested didn't exist OR if it didn't match then we'll try using
     // _from. We pass it through npa to normalize the specifier.
@@ -67,7 +60,7 @@ function doesChildVersionMatch (child, requested, requestor) {
     // really came from the same sources.
     // You'll see this scenario happen with at least tags and git dependencies.
     if (child.package._from) {
-      var fromReq = npa(child.package._from)
+      var fromReq = npa.resolve(moduleName(child), child.package._from.replace(new RegExp('^' + moduleName(child) + '@'), ''))
       if (fromReq.rawSpec === requested.rawSpec) return true
       if (fromReq.type === requested.type && fromReq.saveSpec && fromReq.saveSpec === requested.saveSpec) return true
     }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -37,6 +37,7 @@ var getSaveType = require('./save.js').getSaveType
 var registryTypes = { range: true, version: true }
 
 function doesChildVersionMatch (child, requested, requestor) {
+  if (child.fromShrinkwrap && !child.hasRequiresFromLock) return true
   // ranges of * ALWAYS count as a match, because when downloading we allow
   // prereleases to match * if there are ONLY prereleases
   if (requested.type === 'range' && requested.fetchSpec === '*') return true

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -104,8 +104,10 @@ function computeMetadata (tree, seen) {
   }
 
   const deps = tree.package.dependencies || {}
+  const reqs = tree.swRequires || {}
   for (let name of Object.keys(deps)) {
     if (findChild(name, deps[name])) continue
+    if (findChild(name, reqs[name])) continue
     tree.missingDeps[name] = deps[name]
   }
   if (tree.isTop) {
@@ -510,10 +512,14 @@ function addDependency (name, versionSpec, tree, log, done) {
   var next = andAddParentToErrors(tree, done)
   try {
     var req = childDependencySpecifier(tree, name, versionSpec)
+    if (tree.swRequires && tree.swRequires[name]) {
+      var swReq = childDependencySpecifier(tree, name, tree.swRequires[name])
+    }
   } catch (err) {
     return done(err)
   }
   var child = findRequirement(tree, name, req)
+  if (!child && swReq) child = findRequirement(tree, name, swReq)
   if (child) {
     resolveWithExistingModule(child, tree)
     if (child.package._shrinkwrap === undefined) {

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -612,7 +612,7 @@ function resolveWithNewModule (pkg, tree, log, next) {
       }
 
       if (pkg._shrinkwrap && pkg._shrinkwrap.dependencies) {
-        return inflateShrinkwrap(child, pkg._shrinkwrap.dependencies, function (er) {
+        return inflateShrinkwrap(child, pkg._shrinkwrap, function (er) {
           next(er, child, log)
         })
       }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -464,11 +464,6 @@ function loadDeps (tree, log, next) {
 exports.loadDevDeps = function (tree, log, next) {
   validate('OOF', arguments)
   if (!tree.package.devDependencies) return andFinishTracker.now(log, next)
-  // if any of our prexisting children are from a shrinkwrap then we skip
-  // loading dev deps as the shrinkwrap will already have provided them for us.
-  if (tree.children.some(function (child) { return child.shrinkwrapDev })) {
-    return andFinishTracker.now(log, next)
-  }
   asyncMap(Object.keys(tree.package.devDependencies), function (dep, done) {
     // things defined as both dev dependencies and regular dependencies are treated
     // as the former

--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -1,7 +1,10 @@
 'use strict'
+var npm = require('../npm.js')
 var validate = require('aproba')
 var npa = require('npm-package-arg')
 var flattenTree = require('./flatten-tree.js')
+var isOnlyDev = require('./is-only-dev.js')
+var log = require('npmlog')
 
 function nonRegistrySource (pkg) {
   validate('O', arguments)
@@ -146,9 +149,21 @@ var diffTrees = module.exports._diffTrees = function (oldTree, newTree) {
   })
   Object
     .keys(toRemove)
-    .map(function (path) { return toRemove[path] })
-    .forEach(function (pkg) {
-      setAction(differences, 'remove', pkg)
+    .map((path) => toRemove[path])
+    .forEach((pkg) => setAction(differences, 'remove', pkg))
+
+  const includeDev = npm.config.get('dev') ||
+    (!/^prod(uction)?$/.test(npm.config.get('only')) && !npm.config.get('production')) ||
+    /^dev(elopment)?$/.test(npm.config.get('only')) ||
+    /^dev(elopment)?$/.test(npm.config.get('also'))
+  const includeProd = !/^dev(elopment)?$/.test(npm.config.get('only'))
+  if (!includeProd || !includeDev) {
+    log.silly('diff-trees', 'filtering actions:', 'includeDev', includeDev, 'includeProd', includeProd)
+    differences = differences.filter((diff) => {
+      const pkg = diff[1]
+      const pkgIsOnlyDev = isOnlyDev(pkg)
+      return (!includeProd && pkgIsOnlyDev) || (includeDev && pkgIsOnlyDev) || (includeProd && !pkgIsOnlyDev)
     })
+  }
   return differences
 }

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -26,7 +26,7 @@ module.exports = function (tree, swdeps, opts, finishInflating) {
   if (!npm.config.get('shrinkwrap') || !npm.config.get('package-lock')) {
     return finishInflating()
   }
-  tree.loaded = true
+  tree.loaded = false
   tree.hasRequiresFromLock = Object.keys(swdeps).every((d) => swdeps[d].requires)
   return inflateShrinkwrap(tree.path, tree, swdeps, opts).then(
     () => finishInflating(),
@@ -168,7 +168,7 @@ function fetchChild (topPath, tree, sw, requested) {
     var isLink = pkg._requested.type === 'directory'
     const child = createChild({
       package: pkg,
-      loaded: true,
+      loaded: false,
       parent: tree,
       fromShrinkwrap: requested,
       path: childPath(tree.path, pkg),

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -88,7 +88,7 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     onDiskChild.swRequires = sw.requires
     tree.children.push(onDiskChild)
     return BB.resolve(onDiskChild)
-  } else if (opts.fakeChildren !== false && sw.version && sw.integrity) {
+  } else if (sw.version && sw.integrity) {
     // The shrinkwrap entry has an integrity field. We can fake a pkg to get
     // the installer to do a content-address fetch from the cache, if possible.
     return BB.resolve(makeFakeChild(name, topPath, tree, sw, requested))

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -114,34 +114,28 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
     _where: topPath,
     _args: [[requested.toString(), topPath]]
   }
-  let bundleAdded = BB.resolve()
-  if (Object.keys(sw.dependencies || {}).some((d) => {
-    return sw.dependencies[d].bundled
-  })) {
-    pkg.bundleDependencies = []
-    bundleAdded = addBundled(pkg)
-  }
-  return bundleAdded.then(() => {
-    const child = createChild({
-      package: pkg,
-      loaded: true,
-      parent: tree,
-      children: pkg._bundled || [],
-      fromShrinkwrap: true,
-      fakeChild: sw,
-      fromBundle: sw.bundled ? tree.fromBundle || tree : null,
-      path: childPath(tree.path, pkg),
-      realpath: childPath(tree.realpath, pkg),
-      location: tree.location + '/' + pkg.name,
-      isInLink: tree.isLink
-    })
-    tree.children.push(child)
-    if (pkg._bundled) {
-      delete pkg._bundled
-      inflateBundled(child, child, child.children)
+
+  if (!sw.bundled) {
+    const bundleDependencies = Object.keys(sw.dependencies || {}).filter((d) => sw.dependencies[d].bundled)
+    if (bundleDependencies.length === 0) {
+      pkg.bundleDependencies = bundleDependencies
     }
-    return child
+  }
+  const child = createChild({
+    package: pkg,
+    loaded: true,
+    parent: tree,
+    children: pkg._bundled || [],
+    fromShrinkwrap: true,
+    fakeChild: sw,
+    fromBundle: sw.bundled ? tree.fromBundle || tree : null,
+    path: childPath(tree.path, pkg),
+    realpath: childPath(tree.realpath, pkg),
+    location: tree.location + '/' + pkg.name,
+    isInLink: tree.isLink
   })
+  tree.children.push(child)
+  return child
 }
 
 function adaptResolved (requested, resolved) {

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -27,7 +27,7 @@ module.exports = function (tree, swdeps, opts, finishInflating) {
     return finishInflating()
   }
   tree.loaded = false
-  tree.hasRequiresFromLock = Object.keys(swdeps).every((d) => swdeps[d].requires)
+  tree.hasRequiresFromLock = Object.keys(swdeps).some((d) => swdeps[d].requires)
   return inflateShrinkwrap(tree.path, tree, swdeps, opts).then(
     () => finishInflating(),
     finishInflating

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -27,6 +27,7 @@ module.exports = function (tree, swdeps, opts, finishInflating) {
     return finishInflating()
   }
   tree.loaded = true
+  tree.hasRequiresFromLock = Object.keys(swdeps).every((d) => swdeps[d].requires)
   return inflateShrinkwrap(tree.path, tree, swdeps, opts).then(
     () => finishInflating(),
     finishInflating
@@ -47,15 +48,13 @@ function inflateShrinkwrap (topPath, tree, swdeps, opts) {
 
   return BB.each(Object.keys(swdeps), (name) => {
     const sw = swdeps[name]
-    if (
-      (!prod && !sw.dev) ||
-      (!dev && sw.dev)
-    ) { return null }
+    if ((!prod && !sw.dev) || (!dev && sw.dev)) return null
     const dependencies = sw.dependencies || {}
     const requested = realizeShrinkwrapSpecifier(name, sw, topPath)
     return inflatableChild(
       onDisk[name], name, topPath, tree, sw, requested, opts
     ).then((child) => {
+      child.hasRequiresFromLock = tree.hasRequiresFromLock
       return inflateShrinkwrap(topPath, child, dependencies)
     })
   })
@@ -86,6 +85,7 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     // normalization rules. This ensures we get package data in a consistent,
     // stable format.
     normalizePackageDataNoErrors(onDiskChild.package)
+    onDiskChild.swRequires = sw.requires
     tree.children.push(onDiskChild)
     return BB.resolve(onDiskChild)
   } else if (opts.fakeChildren !== false && sw.version && sw.integrity) {
@@ -112,7 +112,8 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
     _from: from,
     _spec: requested.rawSpec,
     _where: topPath,
-    _args: [[requested.toString(), topPath]]
+    _args: [[requested.toString(), topPath]],
+    dependencies: sw.requires
   }
 
   if (!sw.bundled) {
@@ -132,7 +133,8 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
     path: childPath(tree.path, pkg),
     realpath: childPath(tree.realpath, pkg),
     location: tree.location + '/' + pkg.name,
-    isInLink: tree.isLink
+    isInLink: tree.isLink,
+    swRequires: sw.requires
   })
   tree.children.push(child)
   return child
@@ -174,7 +176,8 @@ function fetchChild (topPath, tree, sw, requested) {
       children: pkg._bundled || [],
       location: tree.location + '/' + pkg.name,
       isLink: isLink,
-      isInLink: tree.isLink
+      isInLink: tree.isLink,
+      swRequires: sw.requires
     })
     tree.children.push(child)
     if (pkg._bundled) {

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -14,7 +14,7 @@ const realizeShrinkwrapSpecifier = require('./realize-shrinkwrap-specifier.js')
 const validate = require('aproba')
 const path = require('path')
 
-module.exports = function (tree, swdeps, opts, finishInflating) {
+module.exports = function (tree, sw, opts, finishInflating) {
   if (!fetchPackageMetadata) {
     fetchPackageMetadata = BB.promisify(require('../fetch-package-metadata.js'))
     addBundled = BB.promisify(fetchPackageMetadata.addBundled)
@@ -27,8 +27,8 @@ module.exports = function (tree, swdeps, opts, finishInflating) {
     return finishInflating()
   }
   tree.loaded = false
-  tree.hasRequiresFromLock = Object.keys(swdeps).some((d) => swdeps[d].requires)
-  return inflateShrinkwrap(tree.path, tree, swdeps, opts).then(
+  tree.hasRequiresFromLock = sw.requires
+  return inflateShrinkwrap(tree.path, tree, sw.dependencies, opts).then(
     () => finishInflating(),
     finishInflating
   )

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -105,6 +105,7 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
   const pkg = {
     name: name,
     version: sw.version,
+    _id: name + '@' + sw.version,
     _resolved: adaptResolved(requested, sw.resolved),
     _requested: requested,
     _optional: sw.optional,

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -85,7 +85,7 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     onDiskChild.swRequires = sw.requires
     tree.children.push(onDiskChild)
     return BB.resolve(onDiskChild)
-  } else if (sw.version && sw.integrity) {
+  } else if ((sw.version && sw.integrity) || sw.bundled) {
     // The shrinkwrap entry has an integrity field. We can fake a pkg to get
     // the installer to do a content-address fetch from the cache, if possible.
     return BB.resolve(makeFakeChild(name, topPath, tree, sw, requested))

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -70,11 +70,13 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
   if (onDiskChild && childIsEquivalent(sw, requested, onDiskChild)) {
     // The version on disk matches the shrinkwrap entry.
     if (!onDiskChild.fromShrinkwrap) onDiskChild.fromShrinkwrap = true
-    if (sw.dev) onDiskChild.shrinkwrapDev = true
     onDiskChild.package._requested = requested
     onDiskChild.package._spec = requested.rawSpec
     onDiskChild.package._where = topPath
-    onDiskChild.fromBundle = sw.bundled ? tree.fromBundle || tree : null
+    onDiskChild.package._optional = sw.optional
+    onDiskChild.package._development = sw.dev
+    onDiskChild.package._inBundle = sw.bundled
+    onDiskChild.fromBundle = (sw.bundled || onDiskChild.package._inBundle) ? tree.fromBundle || tree : null
     if (!onDiskChild.package._args) onDiskChild.package._args = []
     onDiskChild.package._args.push([String(requested), topPath])
     // non-npm registries can and will return unnormalized data, plus
@@ -106,6 +108,8 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
     _resolved: adaptResolved(requested, sw.resolved),
     _requested: requested,
     _optional: sw.optional,
+    _development: sw.dev,
+    _inBundle: sw.bundled,
     _integrity: sw.integrity,
     _from: from,
     _spec: requested.rawSpec,
@@ -156,11 +160,11 @@ function adaptResolved (requested, resolved) {
 }
 
 function fetchChild (topPath, tree, sw, requested) {
-  const from = sw.from || requested.raw
-  const optional = sw.optional
   return fetchPackageMetadata(requested, topPath).then((pkg) => {
-    pkg._from = from
-    pkg._optional = optional
+    pkg._from = sw.from || requested.raw
+    pkg._optional = sw.optional
+    pkg._development = sw.dev
+    pkg._inBundle = false
     return addBundled(pkg).then(() => pkg)
   }).then((pkg) => {
     var isLink = pkg._requested.type === 'directory'
@@ -173,6 +177,7 @@ function fetchChild (topPath, tree, sw, requested) {
       realpath: isLink ? requested.fetchSpec : childPath(tree.realpath, pkg),
       children: pkg._bundled || [],
       location: tree.location + '/' + pkg.name,
+      fromBundle: null,
       isLink: isLink,
       isInLink: tree.isLink,
       swRequires: sw.requires

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -41,14 +41,11 @@ function inflateShrinkwrap (topPath, tree, swdeps, opts) {
   tree.children.forEach((child) => {
     onDisk[moduleName(child)] = child
   })
-  const dev = npm.config.get('dev') || (!/^prod(uction)?$/.test(npm.config.get('only')) && !npm.config.get('production')) || /^dev(elopment)?$/.test(npm.config.get('only'))
-  const prod = !/^dev(elopment)?$/.test(npm.config.get('only'))
 
   tree.children = []
 
   return BB.each(Object.keys(swdeps), (name) => {
     const sw = swdeps[name]
-    if ((!prod && !sw.dev) || (!dev && sw.dev)) return null
     const dependencies = sw.dependencies || {}
     const requested = realizeShrinkwrapSpecifier(name, sw, topPath)
     return inflatableChild(
@@ -127,7 +124,7 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
     package: pkg,
     loaded: true,
     parent: tree,
-    children: pkg._bundled || [],
+    children: [],
     fromShrinkwrap: true,
     fakeChild: sw,
     fromBundle: sw.bundled ? tree.fromBundle || tree : null,

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -35,7 +35,7 @@ module.exports = function (tree, sw, opts, finishInflating) {
 }
 
 function inflateShrinkwrap (topPath, tree, swdeps, opts) {
-  validate('SOO|SOOO', arguments)
+  if (!swdeps) return Promise.resolve()
   if (!opts) opts = {}
   const onDisk = {}
   tree.children.forEach((child) => {

--- a/lib/install/is-only-dev.js
+++ b/lib/install/is-only-dev.js
@@ -1,0 +1,35 @@
+'use strict'
+module.exports = isOnlyDev
+
+const moduleName = require('../utils/module-name.js')
+const isDevDep = require('./is-dev-dep.js')
+const isProdDep = require('./is-prod-dep.js')
+
+// Returns true if the module `node` is only required direcctly as a dev
+// dependency of the top level or transitively _from_ top level dev
+// dependencies.
+// Dual mode modules (that are both dev AND prod) should return false.
+function isOnlyDev (node, seen) {
+  if (!seen) seen = {}
+  return node.requiredBy.length && node.requiredBy.every(andIsOnlyDev(moduleName(node), seen))
+}
+
+// There is a known limitation with this implementation: If a dependency is
+// ONLY required by cycles that are detached from the top level then it will
+// ultimately return true.
+//
+// This is ok though: We don't allow shrinkwraps with extraneous deps and
+// these situation is caught by the extraneous checker before we get here.
+function andIsOnlyDev (name, seen) {
+  return function (req) {
+    const isDev = isDevDep(req, name)
+    const isProd = isProdDep(req, name)
+    if (req.isTop) {
+      return isDev && !isProd
+    } else {
+      if (seen[req.path]) return true
+      seen[req.path] = true
+      return isOnlyDev(req, seen)
+    }
+  }
+}

--- a/lib/install/is-only-optional.js
+++ b/lib/install/is-only-optional.js
@@ -1,0 +1,18 @@
+'use strict'
+module.exports = isOptional
+
+const isOptDep = require('./is-opt-dep.js')
+
+function isOptional (node, seen) {
+  if (!seen) seen = {}
+  // If a node is not required by anything, then we've reached
+  // the top level package.
+  if (seen[node.path] || node.requiredBy.length === 0) {
+    return false
+  }
+  seen[node.path] = true
+
+  return node.requiredBy.every(function (req) {
+    return isOptDep(req, node.package.name) || isOptional(req, seen)
+  })
+}

--- a/lib/install/mutate-into-logical-tree.js
+++ b/lib/install/mutate-into-logical-tree.js
@@ -81,7 +81,12 @@ function translateTree_ (tree, seen) {
   pkg._dependencies = pkg.dependencies
   pkg.dependencies = {}
   tree.children.forEach(function (child) {
-    pkg.dependencies[moduleName(child)] = translateTree_(child, seen)
+    const dep = pkg.dependencies[moduleName(child)] = translateTree_(child, seen)
+    if (child.fakeChild) {
+      dep.missing = true
+      dep.optional = child.package._optional
+      dep.requiredBy = child.package._spec
+    }
   })
 
   function markMissing (name, requiredBy) {

--- a/lib/install/node.js
+++ b/lib/install/node.js
@@ -48,9 +48,7 @@ var create = exports.create = function (node, template, isNotTop) {
       node.isLink = false
       node.isInLink = false
     }
-    if (node.fromBundle == null && node.package) {
-      node.fromBundle = node.package._inBundle
-    } else if (node.fromBundle == null) {
+    if (node.fromBundle == null) {
       node.fromBundle = false
     }
   }

--- a/lib/install/read-shrinkwrap.js
+++ b/lib/install/read-shrinkwrap.js
@@ -47,14 +47,10 @@ function maybeReadFile (name, child) {
   ).catch({code: 'ENOENT'}, () => null)
 }
 
-module.exports.andInflate = function (child, opts, next) {
-  if (arguments.length === 2) {
-    next = opts
-    opts = {}
-  }
+module.exports.andInflate = function (child, next) {
   readShrinkwrap(child, iferr(next, function () {
     if (child.package._shrinkwrap) {
-      return inflateShrinkwrap(child, child.package._shrinkwrap.dependencies || {}, opts, next)
+      return inflateShrinkwrap(child, child.package._shrinkwrap.dependencies || {}, next)
     } else {
       return next()
     }

--- a/lib/install/read-shrinkwrap.js
+++ b/lib/install/read-shrinkwrap.js
@@ -50,7 +50,7 @@ function maybeReadFile (name, child) {
 module.exports.andInflate = function (child, next) {
   readShrinkwrap(child, iferr(next, function () {
     if (child.package._shrinkwrap) {
-      return inflateShrinkwrap(child, child.package._shrinkwrap.dependencies || {}, next)
+      return inflateShrinkwrap(child, child.package._shrinkwrap || {}, next)
     } else {
       return next()
     }

--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -77,8 +77,8 @@ function savePackageJson (tree, next) {
     var toSave = getThingsToSave(tree)
     var toRemove = getThingsToRemove(tree)
     var savingTo = {}
-    toSave.forEach(function (pkg) { savingTo[pkg.save] = true })
-    toRemove.forEach(function (pkg) { savingTo[pkg.save] = true })
+    toSave.forEach(function (pkg) { if (pkg.save) savingTo[pkg.save] = true })
+    toRemove.forEach(function (pkg) { if (pkg.save) savingTo[pkg.save] = true })
 
     Object.keys(savingTo).forEach(function (save) {
       if (!tree.package[save]) tree.package[save] = {}
@@ -87,7 +87,7 @@ function savePackageJson (tree, next) {
     log.verbose('saving', toSave)
     const types = ['dependencies', 'devDependencies', 'optionalDependencies']
     toSave.forEach(function (pkg) {
-      tree.package[pkg.save][pkg.name] = pkg.spec
+      if (pkg.save) tree.package[pkg.save][pkg.name] = pkg.spec
       const movedFrom = []
       for (let saveType of types) {
         if (
@@ -109,7 +109,7 @@ function savePackageJson (tree, next) {
     })
 
     toRemove.forEach(function (pkg) {
-      delete tree.package[pkg.save][pkg.name]
+      if (pkg.save) delete tree.package[pkg.save][pkg.name]
       if (saveBundle) {
         bundle = without(bundle, pkg.name)
       }

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -13,12 +13,12 @@ var archy = require('archy')
 var semver = require('semver')
 var color = require('ansicolors')
 var npa = require('npm-package-arg')
-var iferr = require('iferr')
 var sortedObject = require('sorted-object')
 var extend = Object.assign || require('util')._extend
 var npm = require('./npm.js')
 var mutateIntoLogicalTree = require('./install/mutate-into-logical-tree.js')
 var computeMetadata = require('./install/deps.js').computeMetadata
+var readShrinkwrap = require('./install/read-shrinkwrap.js')
 var packageId = require('./utils/package-id.js')
 var usage = require('./utils/usage')
 var output = require('./utils/output.js')
@@ -36,15 +36,13 @@ function ls (args, silent, cb) {
     silent = false
   }
   var dir = path.resolve(npm.dir, '..')
-  readPackageTree(dir, andComputeMetadata(iferr(cb, function (physicalTree) {
-    lsFromTree(dir, physicalTree, args, silent, cb)
-  })))
-}
-
-function andComputeMetadata (next) {
-  return function (er, tree) {
-    next(null, computeMetadata(tree || {}))
-  }
+  readPackageTree(dir, function (_, physicalTree) {
+    if (!physicalTree) physicalTree = {package: {}, path: dir}
+    physicalTree.isTop = true
+    readShrinkwrap.andInflate(physicalTree, {fakeChildren: true}, function () {
+      lsFromTree(dir, computeMetadata(physicalTree), args, silent, cb)
+    })
+  })
 }
 
 function inList (list, value) {
@@ -224,7 +222,11 @@ function getLite (data, noname, depth) {
             ', required by ' +
             packageId(data)
         lite.problems.push(p)
-        return [d, { required: dep.requiredBy, missing: true }]
+        if (dep.dependencies) {
+          return [d, getLite(dep, true)]
+        } else {
+          return [d, { required: dep.requiredBy, missing: true }]
+        }
       } else if (dep.peerMissing) {
         lite.problems = lite.problems || []
         dep.peerMissing.forEach(function (missing) {
@@ -262,7 +264,7 @@ function unloop (root) {
     var deps = current.dependencies = current.dependencies || {}
     Object.keys(deps).forEach(function (d) {
       var dep = deps[d]
-      if (dep.missing) return
+      if (dep.missing && !dep.dependencies) return
       if (dep.path && seen[dep.path]) {
         dep = deps[d] = extend({}, dep)
         dep.dependencies = {}
@@ -353,11 +355,26 @@ function makeArchy_ (data, long, dir, depth, parent, d) {
           unmet = color.bgBlack(color.red(unmet))
         }
       }
-      data = unmet + ' ' + d + '@' + data.requiredBy
+      var label = data._id || (d + '@' + data.requiredBy)
+      if (data._found === 'explicit' && data._id) {
+        if (npm.color) {
+          label = color.bgBlack(color.yellow(label.trim())) + ' '
+        } else {
+          label = label.trim() + ' '
+        }
+      }
+      return {
+        label: unmet + ' ' + label,
+        nodes: Object.keys(data.dependencies || {})
+          .sort(alphasort).filter(function (d) {
+            return !isCruft(data.dependencies[d])
+          }).map(function (d) {
+            return makeArchy_(sortedObject(data.dependencies[d]), long, dir, depth + 1, data, d)
+          })
+      }
     } else {
-      data = d + '@' + data.requiredBy
+      return {label: d + '@' + data.requiredBy}
     }
-    return data
   }
 
   var out = {}

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -39,7 +39,7 @@ function ls (args, silent, cb) {
   readPackageTree(dir, function (_, physicalTree) {
     if (!physicalTree) physicalTree = {package: {}, path: dir}
     physicalTree.isTop = true
-    readShrinkwrap.andInflate(physicalTree, {fakeChildren: true}, function () {
+    readShrinkwrap.andInflate(physicalTree, function () {
       lsFromTree(dir, computeMetadata(physicalTree), args, silent, cb)
     })
   })

--- a/lib/prune.js
+++ b/lib/prune.js
@@ -26,7 +26,6 @@ function prune (args, cb) {
 
 function Pruner (where, dryrun, args) {
   Installer.call(this, where, dryrun, args)
-  this.fakeChildren = false
 }
 util.inherits(Pruner, Installer)
 

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -127,11 +127,13 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     }
     if (childIsOnlyDev) pkginfo.dev = true
     if (isOptional(child)) pkginfo.optional = true
-    pkginfo.requires = {}
-    child.requires.sort((a, b) => moduleName(a).localeCompare(moduleName(b))).forEach((required) => {
-      var requested = required.package._requested || getRequested(required) || {}
-      pkginfo.requires[moduleName(required)] = childVersion(top, required, requested)
-    })
+    if (child.requires.length) {
+      pkginfo.requires = {}
+      child.requires.sort((a, b) => moduleName(a).localeCompare(moduleName(b))).forEach((required) => {
+        var requested = required.package._requested || getRequested(required) || {}
+        pkginfo.requires[moduleName(required)] = childVersion(top, required, requested)
+      })
+    }
     if (child.children.length) {
       pkginfo.dependencies = {}
       shrinkwrapDeps(pkginfo.dependencies, top, child, seen)

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -101,30 +101,24 @@ function shrinkwrapDeps (deps, top, tree, seen) {
   if (seen[tree.path]) return
   seen[tree.path] = true
   tree.children.sort(function (aa, bb) { return moduleName(aa).localeCompare(moduleName(bb)) }).forEach(function (child) {
-    var childIsOnlyDev = isOnlyDev(child)
     if (child.fakeChild) {
       deps[moduleName(child)] = child.fakeChild
       return
     }
+    var childIsOnlyDev = isOnlyDev(child)
     var pkginfo = deps[moduleName(child)] = {}
-    var req = child.package._requested || getRequested(child) || {}
-    if (req.type === 'directory' || req.type === 'file') {
-      pkginfo.version = 'file:' + path.relative(top.path, child.package._resolved || req.fetchSpec)
-    } else if (!req.registry && !child.fromBundle) {
-      pkginfo.version = child.package._resolved || req.saveSpec || req.rawSpec
-    } else {
-      pkginfo.version = child.package.version
-    }
+    var requested = child.package._requested || getRequested(child) || {}
+    pkginfo.version = childVersion(top, child, requested)
     if (child.fromBundle || child.isInLink) {
       pkginfo.bundled = true
     } else {
-      if (req.registry) {
+      if (requested.registry) {
         pkginfo.resolved = child.package._resolved
       }
       // no integrity for git deps as integirty hashes are based on the
       // tarball and we can't (yet) create consistent tarballs from a stable
       // source.
-      if (req.type !== 'git') {
+      if (requested.type !== 'git') {
         pkginfo.integrity = child.package._integrity
         if (!pkginfo.integrity && child.package._shasum) {
           pkginfo.integrity = ssri.fromHex(child.package._shasum, 'sha1')
@@ -133,11 +127,26 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     }
     if (childIsOnlyDev) pkginfo.dev = true
     if (isOptional(child)) pkginfo.optional = true
+    pkginfo.requires = {}
+    child.requires.sort((a, b) => moduleName(a).localeCompare(moduleName(b))).forEach((required) => {
+      var requested = required.package._requested || getRequested(required) || {}
+      pkginfo.requires[moduleName(required)] = childVersion(top, required, requested)
+    })
     if (child.children.length) {
       pkginfo.dependencies = {}
       shrinkwrapDeps(pkginfo.dependencies, top, child, seen)
     }
   })
+}
+
+function childVersion (top, child, req) {
+  if (req.type === 'directory' || req.type === 'file') {
+    return 'file:' + path.relative(top.path, child.package._resolved || req.fetchSpec)
+  } else if (!req.registry && !child.fromBundle) {
+    return child.package._resolved || req.saveSpec || req.rawSpec
+  } else {
+    return child.package.version
+  }
 }
 
 function shrinkwrap_ (dir, pkginfo, opts, cb) {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -90,6 +90,7 @@ function treeToShrinkwrap (tree) {
   if (tree.package.name) pkginfo.name = tree.package.name
   if (tree.package.version) pkginfo.version = tree.package.version
   if (tree.children.length) {
+    pkginfo.requires = true
     shrinkwrapDeps(pkginfo.dependencies = {}, tree, tree)
   }
   return pkginfo

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -8,9 +8,8 @@ const readFile = BB.promisify(require('graceful-fs').readFile)
 const getRequested = require('./install/get-requested.js')
 const id = require('./install/deps.js')
 const iferr = require('iferr')
-const isDevDep = require('./install/is-dev-dep.js')
-const isOptDep = require('./install/is-opt-dep.js')
-const isProdDep = require('./install/is-prod-dep.js')
+const isOnlyOptional = require('./install/is-only-optional.js')
+const isOnlyDev = require('./install/is-only-dev.js')
 const lifecycle = require('./utils/lifecycle.js')
 const log = require('npmlog')
 const moduleName = require('./utils/module-name.js')
@@ -127,7 +126,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
       }
     }
     if (childIsOnlyDev) pkginfo.dev = true
-    if (isOptional(child)) pkginfo.optional = true
+    if (isOnlyOptional(child)) pkginfo.optional = true
     if (child.requires.length) {
       pkginfo.requires = {}
       child.requires.sort((a, b) => moduleName(a).localeCompare(moduleName(b))).forEach((required) => {
@@ -241,45 +240,3 @@ function checkPackageFile (dir, name) {
   }).catch({code: 'ENOENT'}, () => {})
 }
 
-// Returns true if the module `node` is only required direcctly as a dev
-// dependency of the top level or transitively _from_ top level dev
-// dependencies.
-// Dual mode modules (that are both dev AND prod) should return false.
-function isOnlyDev (node, seen) {
-  if (!seen) seen = {}
-  return node.requiredBy.length && node.requiredBy.every(andIsOnlyDev(moduleName(node), seen))
-}
-
-// There is a known limitation with this implementation: If a dependency is
-// ONLY required by cycles that are detached from the top level then it will
-// ultimately return true.
-//
-// This is ok though: We don't allow shrinkwraps with extraneous deps and
-// these situation is caught by the extraneous checker before we get here.
-function andIsOnlyDev (name, seen) {
-  return function (req) {
-    var isDev = isDevDep(req, name)
-    var isProd = isProdDep(req, name)
-    if (req.isTop) {
-      return isDev && !isProd
-    } else {
-      if (seen[req.path]) return true
-      seen[req.path] = true
-      return isOnlyDev(req, seen)
-    }
-  }
-}
-
-function isOptional (node, seen) {
-  if (!seen) seen = {}
-  // If a node is not required by anything, then we've reached
-  // the top level package.
-  if (seen[node.path] || node.requiredBy.length === 0) {
-    return false
-  }
-  seen[node.path] = true
-
-  return node.requiredBy.every(function (req) {
-    return isOptDep(req, node.package.name) || isOptional(req, seen)
-  })
-}

--- a/lib/uninstall.js
+++ b/lib/uninstall.js
@@ -52,7 +52,6 @@ class Uninstaller extends Installer {
   constructor (where, dryrun, args) {
     super(where, dryrun, args)
     this.remove = []
-    this.fakeChildren = false
   }
 
   loadArgMetadata (next) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "npm",
   "version": "5.0.4",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -42,11 +43,30 @@
       "version": "9.2.9",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz",
       "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
+      "requires": {
+        "bluebird": "3.5.0",
+        "chownr": "1.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lru-cache": "4.1.1",
+        "mississippi": "1.3.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.1",
+        "ssri": "4.1.6",
+        "unique-filename": "1.1.0",
+        "y18n": "3.2.1"
+      },
       "dependencies": {
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          },
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
@@ -80,17 +100,28 @@
     "cmd-shim": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-      "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s="
+      "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1"
+      }
     },
     "columnify": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
       "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+      "requires": {
+        "strip-ansi": "3.0.1",
+        "wcwidth": "1.0.1"
+      },
       "dependencies": {
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          },
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
@@ -103,11 +134,17 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
           "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+          "requires": {
+            "defaults": "1.0.3"
+          },
           "dependencies": {
             "defaults": {
               "version": "1.0.3",
               "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
               "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+              "requires": {
+                "clone": "1.0.2"
+              },
               "dependencies": {
                 "clone": {
                   "version": "1.0.2",
@@ -124,6 +161,10 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "requires": {
+        "ini": "1.3.4",
+        "proto-list": "1.2.4"
+      },
       "dependencies": {
         "proto-list": {
           "version": "1.2.4",
@@ -152,6 +193,10 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "requires": {
+        "asap": "2.0.5",
+        "wrappy": "1.0.2"
+      },
       "dependencies": {
         "asap": {
           "version": "2.0.5",
@@ -168,37 +213,70 @@
     "fs-vacuum": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
-      "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY="
+      "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "path-is-inside": "1.0.2",
+        "rimraf": "2.6.1"
+      }
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk="
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.2"
+      }
     },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1"
+      }
     },
     "fstream-npm": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz",
       "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
+      "requires": {
+        "fstream-ignore": "1.0.5",
+        "inherits": "2.0.3"
+      },
       "dependencies": {
         "fstream-ignore": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          },
           "dependencies": {
             "minimatch": {
               "version": "3.0.4",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "requires": {
+                "brace-expansion": "1.1.8"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                   "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -222,6 +300,14 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      },
       "dependencies": {
         "fs.realpath": {
           "version": "1.0.0",
@@ -232,11 +318,18 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          },
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.8",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
               "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              },
               "dependencies": {
                 "balanced-match": {
                   "version": "1.0.0",
@@ -287,7 +380,11 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -303,11 +400,24 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
       "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
+      "requires": {
+        "glob": "7.1.2",
+        "npm-package-arg": "5.1.2",
+        "promzard": "0.3.0",
+        "read": "1.0.7",
+        "read-package-json": "2.0.9",
+        "semver": "5.3.0",
+        "validate-npm-package-license": "3.0.1",
+        "validate-npm-package-name": "3.0.0"
+      },
       "dependencies": {
         "promzard": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4="
+          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+          "requires": {
+            "read": "1.0.7"
+          }
         }
       }
     },
@@ -315,6 +425,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
       "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      },
       "dependencies": {
         "jsonparse": {
           "version": "1.3.1",
@@ -347,6 +461,10 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
       "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
+      "requires": {
+        "lodash._createset": "4.0.3",
+        "lodash._root": "3.0.1"
+      },
       "dependencies": {
         "lodash._createset": {
           "version": "4.0.3",
@@ -373,7 +491,10 @@
     "lodash._createcache": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM="
+      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+      "requires": {
+        "lodash._getnative": "3.9.1"
+      }
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -409,6 +530,10 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      },
       "dependencies": {
         "pseudomap": {
           "version": "1.0.2",
@@ -432,17 +557,37 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/marked-man/-/marked-man-0.2.1.tgz",
       "integrity": "sha1-8lknFIHeO1ByY0ifUiG3xaz9I4M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "marked": "0.3.6"
+      }
     },
     "mississippi": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
       "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "duplexify": "3.5.0",
+        "end-of-stream": "1.4.0",
+        "flush-write-stream": "1.0.2",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "1.0.2",
+        "pumpify": "1.3.5",
+        "stream-each": "1.2.0",
+        "through2": "2.0.3"
+      },
       "dependencies": {
         "concat-stream": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.2",
+            "typedarray": "0.0.6"
+          },
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
@@ -455,16 +600,28 @@
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
           "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+          "requires": {
+            "end-of-stream": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.2",
+            "stream-shift": "1.0.0"
+          },
           "dependencies": {
             "end-of-stream": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
               "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+              "requires": {
+                "once": "1.3.3"
+              },
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  }
                 }
               }
             },
@@ -478,22 +635,38 @@
         "end-of-stream": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY="
+          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+          "requires": {
+            "once": "1.4.0"
+          }
         },
         "flush-write-stream": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
-          "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc="
+          "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.2"
+          }
         },
         "from2": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8="
+          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.2"
+          }
         },
         "parallel-transform": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
           "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+          "requires": {
+            "cyclist": "0.2.2",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.2"
+          },
           "dependencies": {
             "cyclist": {
               "version": "0.2.2",
@@ -505,17 +678,30 @@
         "pump": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-          "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE="
+          "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+          "requires": {
+            "end-of-stream": "1.4.0",
+            "once": "1.4.0"
+          }
         },
         "pumpify": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
-          "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs="
+          "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+          "requires": {
+            "duplexify": "3.5.0",
+            "inherits": "2.0.3",
+            "pump": "1.0.2"
+          }
         },
         "stream-each": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
           "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
+          "requires": {
+            "end-of-stream": "1.4.0",
+            "stream-shift": "1.0.0"
+          },
           "dependencies": {
             "stream-shift": {
               "version": "1.0.0",
@@ -528,6 +714,10 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "requires": {
+            "readable-stream": "2.3.2",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "xtend": {
               "version": "4.0.1",
@@ -542,6 +732,9 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -554,16 +747,35 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "requires": {
+        "aproba": "1.1.2",
+        "copy-concurrently": "1.0.3",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
+        "run-queue": "1.0.3"
+      },
       "dependencies": {
         "copy-concurrently": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz",
-          "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA="
+          "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
+          "requires": {
+            "aproba": "1.1.2",
+            "fs-write-stream-atomic": "1.0.10",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "run-queue": "1.0.3"
+          }
         },
         "run-queue": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec="
+          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+          "requires": {
+            "aproba": "1.1.2"
+          }
         }
       }
     },
@@ -571,16 +783,38 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+      "requires": {
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.4",
+        "request": "2.81.0",
+        "rimraf": "2.6.1",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.2.14"
+      },
       "dependencies": {
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          },
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.8",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
               "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              },
               "dependencies": {
                 "balanced-match": {
                   "version": "1.0.0",
@@ -599,24 +833,40 @@
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "requires": {
+            "abbrev": "1.1.0"
+          }
         }
       }
     },
     "nopt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00="
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1.1.0",
+        "osenv": "0.1.4"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.3.0",
+        "validate-npm-package-license": "3.0.1"
+      },
       "dependencies": {
         "is-builtin-module": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "requires": {
+            "builtin-modules": "1.1.1"
+          },
           "dependencies": {
             "builtin-modules": {
               "version": "1.1.1",
@@ -635,22 +885,49 @@
     "npm-install-checks": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
-      "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc="
+      "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
+      "requires": {
+        "semver": "5.3.0"
+      }
     },
     "npm-package-arg": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
-      "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA=="
+      "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "osenv": "0.1.4",
+        "semver": "5.3.0",
+        "validate-npm-package-name": "3.0.0"
+      }
     },
     "npm-registry-client": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.4.0.tgz",
       "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "graceful-fs": "4.1.11",
+        "normalize-package-data": "2.4.0",
+        "npm-package-arg": "5.1.2",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "request": "2.81.0",
+        "retry": "0.10.1",
+        "semver": "5.3.0",
+        "slide": "1.1.6",
+        "ssri": "4.1.6"
+      },
       "dependencies": {
         "concat-stream": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.2",
+            "typedarray": "0.0.6"
+          },
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
@@ -666,12 +943,26 @@
       "resolved": "https://registry.npmjs.org/npm-registry-couchapp/-/npm-registry-couchapp-2.6.13.tgz",
       "integrity": "sha512-U3B4J3oMQqQVZhl4GE3LOxv+ZlOjtXg/HVUkwiS8HowdJCPTzIjNjM0u3W6sG4SYqiKqW2GbQBylSrsUKxA7IA==",
       "dev": true,
+      "requires": {
+        "couchapp": "0.11.0",
+        "json": "9.0.6",
+        "semver": "4.3.6"
+      },
       "dependencies": {
         "couchapp": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/couchapp/-/couchapp-0.11.0.tgz",
           "integrity": "sha1-8J3DFdYQ9vbnn9DK9eXWJLDMeD4=",
           "dev": true,
+          "requires": {
+            "coffee-script": "1.12.6",
+            "connect": "3.6.2",
+            "http-proxy": "0.8.7",
+            "nano": "6.3.0",
+            "request": "2.81.0",
+            "url": "0.11.0",
+            "watch": "0.8.0"
+          },
           "dependencies": {
             "coffee-script": {
               "version": "1.12.6",
@@ -684,12 +975,21 @@
               "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.2.tgz",
               "integrity": "sha1-aU6NIGgb/kkCgsiriGvpjwn0L+c=",
               "dev": true,
+              "requires": {
+                "debug": "2.6.7",
+                "finalhandler": "1.0.3",
+                "parseurl": "1.3.1",
+                "utils-merge": "1.0.0"
+              },
               "dependencies": {
                 "debug": {
                   "version": "2.6.7",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
                   "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
                   "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
@@ -704,6 +1004,15 @@
                   "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
                   "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
                   "dev": true,
+                  "requires": {
+                    "debug": "2.6.7",
+                    "encodeurl": "1.0.1",
+                    "escape-html": "1.0.3",
+                    "on-finished": "2.3.0",
+                    "parseurl": "1.3.1",
+                    "statuses": "1.3.1",
+                    "unpipe": "1.0.0"
+                  },
                   "dependencies": {
                     "encodeurl": {
                       "version": "1.0.1",
@@ -722,6 +1031,9 @@
                       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
                       "dev": true,
+                      "requires": {
+                        "ee-first": "1.1.1"
+                      },
                       "dependencies": {
                         "ee-first": {
                           "version": "1.1.1",
@@ -758,6 +1070,11 @@
               "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.7.tgz",
               "integrity": "sha1-p7xThhgJLNJu0ZHkYlkzuu9t6A4=",
               "dev": true,
+              "requires": {
+                "colors": "0.6.2",
+                "optimist": "0.3.7",
+                "pkginfo": "0.2.3"
+              },
               "dependencies": {
                 "colors": {
                   "version": "0.6.2",
@@ -770,6 +1087,9 @@
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
                   "dev": true,
+                  "requires": {
+                    "wordwrap": "0.0.3"
+                  },
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.3",
@@ -792,12 +1112,22 @@
               "resolved": "https://registry.npmjs.org/nano/-/nano-6.3.0.tgz",
               "integrity": "sha1-qcu9giWb/NdDAloqosAWVvbhEeE=",
               "dev": true,
+              "requires": {
+                "debug": "2.6.8",
+                "errs": "0.3.2",
+                "follow": "0.12.1",
+                "request": "2.81.0",
+                "underscore": "1.8.3"
+              },
               "dependencies": {
                 "debug": {
                   "version": "2.6.8",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                   "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                   "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
@@ -818,6 +1148,11 @@
                   "resolved": "https://registry.npmjs.org/follow/-/follow-0.12.1.tgz",
                   "integrity": "sha1-LA76u82RYTsLtzgmQPOQ7ejKuVg=",
                   "dev": true,
+                  "requires": {
+                    "browser-request": "0.3.3",
+                    "debug": "2.6.8",
+                    "request": "2.55.0"
+                  },
                   "dependencies": {
                     "browser-request": {
                       "version": "0.3.3",
@@ -830,6 +1165,26 @@
                       "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
                       "integrity": "sha1-11wc32eddrsQD5v/4f5VG1wk6T0=",
                       "dev": true,
+                      "requires": {
+                        "aws-sign2": "0.5.0",
+                        "bl": "0.9.5",
+                        "caseless": "0.9.0",
+                        "combined-stream": "0.0.7",
+                        "forever-agent": "0.6.1",
+                        "form-data": "0.2.0",
+                        "har-validator": "1.8.0",
+                        "hawk": "2.3.1",
+                        "http-signature": "0.10.1",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.0.14",
+                        "node-uuid": "1.4.8",
+                        "oauth-sign": "0.6.0",
+                        "qs": "2.4.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.4.3"
+                      },
                       "dependencies": {
                         "aws-sign2": {
                           "version": "0.5.0",
@@ -842,12 +1197,21 @@
                           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                           "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
                           "dev": true,
+                          "requires": {
+                            "readable-stream": "1.0.34"
+                          },
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.34",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                               "dev": true,
+                              "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                              },
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
@@ -882,6 +1246,9 @@
                           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                           "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
                           "dev": true,
+                          "requires": {
+                            "delayed-stream": "0.0.5"
+                          },
                           "dependencies": {
                             "delayed-stream": {
                               "version": "0.0.5",
@@ -902,6 +1269,11 @@
                           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                           "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
                           "dev": true,
+                          "requires": {
+                            "async": "0.9.2",
+                            "combined-stream": "0.0.7",
+                            "mime-types": "2.0.14"
+                          },
                           "dependencies": {
                             "async": {
                               "version": "0.9.2",
@@ -916,6 +1288,12 @@
                           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                           "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
                           "dev": true,
+                          "requires": {
+                            "bluebird": "2.11.0",
+                            "chalk": "1.1.3",
+                            "commander": "2.10.0",
+                            "is-my-json-valid": "2.16.0"
+                          },
                           "dependencies": {
                             "bluebird": {
                               "version": "2.11.0",
@@ -928,6 +1306,13 @@
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                               "dev": true,
+                              "requires": {
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
+                              },
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.2.1",
@@ -946,6 +1331,9 @@
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                                   "dev": true,
+                                  "requires": {
+                                    "ansi-regex": "2.1.1"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.1.1",
@@ -960,6 +1348,9 @@
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                                   "dev": true,
+                                  "requires": {
+                                    "ansi-regex": "2.1.1"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.1.1",
@@ -982,6 +1373,9 @@
                               "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
                               "integrity": "sha512-q/r9trjmuikWDRJNTBHAVnWhuU6w+z80KgBq7j9YDclik5E7X4xi0KnlZBNFA1zOQ+SH/vHMWd2mC9QTOz7GpA==",
                               "dev": true,
+                              "requires": {
+                                "graceful-readlink": "1.0.1"
+                              },
                               "dependencies": {
                                 "graceful-readlink": {
                                   "version": "1.0.1",
@@ -996,6 +1390,12 @@
                               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
                               "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
                               "dev": true,
+                              "requires": {
+                                "generate-function": "2.0.0",
+                                "generate-object-property": "1.2.0",
+                                "jsonpointer": "4.0.1",
+                                "xtend": "4.0.1"
+                              },
                               "dependencies": {
                                 "generate-function": {
                                   "version": "2.0.0",
@@ -1008,6 +1408,9 @@
                                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                                   "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                                   "dev": true,
+                                  "requires": {
+                                    "is-property": "1.0.2"
+                                  },
                                   "dependencies": {
                                     "is-property": {
                                       "version": "1.0.2",
@@ -1038,18 +1441,30 @@
                           "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                           "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
                           "dev": true,
+                          "requires": {
+                            "boom": "2.10.1",
+                            "cryptiles": "2.0.5",
+                            "hoek": "2.16.3",
+                            "sntp": "1.0.9"
+                          },
                           "dependencies": {
                             "boom": {
                               "version": "2.10.1",
                               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                               "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                              "dev": true
+                              "dev": true,
+                              "requires": {
+                                "hoek": "2.16.3"
+                              }
                             },
                             "cryptiles": {
                               "version": "2.0.5",
                               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                               "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                              "dev": true
+                              "dev": true,
+                              "requires": {
+                                "boom": "2.10.1"
+                              }
                             },
                             "hoek": {
                               "version": "2.16.3",
@@ -1061,7 +1476,10 @@
                               "version": "1.0.9",
                               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                               "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                              "dev": true
+                              "dev": true,
+                              "requires": {
+                                "hoek": "2.16.3"
+                              }
                             }
                           }
                         },
@@ -1070,6 +1488,11 @@
                           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                           "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
                           "dev": true,
+                          "requires": {
+                            "asn1": "0.1.11",
+                            "assert-plus": "0.1.5",
+                            "ctype": "0.5.3"
+                          },
                           "dependencies": {
                             "asn1": {
                               "version": "0.1.11",
@@ -1108,6 +1531,9 @@
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
                           "dev": true,
+                          "requires": {
+                            "mime-db": "1.12.0"
+                          },
                           "dependencies": {
                             "mime-db": {
                               "version": "1.12.0",
@@ -1146,6 +1572,9 @@
                           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                           "dev": true,
+                          "requires": {
+                            "punycode": "1.4.1"
+                          },
                           "dependencies": {
                             "punycode": {
                               "version": "1.4.1",
@@ -1178,6 +1607,10 @@
               "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
               "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
               "dev": true,
+              "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+              },
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
@@ -1220,12 +1653,19 @@
       "resolved": "https://registry.npmjs.org/npm-registry-mock/-/npm-registry-mock-1.1.0.tgz",
       "integrity": "sha1-bkKiQixLK9AqaChfVr5wIiDGRMw=",
       "dev": true,
+      "requires": {
+        "hock": "0.2.5",
+        "util-extend": "1.0.3"
+      },
       "dependencies": {
         "hock": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/hock/-/hock-0.2.5.tgz",
           "integrity": "sha1-Fk+wUFRMRqM27RmRby8GMAhY0/8=",
           "dev": true,
+          "requires": {
+            "deep-equal": "0.2.1"
+          },
           "dependencies": {
             "deep-equal": {
               "version": "0.2.1",
@@ -1252,11 +1692,21 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      },
       "dependencies": {
         "are-we-there-yet": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.2"
+          },
           "dependencies": {
             "delegates": {
               "version": "1.0.0",
@@ -1274,6 +1724,16 @@
           "version": "2.7.4",
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "requires": {
+            "aproba": "1.1.2",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          },
           "dependencies": {
             "object-assign": {
               "version": "4.1.1",
@@ -1289,6 +1749,11 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "code-point-at": {
                   "version": "1.1.0",
@@ -1299,6 +1764,9 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.1",
@@ -1313,6 +1781,9 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -1324,7 +1795,10 @@
             "wide-align": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
+              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+              "requires": {
+                "string-width": "1.0.2"
+              }
             }
           }
         },
@@ -1338,7 +1812,10 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "opener": {
       "version": "1.4.3",
@@ -1349,6 +1826,10 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      },
       "dependencies": {
         "os-homedir": {
           "version": "1.0.2",
@@ -1366,21 +1847,63 @@
       "version": "2.7.38",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.38.tgz",
       "integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
+      "requires": {
+        "bluebird": "3.5.0",
+        "cacache": "9.2.9",
+        "glob": "7.1.2",
+        "lru-cache": "4.1.1",
+        "make-fetch-happen": "2.4.13",
+        "minimatch": "3.0.4",
+        "mississippi": "1.3.0",
+        "normalize-package-data": "2.4.0",
+        "npm-package-arg": "5.1.2",
+        "npm-pick-manifest": "1.0.4",
+        "osenv": "0.1.4",
+        "promise-inflight": "1.0.1",
+        "promise-retry": "1.1.1",
+        "protoduck": "4.0.0",
+        "safe-buffer": "5.1.1",
+        "semver": "5.3.0",
+        "ssri": "4.1.6",
+        "tar-fs": "1.15.3",
+        "tar-stream": "1.5.4",
+        "unique-filename": "1.1.0",
+        "which": "1.2.14"
+      },
       "dependencies": {
         "make-fetch-happen": {
           "version": "2.4.13",
           "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.4.13.tgz",
           "integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
+          "requires": {
+            "agentkeepalive": "3.3.0",
+            "cacache": "9.2.9",
+            "http-cache-semantics": "3.7.3",
+            "http-proxy-agent": "2.0.0",
+            "https-proxy-agent": "2.0.0",
+            "lru-cache": "4.1.1",
+            "mississippi": "1.3.0",
+            "node-fetch-npm": "2.0.1",
+            "promise-retry": "1.1.1",
+            "socks-proxy-agent": "3.0.0",
+            "ssri": "4.1.6"
+          },
           "dependencies": {
             "agentkeepalive": {
               "version": "3.3.0",
               "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
               "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
+              "requires": {
+                "humanize-ms": "1.2.1"
+              },
               "dependencies": {
                 "humanize-ms": {
                   "version": "1.2.1",
                   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
                   "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+                  "requires": {
+                    "ms": "2.0.0"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
@@ -1400,16 +1923,26 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
               "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
+              "requires": {
+                "agent-base": "4.1.0",
+                "debug": "2.6.8"
+              },
               "dependencies": {
                 "agent-base": {
                   "version": "4.1.0",
                   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
                   "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
+                  "requires": {
+                    "es6-promisify": "5.0.0"
+                  },
                   "dependencies": {
                     "es6-promisify": {
                       "version": "5.0.0",
                       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
                       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+                      "requires": {
+                        "es6-promise": "4.1.1"
+                      },
                       "dependencies": {
                         "es6-promise": {
                           "version": "4.1.1",
@@ -1424,6 +1957,9 @@
                   "version": "2.6.8",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                   "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                  "requires": {
+                    "ms": "2.0.0"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
@@ -1438,16 +1974,26 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.0.0.tgz",
               "integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
+              "requires": {
+                "agent-base": "4.1.0",
+                "debug": "2.6.8"
+              },
               "dependencies": {
                 "agent-base": {
                   "version": "4.1.0",
                   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
                   "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
+                  "requires": {
+                    "es6-promisify": "5.0.0"
+                  },
                   "dependencies": {
                     "es6-promisify": {
                       "version": "5.0.0",
                       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
                       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+                      "requires": {
+                        "es6-promise": "4.1.1"
+                      },
                       "dependencies": {
                         "es6-promise": {
                           "version": "4.1.1",
@@ -1462,6 +2008,9 @@
                   "version": "2.6.8",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                   "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                  "requires": {
+                    "ms": "2.0.0"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
@@ -1476,11 +2025,19 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.1.tgz",
               "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
+              "requires": {
+                "encoding": "0.1.12",
+                "json-parse-helpfulerror": "1.0.3",
+                "safe-buffer": "5.1.1"
+              },
               "dependencies": {
                 "encoding": {
                   "version": "0.1.12",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+                  "requires": {
+                    "iconv-lite": "0.4.18"
+                  },
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.18",
@@ -1493,6 +2050,9 @@
                   "version": "1.0.3",
                   "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
                   "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+                  "requires": {
+                    "jju": "1.3.0"
+                  },
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
@@ -1507,16 +2067,26 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.0.tgz",
               "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
+              "requires": {
+                "agent-base": "4.1.0",
+                "socks": "1.1.10"
+              },
               "dependencies": {
                 "agent-base": {
                   "version": "4.1.0",
                   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
                   "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
+                  "requires": {
+                    "es6-promisify": "5.0.0"
+                  },
                   "dependencies": {
                     "es6-promisify": {
                       "version": "5.0.0",
                       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
                       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+                      "requires": {
+                        "es6-promise": "4.1.1"
+                      },
                       "dependencies": {
                         "es6-promise": {
                           "version": "4.1.1",
@@ -1531,6 +2101,10 @@
                   "version": "1.1.10",
                   "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
                   "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+                  "requires": {
+                    "ip": "1.1.5",
+                    "smart-buffer": "1.1.15"
+                  },
                   "dependencies": {
                     "ip": {
                       "version": "1.1.5",
@@ -1552,11 +2126,18 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          },
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.8",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
               "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              },
               "dependencies": {
                 "balanced-match": {
                   "version": "1.0.0",
@@ -1575,12 +2156,20 @@
         "npm-pick-manifest": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
-          "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ=="
+          "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
+          "requires": {
+            "npm-package-arg": "5.1.2",
+            "semver": "5.3.0"
+          }
         },
         "promise-retry": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
           "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+          "requires": {
+            "err-code": "1.1.2",
+            "retry": "0.10.1"
+          },
           "dependencies": {
             "err-code": {
               "version": "1.1.2",
@@ -1593,6 +2182,9 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
           "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
+          "requires": {
+            "genfun": "4.0.1"
+          },
           "dependencies": {
             "genfun": {
               "version": "4.0.1",
@@ -1605,16 +2197,29 @@
           "version": "1.15.3",
           "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
           "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
+          "requires": {
+            "chownr": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pump": "1.0.2",
+            "tar-stream": "1.5.4"
+          },
           "dependencies": {
             "pump": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
               "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+              "requires": {
+                "end-of-stream": "1.4.0",
+                "once": "1.4.0"
+              },
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.4.0",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY="
+                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+                  "requires": {
+                    "once": "1.4.0"
+                  }
                 }
               }
             }
@@ -1624,16 +2229,28 @@
           "version": "1.5.4",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
           "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+          "requires": {
+            "bl": "1.2.1",
+            "end-of-stream": "1.4.0",
+            "readable-stream": "2.3.2",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "bl": {
               "version": "1.2.1",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-              "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4="
+              "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+              "requires": {
+                "readable-stream": "2.3.2"
+              }
             },
             "end-of-stream": {
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-              "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY="
+              "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+              "requires": {
+                "once": "1.4.0"
+              }
             },
             "xtend": {
               "version": "4.0.1",
@@ -1658,6 +2275,9 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "requires": {
+        "mute-stream": "0.0.7"
+      },
       "dependencies": {
         "mute-stream": {
           "version": "0.0.7",
@@ -1669,12 +2289,24 @@
     "read-cmd-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
-      "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs="
+      "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "read-installed": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
       "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+      "requires": {
+        "debuglog": "1.0.1",
+        "graceful-fs": "4.1.11",
+        "read-package-json": "2.0.9",
+        "readdir-scoped-modules": "1.0.2",
+        "semver": "5.3.0",
+        "slide": "1.1.6",
+        "util-extend": "1.0.3"
+      },
       "dependencies": {
         "util-extend": {
           "version": "1.0.3",
@@ -1687,11 +2319,20 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.9.tgz",
       "integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "json-parse-helpfulerror": "1.0.3",
+        "normalize-package-data": "2.4.0"
+      },
       "dependencies": {
         "json-parse-helpfulerror": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
           "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+          "requires": {
+            "jju": "1.3.0"
+          },
           "dependencies": {
             "jju": {
               "version": "1.3.0",
@@ -1705,12 +2346,28 @@
     "read-package-tree": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
-      "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg=="
+      "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
+      "requires": {
+        "debuglog": "1.0.1",
+        "dezalgo": "1.0.3",
+        "once": "1.4.0",
+        "read-package-json": "2.0.9",
+        "readdir-scoped-modules": "1.0.2"
+      }
     },
     "readable-stream": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
       "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      },
       "dependencies": {
         "core-util-is": {
           "version": "1.0.2",
@@ -1730,7 +2387,10 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -1742,12 +2402,42 @@
     "readdir-scoped-modules": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
-      "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c="
+      "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+      "requires": {
+        "debuglog": "1.0.1",
+        "dezalgo": "1.0.3",
+        "graceful-fs": "4.1.11",
+        "once": "1.4.0"
+      }
     },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      },
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
@@ -1768,6 +2458,9 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "requires": {
+            "delayed-stream": "1.0.0"
+          },
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
@@ -1790,6 +2483,11 @@
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          },
           "dependencies": {
             "asynckit": {
               "version": "0.4.0",
@@ -1802,11 +2500,19 @@
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          },
           "dependencies": {
             "ajv": {
               "version": "4.11.8",
               "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
               "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              },
               "dependencies": {
                 "co": {
                   "version": "4.6.0",
@@ -1817,6 +2523,9 @@
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
                   "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                  "requires": {
+                    "jsonify": "0.0.0"
+                  },
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
@@ -1838,16 +2547,28 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          },
           "dependencies": {
             "boom": {
               "version": "2.10.1",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+              "requires": {
+                "hoek": "2.16.3"
+              }
             },
             "cryptiles": {
               "version": "2.0.5",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+              "requires": {
+                "boom": "2.10.1"
+              }
             },
             "hoek": {
               "version": "2.16.3",
@@ -1857,7 +2578,10 @@
             "sntp": {
               "version": "1.0.9",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+              "requires": {
+                "hoek": "2.16.3"
+              }
             }
           }
         },
@@ -1865,6 +2589,11 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.1"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
@@ -1875,6 +2604,12 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
               "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.0.2",
+                "json-schema": "0.2.3",
+                "verror": "1.3.6"
+              },
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
@@ -1894,7 +2629,10 @@
                 "verror": {
                   "version": "1.3.6",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                  "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+                  "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                  "requires": {
+                    "extsprintf": "1.0.2"
+                  }
                 }
               }
             },
@@ -1902,6 +2640,16 @@
               "version": "1.13.1",
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
               "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              },
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
@@ -1917,23 +2665,35 @@
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
                   "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                  "optional": true
+                  "optional": true,
+                  "requires": {
+                    "tweetnacl": "0.14.5"
+                  }
                 },
                 "dashdash": {
                   "version": "1.14.1",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                  "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA="
+                  "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  }
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                   "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                  "optional": true
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
                 },
                 "getpass": {
                   "version": "0.1.7",
                   "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                  "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
+                  "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  }
                 },
                 "jsbn": {
                   "version": "0.1.1",
@@ -1970,6 +2730,9 @@
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "requires": {
+            "mime-db": "1.27.0"
+          },
           "dependencies": {
             "mime-db": {
               "version": "1.27.0",
@@ -2002,6 +2765,9 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "requires": {
+            "punycode": "1.4.1"
+          },
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
@@ -2013,7 +2779,10 @@
         "tunnel-agent": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         }
       }
     },
@@ -2022,6 +2791,9 @@
       "resolved": "https://registry.npmjs.org/require-inject/-/require-inject-1.4.2.tgz",
       "integrity": "sha512-8NfVYqEhjs1POhjxNzN0DPBcqwZ5ePfe9E3wFc6VML8DwQoz6Jr7Zbe3fqgzbFL6m0INvgPW7rVt+o+8S5f22w==",
       "dev": true,
+      "requires": {
+        "caller": "1.0.1"
+      },
       "dependencies": {
         "caller": {
           "version": "1.0.1",
@@ -2039,7 +2811,10 @@
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -2054,7 +2829,11 @@
     "sha": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-      "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4="
+      "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "readable-stream": "2.3.2"
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -2070,16 +2849,30 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
       "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
+      "requires": {
+        "from2": "1.3.0",
+        "stream-iterate": "1.2.0"
+      },
       "dependencies": {
         "from2": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
           "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "1.1.14"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "1.1.14",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -2104,6 +2897,10 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
           "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
+          "requires": {
+            "readable-stream": "2.3.2",
+            "stream-shift": "1.0.0"
+          },
           "dependencies": {
             "stream-shift": {
               "version": "1.0.0",
@@ -2123,25 +2920,80 @@
     "ssri": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
-      "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA=="
+      "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "standard": {
       "version": "6.0.8",
       "resolved": "https://registry.npmjs.org/standard/-/standard-6.0.8.tgz",
       "integrity": "sha1-sOZl4yJ32jy5nyEmmxBC2B7+sGs=",
       "dev": true,
+      "requires": {
+        "eslint": "2.2.0",
+        "eslint-config-standard": "5.1.0",
+        "eslint-config-standard-jsx": "1.1.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-react": "4.3.0",
+        "eslint-plugin-standard": "1.3.3",
+        "standard-engine": "3.3.1",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "eslint": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.2.0.tgz",
           "integrity": "sha1-bI10OpFUZZW6GG7e0JZoL0dZjeg=",
           "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "debug": "2.6.8",
+            "doctrine": "1.5.0",
+            "es6-map": "0.1.5",
+            "escope": "3.6.0",
+            "espree": "3.4.3",
+            "estraverse": "4.2.0",
+            "estraverse-fb": "1.3.1",
+            "esutils": "2.0.2",
+            "file-entry-cache": "1.3.1",
+            "glob": "6.0.4",
+            "globals": "8.18.0",
+            "ignore": "2.2.19",
+            "inquirer": "0.12.0",
+            "is-my-json-valid": "2.16.0",
+            "is-resolvable": "1.0.0",
+            "js-yaml": "3.8.4",
+            "json-stable-stringify": "1.0.1",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "optionator": "0.8.2",
+            "path-is-absolute": "1.0.1",
+            "path-is-inside": "1.0.2",
+            "pluralize": "1.2.1",
+            "progress": "1.1.8",
+            "require-uncached": "1.0.3",
+            "resolve": "1.3.3",
+            "shelljs": "0.5.3",
+            "strip-json-comments": "1.0.4",
+            "table": "3.8.3",
+            "text-table": "0.2.0",
+            "user-home": "2.0.0"
+          },
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
@@ -2160,6 +3012,9 @@
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -2174,6 +3029,9 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -2196,6 +3054,11 @@
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
               "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
               "dev": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.2",
+                "typedarray": "0.0.6"
+              },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
@@ -2210,6 +3073,9 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
               "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
               "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              },
               "dependencies": {
                 "ms": {
                   "version": "2.0.0",
@@ -2224,6 +3090,10 @@
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
               "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
               "dev": true,
+              "requires": {
+                "esutils": "2.0.2",
+                "isarray": "1.0.0"
+              },
               "dependencies": {
                 "isarray": {
                   "version": "1.0.0",
@@ -2238,42 +3108,77 @@
               "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
               "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
               "dev": true,
+              "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.23",
+                "es6-iterator": "2.0.1",
+                "es6-set": "0.1.5",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+              },
               "dependencies": {
                 "d": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
                   "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "es5-ext": "0.10.23"
+                  }
                 },
                 "es5-ext": {
                   "version": "0.10.23",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
                   "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "es6-iterator": "2.0.1",
+                    "es6-symbol": "3.1.1"
+                  }
                 },
                 "es6-iterator": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
                   "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.23",
+                    "es6-symbol": "3.1.1"
+                  }
                 },
                 "es6-set": {
                   "version": "0.1.5",
                   "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
                   "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.23",
+                    "es6-iterator": "2.0.1",
+                    "es6-symbol": "3.1.1",
+                    "event-emitter": "0.3.5"
+                  }
                 },
                 "es6-symbol": {
                   "version": "3.1.1",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
                   "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.23"
+                  }
                 },
                 "event-emitter": {
                   "version": "0.3.5",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
                   "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.23"
+                  }
                 }
               }
             },
@@ -2282,36 +3187,64 @@
               "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
               "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
               "dev": true,
+              "requires": {
+                "es6-map": "0.1.5",
+                "es6-weak-map": "2.0.2",
+                "esrecurse": "4.2.0",
+                "estraverse": "4.2.0"
+              },
               "dependencies": {
                 "es6-weak-map": {
                   "version": "2.0.2",
                   "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
                   "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
                   "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.23",
+                    "es6-iterator": "2.0.1",
+                    "es6-symbol": "3.1.1"
+                  },
                   "dependencies": {
                     "d": {
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
                       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "es5-ext": "0.10.23"
+                      }
                     },
                     "es5-ext": {
                       "version": "0.10.23",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
                       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "es6-iterator": "2.0.1",
+                        "es6-symbol": "3.1.1"
+                      }
                     },
                     "es6-iterator": {
                       "version": "2.0.1",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
                       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "d": "1.0.0",
+                        "es5-ext": "0.10.23",
+                        "es6-symbol": "3.1.1"
+                      }
                     },
                     "es6-symbol": {
                       "version": "3.1.1",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
                       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "d": "1.0.0",
+                        "es5-ext": "0.10.23"
+                      }
                     }
                   }
                 },
@@ -2320,6 +3253,10 @@
                   "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
                   "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
                   "dev": true,
+                  "requires": {
+                    "estraverse": "4.2.0",
+                    "object-assign": "4.1.1"
+                  },
                   "dependencies": {
                     "object-assign": {
                       "version": "4.1.1",
@@ -2336,6 +3273,10 @@
               "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
               "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
               "dev": true,
+              "requires": {
+                "acorn": "5.0.3",
+                "acorn-jsx": "3.0.1"
+              },
               "dependencies": {
                 "acorn": {
                   "version": "5.0.3",
@@ -2348,6 +3289,9 @@
                   "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
                   "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
                   "dev": true,
+                  "requires": {
+                    "acorn": "3.3.0"
+                  },
                   "dependencies": {
                     "acorn": {
                       "version": "3.3.0",
@@ -2382,12 +3326,22 @@
               "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
               "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
               "dev": true,
+              "requires": {
+                "flat-cache": "1.2.2",
+                "object-assign": "4.1.1"
+              },
               "dependencies": {
                 "flat-cache": {
                   "version": "1.2.2",
                   "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
                   "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
                   "dev": true,
+                  "requires": {
+                    "circular-json": "0.3.1",
+                    "del": "2.2.2",
+                    "graceful-fs": "4.1.11",
+                    "write": "0.2.1"
+                  },
                   "dependencies": {
                     "circular-json": {
                       "version": "0.3.1",
@@ -2400,18 +3354,38 @@
                       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
                       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
                       "dev": true,
+                      "requires": {
+                        "globby": "5.0.0",
+                        "is-path-cwd": "1.0.0",
+                        "is-path-in-cwd": "1.0.0",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "rimraf": "2.6.1"
+                      },
                       "dependencies": {
                         "globby": {
                           "version": "5.0.0",
                           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
                           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
                           "dev": true,
+                          "requires": {
+                            "array-union": "1.0.2",
+                            "arrify": "1.0.1",
+                            "glob": "7.1.2",
+                            "object-assign": "4.1.1",
+                            "pify": "2.3.0",
+                            "pinkie-promise": "2.0.1"
+                          },
                           "dependencies": {
                             "array-union": {
                               "version": "1.0.2",
                               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
                               "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
                               "dev": true,
+                              "requires": {
+                                "array-uniq": "1.0.3"
+                              },
                               "dependencies": {
                                 "array-uniq": {
                                   "version": "1.0.3",
@@ -2432,6 +3406,14 @@
                               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                               "dev": true,
+                              "requires": {
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
+                              },
                               "dependencies": {
                                 "fs.realpath": {
                                   "version": "1.0.0",
@@ -2444,12 +3426,19 @@
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                                   "dev": true,
+                                  "requires": {
+                                    "brace-expansion": "1.1.8"
+                                  },
                                   "dependencies": {
                                     "brace-expansion": {
                                       "version": "1.1.8",
                                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                                       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                                       "dev": true,
+                                      "requires": {
+                                        "balanced-match": "1.0.0",
+                                        "concat-map": "0.0.1"
+                                      },
                                       "dependencies": {
                                         "balanced-match": {
                                           "version": "1.0.0",
@@ -2482,12 +3471,18 @@
                           "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                           "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
                           "dev": true,
+                          "requires": {
+                            "is-path-inside": "1.0.0"
+                          },
                           "dependencies": {
                             "is-path-inside": {
                               "version": "1.0.0",
                               "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
                               "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-                              "dev": true
+                              "dev": true,
+                              "requires": {
+                                "path-is-inside": "1.0.2"
+                              }
                             }
                           }
                         },
@@ -2502,6 +3497,9 @@
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
@@ -2517,7 +3515,10 @@
                       "version": "0.2.1",
                       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
                       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "mkdirp": "0.5.1"
+                      }
                     }
                   }
                 },
@@ -2534,18 +3535,32 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
+              "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
@@ -2582,6 +3597,21 @@
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
               "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
               "dev": true,
+              "requires": {
+                "ansi-escapes": "1.4.0",
+                "ansi-regex": "2.1.1",
+                "chalk": "1.1.3",
+                "cli-cursor": "1.0.2",
+                "cli-width": "2.1.0",
+                "figures": "1.7.0",
+                "lodash": "4.17.4",
+                "readline2": "1.0.1",
+                "run-async": "0.1.0",
+                "rx-lite": "3.1.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "through": "2.3.8"
+              },
               "dependencies": {
                 "ansi-escapes": {
                   "version": "1.4.0",
@@ -2600,12 +3630,19 @@
                   "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
                   "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
                   "dev": true,
+                  "requires": {
+                    "restore-cursor": "1.0.1"
+                  },
                   "dependencies": {
                     "restore-cursor": {
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
                       "dev": true,
+                      "requires": {
+                        "exit-hook": "1.1.1",
+                        "onetime": "1.1.0"
+                      },
                       "dependencies": {
                         "exit-hook": {
                           "version": "1.1.1",
@@ -2634,6 +3671,10 @@
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
                   "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
                   "dev": true,
+                  "requires": {
+                    "escape-string-regexp": "1.0.5",
+                    "object-assign": "4.1.1"
+                  },
                   "dependencies": {
                     "escape-string-regexp": {
                       "version": "1.0.5",
@@ -2654,6 +3695,11 @@
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
                   "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
                   "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "mute-stream": "0.0.5"
+                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
@@ -2666,6 +3712,9 @@
                       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "dev": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
@@ -2687,7 +3736,10 @@
                   "version": "0.1.0",
                   "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
                   "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "once": "1.4.0"
+                  }
                 },
                 "rx-lite": {
                   "version": "3.1.2",
@@ -2700,6 +3752,11 @@
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
@@ -2712,6 +3769,9 @@
                       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "dev": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
@@ -2727,7 +3787,10 @@
                   "version": "3.0.1",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
                 },
                 "through": {
                   "version": "2.3.8",
@@ -2742,6 +3805,12 @@
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
               "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
               "dev": true,
+              "requires": {
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -2754,6 +3823,9 @@
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                   "dev": true,
+                  "requires": {
+                    "is-property": "1.0.2"
+                  },
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
@@ -2776,6 +3848,9 @@
               "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
               "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
               "dev": true,
+              "requires": {
+                "tryit": "1.0.3"
+              },
               "dependencies": {
                 "tryit": {
                   "version": "1.0.3",
@@ -2790,12 +3865,19 @@
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
               "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
               "dev": true,
+              "requires": {
+                "argparse": "1.0.9",
+                "esprima": "3.1.3"
+              },
               "dependencies": {
                 "argparse": {
                   "version": "1.0.9",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                   "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
                   "dev": true,
+                  "requires": {
+                    "sprintf-js": "1.0.3"
+                  },
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
@@ -2818,6 +3900,9 @@
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "dev": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              },
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
@@ -2838,6 +3923,14 @@
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
               "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
               "dev": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+              },
               "dependencies": {
                 "deep-is": {
                   "version": "0.1.3",
@@ -2855,7 +3948,11 @@
                   "version": "0.3.0",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
                   "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2"
+                  }
                 },
                 "prelude-ls": {
                   "version": "1.1.2",
@@ -2867,7 +3964,10 @@
                   "version": "0.3.2",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                   "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2"
+                  }
                 },
                 "wordwrap": {
                   "version": "1.0.0",
@@ -2900,12 +4000,19 @@
               "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
               "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
               "dev": true,
+              "requires": {
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
+              },
               "dependencies": {
                 "caller-path": {
                   "version": "0.1.0",
                   "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
                   "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
                   "dev": true,
+                  "requires": {
+                    "callsites": "0.2.0"
+                  },
                   "dependencies": {
                     "callsites": {
                       "version": "0.2.0",
@@ -2928,6 +4035,9 @@
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
               "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
               "dev": true,
+              "requires": {
+                "path-parse": "1.0.5"
+              },
               "dependencies": {
                 "path-parse": {
                   "version": "1.0.5",
@@ -2954,12 +4064,24 @@
               "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
               "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
               "dev": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "ajv-keywords": "1.5.1",
+                "chalk": "1.1.3",
+                "lodash": "4.17.4",
+                "slice-ansi": "0.0.4",
+                "string-width": "2.1.0"
+              },
               "dependencies": {
                 "ajv": {
                   "version": "4.11.8",
                   "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
                   "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                   "dev": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "json-stable-stringify": "1.0.1"
+                  },
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
@@ -2986,6 +4108,10 @@
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
                   "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
                   "dev": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
@@ -3002,6 +4128,9 @@
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
               "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
               "dev": true,
+              "requires": {
+                "os-homedir": "1.0.2"
+              },
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
@@ -3048,12 +4177,25 @@
           "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-3.3.1.tgz",
           "integrity": "sha1-sveY3k5NPh+s7UJcgTaDGmZ0CO0=",
           "dev": true,
+          "requires": {
+            "defaults": "1.0.3",
+            "deglob": "1.1.2",
+            "find-root": "1.0.0",
+            "get-stdin": "5.0.1",
+            "minimist": "1.2.0",
+            "multiline": "1.0.2",
+            "pkg-config": "1.1.1",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "defaults": {
               "version": "1.0.3",
               "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
               "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
               "dev": true,
+              "requires": {
+                "clone": "1.0.2"
+              },
               "dependencies": {
                 "clone": {
                   "version": "1.0.2",
@@ -3068,6 +4210,15 @@
               "resolved": "https://registry.npmjs.org/deglob/-/deglob-1.1.2.tgz",
               "integrity": "sha1-dtV3wl/j9zKUEqK1nq3qV6xQDj8=",
               "dev": true,
+              "requires": {
+                "find-root": "1.0.0",
+                "glob": "7.1.2",
+                "ignore": "3.3.3",
+                "pkg-config": "1.1.1",
+                "run-parallel": "1.1.6",
+                "uniq": "1.0.1",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "ignore": {
                   "version": "3.3.3",
@@ -3112,12 +4263,18 @@
               "resolved": "https://registry.npmjs.org/multiline/-/multiline-1.0.2.tgz",
               "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
               "dev": true,
+              "requires": {
+                "strip-indent": "1.0.1"
+              },
               "dependencies": {
                 "strip-indent": {
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                   "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                   "dev": true,
+                  "requires": {
+                    "get-stdin": "4.0.1"
+                  },
                   "dependencies": {
                     "get-stdin": {
                       "version": "4.0.1",
@@ -3134,6 +4291,11 @@
               "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
               "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
               "dev": true,
+              "requires": {
+                "debug-log": "1.0.1",
+                "find-root": "1.0.0",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "debug-log": {
                   "version": "1.0.1",
@@ -3157,6 +4319,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "3.0.0"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -3170,12 +4335,27 @@
       "resolved": "https://registry.npmjs.org/tacks/-/tacks-1.2.6.tgz",
       "integrity": "sha1-BL9htjbT0KkcyFP+W1w6ulUt1F0=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
+        "yargs": "3.32.0"
+      },
       "dependencies": {
         "yargs": {
           "version": "3.32.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
+          "requires": {
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "string-width": "1.0.2",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
+          },
           "dependencies": {
             "camelcase": {
               "version": "2.1.1",
@@ -3188,12 +4368,20 @@
               "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -3207,7 +4395,11 @@
                   "version": "2.1.0",
                   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
                   "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1"
+                  }
                 }
               }
             },
@@ -3222,12 +4414,18 @@
               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
               "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
               "dev": true,
+              "requires": {
+                "lcid": "1.0.0"
+              },
               "dependencies": {
                 "lcid": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                   "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                   "dev": true,
+                  "requires": {
+                    "invert-kv": "1.0.0"
+                  },
                   "dependencies": {
                     "invert-kv": {
                       "version": "1.0.0",
@@ -3244,6 +4442,11 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "code-point-at": {
                   "version": "1.1.0",
@@ -3256,6 +4459,9 @@
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.1",
@@ -3270,6 +4476,9 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -3302,6 +4511,34 @@
       "resolved": "https://registry.npmjs.org/tap/-/tap-10.7.0.tgz",
       "integrity": "sha512-rIKS3HvtA+/6weSQW8zgA8bKHt//Srucp6P1pugHUVZ+SexZcPw6N3n8LCAoH2okp/js+honhxwBl7bomZ9+7w==",
       "dev": true,
+      "requires": {
+        "bind-obj-methods": "1.0.0",
+        "bluebird": "3.5.0",
+        "clean-yaml-object": "0.1.0",
+        "color-support": "1.1.3",
+        "coveralls": "2.13.1",
+        "foreground-child": "1.5.6",
+        "fs-exists-cached": "1.0.0",
+        "function-loop": "1.0.1",
+        "glob": "7.1.2",
+        "isexe": "2.0.0",
+        "js-yaml": "3.8.4",
+        "nyc": "11.0.3",
+        "opener": "1.4.3",
+        "os-homedir": "1.0.2",
+        "own-or": "1.0.0",
+        "own-or-env": "1.0.0",
+        "readable-stream": "2.3.2",
+        "signal-exit": "3.0.2",
+        "source-map-support": "0.4.15",
+        "stack-utils": "1.0.1",
+        "tap-mocha-reporter": "3.0.6",
+        "tap-parser": "5.4.0",
+        "tmatch": "3.1.0",
+        "trivial-deferred": "1.0.1",
+        "tsame": "1.1.2",
+        "yapool": "1.0.0"
+      },
       "dependencies": {
         "bind-obj-methods": {
           "version": "1.0.0",
@@ -3326,18 +4563,32 @@
           "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
           "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
           "dev": true,
+          "requires": {
+            "js-yaml": "3.6.1",
+            "lcov-parse": "0.0.10",
+            "log-driver": "1.2.5",
+            "minimist": "1.2.0",
+            "request": "2.79.0"
+          },
           "dependencies": {
             "js-yaml": {
               "version": "3.6.1",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
               "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
               "dev": true,
+              "requires": {
+                "argparse": "1.0.9",
+                "esprima": "2.7.3"
+              },
               "dependencies": {
                 "argparse": {
                   "version": "1.0.9",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                   "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
                   "dev": true,
+                  "requires": {
+                    "sprintf-js": "1.0.3"
+                  },
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
@@ -3378,6 +4629,28 @@
               "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
               "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
               "dev": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "2.0.6",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "qs": "6.3.2",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.4.3",
+                "uuid": "3.1.0"
+              },
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
@@ -3402,6 +4675,9 @@
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
@@ -3428,6 +4704,11 @@
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
                   "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                   "dev": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.15"
+                  },
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
@@ -3442,12 +4723,25 @@
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                   "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                   "dev": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "commander": "2.10.0",
+                    "is-my-json-valid": "2.16.0",
+                    "pinkie-promise": "2.0.1"
+                  },
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                       "dev": true,
+                      "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
@@ -3466,6 +4760,9 @@
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                           "dev": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
@@ -3480,6 +4777,9 @@
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                           "dev": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
@@ -3502,6 +4802,9 @@
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
                       "integrity": "sha512-q/r9trjmuikWDRJNTBHAVnWhuU6w+z80KgBq7j9YDclik5E7X4xi0KnlZBNFA1zOQ+SH/vHMWd2mC9QTOz7GpA==",
                       "dev": true,
+                      "requires": {
+                        "graceful-readlink": "1.0.1"
+                      },
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
@@ -3516,6 +4819,12 @@
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
                       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
                       "dev": true,
+                      "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "4.0.1",
+                        "xtend": "4.0.1"
+                      },
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
@@ -3528,6 +4837,9 @@
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                           "dev": true,
+                          "requires": {
+                            "is-property": "1.0.2"
+                          },
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
@@ -3556,6 +4868,9 @@
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
@@ -3572,18 +4887,30 @@
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "dev": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
                     },
                     "hoek": {
                       "version": "2.16.3",
@@ -3595,7 +4922,10 @@
                       "version": "1.0.9",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     }
                   }
                 },
@@ -3604,6 +4934,11 @@
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                   "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "dev": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.0",
+                    "sshpk": "1.13.1"
+                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
@@ -3616,6 +4951,12 @@
                       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
                       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                       "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                      },
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
@@ -3639,7 +4980,10 @@
                           "version": "1.3.6",
                           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                           "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
                         }
                       }
                     },
@@ -3648,6 +4992,16 @@
                       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
                       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                       "dev": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                      },
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
@@ -3666,26 +5020,38 @@
                           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
                           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                           "dev": true,
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.5"
+                          }
                         },
                         "dashdash": {
                           "version": "1.14.1",
                           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
                           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                           "dev": true,
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.1"
+                          }
                         },
                         "getpass": {
                           "version": "0.1.7",
                           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
                           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "jsbn": {
                           "version": "0.1.1",
@@ -3728,6 +5094,9 @@
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
                   "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                   "dev": true,
+                  "requires": {
+                    "mime-db": "1.27.0"
+                  },
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
@@ -3760,6 +5129,9 @@
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                   "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                   "dev": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  },
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
@@ -3784,12 +5156,20 @@
           "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
           "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          },
           "dependencies": {
             "cross-spawn": {
               "version": "4.0.2",
               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
               "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "which": "1.2.14"
+              }
             }
           }
         },
@@ -3816,12 +5196,19 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
           "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
           "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "3.1.3"
+          },
           "dependencies": {
             "argparse": {
               "version": "1.0.9",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
               "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
               "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
@@ -3844,11 +5231,45 @@
           "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.3.tgz",
           "integrity": "sha1-DCi8ZpqFFiFwm/eghQMDS+44ErY=",
           "dev": true,
+          "requires": {
+            "archy": "1.0.0",
+            "arrify": "1.0.1",
+            "caching-transform": "1.0.1",
+            "convert-source-map": "1.5.0",
+            "debug-log": "1.0.1",
+            "default-require-extensions": "1.0.0",
+            "find-cache-dir": "0.1.1",
+            "find-up": "2.1.0",
+            "foreground-child": "1.5.6",
+            "glob": "7.1.2",
+            "istanbul-lib-coverage": "1.1.1",
+            "istanbul-lib-hook": "1.0.7",
+            "istanbul-lib-instrument": "1.7.3",
+            "istanbul-lib-report": "1.1.1",
+            "istanbul-lib-source-maps": "1.2.1",
+            "istanbul-reports": "1.1.1",
+            "md5-hex": "1.3.0",
+            "merge-source-map": "1.0.4",
+            "micromatch": "2.3.11",
+            "mkdirp": "0.5.1",
+            "resolve-from": "2.0.0",
+            "rimraf": "2.6.1",
+            "signal-exit": "3.0.2",
+            "spawn-wrap": "1.3.7",
+            "test-exclude": "4.1.1",
+            "yargs": "8.0.2",
+            "yargs-parser": "5.0.0"
+          },
           "dependencies": {
             "align-text": {
               "version": "0.1.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+              }
             },
             "amdefine": {
               "version": "1.0.1",
@@ -3868,7 +5289,10 @@
             "append-transform": {
               "version": "0.4.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "default-require-extensions": "1.0.0"
+              }
             },
             "archy": {
               "version": "1.0.0",
@@ -3878,7 +5302,10 @@
             "arr-diff": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "arr-flatten": "1.0.3"
+              }
             },
             "arr-flatten": {
               "version": "1.0.3",
@@ -3903,37 +5330,83 @@
             "babel-code-frame": {
               "version": "6.22.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.1"
+              }
             },
             "babel-generator": {
               "version": "6.25.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.23.0",
+                "babel-types": "6.25.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.4",
+                "source-map": "0.5.6",
+                "trim-right": "1.0.1"
+              }
             },
             "babel-messages": {
               "version": "6.23.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-runtime": "6.23.0"
+              }
             },
             "babel-runtime": {
               "version": "6.23.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "core-js": "2.4.1",
+                "regenerator-runtime": "0.10.5"
+              }
             },
             "babel-template": {
               "version": "6.25.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-runtime": "6.23.0",
+                "babel-traverse": "6.25.0",
+                "babel-types": "6.25.0",
+                "babylon": "6.17.4",
+                "lodash": "4.17.4"
+              }
             },
             "babel-traverse": {
               "version": "6.25.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-code-frame": "6.22.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.23.0",
+                "babel-types": "6.25.0",
+                "babylon": "6.17.4",
+                "debug": "2.6.8",
+                "globals": "9.18.0",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4"
+              }
             },
             "babel-types": {
               "version": "6.25.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-runtime": "6.23.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.4",
+                "to-fast-properties": "1.0.3"
+              }
             },
             "babylon": {
               "version": "6.17.4",
@@ -3948,12 +5421,21 @@
             "brace-expansion": {
               "version": "1.1.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              }
             },
             "braces": {
               "version": "1.8.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              }
             },
             "builtin-modules": {
               "version": "1.1.1",
@@ -3963,7 +5445,12 @@
             "caching-transform": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "md5-hex": "1.3.0",
+                "mkdirp": "0.5.1",
+                "write-file-atomic": "1.3.4"
+              }
             },
             "camelcase": {
               "version": "1.2.1",
@@ -3975,18 +5462,34 @@
               "version": "0.1.3",
               "bundled": true,
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+              }
             },
             "chalk": {
               "version": "1.1.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
             },
             "cliui": {
               "version": "2.1.0",
               "bundled": true,
               "dev": true,
               "optional": true,
+              "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+              },
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
@@ -4024,12 +5527,19 @@
             "cross-spawn": {
               "version": "4.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "which": "1.2.14"
+              }
             },
             "debug": {
               "version": "2.6.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
             },
             "debug-log": {
               "version": "1.0.1",
@@ -4044,17 +5554,26 @@
             "default-require-extensions": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "strip-bom": "2.0.0"
+              }
             },
             "detect-indent": {
               "version": "4.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "repeating": "2.0.1"
+              }
             },
             "error-ex": {
               "version": "1.3.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-arrayish": "0.2.1"
+              }
             },
             "escape-string-regexp": {
               "version": "1.0.5",
@@ -4069,22 +5588,40 @@
             "execa": {
               "version": "0.5.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "cross-spawn": "4.0.2",
+                "get-stream": "2.3.1",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              }
             },
             "expand-brackets": {
               "version": "0.1.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              }
             },
             "expand-range": {
               "version": "1.8.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "fill-range": "2.2.3"
+              }
             },
             "extglob": {
               "version": "0.3.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
             },
             "filename-regex": {
               "version": "2.0.1",
@@ -4094,17 +5631,32 @@
             "fill-range": {
               "version": "2.2.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+              }
             },
             "find-cache-dir": {
               "version": "0.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "commondir": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pkg-dir": "1.0.0"
+              }
             },
             "find-up": {
               "version": "2.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "locate-path": "2.0.0"
+              }
             },
             "for-in": {
               "version": "1.0.2",
@@ -4114,12 +5666,19 @@
             "for-own": {
               "version": "0.1.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "for-in": "1.0.2"
+              }
             },
             "foreground-child": {
               "version": "1.5.6",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "cross-spawn": "4.0.2",
+                "signal-exit": "3.0.2"
+              }
             },
             "fs.realpath": {
               "version": "1.0.0",
@@ -4134,22 +5693,41 @@
             "get-stream": {
               "version": "2.3.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
+              }
             },
             "glob": {
               "version": "7.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
             },
             "glob-base": {
               "version": "0.3.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+              }
             },
             "glob-parent": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-glob": "2.0.1"
+              }
             },
             "globals": {
               "version": "9.18.0",
@@ -4165,18 +5743,30 @@
               "version": "4.0.10",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+              },
               "dependencies": {
                 "source-map": {
                   "version": "0.4.4",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "amdefine": "1.0.1"
+                  }
                 }
               }
             },
             "has-ansi": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
             },
             "has-flag": {
               "version": "1.0.0",
@@ -4196,7 +5786,11 @@
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
             },
             "inherits": {
               "version": "2.0.3",
@@ -4206,7 +5800,10 @@
             "invariant": {
               "version": "2.2.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
             },
             "invert-kv": {
               "version": "1.0.0",
@@ -4226,7 +5823,10 @@
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              }
             },
             "is-dotfile": {
               "version": "1.0.3",
@@ -4236,7 +5836,10 @@
             "is-equal-shallow": {
               "version": "0.1.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-primitive": "2.0.0"
+              }
             },
             "is-extendable": {
               "version": "0.1.1",
@@ -4251,22 +5854,34 @@
             "is-finite": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
             },
             "is-glob": {
               "version": "2.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
             },
             "is-number": {
               "version": "2.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
             },
             "is-posix-bracket": {
               "version": "0.1.1",
@@ -4301,7 +5916,10 @@
             "isobject": {
               "version": "2.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
             },
             "istanbul-lib-coverage": {
               "version": "1.1.1",
@@ -4311,34 +5929,65 @@
             "istanbul-lib-hook": {
               "version": "1.0.7",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "append-transform": "0.4.0"
+              }
             },
             "istanbul-lib-instrument": {
               "version": "1.7.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-generator": "6.25.0",
+                "babel-template": "6.25.0",
+                "babel-traverse": "6.25.0",
+                "babel-types": "6.25.0",
+                "babylon": "6.17.4",
+                "istanbul-lib-coverage": "1.1.1",
+                "semver": "5.3.0"
+              }
             },
             "istanbul-lib-report": {
               "version": "1.1.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "istanbul-lib-coverage": "1.1.1",
+                "mkdirp": "0.5.1",
+                "path-parse": "1.0.5",
+                "supports-color": "3.2.3"
+              },
               "dependencies": {
                 "supports-color": {
                   "version": "3.2.3",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "1.0.0"
+                  }
                 }
               }
             },
             "istanbul-lib-source-maps": {
               "version": "1.2.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "debug": "2.6.8",
+                "istanbul-lib-coverage": "1.1.1",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1",
+                "source-map": "0.5.6"
+              }
             },
             "istanbul-reports": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "handlebars": "4.0.10"
+              }
             },
             "js-tokens": {
               "version": "3.0.1",
@@ -4353,7 +6002,10 @@
             "kind-of": {
               "version": "3.2.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
             },
             "lazy-cache": {
               "version": "1.0.4",
@@ -4364,17 +6016,31 @@
             "lcid": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "invert-kv": "1.0.0"
+              }
             },
             "load-json-file": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+              }
             },
             "locate-path": {
               "version": "2.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+              },
               "dependencies": {
                 "path-exists": {
                   "version": "3.0.0",
@@ -4396,17 +6062,27 @@
             "loose-envify": {
               "version": "1.3.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "js-tokens": "3.0.1"
+              }
             },
             "lru-cache": {
               "version": "4.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+              }
             },
             "md5-hex": {
               "version": "1.3.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "md5-o-matic": "0.1.1"
+              }
             },
             "md5-o-matic": {
               "version": "0.1.1",
@@ -4416,17 +6092,38 @@
             "mem": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "mimic-fn": "1.1.0"
+              }
             },
             "merge-source-map": {
               "version": "1.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "source-map": "0.5.6"
+              }
             },
             "micromatch": {
               "version": "2.3.11",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.3"
+              }
             },
             "mimic-fn": {
               "version": "1.1.0",
@@ -4436,7 +6133,10 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              }
             },
             "minimist": {
               "version": "0.0.8",
@@ -4446,7 +6146,10 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
             },
             "ms": {
               "version": "2.0.0",
@@ -4456,17 +6159,29 @@
             "normalize-package-data": {
               "version": "2.3.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "2.4.2",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.3.0",
+                "validate-npm-package-license": "3.0.1"
+              }
             },
             "normalize-path": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "1.0.2"
+              }
             },
             "npm-run-path": {
               "version": "2.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "path-key": "2.0.1"
+              }
             },
             "number-is-nan": {
               "version": "1.0.1",
@@ -4481,17 +6196,28 @@
             "object.omit": {
               "version": "2.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+              }
             },
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
             },
             "optimist": {
               "version": "0.6.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
+              }
             },
             "os-homedir": {
               "version": "1.0.2",
@@ -4501,7 +6227,12 @@
             "os-locale": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "execa": "0.5.1",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+              }
             },
             "p-finally": {
               "version": "1.0.0",
@@ -4516,22 +6247,37 @@
             "p-locate": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "p-limit": "1.1.0"
+              }
             },
             "parse-glob": {
               "version": "3.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+              }
             },
             "parse-json": {
               "version": "2.2.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "error-ex": "1.3.1"
+              }
             },
             "path-exists": {
               "version": "2.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
             },
             "path-is-absolute": {
               "version": "1.0.1",
@@ -4551,7 +6297,12 @@
             "path-type": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
             },
             "pify": {
               "version": "2.3.0",
@@ -4566,17 +6317,27 @@
             "pinkie-promise": {
               "version": "2.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              }
             },
             "pkg-dir": {
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "find-up": "1.1.2"
+              },
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
                 }
               }
             },
@@ -4594,40 +6355,66 @@
               "version": "1.1.7",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+              },
               "dependencies": {
                 "is-number": {
                   "version": "3.0.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.5"
+                      }
                     }
                   }
                 },
                 "kind-of": {
                   "version": "4.0.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.5"
+                  }
                 }
               }
             },
             "read-pkg": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.3.8",
+                "path-type": "1.1.0"
+              }
             },
             "read-pkg-up": {
               "version": "1.0.1",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
                 }
               }
             },
@@ -4639,7 +6426,11 @@
             "regex-cache": {
               "version": "0.4.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
+              }
             },
             "remove-trailing-separator": {
               "version": "1.0.2",
@@ -4659,7 +6450,10 @@
             "repeating": {
               "version": "2.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-finite": "1.0.2"
+              }
             },
             "require-directory": {
               "version": "2.1.1",
@@ -4680,12 +6474,18 @@
               "version": "0.1.3",
               "bundled": true,
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4"
+              }
             },
             "rimraf": {
               "version": "2.6.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
             },
             "semver": {
               "version": "5.3.0",
@@ -4715,12 +6515,23 @@
             "spawn-wrap": {
               "version": "1.3.7",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "foreground-child": "1.5.6",
+                "mkdirp": "0.5.1",
+                "os-homedir": "1.0.2",
+                "rimraf": "2.6.1",
+                "signal-exit": "3.0.2",
+                "which": "1.2.14"
+              }
             },
             "spdx-correct": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "spdx-license-ids": "1.2.2"
+              }
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
@@ -4736,6 +6547,10 @@
               "version": "2.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
@@ -4747,12 +6562,18 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
             },
             "strip-bom": {
               "version": "2.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
             },
             "strip-eof": {
               "version": "1.0.0",
@@ -4767,7 +6588,14 @@
             "test-exclude": {
               "version": "4.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "arrify": "1.0.1",
+                "micromatch": "2.3.11",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
+              }
             },
             "to-fast-properties": {
               "version": "1.0.3",
@@ -4784,12 +6612,23 @@
               "bundled": true,
               "dev": true,
               "optional": true,
+              "requires": {
+                "source-map": "0.5.6",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
               "dependencies": {
                 "yargs": {
                   "version": "3.10.0",
                   "bundled": true,
                   "dev": true,
-                  "optional": true
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  }
                 }
               }
             },
@@ -4802,12 +6641,19 @@
             "validate-npm-package-license": {
               "version": "3.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
+              }
             },
             "which": {
               "version": "1.2.14",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "isexe": "2.0.0"
+              }
             },
             "which-module": {
               "version": "2.0.0",
@@ -4829,11 +6675,20 @@
               "version": "2.1.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
                 }
               }
             },
@@ -4845,7 +6700,12 @@
             "write-file-atomic": {
               "version": "1.3.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              }
             },
             "y18n": {
               "version": "3.2.1",
@@ -4861,6 +6721,21 @@
               "version": "8.0.2",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "camelcase": "4.1.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.0.0",
+                "read-pkg-up": "2.0.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.0.0",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "7.0.0"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "4.1.0",
@@ -4871,33 +6746,61 @@
                   "version": "3.2.0",
                   "bundled": true,
                   "dev": true,
+                  "requires": {
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wrap-ansi": "2.1.0"
+                  },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      }
                     }
                   }
                 },
                 "load-json-file": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "strip-bom": "3.0.0"
+                  }
                 },
                 "path-type": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "pify": "2.3.0"
+                  }
                 },
                 "read-pkg": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "load-json-file": "2.0.0",
+                    "normalize-package-data": "2.3.8",
+                    "path-type": "2.0.0"
+                  }
                 },
                 "read-pkg-up": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "find-up": "2.1.0",
+                    "read-pkg": "2.0.0"
+                  }
                 },
                 "strip-bom": {
                   "version": "3.0.0",
@@ -4907,7 +6810,10 @@
                 "yargs-parser": {
                   "version": "7.0.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "camelcase": "4.1.0"
+                  }
                 }
               }
             },
@@ -4915,6 +6821,9 @@
               "version": "5.0.0",
               "bundled": true,
               "dev": true,
+              "requires": {
+                "camelcase": "3.0.0"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "3.0.0",
@@ -4954,6 +6863,9 @@
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
           "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
           "dev": true,
+          "requires": {
+            "source-map": "0.5.6"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.5.6",
@@ -4974,12 +6886,26 @@
           "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.6.tgz",
           "integrity": "sha512-UImgw3etckDQCoqZIAIKcQDt0w1JLVs3v0yxLlmwvGLZl6MGFxF7JME5PElXjAoDklVDU42P3vVu5jgr37P4Yg==",
           "dev": true,
+          "requires": {
+            "color-support": "1.1.3",
+            "debug": "2.6.8",
+            "diff": "1.4.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "js-yaml": "3.8.4",
+            "readable-stream": "2.3.2",
+            "tap-parser": "5.4.0",
+            "unicode-length": "1.0.3"
+          },
           "dependencies": {
             "debug": {
               "version": "2.6.8",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
               "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
               "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              },
               "dependencies": {
                 "ms": {
                   "version": "2.0.0",
@@ -5006,6 +6932,10 @@
               "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
               "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
               "dev": true,
+              "requires": {
+                "punycode": "1.4.1",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
@@ -5018,6 +6948,9 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -5036,6 +6969,11 @@
           "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
           "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
           "dev": true,
+          "requires": {
+            "events-to-array": "1.1.2",
+            "js-yaml": "3.8.4",
+            "readable-stream": "2.3.2"
+          },
           "dependencies": {
             "events-to-array": {
               "version": "1.1.2",
@@ -5075,11 +7013,19 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      },
       "dependencies": {
         "block-stream": {
           "version": "0.0.9",
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "requires": {
+            "inherits": "2.0.3"
+          }
         }
       }
     },
@@ -5102,11 +7048,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+      "requires": {
+        "unique-slug": "2.0.0"
+      },
       "dependencies": {
         "unique-slug": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks="
+          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+          "requires": {
+            "imurmurhash": "0.1.4"
+          }
         }
       }
     },
@@ -5119,16 +7071,38 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
       "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
+      "requires": {
+        "boxen": "1.1.0",
+        "chalk": "1.1.3",
+        "configstore": "3.1.0",
+        "import-lazy": "2.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      },
       "dependencies": {
         "boxen": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
           "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
+          "requires": {
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "1.1.3",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.0",
+            "term-size": "0.1.1",
+            "widest-line": "1.0.0"
+          },
           "dependencies": {
             "ansi-align": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-              "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38="
+              "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+              "requires": {
+                "string-width": "2.1.0"
+              }
             },
             "camelcase": {
               "version": "4.1.0",
@@ -5144,6 +7118,10 @@
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
               "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              },
               "dependencies": {
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
@@ -5153,7 +7131,10 @@
                 "strip-ansi": {
                   "version": "4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8="
+                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
                 }
               }
             },
@@ -5161,16 +7142,31 @@
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
               "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
+              "requires": {
+                "execa": "0.4.0"
+              },
               "dependencies": {
                 "execa": {
                   "version": "0.4.0",
                   "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
                   "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+                  "requires": {
+                    "cross-spawn-async": "2.2.5",
+                    "is-stream": "1.1.0",
+                    "npm-run-path": "1.0.0",
+                    "object-assign": "4.1.1",
+                    "path-key": "1.0.0",
+                    "strip-eof": "1.0.0"
+                  },
                   "dependencies": {
                     "cross-spawn-async": {
                       "version": "2.2.5",
                       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-                      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw="
+                      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
+                      "requires": {
+                        "lru-cache": "4.1.1",
+                        "which": "1.2.14"
+                      }
                     },
                     "is-stream": {
                       "version": "1.1.0",
@@ -5180,7 +7176,10 @@
                     "npm-run-path": {
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-                      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8="
+                      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+                      "requires": {
+                        "path-key": "1.0.0"
+                      }
                     },
                     "object-assign": {
                       "version": "4.1.1",
@@ -5205,11 +7204,19 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
               "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+              "requires": {
+                "string-width": "1.0.2"
+              },
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
@@ -5220,6 +7227,9 @@
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
@@ -5232,6 +7242,9 @@
                       "version": "3.0.1",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "requires": {
+                        "ansi-regex": "2.1.1"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
@@ -5250,6 +7263,13 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
@@ -5265,6 +7285,9 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -5277,6 +7300,9 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -5296,11 +7322,22 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
           "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
+          "requires": {
+            "dot-prop": "4.1.1",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.0.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          },
           "dependencies": {
             "dot-prop": {
               "version": "4.1.1",
               "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
               "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
+              "requires": {
+                "is-obj": "1.0.1"
+              },
               "dependencies": {
                 "is-obj": {
                   "version": "1.0.1",
@@ -5313,6 +7350,9 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
               "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+              "requires": {
+                "pify": "2.3.0"
+              },
               "dependencies": {
                 "pify": {
                   "version": "2.3.0",
@@ -5325,6 +7365,9 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
               "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+              "requires": {
+                "crypto-random-string": "1.0.0"
+              },
               "dependencies": {
                 "crypto-random-string": {
                   "version": "1.0.0",
@@ -5349,21 +7392,46 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
           "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+          "requires": {
+            "package-json": "4.0.1"
+          },
           "dependencies": {
             "package-json": {
               "version": "4.0.1",
               "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
               "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+              "requires": {
+                "got": "6.7.1",
+                "registry-auth-token": "3.3.1",
+                "registry-url": "3.1.0",
+                "semver": "5.3.0"
+              },
               "dependencies": {
                 "got": {
                   "version": "6.7.1",
                   "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
                   "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+                  "requires": {
+                    "create-error-class": "3.0.2",
+                    "duplexer3": "0.1.4",
+                    "get-stream": "3.0.0",
+                    "is-redirect": "1.0.0",
+                    "is-retry-allowed": "1.1.0",
+                    "is-stream": "1.1.0",
+                    "lowercase-keys": "1.0.0",
+                    "safe-buffer": "5.1.1",
+                    "timed-out": "4.0.1",
+                    "unzip-response": "2.0.1",
+                    "url-parse-lax": "1.0.0"
+                  },
                   "dependencies": {
                     "create-error-class": {
                       "version": "3.0.2",
                       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
                       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+                      "requires": {
+                        "capture-stack-trace": "1.0.0"
+                      },
                       "dependencies": {
                         "capture-stack-trace": {
                           "version": "1.0.0",
@@ -5416,6 +7484,9 @@
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
                       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+                      "requires": {
+                        "prepend-http": "1.0.4"
+                      },
                       "dependencies": {
                         "prepend-http": {
                           "version": "1.0.4",
@@ -5430,11 +7501,21 @@
                   "version": "3.3.1",
                   "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
                   "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+                  "requires": {
+                    "rc": "1.2.1",
+                    "safe-buffer": "5.1.1"
+                  },
                   "dependencies": {
                     "rc": {
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
                       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+                      "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                      },
                       "dependencies": {
                         "deep-extend": {
                           "version": "0.4.2",
@@ -5459,11 +7540,20 @@
                   "version": "3.1.0",
                   "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
                   "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+                  "requires": {
+                    "rc": "1.2.1"
+                  },
                   "dependencies": {
                     "rc": {
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
                       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+                      "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                      },
                       "dependencies": {
                         "deep-extend": {
                           "version": "0.4.2",
@@ -5491,7 +7581,10 @@
         "semver-diff": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY="
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+          "requires": {
+            "semver": "5.3.0"
+          }
         },
         "xdg-basedir": {
           "version": "3.0.0",
@@ -5509,11 +7602,18 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      },
       "dependencies": {
         "spdx-correct": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          },
           "dependencies": {
             "spdx-license-ids": {
               "version": "1.2.2",
@@ -5533,6 +7633,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "requires": {
+        "builtins": "1.0.3"
+      },
       "dependencies": {
         "builtins": {
           "version": "1.0.3",
@@ -5545,6 +7648,9 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "requires": {
+        "isexe": "2.0.0"
+      },
       "dependencies": {
         "isexe": {
           "version": "2.0.0",
@@ -5557,11 +7663,18 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
       "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
+      "requires": {
+        "errno": "0.1.4",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "errno": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
           "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+          "requires": {
+            "prr": "0.0.0"
+          },
           "dependencies": {
             "prr": {
               "version": "0.0.0",
@@ -5585,7 +7698,12 @@
     "write-file-atomic": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
-      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ=="
+      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
+      }
     }
   }
 }

--- a/test/tap/bundled-no-add-to-move.js
+++ b/test/tap/bundled-no-add-to-move.js
@@ -1,8 +1,7 @@
 'use strict'
 var test = require('tap').test
 var Node = require('../../lib/install/node.js').create
-var diffTrees = require('../../lib/install/diff-trees.js')._diffTrees
-var sortActions = require('../../lib/install/diff-trees.js').sortActions
+var npm = require('../../lib/npm.js')
 
 var oldTree = Node({
   path: '/',
@@ -40,7 +39,12 @@ newTree.children[0].requiredBy.push(newTree)
 newTree.children[0].children[0].requiredBy.push(newTree.children[0])
 
 test('test', function (t) {
-  var differences = sortActions(diffTrees(oldTree, newTree)).map(function (diff) { return diff[0] + diff[1].location })
-  t.isDeeply(differences, ['add/abc/one', 'remove/one', 'add/abc'], 'bundled add/remove stays add/remove')
-  t.end()
+  npm.load({}, (err) => {
+    if (err) throw err
+    var diffTrees = require('../../lib/install/diff-trees.js')._diffTrees
+    var sortActions = require('../../lib/install/diff-trees.js').sortActions
+    var differences = sortActions(diffTrees(oldTree, newTree)).map(function (diff) { return diff[0] + diff[1].location })
+    t.isDeeply(differences, ['add/abc/one', 'remove/one', 'add/abc'], 'bundled add/remove stays add/remove')
+    t.end()
+  })
 })

--- a/test/tap/ls-production-and-dev.js
+++ b/test/tap/ls-production-and-dev.js
@@ -41,8 +41,8 @@ test('setup', function (t) {
       ],
       EXEC_OPTS,
       function (er, c) {
-        t.ifError(er, 'install ran without issue')
-        t.equal(c, 0)
+        if (er) throw er
+        t.equal(c, 0, 'install ran without issue')
         s.close()
         t.end()
       }
@@ -52,8 +52,8 @@ test('setup', function (t) {
 
 test('npm ls --dev', function (t) {
   common.npm(['ls', '--dev'], EXEC_OPTS, function (er, code, stdout) {
-    t.ifError(er, 'ls --dev ran without issue')
-    t.equal(code, 0)
+    if (er) throw er
+    t.equal(code, 0, 'ls --dev ran without issue')
     t.has(
       stdout,
       /test-package-with-one-dep@0\.0\.0/,
@@ -75,8 +75,8 @@ test('npm ls --dev', function (t) {
 
 test('npm ls --only=development', function (t) {
   common.npm(['ls', '--only=development'], EXEC_OPTS, function (er, code, stdout) {
-    t.ifError(er, 'ls --only=development ran without issue')
-    t.equal(code, 0)
+    if (er) throw er
+    t.equal(code, 0, 'ls --only=development ran without issue')
     t.has(
       stdout,
       /test-package-with-one-dep@0\.0\.0/,
@@ -88,8 +88,8 @@ test('npm ls --only=development', function (t) {
 
 test('npm ls --only=dev', function (t) {
   common.npm(['ls', '--only=dev'], EXEC_OPTS, function (er, code, stdout) {
-    t.ifError(er, 'ls --only=dev ran without issue')
-    t.equal(code, 0)
+    if (er) throw er
+    t.equal(code, 0, 'ls --only=dev ran without issue')
     t.has(
       stdout,
       /test-package-with-one-dep@0\.0\.0/,
@@ -101,8 +101,8 @@ test('npm ls --only=dev', function (t) {
 
 test('npm ls --production', function (t) {
   common.npm(['ls', '--production'], EXEC_OPTS, function (er, code, stdout) {
-    t.ifError(er, 'ls --production ran without issue')
-    t.notOk(code, 'npm exited ok')
+    if (er) throw er
+    t.equal(code, 0, 'ls --production ran without issue')
     t.has(
       stdout,
       /test-package-with-one-dep@0\.0\.0/,
@@ -124,8 +124,8 @@ test('npm ls --production', function (t) {
 
 test('npm ls --prod', function (t) {
   common.npm(['ls', '--prod'], EXEC_OPTS, function (er, code, stdout) {
-    t.ifError(er, 'ls --prod ran without issue')
-    t.notOk(code, 'npm exited ok')
+    if (er) throw er
+    t.equal(code, 0, 'ls --prod ran without issue')
     t.has(
       stdout,
       /test-package-with-one-dep@0\.0\.0/,
@@ -137,8 +137,8 @@ test('npm ls --prod', function (t) {
 
 test('npm ls --only=production', function (t) {
   common.npm(['ls', '--only=production'], EXEC_OPTS, function (er, code, stdout) {
-    t.ifError(er, 'ls --only=production ran without issue')
-    t.notOk(code, 'npm exited ok')
+    if (er) throw er
+    t.equal(code, 0, 'ls --only=production ran without issue')
     t.has(
       stdout,
       /test-package-with-one-dep@0\.0\.0/,
@@ -150,8 +150,8 @@ test('npm ls --only=production', function (t) {
 
 test('npm ls --only=prod', function (t) {
   common.npm(['ls', '--only=prod'], EXEC_OPTS, function (er, code, stdout) {
-    t.ifError(er, 'ls --only=prod ran without issue')
-    t.notOk(code, 'npm exited ok')
+    if (er) throw er
+    t.equal(code, 0, 'ls --only=prod ran without issue')
     t.has(
       stdout,
       /test-package-with-one-dep@0\.0\.0/,

--- a/test/tap/shrinkwrap-local-dependency.js
+++ b/test/tap/shrinkwrap-local-dependency.js
@@ -85,7 +85,7 @@ test('shrinkwrap uses resolved with file: on local deps', function (t) {
       t.comment(stderr.trim())
       t.equal(code, 0, 'npm exited normally')
       var data = fs.readFileSync(path.join(testdir, 'npm-shrinkwrap.json'), { encoding: 'utf8' })
-      t.deepEqual(
+      t.like(
         JSON.parse(data).dependencies,
         shrinkwrap.dependencies,
         'shrinkwrap looks correct'

--- a/test/tap/shrinkwrap-shared-dev-dependency.js
+++ b/test/tap/shrinkwrap-shared-dev-dependency.js
@@ -67,7 +67,7 @@ test("shrinkwrap doesn't strip out the shared dependency", function (t) {
   }).spread((code) => {
     t.is(code, 0, 'shrinkwrap')
     var results = JSON.parse(fs.readFileSync(`${pkg}/npm-shrinkwrap.json`))
-    t.deepEqual(results.dependencies, desired.dependencies)
+    t.like(results.dependencies, desired.dependencies)
     t.end()
   })
 })

--- a/test/tap/shrinkwrap-version-match.js
+++ b/test/tap/shrinkwrap-version-match.js
@@ -7,10 +7,6 @@ var fs = require('fs')
 var path = require('path')
 var common = require('../common-tap.js')
 
-// NOTE: This test will only remain relavent until npm@5 when
-// npm-shrinkwrap.json will override EVERYTHING in you package.json.
-// If you're working on npm@5 and this broke, just remove the test.
-
 var testdir = path.resolve(__dirname, path.basename(__filename, '.js'))
 var modAdir = path.resolve(testdir, 'modA')
 var modB1dir = path.resolve(testdir, 'modB@1')
@@ -27,14 +23,17 @@ var fixture = new Tacks(Dir({
     }
   }),
   'npm-shrinkwrap.json': File({
+    requires: true,
+    lockfileVersion: 1,
     dependencies: {
       modA: {
-        version: '1.0.0',
-        resolved: 'file://' + modAdir
+        version: 'file://' + modAdir,
+        requires: {
+          modB: 'file://' + modB1dir
+        }
       },
       modB: {
-        version: '1.0.0',
-        resolved: 'file://' + modB1dir
+        version: 'file://' + modB1dir
       }
     }
   }),

--- a/test/tap/tagged-version-matching.js
+++ b/test/tap/tagged-version-matching.js
@@ -64,6 +64,7 @@ var fixture = new Tacks(Dir({
               directUrl: 'https://raw.githubusercontent.com/npm/example-gitdep/da39a3ee5e6b4b0d3255bfef95601890afd80709/package.json'
             }
           },
+          _resolved: 'github:npm/example-gitdep#da39a3ee5e6b4b0d3255bfef95601890afd80709',
           name: 'gitdep',
           version: '1.0.0'
         })
@@ -72,6 +73,7 @@ var fixture = new Tacks(Dir({
         'package.json': File({
           _from: 'tagdep@latest',
           _id: 'tagdep@1.0.0',
+          _integrity: 'sha1-0EJSKmsdk39848LlrRg/hZQo2B8=',
           _requested: {
             raw: 'tagdep@https://registry.example.com/tagdep/-/tagdep-1.0.0.tgz',
             scope: null,
@@ -89,20 +91,23 @@ var fixture = new Tacks(Dir({
     'npm-shrinkwrap.json': File({
       name: 'tagged-version-matching',
       version: '1.0.0',
+      lockfileVersion: 1,
+      requires: true,
       dependencies: {
         tagdep: {
           version: '1.0.0',
-          from: 'tagdep@latest',
-          resolved: 'https://registry.example.com/tagdep/-/tagdep-1.0.0.tgz'
+          resolved: 'https://registry.example.com/tagdep/-/tagdep-1.0.0.tgz',
+          integrity: 'sha1-0EJSKmsdk39848LlrRg/hZQo2B8='
         },
         example: {
-          version: '1.0.0',
-          from: 'example'
+          version: 'file:example',
+          requires: {
+            tagdep: '1.0.0',
+            gitdep: 'github:npm/example-gitdep#da39a3ee5e6b4b0d3255bfef95601890afd80709'
+          }
         },
         gitdep: {
-          version: '1.0.0',
-          from: 'npm/example-gitdep',
-          resolved: 'git://github.com/npm/example-gitdep.git#da39a3ee5e6b4b0d3255bfef95601890afd80709'
+          version: 'github:npm/example-gitdep#da39a3ee5e6b4b0d3255bfef95601890afd80709'
         }
       }
     }),


### PR DESCRIPTION
This has a handful of fixes:

1. It introduces a new `package-lock.json` field, called `requires`, which tracks which modules a given module requires.
2. It fixes #16839 which was caused by not having this information available, particularly when git dependencies were involved.
3. It fixes #16866, allowing the `package.json` to trump the `package-lock.json`.
4. It stops calling `fetch-package-metadata.addBundled` on fake children (this was harmless, because bundleDependencies would never be set, but also pointless.)
5. `npm ls` now loads the shrinkwrap, which opens the door to showing a full tree of dependencies even when nothing is yet installed. (It doesn't do that yet though.)


