### PR TITLE
outdated: Show results for globals again

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -38,6 +38,7 @@ var long = npm.config.get('long')
 var mapToRegistry = require('./utils/map-to-registry.js')
 var isExtraneous = require('./install/is-extraneous.js')
 var computeMetadata = require('./install/deps.js').computeMetadata
+var computeVersionSpec = require('./install/deps.js').computeVersionSpec
 var moduleName = require('./utils/module-name.js')
 var output = require('./utils/output.js')
 var ansiTrim = require('./utils/ansi-trim')
@@ -201,7 +202,7 @@ function outdated_ (args, path, tree, parentHas, depth, cb) {
   var types = {}
   var pkg = tree.package
 
-  var deps = tree.children.filter(function (child) { return !isExtraneous(child) }) || []
+  var deps = tree.error ? tree.children : tree.children.filter((child) => !isExtraneous(child))
 
   deps.forEach(function (dep) {
     types[moduleName(dep)] = 'dependencies'
@@ -288,7 +289,7 @@ function outdated_ (args, path, tree, parentHas, depth, cb) {
     var required = (tree.package.dependencies)[name] ||
                    (tree.package.optionalDependencies)[name] ||
                    (tree.package.devDependencies)[name] ||
-                   dep.package._requested && dep.package._requested.fetchSpec ||
+                   computeVersionSpec(tree, dep) ||
                    '*'
     if (!long) return shouldUpdate(args, dep, name, has, required, depth, path, cb)
 


### PR DESCRIPTION
Previously `isExtraneous` never flagged anything as extraneous w/o a
package.json.  `isExtraneous` was simplified in the refactorings in npm@5
due to `npm install` creating synthetic dependency data.  As `outdated`
didn't do that too it ended up ignoring all globals as extraneous.