### PR TITLE
decompose-actions: Update should remove the OLD pkg, add the new

### DIFF
--- a/lib/install/decompose-actions.js
+++ b/lib/install/decompose-actions.js
@@ -46,7 +46,7 @@ function addSteps (decomposed, pkg, done) {
 }
 
 function updateSteps (decomposed, pkg, done) {
-  removeSteps(decomposed, pkg, () => {
+  removeSteps(decomposed, pkg.oldPkg, () => {
     addSteps(decomposed, pkg, done)
   })
 }


### PR DESCRIPTION
This is a fix for 7f28a77f3. Things worked prior to 7f28a77f3 because previously we were running `npm.commands.unbuild` and that was reading the `package.json` off disk on its own.
