### PR TITLE
install/deps: fix issue with space in _from

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -62,8 +62,9 @@ function doesChildVersionMatch (child, requested, requestor) {
     // In those cases _from, will be preserved and we can compare that to ensure that they
     // really came from the same sources.
     // You'll see this scenario happen with at least tags and git dependencies.
+    // Note: sometimes _from will be in format 'module@1.2.3', and sometimes it will be 'module @1.2.3'
     if (child.package._from) {
-      var fromReq = npa.resolve(moduleName(child), child.package._from.replace(new RegExp('^' + moduleName(child) + '@'), ''))
+      var fromReq = npa.resolve(moduleName(child), child.package._from.replace(new RegExp('^' + moduleName(child) + '[ ]?@'), ''))
       if (fromReq.rawSpec === requested.rawSpec) return true
       if (fromReq.type === requested.type && fromReq.saveSpec && fromReq.saveSpec === requested.saveSpec) return true
     }


### PR DESCRIPTION
I ran into this issue when migrating a project from `node v6.9.5 (npm v3.10.10)` to `node v8.2.1 (npm v5.3.0)`. The project used npm-shrinkwrap.

I have been able to reproducible the issue, but only in the form of an already installed set of node_modules. Deleting node_modules and npm-shrinkwrap.json, and reinstalling does not cause this issue. But then you run the risk of updating modules you don't want to be updated.

**Steps to reproduce:**
1. Clone my cut-down project: https://github.com/IgorNadj/npm-test-project
2. Use `node v8.2.1 (npm v5.3.0)`
3. Run `npm install`

Expected: install works
Actual: 
```
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "gulp-wrap @0.13.0": Tags may not have any characters that encodeURIComponent encodes.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/inadj/.npm/_logs/2017-08-09T06_54_42_520Z-debug.log
```

**Fix**
The code path executed is explained well by this existing comment:
```
    // If _requested didn't exist OR if it didn't match then we'll try using
    // _from. We pass it through npa to normalize the specifier.
    // This can happen when installing from an `npm-shrinkwrap.json` where `_requested` will
    // be the tarball URL from `resolved` and thus can't match what's in the `package.json`.
    // In those cases _from, will be preserved and we can compare that to ensure that they
    // really came from the same sources.
    // You'll see this scenario happen with at least tags and git dependencies.
```
Unfortunately, sometimes the _from field can have a space. In my example project, the _from field of node_modules/gulp-wrap/package.json is ''gulp-wrap @0.13.0", and the existing code does not correctly pick out the version "0.13.0" because of this space.

**npm-debug.log:**
https://pastebin.com/cKbwP9aM