### PR TITLE
finalize: When rolling back use symlink project-relative path

### DIFF
--- a/lib/install/action/finalize.js
+++ b/lib/install/action/finalize.js
@@ -91,5 +91,5 @@ module.exports = function (staging, pkg, log) {
 module.exports.rollback = function (top, staging, pkg, next) {
   const requested = pkg.package._requested || getRequested(pkg)
   if (requested && requested.type === 'directory') return next()
-  gentlyRm(pkg.realpath, false, top, next)
+  gentlyRm(pkg.path, false, top, next)
 }


### PR DESCRIPTION
Previously it was using the realpath (the path w/o any symlinks in it) which
proceeded to confusing `fs-vacuum` as that path wasn't necessarily in the
base path (our module).

(Partially)
Fixes: #17637