### PR TITLE
doc: clarify usage for the `files` field in `package.json`

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -168,9 +168,12 @@ npm also sets a top-level "maintainers" field with your npm user info.
 
 ## files
 
-The "files" field is an array of files to include in your project.  If
-you name a folder in the array, then it will also include the files
-inside that folder. (Unless they would be ignored by another rule.)
+The optional "files" field is an array of file patterns that describes
+the entries to be included when your package is installed as a
+dependency. If the files array is omitted, everything except
+automatically-excluded files will be included in your publish.
+If you name a folder in the array, then it will also include the files
+inside that folder (unless they would be ignored by another rule).
 
 You can also provide a ".npmignore" file in the root of your package or
 in subdirectories, which will keep files from being included, even


### PR DESCRIPTION
Following up a Twitter discussion with @zkat about the `files` field in `package.json (https://twitter.com/xcambar/status/892066155615203329), here's a documentation PR that attempts to clarify what it does and when it is used.

Mostly taken from https://github.com/npm/npm/wiki/Files-and-Ignores#files + a bit or rewording.

