### PR TITLE
`npm config list --json` support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+# Remove once Trusty can support couchdb, which is part of before_install
+dist: precise
 # need to declare the language as well as the matrix below
 language: node_js
 # having top-level `env:` adds a phantom build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,67 @@
+## v5.4.0 (2017-07-28):
+
+Here's another small release, with a handful of fixes and a couple of small new
+features!
+
+### FEATURES
+
+* [`1ac470dd2`](https://github.com/npm/npm/commit/1ac470dd283cc7758dc37721dd6331d5b316dc99)
+  [#10382](https://github.com/npm/npm/pull/10382)
+  If you make a typo when writing a command now, npm will print a brief "did you
+  mean..." message with some possible alternatives to what you meant.
+  ([@watilde](https://github.com/watilde))
+* [`20c46228d`](https://github.com/npm/npm/commit/20c46228d8f9243910f8c343f4830d52455d754e)
+  [#12356](https://github.com/npm/npm/pull/12356)
+  When running lifecycle scripts, `INIT_CWD` will now contain the original
+  working directory that npm was executed from. Remember that you can use `npm
+  run-script` even if you're not inside your package root directory!
+  ([@MichaelQQ](https://github.com/MichaelQQ))
+* [`be91e1726`](https://github.com/npm/npm/commit/be91e1726e9c21c4532723e4f413b73a93dd53d1)
+  `libnpx@9.5.0`: Fixes a number of issues on Windows and adds support for
+  several more languages: Korean, Norwegian (bokmål and nynorsk), Ukrainian,
+  Serbian, Bahasa Indonesia, and Polish.
+  ([@zkat](https://github.com/zkat))
+
+### BUGFIXES
+
+* [`b6d5549d2`](https://github.com/npm/npm/commit/b6d5549d2c2d38dd0e4319c56b69ad137f0d50cd)
+  [#17844](https://github.com/npm/npm/pull/17844)
+  Make package-lock.json sorting locale-agnostic. Previously, sorting would vary
+  by locale, due to using `localeCompare` for key sorting.
+  ([@LotharSee](https://github.com/LotharSee))
+* [`44b98b9dd`](https://github.com/npm/npm/commit/44b98b9ddcfcccf68967fdf106fca52bf0c3da4b)
+  [#17919](https://github.com/npm/npm/pull/17919)
+  Fix crash where `npm prune --production` would fail while removing `.bin`.
+  ([@fasterthanlime](https://github.com/fasterthanlime))
+* [`c3d1d3ba8`](https://github.com/npm/npm/commit/c3d1d3ba82aa41dfb2bd135e6cdc59f8d33cd9fb)
+  [#17816](https://github.com/npm/npm/pull/17816)
+  Fail more smoothly when attempting to install an invalid package name.
+  ([@SamuelMarks](https://github.com/SamuelMarks))
+
+### DOCUMENTATION
+
+* [`b019680db`](https://github.com/npm/npm/commit/b019680db78ae0a6dff2289dbfe9f61fccbbe824)
+  [#10846](https://github.com/npm/npm/pull/10846)
+  Remind users that they have to install missing `peerDependencies` manually.
+  ([@ryanflorence](https://github.com/ryanflorence))
+* [`3aee5986a`](https://github.com/npm/npm/commit/3aee5986a65add2f815b24541b9f4b69d7fb445f)
+  [#17898](https://github.com/npm/npm/pull/17898)
+  Minor punctuation fixes.
+  ([@AndersDJohnson](https://github.com/AndersDJohnson))
+* [`e0d0a7e1d`](https://github.com/npm/npm/commit/e0d0a7e1dda2c43822b17eb71f4d51900575cc61)
+  [#17832](https://github.com/npm/npm/pull/17832)
+  Fix grammar, format, and spelling in documentation for `run-script`.
+  ([@simonua](https://github.com/simonua))
+* [`3fd6a5f2f`](https://github.com/npm/npm/commit/3fd6a5f2f8802a9768dba2ec32c593b5db5a878d)
+  [#17897](https://github.com/npm/npm/pull/17897)
+  Add more info about using `files` with `npm pack`/`npm publish`.
+  ([@davidjgoss](https://github.com/davidjgoss))
+* [`f00cdc6eb`](https://github.com/npm/npm/commit/f00cdc6eb90a0735bc3c516720de0b1428c79c31)
+  [#17785](https://github.com/npm/npm/pull/17785)
+  Add a note about filenames for certificates on Windows, which use a different
+  extension and file type.
+  ([@lgp1985](https://github.com/lgp1985))
+
 ## v5.3.0 (2017-07-12):
 
 As mentioned before, we're continuing to do relatively rapid, smaller releases

--- a/doc/cli/npm-config.md
+++ b/doc/cli/npm-config.md
@@ -6,7 +6,7 @@ npm-config(1) -- Manage the npm configuration files
     npm config set <key> <value> [-g|--global]
     npm config get <key>
     npm config delete <key>
-    npm config list [-l]
+    npm config list [-l] [--json]
     npm config edit
     npm get <key>
     npm set <key> <value> [-g|--global]
@@ -48,7 +48,8 @@ Echo the config value to stdout.
 
     npm config list
 
-Show all the config settings. Use `-l` to also show defaults.
+Show all the config settings. Use `-l` to also show defaults. Use `--json`
+to show the settings in json format.
 
 ### delete
 

--- a/doc/misc/semver.md
+++ b/doc/misc/semver.md
@@ -1,55 +1,65 @@
 semver(7) -- The semantic versioner for npm
 ===========================================
 
+## Install
+
+```bash
+npm install --save semver
+````
+
 ## Usage
 
-    $ npm install semver
-    $ node
-    var semver = require('semver')
+As a node module:
 
-    semver.valid('1.2.3') // '1.2.3'
-    semver.valid('a.b.c') // null
-    semver.clean('  =v1.2.3   ') // '1.2.3'
-    semver.satisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3') // true
-    semver.gt('1.2.3', '9.8.7') // false
-    semver.lt('1.2.3', '9.8.7') // true
+```js
+const semver = require('semver')
+
+semver.valid('1.2.3') // '1.2.3'
+semver.valid('a.b.c') // null
+semver.clean('  =v1.2.3   ') // '1.2.3'
+semver.satisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3') // true
+semver.gt('1.2.3', '9.8.7') // false
+semver.lt('1.2.3', '9.8.7') // true
+```
 
 As a command-line utility:
 
-    $ semver -h
+```
+$ semver -h
 
-    SemVer 5.1.0
+SemVer 5.3.0
 
-    A JavaScript implementation of the http://semver.org/ specification
-    Copyright Isaac Z. Schlueter
+A JavaScript implementation of the http://semver.org/ specification
+Copyright Isaac Z. Schlueter
 
-    Usage: semver [options] <version> [<version> [...]]
-    Prints valid versions sorted by SemVer precedence
+Usage: semver [options] <version> [<version> [...]]
+Prints valid versions sorted by SemVer precedence
 
-    Options:
-    -r --range <range>
-            Print versions that match the specified range.
+Options:
+-r --range <range>
+        Print versions that match the specified range.
 
-    -i --increment [<level>]
-            Increment a version by the specified level.  Level can
-            be one of: major, minor, patch, premajor, preminor,
-            prepatch, or prerelease.  Default level is 'patch'.
-            Only one version may be specified.
+-i --increment [<level>]
+        Increment a version by the specified level.  Level can
+        be one of: major, minor, patch, premajor, preminor,
+        prepatch, or prerelease.  Default level is 'patch'.
+        Only one version may be specified.
 
-    --preid <identifier>
-            Identifier to be used to prefix premajor, preminor,
-            prepatch or prerelease version increments.
+--preid <identifier>
+        Identifier to be used to prefix premajor, preminor,
+        prepatch or prerelease version increments.
 
-    -l --loose
-            Interpret versions and ranges loosely
+-l --loose
+        Interpret versions and ranges loosely
 
-    Program exits successfully if any valid version satisfies
-    all supplied ranges, and prints all satisfying versions.
+Program exits successfully if any valid version satisfies
+all supplied ranges, and prints all satisfying versions.
 
-    If no satisfying versions are found, then exits failure.
+If no satisfying versions are found, then exits failure.
 
-    Versions are printed in ascending order, so supplying
-    multiple versions to the utility will just sort them.
+Versions are printed in ascending order, so supplying
+multiple versions to the utility will just sort them.
+```
 
 ## Versions
 
@@ -126,20 +136,20 @@ The method `.inc` takes an additional `identifier` string argument that
 will append the value of the string as a prerelease identifier:
 
 ```javascript
-> semver.inc('1.2.3', 'prerelease', 'beta')
-'1.2.4-beta.0'
+semver.inc('1.2.3', 'prerelease', 'beta')
+// '1.2.4-beta.0'
 ```
 
 command-line example:
 
-```shell
+```bash
 $ semver 1.2.3 -i prerelease --preid beta
 1.2.4-beta.0
 ```
 
 Which then can be used to increment further:
 
-```shell
+```bash
 $ semver 1.2.4-beta.0 -i prerelease
 1.2.4-beta.1
 ```
@@ -296,6 +306,8 @@ strings that they parse.
 * `major(v)`: Return the major version number.
 * `minor(v)`: Return the minor version number.
 * `patch(v)`: Return the patch version number.
+* `intersects(r1, r2, loose)`: Return true if the two supplied ranges
+  or comparators intersect.
 
 ### Comparison
 
@@ -319,6 +331,9 @@ strings that they parse.
   (`major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, or `prerelease`),
   or null if the versions are the same.
 
+### Comparators
+
+* `intersects(comparator)`: Return true if the comparators intersect
 
 ### Ranges
 
@@ -337,6 +352,7 @@ strings that they parse.
   the bounds of the range in either the high or low direction.  The
   `hilo` argument must be either the string `'>'` or `'<'`.  (This is
   the function called by `gtr` and `ltr`.)
+* `intersects(range)`: Return true if any of the ranges comparators intersect
 
 Note that, since ranges may be non-contiguous, a version might not be
 greater than a range, less than a range, *or* satisfy a range!  For

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,7 @@ config.usage = usage(
   'npm config set <key> <value>' +
   '\nnpm config get [<key>]' +
   '\nnpm config delete <key>' +
-  '\nnpm config list' +
+  '\nnpm config list [--json]' +
   '\nnpm config edit' +
   '\nnpm set <key> <value>' +
   '\nnpm get [<key>]'
@@ -69,7 +69,7 @@ function config (args, cb) {
       return del(args[0], cb)
     case 'list':
     case 'ls':
-      return list(cb)
+      return npm.config.get('json') ? listJson(cb) : list(cb)
     case 'edit':
       return edit(cb)
     default:
@@ -175,6 +175,23 @@ function publicVar (k) {
 
 function getKeys (data) {
   return Object.keys(data).filter(publicVar).sort(sort)
+}
+
+function listJson (cb) {
+  const publicConf = npm.config.keys.reduce((publicConf, k) => {
+    var value = npm.config.get(k)
+
+    if (publicVar(k) &&
+        // argv is not really config, it's command config
+        k !== 'argv' &&
+        // logstream is a Stream, and would otherwise produce circular refs
+        k !== 'logstream') publicConf[k] = value
+
+    return publicConf
+  }, {})
+
+  output(JSON.stringify(publicConf, null, 2))
+  return cb()
 }
 
 function listFromSource (title, conf, long) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -45,9 +45,11 @@ config.completion = function (opts, cb) {
     case 'rm':
       return cb(null, Object.keys(types))
     case 'edit':
-    case 'list': case 'ls':
+    case 'list':
+    case 'ls':
       return cb(null, [])
-    default: return cb(null, [])
+    default:
+      return cb(null, [])
   }
 }
 
@@ -57,12 +59,21 @@ config.completion = function (opts, cb) {
 function config (args, cb) {
   var action = args.shift()
   switch (action) {
-    case 'set': return set(args[0], args[1], cb)
-    case 'get': return get(args[0], cb)
-    case 'delete': case 'rm': case 'del': return del(args[0], cb)
-    case 'list': case 'ls': return list(cb)
-    case 'edit': return edit(cb)
-    default: return unknown(action, cb)
+    case 'set':
+      return set(args[0], args[1], cb)
+    case 'get':
+      return get(args[0], cb)
+    case 'delete':
+    case 'rm':
+    case 'del':
+      return del(args[0], cb)
+    case 'list':
+    case 'ls':
+      return list(cb)
+    case 'edit':
+      return edit(cb)
+    default:
+      return unknown(action, cb)
   }
 }
 
@@ -159,13 +170,30 @@ function sort (a, b) {
 }
 
 function publicVar (k) {
-  return !(k.charAt(0) === '_' ||
-           k.indexOf(':_') !== -1 ||
-           types[k] !== types[k])
+  return !(k.charAt(0) === '_' || k.indexOf(':_') !== -1)
 }
 
 function getKeys (data) {
   return Object.keys(data).filter(publicVar).sort(sort)
+}
+
+function listFromSource (title, conf, long) {
+  var confKeys = getKeys(conf)
+  var msg = ''
+
+  if (confKeys.length) {
+    msg += '; ' + title + '\n'
+    confKeys.forEach(function (k) {
+      var val = JSON.stringify(conf[k])
+      if (conf[k] !== npm.config.get(k)) {
+        if (!long) return
+        msg += '; ' + k + ' = ' + val + ' (overridden)\n'
+      } else msg += k + ' = ' + val + '\n'
+    })
+    msg += '\n'
+  }
+
+  return msg
 }
 
 function list (cb) {
@@ -185,92 +213,22 @@ function list (cb) {
   }
 
   // env configs
-  var env = npm.config.sources.env.data
-  var envKeys = getKeys(env)
-  if (envKeys.length) {
-    msg += '; environment configs\n'
-    envKeys.forEach(function (k) {
-      if (env[k] !== npm.config.get(k)) {
-        if (!long) return
-        msg += '; ' + k + ' = ' +
-          JSON.stringify(env[k]) + ' (overridden)\n'
-      } else msg += k + ' = ' + JSON.stringify(env[k]) + '\n'
-    })
-    msg += '\n'
-  }
+  msg += listFromSource('environment configs', npm.config.sources.env.data, long)
 
   // project config file
   var project = npm.config.sources.project
-  var pconf = project.data
-  var ppath = project.path
-  var pconfKeys = getKeys(pconf)
-  if (pconfKeys.length) {
-    msg += '; project config ' + ppath + '\n'
-    pconfKeys.forEach(function (k) {
-      var val = (k.charAt(0) === '_')
-              ? '---sekretz---'
-              : JSON.stringify(pconf[k])
-      if (pconf[k] !== npm.config.get(k)) {
-        if (!long) return
-        msg += '; ' + k + ' = ' + val + ' (overridden)\n'
-      } else msg += k + ' = ' + val + '\n'
-    })
-    msg += '\n'
-  }
+  msg += listFromSource('project config ' + project.path, project.data, long)
 
   // user config file
-  var uconf = npm.config.sources.user.data
-  var uconfKeys = getKeys(uconf)
-  if (uconfKeys.length) {
-    msg += '; userconfig ' + npm.config.get('userconfig') + '\n'
-    uconfKeys.forEach(function (k) {
-      var val = (k.charAt(0) === '_')
-              ? '---sekretz---'
-              : JSON.stringify(uconf[k])
-      if (uconf[k] !== npm.config.get(k)) {
-        if (!long) return
-        msg += '; ' + k + ' = ' + val + ' (overridden)\n'
-      } else msg += k + ' = ' + val + '\n'
-    })
-    msg += '\n'
-  }
+  msg += listFromSource('userconfig ' + npm.config.get('userconfig'), npm.config.sources.user.data, long)
 
   // global config file
-  var gconf = npm.config.sources.global.data
-  var gconfKeys = getKeys(gconf)
-  if (gconfKeys.length) {
-    msg += '; globalconfig ' + npm.config.get('globalconfig') + '\n'
-    gconfKeys.forEach(function (k) {
-      var val = (k.charAt(0) === '_')
-              ? '---sekretz---'
-              : JSON.stringify(gconf[k])
-      if (gconf[k] !== npm.config.get(k)) {
-        if (!long) return
-        msg += '; ' + k + ' = ' + val + ' (overridden)\n'
-      } else msg += k + ' = ' + val + '\n'
-    })
-    msg += '\n'
-  }
+  msg += listFromSource('globalconfig ' + npm.config.get('globalconfig'), npm.config.sources.global.data, long)
 
   // builtin config file
   var builtin = npm.config.sources.builtin || {}
   if (builtin && builtin.data) {
-    var bconf = builtin.data
-    var bpath = builtin.path
-    var bconfKeys = getKeys(bconf)
-    if (bconfKeys.length) {
-      msg += '; builtin config ' + bpath + '\n'
-      bconfKeys.forEach(function (k) {
-        var val = (k.charAt(0) === '_')
-                ? '---sekretz---'
-                : JSON.stringify(bconf[k])
-        if (bconf[k] !== npm.config.get(k)) {
-          if (!long) return
-          msg += '; ' + k + ' = ' + val + ' (overridden)\n'
-        } else msg += k + ' = ' + val + '\n'
-      })
-      msg += '\n'
-    }
+    msg += listFromSource('builtin config ' + builtin.path, builtin.data, long)
   }
 
   // only show defaults if --long

--- a/test/tap/config-list.js
+++ b/test/tap/config-list.js
@@ -8,28 +8,54 @@ var common = require('../common-tap.js')
 var pkg = path.resolve(__dirname, 'config-list')
 var opts = { cwd: pkg }
 var npmrc = path.resolve(pkg, '.npmrc')
+var npmrcContents = `
+_private=private;
+registry/:_pwd=pwd;
+foo=1234
+`
 
 test('setup', function (t) {
   rimraf.sync(pkg)
   mkdirp.sync(pkg)
+
+  // Write per-project conf file
+  fs.writeFileSync(npmrc, npmrcContents, 'utf8')
+
+  // Create empty package.json to indicate project root
+  fs.writeFileSync(path.resolve(pkg, 'package.json'), '{}', 'utf8')
   t.end()
 })
 
 test('config list includes project config', function (t) {
-  // Write per-project conf file
-  fs.writeFileSync(npmrc, 'foo=1234', 'utf8')
-
-  // Create empty package.json to indicate project root
-  fs.writeFileSync(path.resolve(pkg, 'package.json'), '{}', 'utf8')
-
   common.npm(
     ['config', 'list'],
     opts,
     function (err, code, stdout, stderr) {
       t.ifError(err)
       t.equal(stderr, '', 'stderr is empty')
+
       var expected = '; project config ' + npmrc + '\nfoo = "1234"'
       t.match(stdout, expected, 'contains project config')
+      t.notMatch(stdout, '_private', 'excludes private config')
+      t.notMatch(stdout, '_pwd', 'excludes private segmented config')
+      t.end()
+    }
+  )
+})
+
+test('config list --json outputs json', function (t) {
+  common.npm(
+    ['config', 'list', '--json'],
+    opts,
+    function (err, code, stdout, stderr) {
+      t.ifError(err)
+      t.equal(stderr, '', 'stderr is empty')
+
+      var json = JSON.parse(stdout)
+      t.equal(json.foo, '1234', 'contains project config')
+      t.equal(json.argv, undefined, 'excludes argv')
+      t.equal(json._private, undefined, 'excludes private config')
+      t.equal(json['registry/:_pwd'], undefined, 'excludes private config')
       t.end()
     }
   )


### PR DESCRIPTION
As per a conversation with @zkat, this is to support other CLI tools like `cipm` that will need to query npm for config and avoid the hassle of ini parsing the result.

Please let me know if you have any questions, and thanks for all the great work you do on npm!

I also took the time to clean up some of the config code while I was there, and learned a lot about npm's history. Changes annotated!