### PR TITLE
install: Fix deps getting moved on update

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -370,6 +370,7 @@ Installer.prototype.normalizeCurrentTree = function (cb) {
       }
     }
   }
+  computeMetadata(this.currentTree)
   return cb()
 
   function normalizeTree (tree, seen) {

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -31,6 +31,7 @@ var isProdDep = require('./is-prod-dep.js')
 var reportOptionalFailure = require('./report-optional-failure.js')
 var getSaveType = require('./save.js').getSaveType
 var unixFormatPath = require('../utils/unix-format-path.js')
+var isExtraneous = require('./is-extraneous.js')
 
 // The export functions in this module mutate a dependency tree, adding
 // items to them.
@@ -172,7 +173,9 @@ function removeObsoleteDep (child, log) {
   var requires = child.requires || []
   requires.forEach(function (requirement) {
     requirement.requiredBy = requirement.requiredBy.filter(function (reqBy) { return reqBy !== child })
-    if (requirement.requiredBy.length === 0) removeObsoleteDep(requirement, log)
+    // we don't just check requirement.requires because that doesn't account
+    // for circular deps.  isExtraneous does.
+    if (isExtraneous(requirement)) removeObsoleteDep(requirement, log)
   })
 }
 


### PR DESCRIPTION
This makes circular deps get pruned when removing obsolete dependencies (for instance, when removing an older version of a dep when updating).