### PR TITLE
Make package-lock.json sorting locale-agnostic

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -101,7 +101,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
   if (!seen) seen = new Set()
   if (seen.has(tree)) return
   seen.add(tree)
-  tree.children.sort(function (aa, bb) { return moduleName(aa).localeCompare(moduleName(bb)) }).forEach(function (child) {
+  sortModules(tree.children).forEach(function (child) {
     if (child.fakeChild) {
       deps[moduleName(child)] = child.fakeChild
       return
@@ -130,7 +130,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     if (isOnlyOptional(child)) pkginfo.optional = true
     if (child.requires.length) {
       pkginfo.requires = {}
-      child.requires.sort((a, b) => moduleName(a).localeCompare(moduleName(b))).forEach((required) => {
+      sortModules(child.requires).forEach((required) => {
         var requested = required.package._requested || getRequested(required) || {}
         pkginfo.requires[moduleName(required)] = childVersion(top, required, requested)
       })
@@ -140,6 +140,14 @@ function shrinkwrapDeps (deps, top, tree, seen) {
       shrinkwrapDeps(pkginfo.dependencies, top, child, seen)
     }
   })
+}
+
+function sortModules(modules) {
+  // sort modules with the locale-agnostic Unicode sort
+  var sortedModuleNames = modules.map(moduleName).sort();
+  return modules.sort((a, b) => (
+    sortedModuleNames.indexOf(moduleName(a)) - sortedModuleNames.indexOf(moduleName(b))
+  ));
 }
 
 function childVersion (top, child, req) {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -142,12 +142,12 @@ function shrinkwrapDeps (deps, top, tree, seen) {
   })
 }
 
-function sortModules(modules) {
+function sortModules (modules) {
   // sort modules with the locale-agnostic Unicode sort
-  var sortedModuleNames = modules.map(moduleName).sort();
+  var sortedModuleNames = modules.map(moduleName).sort()
   return modules.sort((a, b) => (
     sortedModuleNames.indexOf(moduleName(a)) - sortedModuleNames.indexOf(moduleName(b))
-  ));
+  ))
 }
 
 function childVersion (top, child, req) {


### PR DESCRIPTION
### Summary

Make `package-lock.json` sorting of its dependencies locale-agnostic.
Use `sort()` on the module names without providing a custom `compareFunction`. This is Unicode-based and locale-agnostic.

Fix https://github.com/npm/npm/issues/17048


### How to reproduce

Reason of the trouble: 

```bash
$ LANG='' node -e 'console.log("string_decoder".localeCompare("string-width"))'
1
$ LANG='en' node -e 'console.log("string_decoder".localeCompare("string-width"))'
-1
```

To reproduce the locale-dependent lock file, create a directory with a `package.json`.
Done with npm 5.3.0.

```json
{
  "name": "example",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "author": "",
  "license": "ISC",
  "dependencies": {
    "fsevents": "1.1.2"
  }
}
```

Then compare the `package-lock.json` with:

- `LANG="" LC_ALL="" npm i`
- `LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8" npm i`

They put `string_decoder` and `string-width` in a different order in `["dependencies"]["fsevents"]["dependencies"]`.


### Implications

- It makes the package-lock more deterministic and no longer depends on user's locale, fixing #17048 
- It means it will potentially reorder dependencies of existing `package-lock.json` if user's locale was making `localeCompare` behave differently than the default `sort`. That would happen only once and for all but would need to properly appear in the changelog.