### PR TITLE
selfinstall: Fix self install in Makefile and install.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ latest:
 	node bin/npm-cli.js install -g -f npm ${NPMOPTS}
 
 install: all
-	node bin/npm-cli.js install -g -f ${NPMOPTS}
+	node bin/npm-cli.js install -g -f ${NPMOPTS} $(shell node bin/npm-cli.js pack | tail -1)
 
 # backwards compat
 dev: install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -257,7 +257,7 @@ cd "$TMP" \
       fi
       if [ "$make" = "NOMAKE" ]; then
         "$node" bin/npm-cli.js rm npm -gf
-        "$node" bin/npm-cli.js install -gf
+        "$node" bin/npm-cli.js install -gf $("$node" bin/npm-cli.js pack | tail -1)
       fi) \
   && cd "$BACK" \
   && rm -rf "$TMP" \


### PR DESCRIPTION
We were doing `npm install -g` on `make install` and in the `install.sh`
bootstrapper, which now makes a symlink.  This updates it to go back to
creating a global copy.

Fixes: #17554, #17377 and (part of) #16916 
