### PR TITLE
`catch` whence "npm-package-arg" `throw`s: Fixes Invalid tag name - Unhandled rejection Error

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -197,26 +197,35 @@ function matchingDep (tree, name) {
 
 exports.getAllMetadata = function (args, tree, where, next) {
   asyncMap(args, function (arg, done) {
+    let spec
     try {
-        var spec = npa(arg);
-        if (spec.type !== 'file' && spec.type !== 'directory' && (spec.name == null || spec.rawSpec === '')) {
-          return fs.stat(path.join(arg, 'package.json'), (err) => {
-            if (err) {
-              var version = matchingDep(tree, spec.name)
-              if (version) {
-                return fetchPackageMetadata(npa.resolve(spec.name, version), where, done)
-              } else {
-                return fetchPackageMetadata(spec, where, done)
-              }
-            } else {
-              return fetchPackageMetadata(npa('file:' + arg), where, done)
+      spec = npa(arg)
+    } catch (e) {
+      return done(e)
+    }
+    if (spec.type !== 'file' && spec.type !== 'directory' && (spec.name == null || spec.rawSpec === '')) {
+      return fs.stat(path.join(arg, 'package.json'), (err) => {
+        if (err) {
+          var version = matchingDep(tree, spec.name)
+          if (version) {
+            try {
+             return fetchPackageMetadata(npa.resolve(spec.name, version), where, done)
+            } catch (e) {
+              return done(e)
             }
-          })
+          } else {
+            return fetchPackageMetadata(spec, where, done)
+          }
         } else {
-          return fetchPackageMetadata(spec, where, done)
+          try {
+            return fetchPackageMetadata(npa('file:' + arg), where, done)
+          } catch (e) {
+            return done(e)
+          }
         }
-    } catch(e) {
-        return done(e);
+      })
+    } else {
+      return fetchPackageMetadata(spec, where, done)
     }
   }, next)
 }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -209,7 +209,7 @@ exports.getAllMetadata = function (args, tree, where, next) {
           var version = matchingDep(tree, spec.name)
           if (version) {
             try {
-             return fetchPackageMetadata(npa.resolve(spec.name, version), where, done)
+              return fetchPackageMetadata(npa.resolve(spec.name, version), where, done)
             } catch (e) {
               return done(e)
             }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -197,22 +197,26 @@ function matchingDep (tree, name) {
 
 exports.getAllMetadata = function (args, tree, where, next) {
   asyncMap(args, function (arg, done) {
-    var spec = npa(arg)
-    if (spec.type !== 'file' && spec.type !== 'directory' && (spec.name == null || spec.rawSpec === '')) {
-      return fs.stat(path.join(arg, 'package.json'), (err) => {
-        if (err) {
-          var version = matchingDep(tree, spec.name)
-          if (version) {
-            return fetchPackageMetadata(npa.resolve(spec.name, version), where, done)
-          } else {
-            return fetchPackageMetadata(spec, where, done)
-          }
+    try {
+        var spec = npa(arg);
+        if (spec.type !== 'file' && spec.type !== 'directory' && (spec.name == null || spec.rawSpec === '')) {
+          return fs.stat(path.join(arg, 'package.json'), (err) => {
+            if (err) {
+              var version = matchingDep(tree, spec.name)
+              if (version) {
+                return fetchPackageMetadata(npa.resolve(spec.name, version), where, done)
+              } else {
+                return fetchPackageMetadata(spec, where, done)
+              }
+            } else {
+              return fetchPackageMetadata(npa('file:' + arg), where, done)
+            }
+          })
         } else {
-          return fetchPackageMetadata(npa('file:' + arg), where, done)
+          return fetchPackageMetadata(spec, where, done)
         }
-      })
-    } else {
-      return fetchPackageMetadata(spec, where, done)
+    } catch(e) {
+        return done(e);
     }
   }, next)
 }


### PR DESCRIPTION
### Bug

    $ npm i @foo.bar
    Unhandled rejection Error: Invalid tag name "@foo.bar": Tags may not have any characters that encodeURIComponent encodes.
        at invalidTagName (lib/node_modules/npm/node_modules/npm-package-arg/npa.js:76:15)
    at fromRegistry (lib/node_modules/npm/node_modules/npm-package-arg/npa.js:265:13)
    at resolve (lib/node_modules/npm/node_modules/npm-package-arg/npa.js:66:12)
    at npa (lib/node_modules/npm/node_modules/npm-package-arg/npa.js:39:10)
    at lib/node_modules/npm/lib/install/deps.js:200:16
    at lib/node_modules/npm/node_modules/slide/lib/async-map.js:52:35
    at Array.forEach (native)
    at lib/node_modules/npm/node_modules/slide/lib/async-map.js:52:11
    at Array.forEach (native)
    at asyncMap (lib/node_modules/npm/node_modules/slide/lib/async-map.js:51:8)
    at exports.getAllMetadata (lib/node_modules/npm/lib/install/deps.js:199:3)
    at Installer.loadArgMetadata (lib/node_modules/npm/lib/install.js:325:3)
    at lib/node_modules/npm/lib/install.js:656:16
    at BB.join.then (lib/node_modules/npm/lib/install/read-shrinkwrap.js:41:16)
    at tryCatcher (lib/node_modules/npm/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:512:31)

    npm ERR! cb() never called!

        npm ERR! This is an error with npm itself. Please report this error at:
        npm ERR!     <https://github.com/npm/npm/issues>

### Fix

Wrap it in a `try`/`catch`; `return`ing error in the callback.

BTW: This OP reported it but didn't understand the issue - https://github.com/npm/npm/issues/17283