### PR TITLE
remove: Make file: spec/link removal match specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,270 @@
+## v5.1.0 (2017-07-05):
+
+Hey y'all~
+
+We've got some goodies for you here, including `npm@5`'s first semver-minor
+release! This version includes a huge number of fixes, particularly for some of
+the critical bugs users were running into after upgrading npm. You should
+overall see a much more stable experience, and we're going to continue hacking
+on fixes for the time being. Semver-major releases, specially for tools like
+npm, are bound to cause some instability, and getting `npm@5` stable is the CLI
+team's top priority for now!
+
+Not that bugfixes are the only things that landed, either: between improvements
+that fell out of the bugfixes, and some really cool work by community members
+like [@mikesherov](https://github.com/mikesherov), `npm@5.1.0` is _twice as
+fast_ as `npm@5.0.0` in some benchmarks. We're not stopping there, either: you
+can expect a steady stream of speed improvements over the course of the year.
+It's not _top_ priority, but we'll keep doing what we can to make sure npm saves
+its users as much time as possible.
+
+Hang on to your seats. This release is a bit of a doozy. 😎
+
+### FEATURES
+
+Semver-minor releases, of course, mean that there's a new feature somewhere,
+right? Here's what's bumping that number for us this time:
+
+* [`a09c1a69d`](https://github.com/npm/npm/commit/a09c1a69df05b753464cc1272cdccc6af0f4da5a)
+  [#16687](https://github.com/npm/npm/pull/16687)
+  Allow customizing the shell used to execute `run-script`s.
+  ([@mmkal](https://github.com/mmkal))
+* [`4f45ba222`](https://github.com/npm/npm/commit/4f45ba222e2ac6dbe6d696cb7a8e678bbda7c839) [`a48958598`](https://github.com/npm/npm/commit/a489585985540deed4edc03418636c9e97aa9e40) [`901bef0e1`](https://github.com/npm/npm/commit/901bef0e1ea806fc08d8d58744a9f813b6c020ab)
+  [#17508](https://github.com/npm/npm/pull/17508)
+  Add a new `requires` field to `package-lock.json` with information about the
+  _logical_ dependency tree. This includes references to the specific version
+  each package is intended to see, and can be used for many things, such as
+  [converting `package-lock.json` to other lockfile
+  formats](https://twitter.com/maybekatz/status/880578566907248640), various
+  optimizations, and verifying correctness of a package tree.
+  ([@iarna](https://github.com/iarna))
+* [`47e8fc8eb`](https://github.com/npm/npm/commit/47e8fc8eb9b5faccef9e03ab991cf37458c16249)
+  [#17508](https://github.com/npm/npm/pull/17508)
+  Make `npm ls` take package locks (and shrinkwraps) into account. This means
+  `npm ls` can now be used to see [which dependencies are
+  missing](https://twitter.com/maybekatz/status/880446509547794437), so long as
+  a package lock has been previously generated with it in.
+  ([@iarna](https://github.com/iarna))
+* [`f0075e7ca`](https://github.com/npm/npm/commit/f0075e7caa3e151424a254d7809ae4489ed8df90)
+  [#17508](https://github.com/npm/npm/pull/17508)
+  Take `package.json` changes into account when running installs -- if you
+  remove or add a dependency to `package.json` manually, npm will now pick that
+  up and update your tree and package lock accordingly.
+  ([@iarna](https://github.com/iarna))
+* [`83a5455aa`](https://github.com/npm/npm/commit/83a5455aac3c5cc2511ab504923b652b13bd66a0)
+  [#17205](https://github.com/npm/npm/pull/17205)
+  Add `npm udpate` as an alias for `npm update`, for symmetry with
+  `install`/`isntall`.
+  ([@gdassori](https://github.com/gdassori))
+* [`57225d394`](https://github.com/npm/npm/commit/57225d394b6174eb0be48393d8e18da0991f67b6)
+  [#17120](https://github.com/npm/npm/pull/17120)
+  npm will no longer warn about `preferGlobal`, and the option is now
+  deprecated.
+  ([@zkat](https://github.com/zkat))
+* [`82df7bb16`](https://github.com/npm/npm/commit/82df7bb16fc29c47a024db4a8c393e55f883744b)
+  [#17351](https://github.com/npm/npm/pull/17351)
+  As some of you may already know `npm build` doesn't do what a lot of people
+  expect: It's mainly an npm plumbing command, and is part of the more familiar
+  `npm rebuild` command. That said, a lot of users assume that this is the way
+  to run an npm `run-script` named `build`, which is an incredibly common script
+  name to use. To clarify things for users, and encourage them to use `npm run
+  build` instead, npm will now warn if `npm build` is run without any arguments.
+  ([@lennym](https://github.com/lennym))
+* [`d57d4f48c`](https://github.com/npm/npm/commit/d57d4f48c6cd00fdf1e694eb49e9358071d8e105)
+  [#17319](https://github.com/npm/npm/pull/17319)
+  Add new `--silent` option to `npm run-script` to suppress output from the
+  scripts themselves, since `--loglevel=silent` is only for `npmlog` itself.
+  ([@styfle](https://github.com/styfle))
+
+### PERFORMANCE
+
+* [`59f86ef90`](https://github.com/npm/npm/commit/59f86ef90a58d8dc925c9613f1c96e68bee5ec7b) [`43be9d222`](https://github.com/npm/npm/commit/43be9d2222b23ebb0a427ed91824ae217e6d077a) [`e906cdd98`](https://github.com/npm/npm/commit/e906cdd980b4722e66618ce295c682b9a8ffaf8f)
+  [#16633](https://github.com/npm/npm/pull/16633)
+  npm now parallelizes tarball extraction across multiple child process workers.
+  This can significantly speed up installations, specially when installing from
+  cache, and will improve with number of processors.
+  ([@zkat](https://github.com/zkat))
+* [`e0849878d`](https://github.com/npm/npm/commit/e0849878dd248de8988c2ef3fc941054625712ca)
+  [#17441](https://github.com/npm/npm/pull/17441)
+  Avoid building environment for empty lifecycle scripts. This change alone
+  accounted for as much as a 15% speed boost for npm installations by outright
+  skipping entire steps of the installer when not needed.
+  ([@mikesherov](https://github.com/mikesherov))
+* [`265c2544c`](https://github.com/npm/npm/commit/265c2544c8ded10854909243482e6437ed03c261)
+  [npm/hosted-git-info#24](https://github.com/npm/hosted-git-info/pull/24)
+  `hosted-git-info@2.5.0`: Add caching to `fromURL`, which gets called many,
+  many times by the installer. This improved installation performance by around
+  10% on realistic application repositories.
+  ([@mikesherov](https://github.com/mikesherov))
+* [`44e37045d`](https://github.com/npm/npm/commit/44e37045d77bc40adf339b423d42bf5e9b4d4d91)
+  Eliminate `Bluebird.promisifyAll` from our codebase.
+  ([@iarna](https://github.com/iarna))
+* [`3b4681b53`](https://github.com/npm/npm/commit/3b4681b53db7757985223932072875d099694677)
+  [#17508](https://github.com/npm/npm/pull/17508)
+  Stop calling `addBundle` on locked deps, speeding up the
+  `package-lock.json`-based fast path.
+  ([@iarna](https://github.com/iarna))
+
+### BUGFIXES
+
+* [#17508](https://github.com/npm/npm/pull/17508)
+  This is a big PR that fixes a variety of issues when installing from package
+  locks. If you were previously having issues with missing dependencies or
+  unwanted removals, this might have fixed it:
+  * It introduces a new `package-lock.json` field, called `requires`, which tracks which modules a given module requires.
+  * It fixes [#16839](https://github.com/npm/npm/issue/16839) which was caused by not having this information available, particularly when git dependencies were involved.
+  * It fixes [#16866](https://github.com/npm/npm/issue/16866), allowing the `package.json` to trump the `package-lock.json`.
+  * `npm ls` now loads the shrinkwrap, which opens the door to showing a full tree of dependencies even when nothing is yet installed. (It doesn't do that yet though.)
+  ([@iarna](https://github.com/iarna))
+* [`656544c31`](https://github.com/npm/npm/commit/656544c31cdef3cef64fc10c24f03a8ae2685e35) [`d21ab57c3`](https://github.com/npm/npm/commit/d21ab57c3ef4f01d41fb6c2103debe884a17dc22)
+  [#16637](https://github.com/npm/npm/pull/16637)
+  Fix some cases where `npm prune` was leaving some dependencies unpruned if
+  to-be-pruned dependencies depended on them.
+  ([@exogen](https://github.com/exogen))
+* [`394436b09`](https://github.com/npm/npm/commit/394436b098dcca2d252061f95c4eeb92c4a7027c)
+  [#17552](https://github.com/npm/npm/pull/17552)
+  Make `refresh-package-json` re-verify the package platform. This fixes an
+  issue most notably experienced by Windows users using `create-react-app` where
+  `fsevents` would not short-circuit and cause a crash during its
+  otherwise-skipped native build phase.
+  ([@zkat](https://github.com/zkat))
+* [`9e5a94354`](https://github.com/npm/npm/commit/9e5a943547b29c8d022192afd9398b3a136a7e5a)
+  [#17590](https://github.com/npm/npm/pull/17590)
+  Fix an issue where `npm@5` would crash when trying to remove packages
+  installed with `npm@<5`.
+  ([@iarna](https://github.com/iarna))
+* [`c3b586aaf`](https://github.com/npm/npm/commit/c3b586aafa9eabac572eb6e2b8a7266536dbc65b)
+  [#17141](https://github.com/npm/npm/issue/17141)
+  Don't update the package.json when modifying packages that don't go there.
+  This was previously causing `package.json` to get a `"false": {}` field added.
+  ([@iarna](https://github.com/iarna))
+* [`d04a23de2`](https://github.com/npm/npm/commit/d04a23de21dd9991b32029d839b71e10e07b400d) [`4a5b360d5`](https://github.com/npm/npm/commit/4a5b360d561f565703024085da0927ccafe8793e) [`d9e53db48`](https://github.com/npm/npm/commit/d9e53db48ca227b21bb67df48c9b3580cb390e9e)
+  `pacote@2.7.38`:
+  * [zkat/pacote#102](https://github.com/zkat/pacote/pull/102) Fix issue with tar extraction and special characters.
+  * Enable loose semver parsing in some missing corner cases.
+  ([@colinrotherham](https://github.com/colinrotherham), [@zkat](https://github.com/zkat), [@mcibique](https://github.com/mcibique))
+* [`e2f815f87`](https://github.com/npm/npm/commit/e2f815f87676b7c50b896e939cee15a01aa976e4)
+  [#17104](https://github.com/npm/npm/pull/17104)
+  Write an empty str and wait for flush to exit to reduce issues with npm
+  exiting before all output is complete when it's a child process.
+  ([@zkat](https://github.com/zkat))
+* [`835fcec60`](https://github.com/npm/npm/commit/835fcec601204971083aa3a281c3a9da6061a7c2)
+  [#17060](https://github.com/npm/npm/pull/17060)
+  Make git repos with prepare scripts always install with both dev and prod
+  flags.
+  ([@intellix](https://github.com/intellix))
+* [`f1dc8a175`](https://github.com/npm/npm/commit/f1dc8a175eed56f1ed23bd5773e5e10beaf6cb31)
+  [#16879](https://github.com/npm/npm/pull/16879)
+  Fix support for `always-auth` and `_auth`. They are now both available in both
+  unscoped and registry-scoped configurations.
+  ([@jozemlakar](https://github.com/jozemlakar))
+* [`ddd8a1ca2`](https://github.com/npm/npm/commit/ddd8a1ca2fa3377199af74ede9d0c1a406d19793)
+  Serialize package specs to prevent `[object Object]` showing up in logs during
+  extraction.
+  ([@zkat](https://github.com/zkat))
+* [`99ef3b52c`](https://github.com/npm/npm/commit/99ef3b52caa7507e87a4257e622f8964b1c1f5f3)
+  [#17505](https://github.com/npm/npm/pull/17505)
+  Stop trying to commit updated `npm-shrinkwrap.json` and `package-lock.json` if
+  they're `.gitignore`d.
+  ([@zkat](https://github.com/zkat))
+* [`58be2ec59`](https://github.com/npm/npm/commit/58be2ec596dfb0353ad2570e6750e408339f1478)
+  Make sure uid and gid are getting correctly set even when they're `0`. This
+  should fix some Docker-related issues with bad permissions/broken ownership.
+  ([@rgrove](https://github.com/rgrove))
+  ([@zkat](https://github.com/zkat))
+* [`9d1e3b6fa`](https://github.com/npm/npm/commit/9d1e3b6fa01bb563d76018ee153259d9507658cf)
+  [#17506](https://github.com/npm/npm/pull/17506)
+  Skip writing package.json and locks if on-disk version is identical to the new
+  one.
+  ([@zkat](https://github.com/zkat))
+* [`3fc6477a8`](https://github.com/npm/npm/commit/3fc6477a89773786e6c43ef43a23e5cdc662ff8e)
+  [#17592](https://github.com/npm/npm/pull/17592)
+  Fix an issue where `npm install -g .` on a package with no `name` field would
+  cause the entire global `node_modules` directory to be replaced with a symlink
+  to `$CWD`. lol.
+  ([@iarna](https://github.com/iarna))
+* [`06ba0a14a`](https://github.com/npm/npm/commit/06ba0a14a6c1c8cdcc8c062b68c8c63041b0cec0)
+  [#17591](https://github.com/npm/npm/pull/17591)
+  Fix spurious removal reporting: if you tried to remove something that didn't
+  actually exist, npm would tell you it removed 1 package even though there was
+  nothing to do.
+  ([@iarna](https://github.com/iarna))
+
+### DOCS
+
+* [`fd5fab595`](https://github.com/npm/npm/commit/fd5fab5955a20a9bb8c0e77092ada1435f73a8d2)
+  [#16441](https://github.com/npm/npm/pull/16441)
+  Add spec for `npm-shrinkwrap.json` and `package-lock.json` from RFC.
+  ([@iarna](https://github.com/iarna))
+* [`9589c1ccb`](https://github.com/npm/npm/commit/9589c1ccb3f794abaaa48c2a647ada311dd881ef)
+  [#17451](https://github.com/npm/npm/pull/17451)
+  Fix typo in changelog.
+  ([@watilde](https://github.com/watilde))
+* [`f8e76d856`](https://github.com/npm/npm/commit/f8e76d8566ae1965e57d348df74edad0643b66a6)
+  [#17370](https://github.com/npm/npm/pull/17370)
+  Correct the default prefix config path for Windows operating systems in the
+  documentation for npm folders.
+  ([@kierendixon](https://github.com/kierendixon))
+* [`d0f3b5a12`](https://github.com/npm/npm/commit/d0f3b5a127718b0347c6622a2b9c28341c530d36)
+  [#17369](https://github.com/npm/npm/pull/17369)
+  Fix `npm-config` reference to `userconfig` & `globalconfig` environment
+  variables.
+  ([@racztiborzoltan](https://github.com/racztiborzoltan))
+* [`87629880a`](https://github.com/npm/npm/commit/87629880a71baec352c1b5345bc29268d6212467)
+  [#17336](https://github.com/npm/npm/pull/17336)
+  Remove note in docs about `prepublish` being entirely removed.
+  ([@Hirse](https://github.com/Hirse))
+* [`a1058afd9`](https://github.com/npm/npm/commit/a1058afd9a7a569bd0ac65b86eadd4fe077a7221)
+  [#17169](https://github.com/npm/npm/pull/17169)
+  Document `--no-package-lock` flag.
+  ([@leggsimon](https://github.com/leggsimon))
+* [`32fc6e41a`](https://github.com/npm/npm/commit/32fc6e41a2ce4dbcd5ce1e5f291e2e2efc779d48)
+  [#17250](https://github.com/npm/npm/pull/17250)
+  Fix a typo in the shrinkwrap docs.
+  ([@Zarel](https://github.com/Zarel))
+* [`f19bd3c8c`](https://github.com/npm/npm/commit/f19bd3c8cbd37c8a99487d6b5035282580ac3e9d)
+  [#17249](https://github.com/npm/npm/pull/17249)
+  Fix a package-lock.json cross-reference link.
+  ([@not-an-aardvark](https://github.com/not-an-aardvark))
+* [`153245edc`](https://github.com/npm/npm/commit/153245edc4845db670ada5e95ef384561706a751)
+  [#17075](https://github.com/npm/npm/pull/17075/files)
+  Fix a typo in `npm-config` docs.
+  ([@KennethKinLum](https://github.com/KennethKinLum))
+* [`c9b534a14`](https://github.com/npm/npm/commit/c9b534a148818d1a97787c0dfdba5f64ce3618a6)
+  [#17074](https://github.com/npm/npm/pull/17074)
+  Clarify config documention with multiple boolean flags.
+  ([@KennethKinLum](https://github.com/KennethKinLum))
+* [`e111b0a40`](https://github.com/npm/npm/commit/e111b0a40c4bc6691d7b8d67ddce5419e67bfd27)
+  [#16768](https://github.com/npm/npm/pull/16768)
+  Document the `-l` option to `npm config list`.
+  ([@happylynx](https://github.com/happylynx))
+* [`5a803ebad`](https://github.com/npm/npm/commit/5a803ebadd61229bca3d64fb3ef1981729b2548e)
+  [#16548](https://github.com/npm/npm/pull/16548)
+  Fix permissions for documentation files. Some of them had `+x` set. (???)
+  ([@metux](https://github.com/metux))
+
+### MISC
+
+Not all contributions need to be visible features, docs, or bugfixes! It's super
+helpful when community members go over our code and help clean it up, too!
+
+* [`9e5b76140`](https://github.com/npm/npm/commit/9e5b76140ffdb7dcd12aa402793644213fb8c5d7)
+  [#17411](https://github.com/npm/npm/pull/17411)
+  Convert all callback-style `move` usage to use Promises.
+  ([@vramana](https://github.com/vramana))
+* [`0711c08f7`](https://github.com/npm/npm/commit/0711c08f779ac641ec42ecc96f604c8861008b28)
+  [#17394](https://github.com/npm/npm/pull/17394)
+  Remove unused argument in `deepSortObject`.
+  ([@vramana](https://github.com/vramana))
+* [`7d650048c`](https://github.com/npm/npm/commit/7d650048c8ed5faa0486492f1eeb698e7383e32f)
+  [#17563](https://github.com/npm/npm/pull/17563)
+  Refactor some code to use `Object.assign`.
+  ([@vramana](https://github.com/vramana))
+* [`993f673f0`](https://github.com/npm/npm/commit/993f673f056aea5f602ea04b1e697b027c267a2d)
+  [#17600](https://github.com/npm/npm/pull/17600)
+  Remove an old comment.
+  ([@vramana](https://github.com/vramana))
+
 ## v5.0.4 (2017-06-13):
 
 Hey y'all. This is another minor patch release with a variety of little fixes

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -671,6 +671,7 @@ var findRequirement = exports.findRequirement = function (tree, name, requested,
     return null
   }
   if (tree.isTop) return null
+  if (!preserveSymlinks() && /^[.][.][\\/]/.test(path.relative(tree.parent.realpath, tree.realpath))) return null
   return findRequirement(tree.parent, name, requested, requestor)
 }
 

--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -5,6 +5,7 @@ var npa = require('npm-package-arg')
 var flattenTree = require('./flatten-tree.js')
 var isOnlyDev = require('./is-only-dev.js')
 var log = require('npmlog')
+var path = require('path')
 
 function nonRegistrySource (pkg) {
   validate('O', arguments)
@@ -122,6 +123,8 @@ var diffTrees = module.exports._diffTrees = function (oldTree, newTree) {
   Object.keys(flatOldTree).forEach(function (flatname) {
     if (flatNewTree[flatname]) return
     var pkg = flatOldTree[flatname]
+    if (pkg.isInLink && /^[.][.][/\\]/.test(path.relative(newTree.realpath, pkg.realpath))) return
+
     toRemove[flatname] = pkg
     var pkgunique = getUniqueId(pkg.package)
     if (!toRemoveByUniqueId[pkgunique]) toRemoveByUniqueId[pkgunique] = []

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -135,6 +135,7 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
     path: childPath(tree.path, pkg),
     realpath: childPath(tree.realpath, pkg),
     location: tree.location + '/' + pkg.name,
+    isLink: requested.type === 'directory',
     isInLink: tree.isLink,
     swRequires: sw.requires
   })

--- a/lib/install/node.js
+++ b/lib/install/node.js
@@ -27,6 +27,9 @@ var defaultTemplate = {
 function isLink (node) {
   return node && node.isLink
 }
+function isInLink (node) {
+  return node && (node.isInLink || node.isLink)
+}
 
 var create = exports.create = function (node, template, isNotTop) {
   if (!template) template = defaultTemplate
@@ -41,13 +44,8 @@ var create = exports.create = function (node, template, isNotTop) {
   if (!isNotTop) {
     // isLink is true for the symlink and everything inside it.
     // by contrast, isInLink is true for only the things inside a link
-    if (node.isLink == null && isLink(node.parent)) {
-      node.isLink = true
-      node.isInLink = true
-    } else if (node.isLink == null) {
-      node.isLink = false
-      node.isInLink = false
-    }
+    if (node.isLink == null) node.isLink = isLink(node.parent)
+    if (node.isInLink == null) node.isInLink = isInLink(node.parent)
     if (node.fromBundle == null) {
       node.fromBundle = false
     }

--- a/test/tap/spec-local-specifiers.js
+++ b/test/tap/spec-local-specifiers.js
@@ -609,11 +609,133 @@ test('save behavior', function (t) {
   })
 })
 
+var rmdir = testdir + '/remove-behavior'
+testdirContent['remove-behavior'] = Dir({
+  'rmsymlink': Dir({
+    'package.json': File({
+      name: 'remove-behavior',
+      version: '1.0.0',
+      dependencies: {
+        dep1: 'file:dep1',
+      }
+    }),
+    'package-lock.json': File({
+      name: 'remove-behavior',
+      version: '1.0.0',
+      lockfileVersion: 1,
+      requires: true,
+      dependencies: {
+        dep1: {
+          version: 'file:dep1',
+          requires: {
+            dep2: 'file:dep2'
+          },
+          dependencies: {
+            dep2: {
+              version: 'file:dep2',
+              bundled: true
+            }
+          }
+        }
+      }
+    }),
+    dep1: Dir({
+      'package.json': File({
+        name: 'dep1',
+        version: '1.0.0',
+        dependencies: {
+          dep2: 'file:../dep2'
+        }
+      }),
+      'node_modules': Dir({
+        dep2: Symlink('../../dep2')
+      })
+    }),
+    dep2: Dir({
+      'package.json': File({
+        name: 'dep2',
+        version: '1.0.0'
+      })
+    }),
+    'node_modules': Dir({
+      dep1: Symlink('../dep1')
+    })
+  }),
+  'rmesymlink': Dir({
+    'package.json': File({
+      name: 'remove-behavior',
+      version: '1.0.0',
+      dependencies: {
+        edep1: 'file:../edep1',
+      }
+    }),
+    'package-lock.json': File({
+      name: 'remove-behavior',
+      version: '1.0.0',
+      lockfileVersion: 1,
+      requires: true,
+      dependencies: {
+        edep1: {
+          version: 'file:../edep1',
+          requires: {
+            edep2: 'file:../edep2'
+          },
+          dependencies: {
+            edep2: {
+              version: 'file:../edep2',
+              bundled: true
+            }
+          }
+        }
+      }
+    }),
+    'node_modules': Dir({
+      edep1: Symlink('../../edep1')
+    })
+  }),
+  edep1: Dir({
+    'package.json': File({
+      name: 'edep1',
+      version: '1.0.0',
+      dependencies: {
+        edep2: 'file:../edep2'
+      }
+    }),
+    'node_modules': Dir({
+      edep2: Symlink('../../edep2')
+    })
+  }),
+  edep2: Dir({
+    'package.json': File({
+      name: 'edep2',
+      version: '1.0.0'
+    })
+  }),
+})
+
 test('removal', function (t) {
-  t.plan(3)
-  t.test('should remove the symlink')
-  t.test('should not remove the transitive deps if it was not a `link:` type specifier.')
-  t.test("should not remove transitive deps if it's outside the package and --preserver-symlinks isn't set")
+  t.plan(2)
+
+  t.test('should remove the symlink', t => {
+    const rmconf = {cwd: `${rmdir}/rmsymlink`, env: conf.env, stdio: conf.stdio}
+    return common.npm(['uninstall', 'dep1'], rmconf).spread((code, stdout) => {
+      t.is(code, 0, 'uninstall ran ok')
+      t.comment(stdout)
+      noFileExists(t, `${rmdir}/rmsymlink/node_modules/dep1`, 'removed symlink')
+      noFileExists(t, `${rmdir}/rmsymlink/dep1/node_modules/dep2`, 'removed transitive dep')
+      fileExists(t, `${rmdir}/rmsymlink/dep2`, 'original transitive dep still exists')
+    })
+  })
+  t.test("should not remove transitive deps if it's outside the package and --preserver-symlinks isn't set", t => {
+    const rmconf = {cwd: `${rmdir}/rmesymlink`, env: conf.env, stdio: conf.stdio}
+    return common.npm(['uninstall', 'edep1'], rmconf).spread((code, stdout) => {
+      t.is(code, 0, 'uninstall ran ok')
+      t.comment(stdout)
+      noFileExists(t, `${rmdir}/rmsymlink/node_modules/edep1`, 'removed symlink')
+      fileExists(t, `${rmdir}/edep1/node_modules/edep2`, 'did NOT remove transitive dep')
+      fileExists(t, `${rmdir}/edep2`, 'original transitive dep still exists')
+    })
+  })
 })
 
 test('misc', function (t) {


### PR DESCRIPTION
When removing a link, dependencies that are installed inside of it should
not be removed if the link target is not inside the current project.

This fixes the "removing globally installed link deletes local deps"
problem, amongst others.