### PR TITLE
Fix spurious removal reporting

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -718,8 +718,11 @@ Installer.prototype.printInstalled = function (cb) {
   log.silly('install', 'printInstalled')
   const diffs = this.differences
   if (!this.idealTree.error && this.idealTree.removedChildren) {
+    const deps = this.currentTree.package.dependencies || {}
+    const dev = this.currentTree.package.devDependencies || {}
     this.idealTree.removedChildren.forEach((r) => {
       if (diffs.some((d) => d[0] === 'remove' && d[1].path === r.path)) return
+      if (!deps[moduleName(r)] && !dev[moduleName(r)]) return
       diffs.push(['remove', r])
     })
   }

--- a/lib/install.js
+++ b/lib/install.js
@@ -717,7 +717,7 @@ Installer.prototype.printInstalled = function (cb) {
   if (this.failing) return cb()
   log.silly('install', 'printInstalled')
   const diffs = this.differences
-  if (this.idealTree.removedChildren) {
+  if (!this.idealTree.error && this.idealTree.removedChildren) {
     this.idealTree.removedChildren.forEach((r) => {
       if (diffs.some((d) => d[0] === 'remove' && d[1].path === r.path)) return
       diffs.push(['remove', r])


### PR DESCRIPTION
Previously, if you asked to remove something that wasn't in your `node_modules` and wasn't in your `package.json` (or you didn't have a `package.json`) we would still report that we removed something even though there was no work for us to do.
