### PR TITLE
pack: never ignore COPYING files

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -71,7 +71,7 @@ BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
     if (entry.match(/^readme(\.[^\.]*)$/i)) return true
 
     // license files should never be ignored.
-    if (entry.match(/^(license|licence)(\.[^\.]*)?$/i)) return true
+    if (entry.match(/^(license|licence|copying)(\.[^\.]*)?$/i)) return true
 
     // copyright notice files should never be ignored.
     if (entry.match(/^(notice)(\.[^\.]*)?$/i)) return true


### PR DESCRIPTION
GNU's GPL usage guides recommend using this name, so never ignore it as it may include a copy of the GPL.

I couldn't find any documentation as to exactly how npm commit messages should be formatted (and in particular what should go before the `:`) so I guessed. Happy to amend if necessary.