### PR TITLE
validate-args: Check for name and version

### DIFF
--- a/lib/install/validate-args.js
+++ b/lib/install/validate-args.js
@@ -14,10 +14,21 @@ module.exports = function (idealTree, args, next) {
 
   asyncMap(args, function (pkg, done) {
     chain([
+      [hasMinimumFields, pkg],
       [checkSelf, idealTree, pkg, force],
       [isInstallable, pkg]
     ], done)
   }, next)
+}
+
+function hasMinimumFields (pkg, cb) {
+  if (pkg.name === '' || pkg.name == null) {
+    return cb(new Error(`Can't install ${pkg._resolved}: Missing package name`))
+  } else if (pkg.version === '' || pkg.version == null) {
+    return cb(new Error(`Can't install ${pkg._resolved}: Missing package version`))
+  } else {
+    return cb()
+  }
 }
 
 function getWarnings (pkg) {


### PR DESCRIPTION
If you didn't have a name and you tried to install something it would end up linking to the `node_modules` where it was installing to, removing the `node_modules`.  This mostly showed up in `npm install -g .` in a package w/o a name field.

Fixes: #16891