### PR TITLE
Documentation: fix minor stylistic issue on page about “scripts” field

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -3,7 +3,7 @@ npm-scripts(7) -- How npm handles the "scripts" field
 
 ## DESCRIPTION
 
-npm supports the "scripts" property of the package.json script, for the
+npm supports the "scripts" property of the package.json file, for the
 following scripts:
 
 * prepublish:


### PR DESCRIPTION
I wouldn't call `package.json` a &ldquo;script&rdquo;, but a &ldquo;file&rdquo;.
Besides, there are two other occurrences of the word &ldquo;script&rdquo; in that sentence already.