### PR TITLE
tar: ignore Vim backup files (Fix #17560)

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -63,6 +63,29 @@ function BundledPacker (props) {
 inherits(BundledPacker, Packer)
 
 BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
+  // some files are *never* allowed under any circumstances
+  // (VCS folders, native build cruft, npm cruft, regular cruft)
+  if (entry === '.git' ||
+      entry === 'CVS' ||
+      entry === '.svn' ||
+      entry === '.hg' ||
+      entry === '.lock-wscript' ||
+      entry.match(/^\.wafpickle-[0-9]+$/) ||
+      (this.parent && this.parent.packageRoot && this.basename === 'build' &&
+       entry === 'config.gypi') ||
+      entry === 'npm-debug.log' ||
+      entry === '.npmrc' ||
+      entry.match(/^\..*\.swp$/) ||
+      entry === '.DS_Store' ||
+      entry.match(/^\._/) ||
+      entry.match(/^.*\.orig$/) ||
+      entry.match(/^.+~$/) || // Vim backup files
+      // Package locks are never allowed in tarballs -- use shrinkwrap instead
+      entry === 'package-lock.json'
+    ) {
+    return false
+  }
+
   if (!entryObj || entryObj.type !== 'Directory') {
     // package.json files can never be ignored.
     if (entry === 'package.json') return true
@@ -86,28 +109,6 @@ BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
   // package.json main file should never be ignored.
   var mainFile = this.package && this.package.main
   if (mainFile && path.resolve(this.path, entry) === path.resolve(this.path, mainFile)) return true
-
-  // some files are *never* allowed under any circumstances
-  // (VCS folders, native build cruft, npm cruft, regular cruft)
-  if (entry === '.git' ||
-      entry === 'CVS' ||
-      entry === '.svn' ||
-      entry === '.hg' ||
-      entry === '.lock-wscript' ||
-      entry.match(/^\.wafpickle-[0-9]+$/) ||
-      (this.parent && this.parent.packageRoot && this.basename === 'build' &&
-       entry === 'config.gypi') ||
-      entry === 'npm-debug.log' ||
-      entry === '.npmrc' ||
-      entry.match(/^\..*\.swp$/) ||
-      entry === '.DS_Store' ||
-      entry.match(/^\._/) ||
-      entry.match(/^.*\.orig$/) ||
-      // Package locks are never allowed in tarballs -- use shrinkwrap instead
-      entry === 'package-lock.json'
-    ) {
-    return false
-  }
 
   // in a node_modules folder, we only include bundled dependencies
   // also, prevent packages in node_modules from being affected

--- a/test/tap/files-and-ignores.js
+++ b/test/tap/files-and-ignores.js
@@ -477,6 +477,7 @@ test('certain files included unconditionally', function (t) {
       'README': File(''),
       'Readme': File(''),
       'readme.md': File(''),
+      'readme.md~': File(''),
       'readme.randomext': File(''),
       'changelog': File(''),
       'CHAngelog': File(''),
@@ -495,6 +496,7 @@ test('certain files included unconditionally', function (t) {
     t.ok(fileExists('README'), 'README included')
     t.ok(fileExists('Readme'), 'Readme included')
     t.ok(fileExists('readme.md'), 'readme.md included')
+    t.notOk(fileExists('readme.md~'), 'readme.md~ not included')
     t.ok(fileExists('readme.randomext'), 'readme.randomext included')
     t.ok(fileExists('changelog'), 'changelog included')
     t.ok(fileExists('CHAngelog'), 'CHAngelog included')


### PR DESCRIPTION
In order to ignore Vim backup of README.md, move ignore rule in front of
READMEs condition.