### PR TITLE
Add possibility to ls only linked packages

### DIFF
--- a/doc/cli/npm-ls.md
+++ b/doc/cli/npm-ls.md
@@ -91,7 +91,7 @@ When "dev" or "development", is an alias to `dev`.
 
 When "prod" or "production", is an alias to `production`.
 
-### links
+### link-only
 
 * Type: Boolean
 * Default: false

--- a/doc/cli/npm-ls.md
+++ b/doc/cli/npm-ls.md
@@ -91,6 +91,13 @@ When "dev" or "development", is an alias to `dev`.
 
 When "prod" or "production", is an alias to `production`.
 
+### links
+
+* Type: Boolean
+* Default: false
+
+Only list packages which are linked.
+
 ## SEE ALSO
 
 * npm-config(1)

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -560,6 +560,13 @@ if one of the two conditions are met:
 * the globally installed version is identical to the version that is
   being installed locally.
 
+### link-only
+
+* Type: Boolean
+* Default: false
+
+Only list packages which are linked.
+
 ### local-address
 
 * Default: undefined

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -165,6 +165,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     key: null,
     'legacy-bundling': false,
     link: false,
+    'link-only': false,
     'local-address': undefined,
     loglevel: 'notice',
     logstream: process.stderr,
@@ -291,6 +292,7 @@ exports.types = {
   key: [null, String],
   'legacy-bundling': Boolean,
   link: Boolean,
+  'link-only': Boolean,
   // local-address must be listed as an IP for a local network interface
   // must be IPv4 due to node bug
   'local-address': getLocalAddresses(),

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -81,6 +81,8 @@ var lsFromTree = ls.fromTree = function (dir, physicalTree, args, silent, cb) {
 
   pruneNestedExtraneous(data)
   filterByEnv(data)
+  filterByLink(data)
+
   var unlooped = filterFound(unloop(data), args)
   var lite = getLite(unlooped)
 
@@ -147,6 +149,19 @@ function filterByEnv (data) {
     }
   })
   data.dependencies = dependencies
+}
+
+function filterByLink (data) {
+  if (npm.config.get('link-only')) {
+    var dependencies = {}
+    Object.keys(data.dependencies).forEach(function (name) {
+      var dependency = data.dependencies[name]
+      if (dependency.link) {
+        dependencies[name] = dependency
+      }
+    })
+    data.dependencies = dependencies
+  }
 }
 
 function alphasort (a, b) {


### PR DESCRIPTION
This is a fix for #16126 (Even though it was automatically closed by the bot) which I finally got around to implementing. The idea is to give users the ability to list only packages which have been linked using `npm link`, to get an overview of those (Useful for teams with many internal modules).

Also see this [Stackoverflow question](https://stackoverflow.com/q/24933955/1091402) (Not mine) for proof that there is demand for this feature.

I'm looking for feedback on the overall approach as well as the name of the config, are these OK? If so I will go ahead and update documentation as well as (Try to) add a test case for it.