### PR TITLE
allows the option to extend npm commands

### DIFF
--- a/lib/config/cmd-elsewhere.js
+++ b/lib/config/cmd-elsewhere.js
@@ -1,0 +1,26 @@
+var path = require('path')
+var fs = require('fs');
+var log = require('npmlog')
+
+var npmconf = require('./core.js')
+var cmdElseWhere = {}
+
+Object.defineProperty(cmdElseWhere, 'cmdList', {
+    get: function get() {
+        try {
+            var bin = path.resolve(npmconf.defaults.prefix, 'bin');
+            var commands = fs.readdirSync(bin).filter(function(name) {
+                return name.substring(0, 4) == 'npm-'
+            }).map(function(name) {
+                return name.substring(4, name.length)
+            })
+            return commands;
+        } catch(ex) {
+            // silently ignore error
+            log.error('cmdElseWhere', ex.toString());
+            return [];
+        }
+    }
+});
+
+module.exports = cmdElseWhere

--- a/lib/help.js
+++ b/lib/help.js
@@ -12,6 +12,7 @@ var npm = require('./npm.js')
 var log = require('npmlog')
 var opener = require('opener')
 var glob = require('glob')
+var cmdElseWhere = require('./config/cmd-elsewhere').cmdList
 var cmdList = require('./config/cmd-list').cmdList
 var shorthands = require('./config/cmd-list').shorthands
 var commands = cmdList.concat(Object.keys(shorthands))
@@ -173,6 +174,10 @@ function npmUsage (valid, cb) {
     'npm -l           display full usage info',
     'npm help <term>  search for help on <term>',
     'npm help npm     involved overview',
+    '',
+    '',
+    'npm commands available from elsewhere on your $PATH',
+    '    ' + wrap(cmdElseWhere),
     '',
     'Specify configs in the ini-formatted file:',
     '    ' + npm.config.get('userconfig'),

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -37,9 +37,11 @@
   var aliases = require('./config/cmd-list').aliases
   var cmdList = require('./config/cmd-list').cmdList
   var plumbing = require('./config/cmd-list').plumbing
+  var cmdElseWhere = require('./config/cmd-elsewhere').cmdList
   var output = require('./utils/output.js')
   var startMetrics = require('./utils/metrics.js').start
   var perf = require('./utils/perf.js')
+  var spawn = require('child_process').spawn
 
   perf.emit('time', 'npm')
   perf.on('timing', function (name, finished) {
@@ -172,6 +174,7 @@
   }
 
   npm.deref = function (c) {
+    if (cmdElseWhere.indexOf(c) !== -1) return c
     if (!c) return ''
     if (c.match(/[A-Z]/)) {
       c = c.replace(/([A-Z])/g, function (m) {
@@ -448,6 +451,19 @@
       }
     }, enumerable: false, configurable: true })
   })
+
+  cmdElseWhere.forEach(function(cmd) {
+      var args = process.argv.slice(3, process.argv.length);
+
+      npm.commands[cmd] = (_arg, cb) => {
+        var bin = path.resolve(process.env.PATH.split(path.delimiter)[1], `npm-${cmd}`);
+        var ex = spawn(bin, args, { stdio:'inherit' });
+
+        ex.on('close', (code) => {
+            cb();
+        });
+      }
+  });
 
   if (require.main === module) {
     require('../bin/npm-cli.js')

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -8,6 +8,7 @@ var log = require('npmlog')
 var chain = require('slide').chain
 var usage = require('./utils/usage')
 var output = require('./utils/output.js')
+var cmdElseWhere = require('./config/cmdElseWhere').cmdList
 
 runScript.usage = usage(
   'run-script',
@@ -75,7 +76,7 @@ function list (cb) {
     'version'
   ].reduce(function (l, p) {
     return l.concat(['pre' + p, p, 'post' + p])
-  }, [])
+  }, []).concat(cmdElseWhere);
   return readJson(json, function (er, d) {
     if (er && er.code !== 'ENOENT' && er.code !== 'ENOTDIR') return cb(er)
     if (er) d = {}


### PR DESCRIPTION
# Problem Statement

How do I run binaries in context, without using the scripts command?

# Solution

> allow npm to run global modules under the context of the binary

I have long wanted the feature to be able to extend npm to do more things with global modules.

For example if I install a module `npm-what`, the shorthand for running this should be `npm what`.

Git has had this functionality for a [while](https://github.com/git/git/blob/master/git.c#L528) and people have been extending git via this [method](https://coderwall.com/p/bt93ia/extend-git-with-custom-commands)

The previous help menu used to read as

```
Usage: npm <command>

where <command> is one of:
    access, adduser, bin, bugs, c, cache, completion, config,
    ddp, dedupe, deprecate, dist-tag, docs, edit, explore, get,
    help, help-search, i, init, install, install-test, it, link,
    list, ln, login, logout, ls, outdated, owner, pack, ping,
    prefix, prune, publish, rb, rebuild, repo, restart, root,
    run, run-script, s, se, search, set, shrinkwrap, star,
    stars, start, stop, t, team, test, tst, un, uninstall,
    unpublish, unstar, up, update, v, version, view, whoami

npm <cmd> -h     quick help on <cmd>
npm -l           display full usage info
npm help <term>  search for help on <term>
npm help npm     involved overview

Specify configs in the ini-formatted file:
    /Users/gabrielcsapo/.npmrc
or on the command line via: npm <command> --key value
Config info can be viewed via: npm help config

npm@4.0.5 /Users/gabrielcsapo/.nvm/versions/node/v4.7.0/lib/node_modules/npm
```

now will read as 

```
Usage: npm <command>

where <command> is one of:
    access, adduser, bin, bugs, c, cache, completion, config,
    ddp, dedupe, deprecate, dist-tag, docs, doctor, edit,
    explore, get, help, help-search, i, init, install,
    install-test, it, link, list, ln, login, logout, ls,
    outdated, owner, pack, ping, prefix, prune, publish, rb,
    rebuild, repo, restart, root, run, run-script, s, se,
    search, set, shrinkwrap, star, stars, start, stop, t, team,
    test, tst, un, uninstall, unpublish, unstar, up, update, v,
    version, view, whoami

npm <command> -h     quick help on <command>
npm -l           display full usage info
npm help <term>  search for help on <term>
npm help npm     involved overview


npm commands available from elsewhere on your $PATH
    check, what

Specify configs in the ini-formatted file:
    /Users/gabrielcsapo/.npmrc
or on the command line via: npm <command> --key value
Config info can be viewed via: npm help config

npm@5.1.0 /Users/gabrielcsapo/Documents/npm
```

This format is comparable with the `git --help -a` response

```
usage: git [--version] [--help] [-C <path>] [-c name=value]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | --no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           <command> [<args>]

available git commands in '/Applications/Xcode.app/Contents/Developer/usr/libexec/git-core'

  add                       merge-octopus
 *** 

git commands available from elsewhere on your $PATH

  unstaged

'git help -a' and 'git help -g' list available subcommands and some
concept guides. See 'git help <command>' or 'git help <concept>'
to read about a specific subcommand or concept.
```

## Example Usage
> this example is with [npm-check](https://www.npmjs.com/package/npm-check) installed globally

![out](https://user-images.githubusercontent.com/1854811/27983342-ff26533a-636e-11e7-90c3-df61b858d459.gif)


I am looking for feedback before completing the rest of the implementation as well as edge cases and tests, if this is something that is wanted for `npm`.