### PR TITLE
Fix: normalize windows-like slashes inside `npm rebuild` and magical cure for Meteor Up deployment with `bcrypt` etc.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -177,6 +177,10 @@ function linkBins (pkg, folder, parent, gtop, cb) {
     /**
      * Fix: normalize windows-like slashes in path, to be unix-like.
      * Replace symbols `\\` to `/`.
+     *
+     * We do it because on Windows `npm install` creates inside `node_modules` `package.json` files
+     * with `bin` section that contains records with non-POSIX path separators.
+     * With this fix `npm rebuild` on Linux will find binary files
      */
     var binPath = pkg.bin[b].replace(/[\\]+/g, '/')
     linkBin(

--- a/lib/build.js
+++ b/lib/build.js
@@ -174,15 +174,20 @@ function linkBins (pkg, folder, parent, gtop, cb) {
   log.verbose('linkBins', [pkg.bin, binRoot, gtop])
 
   asyncMap(Object.keys(pkg.bin), function (b, cb) {
+    /**
+     * Fix: normalize windows-like slashes in path, to be unix-like.
+     * Replace symbols `\\` to `/`.
+     */
+    var bin_path = pkg.bin[b].replace(/[\\\/]+/g, '/');
     linkBin(
-      path.resolve(folder, pkg.bin[b]),
+      path.resolve(folder, bin_path),
       path.resolve(binRoot, b),
       gtop && folder,
       function (er) {
         if (er) return cb(er)
         // bins should always be executable.
         // XXX skip chmod on windows?
-        var src = path.resolve(folder, pkg.bin[b])
+        var src = path.resolve(folder, bin_path)
         fs.chmod(src, npm.modes.exec, function (er) {
           if (er && er.code === 'ENOENT' && npm.config.get('ignore-scripts')) {
             return cb()

--- a/lib/build.js
+++ b/lib/build.js
@@ -178,7 +178,7 @@ function linkBins (pkg, folder, parent, gtop, cb) {
      * Fix: normalize windows-like slashes in path, to be unix-like.
      * Replace symbols `\\` to `/`.
      */
-    var binPath = pkg.bin[b].replace(/[\\\/]+/g, '/')
+    var binPath = pkg.bin[b].replace(/[\\]+/g, '/')
     linkBin(
       path.resolve(folder, binPath),
       path.resolve(binRoot, b),

--- a/lib/build.js
+++ b/lib/build.js
@@ -178,16 +178,16 @@ function linkBins (pkg, folder, parent, gtop, cb) {
      * Fix: normalize windows-like slashes in path, to be unix-like.
      * Replace symbols `\\` to `/`.
      */
-    var bin_path = pkg.bin[b].replace(/[\\\/]+/g, '/')
+    var binPath = pkg.bin[b].replace(/[\\\/]+/g, '/')
     linkBin(
-      path.resolve(folder, bin_path),
+      path.resolve(folder, binPath),
       path.resolve(binRoot, b),
       gtop && folder,
       function (er) {
         if (er) return cb(er)
         // bins should always be executable.
         // XXX skip chmod on windows?
-        var src = path.resolve(folder, bin_path)
+        var src = path.resolve(folder, binPath)
         fs.chmod(src, npm.modes.exec, function (er) {
           if (er && er.code === 'ENOENT' && npm.config.get('ignore-scripts')) {
             return cb()

--- a/lib/build.js
+++ b/lib/build.js
@@ -178,7 +178,7 @@ function linkBins (pkg, folder, parent, gtop, cb) {
      * Fix: normalize windows-like slashes in path, to be unix-like.
      * Replace symbols `\\` to `/`.
      */
-    var bin_path = pkg.bin[b].replace(/[\\\/]+/g, '/');
+    var bin_path = pkg.bin[b].replace(/[\\\/]+/g, '/')
     linkBin(
       path.resolve(folder, bin_path),
       path.resolve(binRoot, b),


### PR DESCRIPTION
Hello.

When you try to deploy a Meteor 1.4.2+ project from the Windows host to the Linux server
using the `mup deploy` or `meteor build --architecture os.linux.x86_64` and you having in the `packages.json` any native Node.js modules you get failed deployment.

## :cocktail: Instant cure for Meteor Up deployment

Open `mup.js` and change value of field `docker.image` to [`mrauhu/meteord:base`](https://github.com/mrauhu/meteord), which uses patched scoped NPM: [@mrauhu/npm](https://github.com/mrauhu/npm)

## Why NPM repository?

Because Meteor  using NPM on the host with `meteor build` and on the server with `npm-rebuild.js`.

> Note:
> Meteor 1.5 working with `npm@4`, and only future release 1.6 will be used `npm@5`.

## How to reproduce

### Prerequisites

1. Machine with Windows >= 7.
2. 64-bit Debian/Ubuntu GNU/Linux server with remote access via SSH.
3. Installed [Meteor](https://github.com/meteor/meteor) with version >= 1.4.2, because of this commit https://github.com/meteor/meteor/commit/4618b3d8de240db33bb48c1f42eaabd47535183b, grab it here:
https://www.meteor.com/install
4. [Meteor Up](https://github.com/zodern/meteor-up)
`npm install -g mup`


### Steps

1. Create Meteor application

```
meteor create --bare test-app
cd test-app
```
2. Add `bcrypt` node package

```
meteor npm install --save bcrypt
```

3. Init Meteor Up.

```
mkdir private
cd private
mup.cmd init
```

4. Edit config file `mup.js`.

5. Setup server and deploy
```
mup.cmd setup
mup.cmd deploy --verbose && mup.cmd logs -f
```

6. You get error

<details>
  <summary><code>ERR! path /bundle/bundle/programs/server/npm/node_modules/meteor/npm-container/node_modules/sshpk/bin\sshpk-conv</code></summary>
<pre>
[xx.xx.xx.xx]> meteor-dev-bundle@0.0.0 install /bundle/bundle/programs/server
[xx.xx.xx.xx]> node npm-rebuild.js
[xx.xx.xx.xx]npm ERR! Linux 4.4.0-78-generic
[xx.xx.xx.xx]npm ERR! argv "/opt/nodejs/bin/node" "/opt/nodejs/bin/npm" "rebuild" "--update-binary"
[xx.xx.xx.xx]npm ERR! node v4.8.0
[xx.xx.xx.xx]npm ERR! npm v3.10.10
[xx.xx.xx.xx]npm ERR! path /bundle/bundle/programs/server/npm/node_modules/meteor/npm-container/node_modules/sshpk/bin\sshpk-conv
[xx.xx.xx.xx]npm ERR! code ENOENT
[xx.xx.xx.xx]npm ERR! errno -2
[xx.xx.xx.xx]npm ERR! syscall chmod
[xx.xx.xx.xx]npm ERR! enoent ENOENT: no such file or directory, chmod '/bundle/bundle/programs/server/npm/node_modules/meteor/npm-container/node_modules/sshpk/bin\sshpk-conv'
[xx.xx.xx.xx]npm ERR! enoent ENOENT: no such file or directory, chmod '/bundle/bundle/programs/server/npm/node_modules/meteor/npm-container/node_modules/sshpk/bin\sshpk-conv'
[xx.xx.xx.xx]npm ERR! enoent This is most likely not a problem with npm itself
</pre>
</details>

Because NPM try to rebuild packages on Linux and it failed use windows-like executable path in the `node-sshpk` dependency of `bcrypt`.

### Linked issues

* Tarball created in Windows using "meteor build" fails to deploy to hosting environment
https://github.com/meteor/meteor/issues/7401
* Bcrypt issue 
https://github.com/abernix/meteord/issues/8
* Deployment fails with exit error 254 !!!!
https://github.com/zodern/meteor-up/issues/642
* Bcrypt
https://github.com/zodern/meteor-up/issues/267
* Working with Meteor 1.4? 
fix https://github.com/zodern/meteor-up/issues/172
