### PR TITLE
install: fix package.json and package-lock.json to use unix style paths (#17338)

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -30,6 +30,7 @@ var isDevDep = require('./is-dev-dep.js')
 var isProdDep = require('./is-prod-dep.js')
 var reportOptionalFailure = require('./report-optional-failure.js')
 var getSaveType = require('./save.js').getSaveType
+var unixFormatPath = require('../utils/unix-format-path.js')
 
 // The export functions in this module mutate a dependency tree, adding
 // items to them.
@@ -279,7 +280,7 @@ function computeVersionSpec (tree, child) {
     }
     return rangeDescriptor + version
   } else if (requested.type === 'directory' || requested.type === 'file') {
-    return 'file:' + path.relative(tree.path, requested.fetchSpec)
+    return 'file:' + unixFormatPath(path.relative(tree.path, requested.fetchSpec))
   } else {
     return requested.saveSpec
   }

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -21,6 +21,7 @@ const readPackageTree = BB.promisify(require('read-package-tree'))
 const ssri = require('ssri')
 const validate = require('aproba')
 const writeFileAtomic = require('write-file-atomic')
+const unixFormatPath = require('./utils/unix-format-path.js')
 
 const PKGLOCK = 'package-lock.json'
 const SHRINKWRAP = 'npm-shrinkwrap.json'
@@ -109,7 +110,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     var pkginfo = deps[moduleName(child)] = {}
     var req = child.package._requested || getRequested(child) || {}
     if (req.type === 'directory' || req.type === 'file') {
-      pkginfo.version = 'file:' + path.relative(top.path, child.package._resolved || req.fetchSpec)
+      pkginfo.version = 'file:' + unixFormatPath(path.relative(top.path, child.package._resolved || req.fetchSpec))
     } else if (!req.registry && !child.fromBundle) {
       pkginfo.version = child.package._resolved || req.saveSpec || req.rawSpec
     } else {

--- a/lib/utils/unix-format-path.js
+++ b/lib/utils/unix-format-path.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function (path) {
+  return path.replace(/\\/g, '/');
+}

--- a/test/tap/install-save-local.js
+++ b/test/tap/install-save-local.js
@@ -53,7 +53,7 @@ test('\'npm install --save ../local/path\' should save to package.json', functio
       var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
       t.is(Object.keys(pkgJson.dependencies).length, 1, 'only one dep')
       t.ok(
-        /file:.*?[/\\]package-local-dependency$/.test(pkgJson.dependencies['package-local-dependency']),
+        /file:.*?[/]package-local-dependency$/.test(pkgJson.dependencies['package-local-dependency']),
         'local package saved correctly'
       )
       t.end()

--- a/test/tap/shrinkwrap-local-dependency.js
+++ b/test/tap/shrinkwrap-local-dependency.js
@@ -4,6 +4,7 @@ var fs = require('fs')
 var rimraf = require('rimraf')
 var common = require('../common-tap.js')
 var Tacks = require('tacks')
+var unixFormatPath = require('../../lib/utils/unix-format-path.js')
 var File = Tacks.File
 var Dir = Tacks.Dir
 
@@ -16,10 +17,10 @@ var shrinkwrap = {
   version: '1.0.0',
   dependencies: {
     mod2: {
-      version: 'file:' + path.join('mods', 'mod2'),
+      version: 'file:' + unixFormatPath(path.join('mods', 'mod2')),
       dependencies: {
         mod1: {
-          version: 'file:' + path.join('mods', 'mod1'),
+          version: 'file:' + unixFormatPath(path.join('mods', 'mod1')),
           bundled: true
         }
       }


### PR DESCRIPTION
This changes npm to write unix style paths regardless of platform into package.json and package-lock.json files.