### PR TITLE
lifecycle: remove all local dependencies other than spawn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+# Remove once Trusty can support couchdb, which is part of before_install
+dist: precise
 # need to declare the language as well as the matrix below
 language: node_js
 # having top-level `env:` adds a phantom build

--- a/doc/cli/npm-config.md
+++ b/doc/cli/npm-config.md
@@ -6,7 +6,7 @@ npm-config(1) -- Manage the npm configuration files
     npm config set <key> <value> [-g|--global]
     npm config get <key>
     npm config delete <key>
-    npm config list [-l]
+    npm config list [-l] [--json]
     npm config edit
     npm get <key>
     npm set <key> <value> [-g|--global]
@@ -48,7 +48,8 @@ Echo the config value to stdout.
 
     npm config list
 
-Show all the config settings. Use `-l` to also show defaults.
+Show all the config settings. Use `-l` to also show defaults. Use `--json`
+to show the settings in json format.
 
 ### delete
 

--- a/doc/misc/semver.md
+++ b/doc/misc/semver.md
@@ -1,55 +1,65 @@
 semver(7) -- The semantic versioner for npm
 ===========================================
 
+## Install
+
+```bash
+npm install --save semver
+````
+
 ## Usage
 
-    $ npm install semver
-    $ node
-    var semver = require('semver')
+As a node module:
 
-    semver.valid('1.2.3') // '1.2.3'
-    semver.valid('a.b.c') // null
-    semver.clean('  =v1.2.3   ') // '1.2.3'
-    semver.satisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3') // true
-    semver.gt('1.2.3', '9.8.7') // false
-    semver.lt('1.2.3', '9.8.7') // true
+```js
+const semver = require('semver')
+
+semver.valid('1.2.3') // '1.2.3'
+semver.valid('a.b.c') // null
+semver.clean('  =v1.2.3   ') // '1.2.3'
+semver.satisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3') // true
+semver.gt('1.2.3', '9.8.7') // false
+semver.lt('1.2.3', '9.8.7') // true
+```
 
 As a command-line utility:
 
-    $ semver -h
+```
+$ semver -h
 
-    SemVer 5.1.0
+SemVer 5.3.0
 
-    A JavaScript implementation of the http://semver.org/ specification
-    Copyright Isaac Z. Schlueter
+A JavaScript implementation of the http://semver.org/ specification
+Copyright Isaac Z. Schlueter
 
-    Usage: semver [options] <version> [<version> [...]]
-    Prints valid versions sorted by SemVer precedence
+Usage: semver [options] <version> [<version> [...]]
+Prints valid versions sorted by SemVer precedence
 
-    Options:
-    -r --range <range>
-            Print versions that match the specified range.
+Options:
+-r --range <range>
+        Print versions that match the specified range.
 
-    -i --increment [<level>]
-            Increment a version by the specified level.  Level can
-            be one of: major, minor, patch, premajor, preminor,
-            prepatch, or prerelease.  Default level is 'patch'.
-            Only one version may be specified.
+-i --increment [<level>]
+        Increment a version by the specified level.  Level can
+        be one of: major, minor, patch, premajor, preminor,
+        prepatch, or prerelease.  Default level is 'patch'.
+        Only one version may be specified.
 
-    --preid <identifier>
-            Identifier to be used to prefix premajor, preminor,
-            prepatch or prerelease version increments.
+--preid <identifier>
+        Identifier to be used to prefix premajor, preminor,
+        prepatch or prerelease version increments.
 
-    -l --loose
-            Interpret versions and ranges loosely
+-l --loose
+        Interpret versions and ranges loosely
 
-    Program exits successfully if any valid version satisfies
-    all supplied ranges, and prints all satisfying versions.
+Program exits successfully if any valid version satisfies
+all supplied ranges, and prints all satisfying versions.
 
-    If no satisfying versions are found, then exits failure.
+If no satisfying versions are found, then exits failure.
 
-    Versions are printed in ascending order, so supplying
-    multiple versions to the utility will just sort them.
+Versions are printed in ascending order, so supplying
+multiple versions to the utility will just sort them.
+```
 
 ## Versions
 
@@ -126,20 +136,20 @@ The method `.inc` takes an additional `identifier` string argument that
 will append the value of the string as a prerelease identifier:
 
 ```javascript
-> semver.inc('1.2.3', 'prerelease', 'beta')
-'1.2.4-beta.0'
+semver.inc('1.2.3', 'prerelease', 'beta')
+// '1.2.4-beta.0'
 ```
 
 command-line example:
 
-```shell
+```bash
 $ semver 1.2.3 -i prerelease --preid beta
 1.2.4-beta.0
 ```
 
 Which then can be used to increment further:
 
-```shell
+```bash
 $ semver 1.2.4-beta.0 -i prerelease
 1.2.4-beta.1
 ```
@@ -296,6 +306,8 @@ strings that they parse.
 * `major(v)`: Return the major version number.
 * `minor(v)`: Return the minor version number.
 * `patch(v)`: Return the patch version number.
+* `intersects(r1, r2, loose)`: Return true if the two supplied ranges
+  or comparators intersect.
 
 ### Comparison
 
@@ -319,6 +331,9 @@ strings that they parse.
   (`major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, or `prerelease`),
   or null if the versions are the same.
 
+### Comparators
+
+* `intersects(comparator)`: Return true if the comparators intersect
 
 ### Ranges
 
@@ -337,6 +352,7 @@ strings that they parse.
   the bounds of the range in either the high or low direction.  The
   `hilo` argument must be either the string `'>'` or `'<'`.  (This is
   the function called by `gtr` and `ltr`.)
