### PR TITLE
install/deps: Stop flattening modules that require peer deps

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -693,6 +693,10 @@ var earliestInstallable = exports.earliestInstallable = function (requiredBy, tr
   }
   if (tree.children.some(undeletedModuleMatches)) return null
 
+  // Peer deps can't be flattened because we don't know where they'll be installed.
+  // We can later add optimiations to flatten the dep if that's valid.
+  if (pkg.peerDependencies && Object.keys(pkg.peerDependencies).length) return null
+
   // If any of the children of this tree have conflicting
   // binaries then we need to decline to install this package here.
   var binaryMatches = pkg.bin && tree.children.some(function (child) {


### PR DESCRIPTION
This is necessary because we don't know where their peer dep is installed.
In fact, it might not _be_ installed and that's still a valid tree.  By not
flattening it we can ensure that it's always able to load it regardless of where
it was required.

Fixes: #17639