### PR TITLE
Add possibility to ls only linked packages

### DIFF
--- a/doc/cli/npm-ls.md
+++ b/doc/cli/npm-ls.md
@@ -91,6 +91,13 @@ When "dev" or "development", is an alias to `dev`.
 
 When "prod" or "production", is an alias to `production`.
 
+### link
+
+* Type: Boolean
+* Default: false
+
+Display only dependencies which are linked
+
 ## SEE ALSO
 
 * npm-config(1)

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -78,6 +78,8 @@ var lsFromTree = ls.fromTree = function (dir, physicalTree, args, silent, cb) {
 
   pruneNestedExtraneous(data)
   filterByEnv(data)
+  filterByLink(data)
+
   var unlooped = filterFound(unloop(data), args)
   var lite = getLite(unlooped)
 
@@ -144,6 +146,19 @@ function filterByEnv (data) {
     }
   })
   data.dependencies = dependencies
+}
+
+function filterByLink (data) {
+  if (npm.config.get('link')) {
+    var dependencies = {}
+    Object.keys(data.dependencies).forEach(function (name) {
+      var dependency = data.dependencies[name]
+      if (dependency.link) {
+        dependencies[name] = dependency
+      }
+    })
+    data.dependencies = dependencies
+  }
 }
 
 function alphasort (a, b) {

--- a/test/tap/link.js
+++ b/test/tap/link.js
@@ -160,6 +160,18 @@ test('link-install the scoped package', function (t) {
   })
 })
 
+test('ls the linked packages', function (t) {
+  process.chdir(linkInstall)
+  common.npm(['ls', '--link'], OPTS, function (err, c, out) {
+    t.ifError(err, 'ls --link did not have an error')
+    t.equal(c, 1)
+    t.has(out, /@scope\/foo@1\.0\.0 ->/, 'output contains scoped link')
+    t.has(out, /foo@1\.0\.0 ->/, 'output contains link')
+    t.doesNotHave(out, /inside@1\.0\.0/, 'output does not contain unlinked dependency')
+    t.end()
+  })
+})
+
 test('cleanup', function (t) {
   process.chdir(osenv.tmpdir())
   common.npm(['rm', 'foo'], OPTS, function (err, code) {


### PR DESCRIPTION
This is a fix for #16126 (Even though it was automatically closed by the bot) which I finally got around to implementing. The idea is to give users the ability to list only packages which have been linked using `npm link`, to get an overview of those (Useful for teams with many internal modules).

Also see this [Stackoverflow question](https://stackoverflow.com/q/24933955/1091402) (Not mine) for proof that there is demand for this feature.