+* `intersects(range)`: Return true if any of the ranges comparators intersect
 
 Note that, since ranges may be non-contiguous, a version might not be
 greater than a range, less than a range, *or* satisfy a range!  For

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,7 @@ config.usage = usage(
   'npm config set <key> <value>' +
   '\nnpm config get [<key>]' +
   '\nnpm config delete <key>' +
-  '\nnpm config list' +
+  '\nnpm config list [--json]' +
   '\nnpm config edit' +
   '\nnpm set <key> <value>' +
   '\nnpm get [<key>]'
@@ -69,7 +69,7 @@ function config (args, cb) {
       return del(args[0], cb)
     case 'list':
     case 'ls':
-      return list(cb)
+      return npm.config.get('json') ? listJson(cb) : list(cb)
     case 'edit':
       return edit(cb)
     default:
@@ -175,6 +175,23 @@ function publicVar (k) {
 
 function getKeys (data) {
   return Object.keys(data).filter(publicVar).sort(sort)
+}
+
+function listJson (cb) {
+  const publicConf = npm.config.keys.reduce((publicConf, k) => {
+    var value = npm.config.get(k)
+
+    if (publicVar(k) &&
+        // argv is not really config, it's command config
+        k !== 'argv' &&
+        // logstream is a Stream, and would otherwise produce circular refs
+        k !== 'logstream') publicConf[k] = value
+
+    return publicConf
+  }, {})
+
+  output(JSON.stringify(publicConf, null, 2))
+  return cb()
 }
 
 function listFromSource (title, conf, long) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -45,9 +45,11 @@ config.completion = function (opts, cb) {
     case 'rm':
       return cb(null, Object.keys(types))
     case 'edit':
-    case 'list': case 'ls':
+    case 'list':
+    case 'ls':
       return cb(null, [])
-    default: return cb(null, [])
+    default:
+      return cb(null, [])
   }
 }
 
@@ -57,12 +59,21 @@ config.completion = function (opts, cb) {
 function config (args, cb) {
   var action = args.shift()
   switch (action) {
-    case 'set': return set(args[0], args[1], cb)
-    case 'get': return get(args[0], cb)
-    case 'delete': case 'rm': case 'del': return del(args[0], cb)
-    case 'list': case 'ls': return list(cb)
-    case 'edit': return edit(cb)
-    default: return unknown(action, cb)
+    case 'set':
+      return set(args[0], args[1], cb)
+    case 'get':
+      return get(args[0], cb)
+    case 'delete':
+    case 'rm':
+    case 'del':
+      return del(args[0], cb)
+    case 'list':
+    case 'ls':
+      return list(cb)
+    case 'edit':
+      return edit(cb)
+    default:
+      return unknown(action, cb)
   }
 }
 
@@ -159,13 +170,30 @@ function sort (a, b) {
 }
 
 function publicVar (k) {
-  return !(k.charAt(0) === '_' ||
-           k.indexOf(':_') !== -1 ||
-           types[k] !== types[k])
+  return !(k.charAt(0) === '_' || k.indexOf(':_') !== -1)
 }
 
 function getKeys (data) {
   return Object.keys(data).filter(publicVar).sort(sort)
+}
+
+function listFromSource (title, conf, long) {
+  var confKeys = getKeys(conf)
+  var msg = ''
+
+  if (confKeys.length) {
+    msg += '; ' + title + '\n'
+    confKeys.forEach(function (k) {
+      var val = JSON.stringify(conf[k])
+      if (conf[k] !== npm.config.get(k)) {
+        if (!long) return
+        msg += '; ' + k + ' = ' + val + ' (overridden)\n'
+      } else msg += k + ' = ' + val + '\n'
+    })
+    msg += '\n'
+  }
+
+  return msg
 }
 
 function list (cb) {
@@ -185,92 +213,22 @@ function list (cb) {
   }
 
   // env configs
-  var env = npm.config.sources.env.data
-  var envKeys = getKeys(env)
-  if (envKeys.length) {
-    msg += '; environment configs\n'
-    envKeys.forEach(function (k) {
-      if (env[k] !== npm.config.get(k)) {
-        if (!long) return
-        msg += '; ' + k + ' = ' +
-          JSON.stringify(env[k]) + ' (overridden)\n'
-      } else msg += k + ' = ' + JSON.stringify(env[k]) + '\n'
-    })
-    msg += '\n'
-  }
+  msg += listFromSource('environment configs', npm.config.sources.env.data, long)
 
   // project config file
   var project = npm.config.sources.project
-  var pconf = project.data
-  var ppath = project.path
-  var pconfKeys = getKeys(pconf)
-  if (pconfKeys.length) {
-    msg += '; project config ' + ppath + '\n'
-    pconfKeys.forEach(function (k) {
-      var val = (k.charAt(0) === '_')
-              ? '---sekretz---'
-              : JSON.stringify(pconf[k])
-      if (pconf[k] !== npm.config.get(k)) {
-        if (!long) return
-        msg += '; ' + k + ' = ' + val + ' (overridden)\n'
-      } else msg += k + ' = ' + val + '\n'
-    })
-    msg += '\n'
-  }
+  msg += listFromSource('project config ' + project.path, project.data, long)
 
   // user config file
-  var uconf = npm.config.sources.user.data
-  var uconfKeys = getKeys(uconf)
-  if (uconfKeys.length) {
-    msg += '; userconfig ' + npm.config.get('userconfig') + '\n'
-    uconfKeys.forEach(function (k) {
-      var val = (k.charAt(0) === '_')
-              ? '---sekretz---'
-              : JSON.stringify(uconf[k])
-      if (uconf[k] !== npm.config.get(k)) {
-        if (!long) return
-        msg += '; ' + k + ' = ' + val + ' (overridden)\n'
-      } else msg += k + ' = ' + val + '\n'
-    })
-    msg += '\n'
-  }
+  msg += listFromSource('userconfig ' + npm.config.get('userconfig'), npm.config.sources.user.data, long)
 
   // global config file
-  var gconf = npm.config.sources.global.data
-  var gconfKeys = getKeys(gconf)
-  if (gconfKeys.length) {
-    msg += '; globalconfig ' + npm.config.get('globalconfig') + '\n'
-    gconfKeys.forEach(function (k) {
-      var val = (k.charAt(0) === '_')
-              ? '---sekretz---'
-              : JSON.stringify(gconf[k])
-      if (gconf[k] !== npm.config.get(k)) {
-        if (!long) return
-        msg += '; ' + k + ' = ' + val + ' (overridden)\n'
-      } else msg += k + ' = ' + val + '\n'
-    })
-    msg += '\n'
-  }
+  msg += listFromSource('globalconfig ' + npm.config.get('globalconfig'), npm.config.sources.global.data, long)
 
   // builtin config file
   var builtin = npm.config.sources.builtin || {}
   if (builtin && builtin.data) {
-    var bconf = builtin.data
-    var bpath = builtin.path
-    var bconfKeys = getKeys(bconf)
-    if (bconfKeys.length) {
-      msg += '; builtin config ' + bpath + '\n'
-      bconfKeys.forEach(function (k) {
-        var val = (k.charAt(0) === '_')
-                ? '---sekretz---'
-                : JSON.stringify(bconf[k])
-        if (bconf[k] !== npm.config.get(k)) {
-          if (!long) return
-          msg += '; ' + k + ' = ' + val + ' (overridden)\n'
-        } else msg += k + ' = ' + val + '\n'
-      })
-      msg += '\n'
-    }
+    msg += listFromSource('builtin config ' + builtin.path, builtin.data, long)
   }
 
   // only show defaults if --long

--- a/lib/config/lifecycle.js
+++ b/lib/config/lifecycle.js
@@ -4,18 +4,25 @@ const npm = require('../npm.js')
 
 module.exports = lifecycleOpts
 
-function lifecycleOpts () {
-  return {
-    config: npm.config.snapshot,
-    dir: npm.dir,
-    force: npm.config.get('force'),
-    group: npm.config.get('group'),
-    ignorePrepublish: npm.config.get('ignore-prepublish'),
-    ignoreScripts: npm.config.get('ignore-scripts'),
-    production: npm.config.get('production'),
-    scriptShell: npm.config.get('script-shell'),
-    scriptsPrependNodePath: npm.config.get('scripts-prepend-node-path'),
-    unsafePerm: npm.config.get('unsafe-perm'),
-    user: npm.config.get('user')
+let opts
+
+function lifecycleOpts (moreOpts) {
+  if (!opts) {
+    opts = {
+      config: npm.config.snapshot,
+      dir: npm.dir,
+      failOk: false,
+      force: npm.config.get('force'),
+      group: npm.config.get('group'),
+      ignorePrepublish: npm.config.get('ignore-prepublish'),
+      ignoreScripts: npm.config.get('ignore-scripts'),
+      production: npm.config.get('production'),
+      scriptShell: npm.config.get('script-shell'),
+      scriptsPrependNodePath: npm.config.get('scripts-prepend-node-path'),
+      unsafePerm: npm.config.get('unsafe-perm'),
+      user: npm.config.get('user')
+    }
   }
+
+  return moreOpts ? Object.assign({}, opts, moreOpts) : opts
 }

--- a/lib/config/lifecycle.js
+++ b/lib/config/lifecycle.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const npm = require('../npm.js')
+
+module.exports = lifecycleOpts
+
+function lifecycleOpts () {
+  return {
+    config: npm.config.snapshot,
+    dir: npm.dir,
+    force: npm.config.get('force'),
+    group: npm.config.get('group'),
+    ignorePrepublish: npm.config.get('ignore-prepublish'),
+    ignoreScripts: npm.config.get('ignore-scripts'),
+    production: npm.config.get('production'),
+    scriptShell: npm.config.get('script-shell'),
+    scriptsPrependNodePath: npm.config.get('scripts-prepend-node-path'),
+    unsafePerm: npm.config.get('unsafe-perm'),
+    user: npm.config.get('user')
+  }
+}

--- a/lib/install/action/install.js
+++ b/lib/install/action/install.js
@@ -4,5 +4,5 @@ var packageId = require('../../utils/package-id.js')
 
 module.exports = function (staging, pkg, log, next) {
   log.silly('install', packageId(pkg))
-  lifecycle(pkg.package, 'install', pkg.path, false, false, next)
+  lifecycle(pkg.package, 'install', pkg.path, next)
 }

--- a/lib/install/action/move.js
+++ b/lib/install/action/move.js
@@ -19,12 +19,12 @@ var move = require('../../utils/move.js')
 module.exports = function (staging, pkg, log, next) {
   log.silly('move', pkg.fromPath, pkg.path)
   chain([
-    [lifecycle, pkg.package, 'preuninstall', pkg.fromPath, false, true],
-    [lifecycle, pkg.package, 'uninstall', pkg.fromPath, false, true],
+    [lifecycle, pkg.package, 'preuninstall', pkg.fromPath, { failOk: true }],
+    [lifecycle, pkg.package, 'uninstall', pkg.fromPath, { failOk: true }],
     [rmStuff, pkg.package, pkg.fromPath],
-    [lifecycle, pkg.package, 'postuninstall', pkg.fromPath, false, true],
+    [lifecycle, pkg.package, 'postuninstall', pkg.fromPath, { failOk: true }],
     [moveModuleOnly, pkg.fromPath, pkg.path, log],
-    [lifecycle, pkg.package, 'preinstall', pkg.path, false, true],
+    [lifecycle, pkg.package, 'preinstall', pkg.path, { failOk: true }],
     [removeEmptyParents, path.resolve(pkg.fromPath, '..')],
     [updatePackageJson, pkg, pkg.path]
   ], next)

--- a/lib/install/action/postinstall.js
+++ b/lib/install/action/postinstall.js
@@ -4,5 +4,5 @@ var packageId = require('../../utils/package-id.js')
 
 module.exports = function (staging, pkg, log, next) {
   log.silly('postinstall', packageId(pkg))
-  lifecycle(pkg.package, 'postinstall', pkg.path, false, false, next)
+  lifecycle(pkg.package, 'postinstall', pkg.path, next)
 }

--- a/lib/install/action/preinstall.js
+++ b/lib/install/action/preinstall.js
@@ -4,5 +4,5 @@ var packageId = require('../../utils/package-id.js')
 
 module.exports = function (staging, pkg, log, next) {
   log.silly('preinstall', packageId(pkg))
-  lifecycle(pkg.package, 'preinstall', pkg.path, false, false, next)
+  lifecycle(pkg.package, 'preinstall', pkg.path, next)
 }

--- a/lib/install/action/prepare.js
+++ b/lib/install/action/prepare.js
@@ -19,8 +19,8 @@ module.exports = function (staging, pkg, log, next) {
   var buildpath = moduleStagingPath(staging, pkg)
   chain(
     [
-      [lifecycle, pkg.package, 'prepublish', buildpath, false, false],
-      [lifecycle, pkg.package, 'prepare', buildpath, false, false]
+      [lifecycle, pkg.package, 'prepublish', buildpath],
+      [lifecycle, pkg.package, 'prepare', buildpath]
     ],
     next
   )

--- a/lib/install/action/unbuild.js
+++ b/lib/install/action/unbuild.js
@@ -6,11 +6,11 @@ var rmStuff = Bluebird.promisify(require('../../unbuild.js').rmStuff)
 
 module.exports = function (staging, pkg, log) {
   log.silly('unbuild', packageId(pkg))
-  return lifecycle(pkg.package, 'preuninstall', pkg.path, false, true).then(() => {
-    return lifecycle(pkg.package, 'uninstall', pkg.path, false, true)
+  return lifecycle(pkg.package, 'preuninstall', pkg.path, { failOk: true }).then(() => {
+    return lifecycle(pkg.package, 'uninstall', pkg.path, { failOk: true })
   }).then(() => {
     return rmStuff(pkg.package, pkg.path)
   }).then(() => {
-    return lifecycle(pkg.package, 'postuninstall', pkg.path, false, true)
+    return lifecycle(pkg.package, 'postuninstall', pkg.path, { failOk: true })
   })
 }

--- a/lib/restart.js
+++ b/lib/restart.js
@@ -1,1 +1,1 @@
-module.exports = require('./utils/lifecycle.js').cmd('restart')
+module.exports = require('./utils/lifecycle-cmd.js')('restart')

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -166,7 +166,7 @@ function run (pkg, wd, cmd, args, cb) {
     }
 
     // when running scripts explicitly, assume that they're trusted.
-    return [lifecycle, pkg, c, wd, true]
+    return [lifecycle, pkg, c, wd, { unsafePerm: true }]
   }), cb)
 }
 

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,1 +1,1 @@
-module.exports = require('./utils/lifecycle.js').cmd('start')
+module.exports = require('./utils/lifecycle-cmd.js')('start')

--- a/lib/stop.js
+++ b/lib/stop.js
@@ -1,1 +1,1 @@
-module.exports = require('./utils/lifecycle.js').cmd('stop')
+module.exports = require('./utils/lifecycle-cmd.js')('stop')

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,12 +1,8 @@
 module.exports = test
 
-const testCmd = require('./utils/lifecycle.js').cmd('test')
-const usage = require('./utils/usage')
+const testCmd = require('./utils/lifecycle-cmd.js')('test')
 
-test.usage = usage(
-  'test',
-  'npm test [-- <args>]'
-)
+test.usage = testCmd.usage
 
 function test (args, cb) {
   testCmd(args, function (er) {

--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -38,14 +38,14 @@ function unbuild_ (silent) {
       if (er) return gentlyRm(folder, false, base, cb)
       chain(
         [
-          [lifecycle, pkg, 'preuninstall', folder, false, true],
-          [lifecycle, pkg, 'uninstall', folder, false, true],
+          [lifecycle, pkg, 'preuninstall', folder, { failOk: true }],
+          [lifecycle, pkg, 'uninstall', folder, { failOk: true }],
           !silent && function (cb) {
             output('unbuild ' + pkg._id)
             cb()
           },
           [rmStuff, pkg, folder],
-          [lifecycle, pkg, 'postuninstall', folder, false, true],
+          [lifecycle, pkg, 'postuninstall', folder, { failOk: true }],
           [gentlyRm, folder, false, base]
         ],
         cb

--- a/lib/utils/lifecycle-cmd.js
+++ b/lib/utils/lifecycle-cmd.js
@@ -1,0 +1,18 @@
+exports = module.exports = cmd
+
+var npm = require('../npm.js')
+var usage = require('./usage.js')
+
+function cmd (stage) {
+  function CMD (args, cb) {
+    npm.commands['run-script']([stage].concat(args), cb)
+  }
+  CMD.usage = usage(stage, 'npm ' + stage + ' [-- <args>]')
+  var installedShallow = require('./completion/installed-shallow.js')
+  CMD.completion = function (opts, cb) {
+    installedShallow(opts, function (d) {
+      return d.scripts && d.scripts[stage]
+    }, cb)
+  }
+  return CMD
+}

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -28,25 +28,17 @@ function logid (pkg, stage) {
   return pkg._id + '~' + stage + ':'
 }
 
-function runLifecycle (pkg, stage, wd, unsafe, failOk, cb) {
-  const opts = lifecycleOpts()
-  return lifecycle(pkg, stage, wd, unsafe, failOk, cb, opts)
+function runLifecycle (pkg, stage, wd, moreOpts, cb) {
+  if (typeof moreOpts === 'function') {
+    cb = moreOpts
+    moreOpts = null
+  }
+
+  const opts = lifecycleOpts(moreOpts)
+  return lifecycle(pkg, stage, wd, opts, cb)
 }
 
-function lifecycle (pkg, stage, wd, unsafe, failOk, cb, opts) {
-  if (typeof cb !== 'function') {
-    cb = failOk
-    failOk = false
-  }
-  if (typeof cb !== 'function') {
-    cb = unsafe
-    unsafe = false
-  }
-  if (typeof cb !== 'function') {
-    cb = wd
-    wd = null
-  }
-
+function lifecycle (pkg, stage, wd, opts, cb) {
   while (pkg && pkg._data) pkg = pkg._data
   if (!pkg) return cb(new Error('Invalid package data'))
 
@@ -67,10 +59,8 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb, opts) {
   validWd(wd || path.resolve(opts.dir, pkg.name), function (er, wd) {
     if (er) return cb(er)
 
-    unsafe = unsafe || opts.unsafePerm
-
     if ((wd.indexOf(opts.dir) !== 0 || _incorrectWorkingDirectory(wd, pkg)) &&
-        !unsafe && pkg.scripts[stage]) {
+        !opts.unsafePerm && pkg.scripts[stage]) {
       log.warn('lifecycle', logid(pkg, stage), 'cannot run in wd',
         '%s %s (wd=%s)', pkg._id, pkg.scripts[stage], wd
       )
@@ -87,7 +77,7 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb, opts) {
     // even if it's never used, sh freaks out.
     if (!opts.unsafePerm) env.TMPDIR = wd
 
-    lifecycle_(pkg, stage, wd, opts, env, unsafe, failOk, cb)
+    lifecycle_(pkg, stage, wd, opts, env, cb)
   })
 }
 
@@ -95,7 +85,7 @@ function _incorrectWorkingDirectory (wd, pkg) {
   return wd.lastIndexOf(pkg.name) !== wd.length - pkg.name.length
 }
 
-function lifecycle_ (pkg, stage, wd, opts, env, unsafe, failOk, cb) {
+function lifecycle_ (pkg, stage, wd, opts, env, cb) {
   var pathArr = []
   var p = wd.split(/[\\\/]node_modules[\\\/]/)
   var acc = path.resolve(p.shift())
@@ -132,7 +122,7 @@ function lifecycle_ (pkg, stage, wd, opts, env, unsafe, failOk, cb) {
       if (opts.force) {
         log.info('lifecycle', logid(pkg, stage), 'forced, continuing', er)
         er = null
-      } else if (failOk) {
+      } else if (opts.failOk) {
         log.warn('lifecycle', logid(pkg, stage), 'continuing anyway', er.message)
         er = null
       }
@@ -142,8 +132,8 @@ function lifecycle_ (pkg, stage, wd, opts, env, unsafe, failOk, cb) {
 
   chain(
     [
-      packageLifecycle && [runPackageLifecycle, pkg, env, wd, opts, unsafe],
-      [runHookLifecycle, pkg, env, wd, opts, unsafe]
+      packageLifecycle && [runPackageLifecycle, pkg, env, wd, opts],
+      [runHookLifecycle, pkg, env, wd, opts]
     ],
     done
   )
@@ -195,14 +185,14 @@ function validWd (d, cb) {
   })
 }
 
-function runPackageLifecycle (pkg, env, wd, opts, unsafe, cb) {
+function runPackageLifecycle (pkg, env, wd, opts, cb) {
   // run package lifecycle scripts in the package root, or the nearest parent.
   var stage = env.npm_lifecycle_event
   var cmd = env.npm_lifecycle_script
 
   var note = '\n> ' + pkg._id + ' ' + stage + ' ' + wd +
              '\n> ' + cmd + '\n'
-  runCmd(note, cmd, pkg, env, stage, wd, opts, unsafe, cb)
+  runCmd(note, cmd, pkg, env, stage, wd, opts, cb)
 }
 
 var running = false
@@ -215,14 +205,15 @@ function dequeue () {
   }
 }
 
-function runCmd (note, cmd, pkg, env, stage, wd, opts, unsafe, cb) {
+function runCmd (note, cmd, pkg, env, stage, wd, opts, cb) {
   if (running) {
-    queue.push([note, cmd, pkg, env, stage, wd, unsafe, cb])
+    queue.push([note, cmd, pkg, env, stage, wd, cb])
     return
   }
 
   running = true
   log.pause()
+  var unsafe = opts.unsafePerm
   var user = unsafe ? null : opts.user
   var group = unsafe ? null : opts.group
 
@@ -332,7 +323,7 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
   }
 }
 
-function runHookLifecycle (pkg, env, wd, opts, unsafe, cb) {
+function runHookLifecycle (pkg, env, wd, opts, cb) {
   // check for a hook script, run if present.
   var stage = env.npm_lifecycle_event
   var hook = path.join(opts.dir, '.hooks', stage)
@@ -342,7 +333,7 @@ function runHookLifecycle (pkg, env, wd, opts, unsafe, cb) {
     if (er) return cb()
     var note = '\n> ' + pkg._id + ' ' + stage + ' ' + wd +
                '\n> ' + cmd
-    runCmd(note, hook, pkg, env, stage, wd, opts, unsafe, cb)
+    runCmd(note, hook, pkg, env, stage, wd, opts, cb)
   })
 }
 

--- a/lib/utils/lifecycle.js
+++ b/lib/utils/lifecycle.js
@@ -1,20 +1,17 @@
-exports = module.exports = lifecycle
-exports.cmd = cmd
+exports = module.exports = runLifecycle
 exports.makeEnv = makeEnv
 exports._incorrectWorkingDirectory = _incorrectWorkingDirectory
 
 var log = require('npmlog')
 var spawn = require('./spawn')
-var npm = require('../npm.js')
+const lifecycleOpts = require('../config/lifecycle')
 var path = require('path')
 var fs = require('graceful-fs')
 var chain = require('slide').chain
 var Stream = require('stream').Stream
 var PATH = 'PATH'
 var uidNumber = require('uid-number')
-var umask = require('./umask')
-var usage = require('./usage')
-var output = require('./output.js')
+var umask = require('umask')
 var which = require('which')
 
 // windows calls it's path 'Path' usually, but this is not guaranteed.
@@ -31,7 +28,12 @@ function logid (pkg, stage) {
   return pkg._id + '~' + stage + ':'
 }
 
-function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
+function runLifecycle (pkg, stage, wd, unsafe, failOk, cb) {
+  const opts = lifecycleOpts()
+  return lifecycle(pkg, stage, wd, unsafe, failOk, cb, opts)
+}
+
+function lifecycle (pkg, stage, wd, unsafe, failOk, cb, opts) {
   if (typeof cb !== 'function') {
     cb = failOk
     failOk = false
@@ -51,23 +53,23 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
   log.info('lifecycle', logid(pkg, stage), pkg._id)
   if (!pkg.scripts) pkg.scripts = {}
 
-  if (npm.config.get('ignore-scripts')) {
+  if (opts.ignoreScripts) {
     log.info('lifecycle', logid(pkg, stage), 'ignored because ignore-scripts is set to true', pkg._id)
     pkg.scripts = {}
   }
-  if (stage === 'prepublish' && npm.config.get('ignore-prepublish')) {
+  if (stage === 'prepublish' && opts.ignorePrepublish) {
     log.info('lifecycle', logid(pkg, stage), 'ignored because ignore-prepublish is set to true', pkg._id)
     delete pkg.scripts.prepublish
   }
 
   if (!pkg.scripts[stage]) return cb()
 
-  validWd(wd || path.resolve(npm.dir, pkg.name), function (er, wd) {
+  validWd(wd || path.resolve(opts.dir, pkg.name), function (er, wd) {
     if (er) return cb(er)
 
-    unsafe = unsafe || npm.config.get('unsafe-perm')
+    unsafe = unsafe || opts.unsafePerm
 
-    if ((wd.indexOf(npm.dir) !== 0 || _incorrectWorkingDirectory(wd, pkg)) &&
+    if ((wd.indexOf(opts.dir) !== 0 || _incorrectWorkingDirectory(wd, pkg)) &&
         !unsafe && pkg.scripts[stage]) {
       log.warn('lifecycle', logid(pkg, stage), 'cannot run in wd',
         '%s %s (wd=%s)', pkg._id, pkg.scripts[stage], wd
@@ -76,16 +78,16 @@ function lifecycle (pkg, stage, wd, unsafe, failOk, cb) {
     }
 
     // set the env variables, then run scripts as a child process.
-    var env = makeEnv(pkg)
+    var env = makeEnv(pkg, opts)
     env.npm_lifecycle_event = stage
     env.npm_node_execpath = env.NODE = env.NODE || process.execPath
     env.npm_execpath = require.main.filename
 
     // 'nobody' typically doesn't have permission to write to /tmp
     // even if it's never used, sh freaks out.
-    if (!npm.config.get('unsafe-perm')) env.TMPDIR = wd
+    if (!opts.unsafePerm) env.TMPDIR = wd
 
-    lifecycle_(pkg, stage, wd, env, unsafe, failOk, cb)
+    lifecycle_(pkg, stage, wd, opts, env, unsafe, failOk, cb)
   })
 }
 
@@ -93,7 +95,7 @@ function _incorrectWorkingDirectory (wd, pkg) {
   return wd.lastIndexOf(pkg.name) !== wd.length - pkg.name.length
 }
 
-function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
+function lifecycle_ (pkg, stage, wd, opts, env, unsafe, failOk, cb) {
   var pathArr = []
   var p = wd.split(/[\\\/]node_modules[\\\/]/)
   var acc = path.resolve(p.shift())
@@ -108,7 +110,7 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
   // the bundled one will be used for installing things.
   pathArr.unshift(path.join(__dirname, '..', '..', 'bin', 'node-gyp-bin'))
 
-  if (shouldPrependCurrentNodeDirToPATH()) {
+  if (shouldPrependCurrentNodeDirToPATH(opts.scriptsPrependNodePath)) {
     // prefer current node interpreter in child scripts
     pathArr.push(path.dirname(process.execPath))
   }
@@ -127,7 +129,7 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
 
   function done (er) {
     if (er) {
-      if (npm.config.get('force')) {
+      if (opts.force) {
         log.info('lifecycle', logid(pkg, stage), 'forced, continuing', er)
         er = null
       } else if (failOk) {
@@ -140,15 +142,14 @@ function lifecycle_ (pkg, stage, wd, env, unsafe, failOk, cb) {
 
   chain(
     [
-      packageLifecycle && [runPackageLifecycle, pkg, env, wd, unsafe],
-      [runHookLifecycle, pkg, env, wd, unsafe]
+      packageLifecycle && [runPackageLifecycle, pkg, env, wd, opts, unsafe],
+      [runHookLifecycle, pkg, env, wd, opts, unsafe]
     ],
     done
   )
 }
 
-function shouldPrependCurrentNodeDirToPATH () {
-  var cfgsetting = npm.config.get('scripts-prepend-node-path')
+function shouldPrependCurrentNodeDirToPATH (cfgsetting) {
   if (cfgsetting === false) return false
   if (cfgsetting === true) return true
 
@@ -194,14 +195,14 @@ function validWd (d, cb) {
   })
 }
 
-function runPackageLifecycle (pkg, env, wd, unsafe, cb) {
+function runPackageLifecycle (pkg, env, wd, opts, unsafe, cb) {
   // run package lifecycle scripts in the package root, or the nearest parent.
   var stage = env.npm_lifecycle_event
   var cmd = env.npm_lifecycle_script
 
   var note = '\n> ' + pkg._id + ' ' + stage + ' ' + wd +
              '\n> ' + cmd + '\n'
-  runCmd(note, cmd, pkg, env, stage, wd, unsafe, cb)
+  runCmd(note, cmd, pkg, env, stage, wd, opts, unsafe, cb)
 }
 
 var running = false
@@ -214,7 +215,7 @@ function dequeue () {
   }
 }
 
-function runCmd (note, cmd, pkg, env, stage, wd, unsafe, cb) {
+function runCmd (note, cmd, pkg, env, stage, wd, opts, unsafe, cb) {
   if (running) {
     queue.push([note, cmd, pkg, env, stage, wd, unsafe, cb])
     return
@@ -222,11 +223,13 @@ function runCmd (note, cmd, pkg, env, stage, wd, unsafe, cb) {
 
   running = true
   log.pause()
-  var user = unsafe ? null : npm.config.get('user')
-  var group = unsafe ? null : npm.config.get('group')
+  var user = unsafe ? null : opts.user
+  var group = unsafe ? null : opts.group
 
   if (log.level !== 'silent') {
-    output(note)
+    log.clearProgress()
+    console.log(note)
+    log.showProgress()
   }
   log.verbose('lifecycle', logid(pkg, stage), 'unsafe-perm in lifecycle', unsafe)
 
@@ -235,15 +238,15 @@ function runCmd (note, cmd, pkg, env, stage, wd, unsafe, cb) {
   }
 
   if (unsafe) {
-    runCmd_(cmd, pkg, env, wd, stage, unsafe, 0, 0, cb)
+    runCmd_(cmd, pkg, env, wd, opts, stage, unsafe, 0, 0, cb)
   } else {
     uidNumber(user, group, function (er, uid, gid) {
-      runCmd_(cmd, pkg, env, wd, stage, unsafe, uid, gid, cb)
+      runCmd_(cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb)
     })
   }
 }
 
-function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
+function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
   function cb (er) {
     cb_.apply(null, arguments)
     log.resume()
@@ -264,7 +267,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
   var sh = 'sh'
   var shFlag = '-c'
 
-  var customShell = npm.config.get('script-shell')
+  var customShell = opts.scriptShell
 
   if (customShell) {
     sh = customShell
@@ -302,8 +305,8 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
       if (er.code !== 'EPERM') {
         er.code = 'ELIFECYCLE'
       }
-      fs.stat(npm.dir, function (statError, d) {
-        if (statError && statError.code === 'ENOENT' && npm.dir.split(path.sep).slice(-1)[0] === 'node_modules') {
+      fs.stat(opts.dir, function (statError, d) {
+        if (statError && statError.code === 'ENOENT' && opts.dir.split(path.sep).slice(-1)[0] === 'node_modules') {
           log.warn('', 'Local package.json exists, but node_modules missing, did you mean to install?')
         }
       })
@@ -329,21 +332,21 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
   }
 }
 
-function runHookLifecycle (pkg, env, wd, unsafe, cb) {
+function runHookLifecycle (pkg, env, wd, opts, unsafe, cb) {
   // check for a hook script, run if present.
   var stage = env.npm_lifecycle_event
-  var hook = path.join(npm.dir, '.hooks', stage)
+  var hook = path.join(opts.dir, '.hooks', stage)
   var cmd = hook
 
   fs.stat(hook, function (er) {
     if (er) return cb()
     var note = '\n> ' + pkg._id + ' ' + stage + ' ' + wd +
                '\n> ' + cmd
-    runCmd(note, hook, pkg, env, stage, wd, unsafe, cb)
+    runCmd(note, hook, pkg, env, stage, wd, opts, unsafe, cb)
   })
 }
 
-function makeEnv (data, prefix, env) {
+function makeEnv (data, opts, prefix, env) {
   prefix = prefix || 'npm_package_'
   if (!env) {
     env = {}
@@ -354,7 +357,7 @@ function makeEnv (data, prefix, env) {
     }
 
     // express and others respect the NODE_ENV value.
-    if (npm.config.get('production')) env.NODE_ENV = 'production'
+    if (opts.production) env.NODE_ENV = 'production'
   } else if (!data.hasOwnProperty('_lifecycleEnv')) {
     Object.defineProperty(data, '_lifecycleEnv',
       {
@@ -374,13 +377,14 @@ function makeEnv (data, prefix, env) {
         try {
           // quick and dirty detection for cyclical structures
           JSON.stringify(data[i])
-          makeEnv(data[i], envKey + '_', env)
+          makeEnv(data[i], opts, envKey + '_', env)
         } catch (ex) {
           // usually these are package objects.
           // just get the path and basic details.
           var d = data[i]
           makeEnv(
             { name: d.name, version: d.version, path: d.path },
+            opts,
             envKey + '_',
             env
           )
@@ -398,18 +402,17 @@ function makeEnv (data, prefix, env) {
 
   prefix = 'npm_config_'
   var pkgConfig = {}
-  var keys = npm.config.keys
   var pkgVerConfig = {}
   var namePref = data.name + ':'
   var verPref = data.name + '@' + data.version + ':'
 
-  keys.forEach(function (i) {
+  Object.keys(opts.config).forEach(function (i) {
     // in some rare cases (e.g. working with nerf darts), there are segmented
     // "private" (underscore-prefixed) config names -- don't export
     if (i.charAt(0) === '_' && i.indexOf('_' + namePref) !== 0 || i.match(/:_/)) {
       return
     }
-    var value = npm.config.get(i)
+    var value = opts.config[i]
     if (value instanceof Stream || Array.isArray(value)) return
     if (i.match(/umask/)) value = umask.toString(value)
     if (!value) value = ''
@@ -441,18 +444,4 @@ function makeEnv (data, prefix, env) {
   })
 
   return env
-}
-
-function cmd (stage) {
-  function CMD (args, cb) {
-    npm.commands['run-script']([stage].concat(args), cb)
-  }
-  CMD.usage = usage(stage, 'npm ' + stage + ' [-- <args>]')
-  var installedShallow = require('./completion/installed-shallow.js')
-  CMD.completion = function (opts, cb) {
-    installedShallow(opts, function (d) {
-      return d.scripts && d.scripts[stage]
-    }, cb)
-  }
-  return CMD
 }

--- a/test/tap/config-list.js
+++ b/test/tap/config-list.js
@@ -8,28 +8,54 @@ var common = require('../common-tap.js')
 var pkg = path.resolve(__dirname, 'config-list')
 var opts = { cwd: pkg }
 var npmrc = path.resolve(pkg, '.npmrc')
+var npmrcContents = `
+_private=private;
+registry/:_pwd=pwd;
+foo=1234
+`
 
 test('setup', function (t) {
   rimraf.sync(pkg)
   mkdirp.sync(pkg)
+
+  // Write per-project conf file
+  fs.writeFileSync(npmrc, npmrcContents, 'utf8')
+
+  // Create empty package.json to indicate project root
+  fs.writeFileSync(path.resolve(pkg, 'package.json'), '{}', 'utf8')
   t.end()
 })
 
 test('config list includes project config', function (t) {
-  // Write per-project conf file
-  fs.writeFileSync(npmrc, 'foo=1234', 'utf8')
-
-  // Create empty package.json to indicate project root
-  fs.writeFileSync(path.resolve(pkg, 'package.json'), '{}', 'utf8')
-
   common.npm(
     ['config', 'list'],
     opts,
     function (err, code, stdout, stderr) {
       t.ifError(err)
       t.equal(stderr, '', 'stderr is empty')
+
       var expected = '; project config ' + npmrc + '\nfoo = "1234"'
       t.match(stdout, expected, 'contains project config')
+      t.notMatch(stdout, '_private', 'excludes private config')
+      t.notMatch(stdout, '_pwd', 'excludes private segmented config')
+      t.end()
+    }
+  )
+})
+
+test('config list --json outputs json', function (t) {
+  common.npm(
+    ['config', 'list', '--json'],
+    opts,
+    function (err, code, stdout, stderr) {
+      t.ifError(err)
+      t.equal(stderr, '', 'stderr is empty')
+
+      var json = JSON.parse(stdout)
+      t.equal(json.foo, '1234', 'contains project config')
+      t.equal(json.argv, undefined, 'excludes argv')
+      t.equal(json._private, undefined, 'excludes private config')
+      t.equal(json['registry/:_pwd'], undefined, 'excludes private config')
       t.end()
     }
   )

--- a/test/tap/lifecycle.js
+++ b/test/tap/lifecycle.js
@@ -3,12 +3,39 @@ var npm = require('../../')
 var lifecycle = require('../../lib/utils/lifecycle')
 
 test('lifecycle: make env correctly', function (t) {
-  npm.load({enteente: Infinity}, function () {
-    var env = lifecycle.makeEnv({}, null, process.env)
+  const pkg = {
+    name: 'myPackage',
+    version: '1.0.0',
+    contributors: [{ name: 'Mike Sherov', email: 'beep@boop.com' }]
+  }
+  const config = {
+    enteente: Infinity,
+    '_privateVar': 1,
+    '_myPackage:myPrivateVar': 1,
+    'myPackage:bar': 2,
+    'myPackage:foo': 3,
+    'myPackage@1.0.0:baz': 4,
+    'myPackage@1.0.0:foo': 5
+  }
 
-    t.equal('Infinity', env.npm_config_enteente)
-    t.end()
-  })
+  var env = lifecycle.makeEnv(pkg, { config }, null, process.env)
+
+  t.equal('myPackage', env.npm_package_name, 'package data is included')
+  t.equal('Mike Sherov', env.npm_package_contributors_0_name, 'nested package data is included')
+
+  t.equal('Infinity', env.npm_config_enteente, 'public config is included')
+  t.equal(undefined, env.npm_config_privateVar, 'private config is excluded')
+
+  t.equal('1', env.npm_config_myPackage_myPrivateVar, 'private package config is included by name')
+  t.equal('2', env.npm_config_myPackage_bar, 'public package config is included by name')
+
+  t.equal('5', env.npm_config_myPackage_1_0_0_foo, 'public package@version config is included by name')
+
+  t.equal('1', env.npm_package_config_myPrivateVar, 'package private config is included')
+  t.equal('2', env.npm_package_config_bar, 'package config is included')
+  t.equal('4', env.npm_package_config_baz, 'package@version config is included')
+  t.equal('5', env.npm_package_config_foo, 'package@version config overrides package config')
+  t.end()
 })
 
 test('lifecycle : accepts wd for package that matches project\'s name', function (t) {

--- a/test/tap/verify-no-lifecycle-on-repo.js
+++ b/test/tap/verify-no-lifecycle-on-repo.js
@@ -23,7 +23,11 @@ var baseJSON = {
 
 var lastOpened
 var npm = requireInject.installGlobally('../../lib/npm.js', {
-  '../../lib/utils/lifecycle.js': function (pkg, stage, wd, unsafe, failOk, cb) {
+  '../../lib/utils/lifecycle.js': function (pkg, stage, wd, moreOpts, cb) {
+    if (typeof moreOpts === 'function') {
+      cb = moreOpts
+    }
+
     cb(new Error("Shouldn't be calling lifecycle scripts"))
   },
   opener: function (url, options, cb) {


### PR DESCRIPTION
**Ignore all but the last commit. The other commits are in a separate PR: https://github.com/npm/npm/pull/18073/files**

## Abstract

This PR extracts all of npm out of lifecycle.js, and prepares it for extraction to another repo (other than spawn.js, which will be copy-pasted for now).

## The Plan

0. Get https://github.com/npm/npm/pull/18073 merged.
1. Rebase this. Get this merged.
2. yank `lifecycle.js` out, other than the `runLifecycle` function, which will remain as a local adapter for the generic `lifecycle` function. Publish it as `npm/lifecycle`... taking the tests with it.
3. Pulling in `npm/lifecycle` and using it in npm proper.
4. Use #18073 to grab config and input it into `npm/lifecycle` in `cipm`.

Let me know if you have thoughts, questions, or concerns! Thanks again