### PR TITLE
test: Unbuild actions happen in reverse now, not remove

### DIFF
--- a/test/tap/uninstall-in-reverse.js
+++ b/test/tap/uninstall-in-reverse.js
@@ -8,10 +8,10 @@ The remove actions need to happen in the opposite of their normally defined
 order. That is, they need to go shallow -> deep.
 */
 
-var removed = []
+var unbuilt = []
 var npm = requireInject.installGlobally('../../lib/npm.js', {
-  '../../lib/install/action/remove.js': function (staging, pkg, log, next) {
-    removed.push(pkg.package.name)
+  '../../lib/install/action/unbuild.js': function (staging, pkg, log, next) {
+    unbuilt.push(pkg.package.name)
     next()
   }
 })
@@ -28,11 +28,11 @@ test('abc', function (t) {
   var inst = new Installer(__dirname, false, [])
   inst.progress = {executeActions: log}
   inst.todo = [
-    ['remove', {package: {name: 'first'}}],
-    ['remove', {package: {name: 'second'}}]
+    ['unbuild', {package: {name: 'first'}}],
+    ['unbuild', {package: {name: 'second'}}]
   ]
   inst.executeActions(function () {
-    t.isDeeply(removed, ['second', 'first'])
+    t.isDeeply(unbuilt, ['second', 'first'])
     t.end()
   })
 })


### PR DESCRIPTION
This test was insisting that the `remove` lifecycle happen in reverse.

Previously, the `remove` action ran the lifecycle events and removed man pages and binaries and also removed the actual directory from `node_modules`.

It has now been split and `remove` only does the actual directory removal and it runs after the `unbuild` action, which does the lifecycle events and man/bin removal. The `unbuild` piece is the part that needs to happen in reverse.