### PR TITLE
Fix `npm prune --production` when devDependencies contain bins

### DIFF
--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -60,7 +60,9 @@ function rmStuff (pkg, folder, cb) {
   // otherwise, then bins are in folder/../.bin
   var parent = pkg.name[0] === '@' ? path.dirname(path.dirname(folder)) : path.dirname(folder)
   var gnm = npm.dir
-  var top = gnm === parent
+  // gnm might be an absolute path, parent might be relative
+  // this checks they're the same directory regardless
+  var top = path.relative(gnm, parent) === ''
 
   log.verbose('unbuild rmStuff', pkg._id, 'from', gnm)
   if (!top) log.verbose('unbuild rmStuff', 'in', parent)

--- a/test/tap/prune-dev-dep-with-bins.js
+++ b/test/tap/prune-dev-dep-with-bins.js
@@ -1,0 +1,105 @@
+'use strict'
+var fs = require('fs')
+var path = require('path')
+var test = require('tap').test
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+var common = require('../common-tap.js')
+var testdir = path.join(__dirname, path.basename(__filename, '.js'))
+
+var fixture = new Tacks(
+  Dir({
+    node_modules: Dir({
+      'yes': Dir({
+        'package.json': File({
+          _requested: {
+            rawSpec: 'file:///mods/yes'
+          },
+          dependencies: {},
+          bin: {
+            'yes': 'yes.js'
+          },
+          name: 'yes',
+          version: '1.0.0'
+        }),
+        'yes.js': File('while (true) { console.log("y") }')
+      }),
+      '.bin': Dir({
+        // verbose, but needed for `read-cmd-shim` to properly identify which
+        // package this belongs to
+        'yes': File(
+          '#!/bin/sh\n' +
+          'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\\\,/,g\')")\n' +
+          '\n' +
+          'case `uname` in\n' +
+          '    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;\n' +
+          'esac\n' +
+          '\n' +
+          'if [ -x "$basedir/node" ]; then\n' +
+          '  "$basedir/node"  "$basedir/../yes/yes.js" "$@"\n' +
+          '  ret=$?\n' +
+          'else\n' +
+          '  node  "$basedir/../yes/yes.js" "$@"\n' +
+          '  ret=$?\n' +
+          'fi\n' +
+          'exit $ret\n'),
+        'yes.cmd': File(
+          '@IF EXIST "%~dp0\node.exe" (\n' +
+          '"%~dp0\\node.exe"  "%~dp0\\..\\yes\\yes.js" %*\n' +
+          ') ELSE (\n' +
+          '@SETLOCAL\n' +
+          '@SET PATHEXT=%PATHEXT:;.JS;=;%\n' +
+          'node  "%~dp0\..\yes\yes.js" %*')
+      })
+    }),
+    'package.json': File({
+      name: 'test',
+      version: '1.0.0',
+      devDependencies: {
+        'yes': 'file:///mods/yes'
+      }
+    })
+  })
+)
+
+function setup () {
+  cleanup()
+  fixture.create(testdir)
+}
+
+function cleanup () {
+  fixture.remove(testdir)
+}
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+function readdir (dir) {
+  try {
+    return fs.readdirSync(dir)
+  } catch (ex) {
+    if (ex.code === 'ENOENT') return []
+    throw ex
+  }
+}
+
+test('prune cycle in dev deps', function (t) {
+  common.npm(['prune', '--production', '--json'], {cwd: testdir}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'prune finished successfully')
+    t.like(JSON.parse(stdout), {removed: [{name: 'yes'}]}, 'removed the right modules')
+    var dirs = readdir(testdir + '/node_modules').sort()
+    // bindirs are never removed, it's ok for them to remain after prune
+    t.same(dirs, ['.bin'])
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+


### PR DESCRIPTION
This closes #17781.

*Caveat: all that follows is based on my current understanding of npm after one morning's exploration into it, feel free to point out mistakes*

## The bug

When pruning, `unbuild.rmStuff` ends up being called.

Several async calls deeper, the `gentlyRmBinRoot` closure gets called (if removing the shims went fine) in `rmBins`:

```javascript
function rmBins (pkg, folder, parent, top, cb) {
  if (!pkg.bin) return cb()
  var binRoot = top ? npm.bin : path.resolve(parent, '.bin')
  asyncMap(Object.keys(pkg.bin), function (b, cb) {
    if (process.platform === 'win32') {
      chain([ [gentlyRm, path.resolve(binRoot, b) + '.cmd', true, folder],
              [gentlyRm, path.resolve(binRoot, b), true, folder] ], cb)
    } else {
      gentlyRm(path.resolve(binRoot, b), true, folder, cb)
    }
  }, gentlyRmBinRoot)

  function gentlyRmBinRoot (err) {
    if (err || top) return cb(err)
    return gentlyRm(binRoot, true, parent, cb)
  }
}
```

If `top` is true, `gentlyRmBinRoot` will not attempt to gentlyRm `binRoot`, which I believe is what *should* happen. However, it doesn't, because back in `rmStuff`, we do this:

```javascript
  var parent = pkg.name[0] === '@' ? path.dirname(path.dirname(folder)) : path.dirname(folder)
  var gnm = npm.dir
  var top = gnm === parent
```

and top ends up being false, because (when running [this new test case](https://github.com/fasterthanlime/npm/blob/gh-17781-prune/test/tap/prune-dev-dep-with-bins.js) on windows, at least), `gnm` is the absolute path `C:\Dev\npm\node_modules` whereas `parent` is the relative path `node_modules`.

So, even though they're the same folder, `top` is false, `gentlyRmBinRoot` attempts to remove `node_modules/.bin`, which `gentlyRm` forbids (by checking for 6-ish known prefixes), that throws an exception and the whole pruning is aborted.

## A fix

Here's the crux of my fix:

```javascript
 // in rmStuff:
 var top = '' === path.relative(gnm, parent)
```

There's comments above this line, because it might not be well-known that `path.relative` returns an empty string if they're the same directory. This method works if either path is relative or absolute (doesn't matter which).

I'm not aware of a better method in node.js, but feel free to use another one if it fits the codebase better.

## A test

[This test](https://github.com/fasterthanlime/npm/find/gh-17781-prune) simulates what happens when following the [repro steps](https://github.com/npm/npm/issues/17781#issuecomment-317678191) I posted in the original issue.

It's a bit lenghty, because the shims need to be something [read-cmd-shim](https://www.npmjs.com/package/read-cmd-shim) can resolve to an in-package location.

*It might be possible to make this test shorter by just including the bare minimum read-cmd-shim is looking for, but imho it's not that problematic to keep it exactly lke what an npm@5 install would produce*