### PR TITLE
Fix for #17701 (install devDeps not working if organisation contains regex-unsafe characters)

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -63,7 +63,10 @@ function doesChildVersionMatch (child, requested, requestor) {
     // really came from the same sources.
     // You'll see this scenario happen with at least tags and git dependencies.
     if (child.package._from) {
-      var fromReq = npa.resolve(moduleName(child), child.package._from.replace(new RegExp('^' + moduleName(child) + '@'), ''))
+      var modName = moduleName(child)
+      var modVersion = child.package._from
+      if (modVersion.substr(0, modName.length + 1) === modName + '@') modVersion = modVersion.substr(modName.length + 1)
+      var fromReq = npa.resolve(modName, modVersion)
       if (fromReq.rawSpec === requested.rawSpec) return true
       if (fromReq.type === requested.type && fromReq.saveSpec && fromReq.saveSpec === requested.saveSpec) return true
     }


### PR DESCRIPTION
Replaced regular expression with simple string manipulation to avoid module names that contain unsafe characters (possible with an organization) to break things
