### PR TITLE
tar: ignoring Vim backup files (e.g. README.md~)

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -63,6 +63,29 @@ function BundledPacker (props) {
 inherits(BundledPacker, Packer)
 
 BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
+  // some files are *never* allowed under any circumstances
+  // (VCS folders, native build cruft, npm cruft, regular cruft)
+  if (entry === '.git' ||
+      entry === 'CVS' ||
+      entry === '.svn' ||
+      entry === '.hg' ||
+      entry === '.lock-wscript' ||
+      entry.match(/^\.wafpickle-[0-9]+$/) ||
+      (this.parent && this.parent.packageRoot && this.basename === 'build' &&
+       entry === 'config.gypi') ||
+      entry === 'npm-debug.log' ||
+      entry === '.npmrc' ||
+      entry.match(/^\..*\.swp$/) ||
+      entry.match(/^.*~$/) || // Vim backup files
+      entry === '.DS_Store' ||
+      entry.match(/^\._/) ||
+      entry.match(/^.*\.orig$/) ||
+      // Package locks are never allowed in tarballs -- use shrinkwrap instead
+      entry === 'package-lock.json'
+    ) {
+    return false
+  }
+
   if (!entryObj || entryObj.type !== 'Directory') {
     // package.json files can never be ignored.
     if (entry === 'package.json') return true
@@ -86,28 +109,6 @@ BundledPacker.prototype.applyIgnores = function (entry, partial, entryObj) {
   // package.json main file should never be ignored.
   var mainFile = this.package && this.package.main
   if (mainFile && path.resolve(this.path, entry) === path.resolve(this.path, mainFile)) return true
-
-  // some files are *never* allowed under any circumstances
-  // (VCS folders, native build cruft, npm cruft, regular cruft)
-  if (entry === '.git' ||
-      entry === 'CVS' ||
-      entry === '.svn' ||
-      entry === '.hg' ||
-      entry === '.lock-wscript' ||
-      entry.match(/^\.wafpickle-[0-9]+$/) ||
-      (this.parent && this.parent.packageRoot && this.basename === 'build' &&
-       entry === 'config.gypi') ||
-      entry === 'npm-debug.log' ||
-      entry === '.npmrc' ||
-      entry.match(/^\..*\.swp$/) ||
-      entry === '.DS_Store' ||
-      entry.match(/^\._/) ||
-      entry.match(/^.*\.orig$/) ||
-      // Package locks are never allowed in tarballs -- use shrinkwrap instead
-      entry === 'package-lock.json'
-    ) {
-    return false
-  }
 
   // in a node_modules folder, we only include bundled dependencies
   // also, prevent packages in node_modules from being affected

--- a/test/tap/files-and-ignores.js
+++ b/test/tap/files-and-ignores.js
@@ -406,7 +406,11 @@ test('certain files ignored unconditionally', function (t) {
           '.DS_Store',
           '._ohno',
           'foo.orig',
-          'package-lock.json'
+          'package-lock.json',
+          'README~',
+          'LICENSE.txt~',
+          'changelog.md~',
+          'notice~'
         ]
       }),
       '.git': Dir({foo: File('')}),
@@ -425,7 +429,11 @@ test('certain files ignored unconditionally', function (t) {
       '._ohno': File(''),
       '._ohnoes': Dir({noes: File('')}),
       'foo.orig': File(''),
-      'package-lock.json': File('')
+      'package-lock.json': File(''),
+      'README~': File(''),
+      'LICENSE.txt~': File(''),
+      'changelog.md~': File(''),
+      'notice~': File('')
     })
   )
   withFixture(t, fixture, function (done) {
@@ -446,6 +454,10 @@ test('certain files ignored unconditionally', function (t) {
     t.notOk(fileExists('._ohnoes'), '._ohnoes not included')
     t.notOk(fileExists('foo.orig'), 'foo.orig not included')
     t.notOk(fileExists('package-lock.json'), 'package-lock.json not included')
+    t.notOk(fileExists('README~'), 'README~ not included')
+    t.notOk(fileExists('LICENSE.txt~'), 'LICENSE.txt~ not included')
+    t.notOk(fileExists('changelog.md~'), 'changelog.md~ not included')
+    t.notOk(fileExists('notice~'), 'notice~ not included')
     done()
   })
 })


### PR DESCRIPTION
Fixes: https://github.com/npm/npm/issues/17560

``entry.match(/^.*~$/)`` rule is added to excluding rules
To exclude unconditionally included files (README, LICENSE and etc.), excluding rules are placed before all other rules
