### PR TITLE
Fix hierarchy of headings in package.json documentation

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -462,7 +462,7 @@ Git urls can be of the form:
 The `commit-ish` can be any tag, sha, or branch which can be supplied as
 an argument to `git checkout`.  The default is `master`.
 
-## GitHub URLs
+### GitHub URLs
 
 As of version 1.1.65, you can refer to GitHub urls as just "foo":
 "user/foo-project".  Just as with git URLs, a `commit-ish` suffix can be
@@ -478,7 +478,7 @@ included.  For example:
       }
     }
 
-## Local Paths
+### Local Paths
 
 As of version 2.0.0 you can provide a path to a local directory that contains a
 package. Local paths can be saved using `npm install -S` or


### PR DESCRIPTION
Since [URLs as Dependencies](https://github.com/npm/npm/blob/v5.1.0/doc/files/package.json.md#urls-as-dependencies) and [Git URLs as Dependencies](https://github.com/npm/npm/blob/v5.1.0/doc/files/package.json.md#git-urls-as-dependencies) are third-level headings, both [GitHub URLs](https://github.com/npm/npm/blob/v5.1.0/doc/files/package.json.md#github-urls) and [Local Paths](https://github.com/npm/npm/blob/v5.1.0/doc/files/package.json.md#local-paths) should be third-level headings, too (as they all describe details of [`dependencies`](https://github.com/npm/npm/blob/v5.1.0/doc/files/package.json.md#dependencies), the upper second-level heading).