### PR TITLE
Use semver to compare node versions in npm doctor

### DIFF
--- a/lib/doctor/get-latest-nodejs-version.js
+++ b/lib/doctor/get-latest-nodejs-version.js
@@ -5,7 +5,7 @@ var semver = require('semver')
 function getLatestNodejsVersion (url, cb) {
   var tracker = log.newItem('getLatestNodejsVersion', 1)
   tracker.info('getLatestNodejsVersion', 'Getting Node.js release information')
-  var version = ''
+  var version = 'v0.0.0'
   url = url || 'https://nodejs.org/dist/index.json'
   request(url, function (e, res, index) {
     tracker.finish()

--- a/lib/doctor/get-latest-nodejs-version.js
+++ b/lib/doctor/get-latest-nodejs-version.js
@@ -1,5 +1,6 @@
 var log = require('npmlog')
 var request = require('request')
+var semver = require('semver')
 
 function getLatestNodejsVersion (url, cb) {
   var tracker = log.newItem('getLatestNodejsVersion', 1)
@@ -14,7 +15,7 @@ function getLatestNodejsVersion (url, cb) {
     }
     try {
       JSON.parse(index).forEach(function (item) {
-        if (item.lts && item.version > version) version = item.version
+        if (item.lts && semver.gt(item.version, version)) version = item.version
       })
       cb(null, version)
     } catch (e) {


### PR DESCRIPTION
`npm doctor` suggests to upgrade the version of node if it is outdated.
The suggestion is to use the latest LTS version.
Comparing versions was done by comparing strings.
A lexicografical comparison can give incorrect results. e.g.:
'v6.10.0' > 'v6.9.0' => false

To correct the issue the comparison is done using `semver` which is a dependency `npm` aleady includes.