### PR TITLE
install/deps: Computed required package in legacy npm compatible way

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -254,11 +254,16 @@ exports.loadRequestedDeps = function (args, tree, saveToDependencies, log, next)
   }, andForEachChild(loadDeps, andFinishTracker(log, next)))
 }
 
+function isNotEmpty (value) {
+  return value != null && value !== ''
+}
+
 module.exports.computeVersionSpec = computeVersionSpec
 function computeVersionSpec (tree, child) {
   validate('OO', arguments)
   var requested
-  if (child.package._requested) {
+  var childReq = child.package._requested
+  if (childReq && (isNotEmpty(childReq.saveSpec) || (isNotEmpty(childReq.rawSpec) && isNotEmpty(childReq.fetchSpec)))) {
     requested = child.package._requested
   } else if (child.package._from) {
     requested = npa(child.package._from)
@@ -277,7 +282,7 @@ function computeVersionSpec (tree, child) {
   } else if (requested.type === 'directory' || requested.type === 'file') {
     return 'file:' + path.relative(tree.path, requested.fetchSpec)
   } else {
-    return requested.saveSpec
+    return requested.saveSpec || requested.rawSpec
   }
 }
 


### PR DESCRIPTION
Not having this meant that uninstalls of globals installed by npm@4 or
earlier would fail, due to _requested not having the fields we expected.