### PR TITLE
.npmignore will not override files in package.json

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -172,11 +172,6 @@ The "files" field is an array of files to include in your project.  If
 you name a folder in the array, then it will also include the files
 inside that folder. (Unless they would be ignored by another rule.)
 
-You can also provide a ".npmignore" file in the root of your package or
-in subdirectories, which will keep files from being included, even
-if they would be picked up by the files array.  The `.npmignore` file
-works just like a `.gitignore`.
-
 Certain files are always included, regardless of settings:
 
 * `package.json`


### PR DESCRIPTION
At least, I believe this test case shows the current behavior.
https://github.com/npm/npm/blob/v5.3.0/test/tap/files-and-ignores.js#L194
```
test('.npmignore should always be overridden by files array', function (t) {
  var fixture = new Tacks(
    Dir({
      'package.json': File({
        name: 'npm-test-files',
        version: '1.2.5',
        files: [
          'include',
          'sub'
        ]
      }),
      '.npmignore': File(
        'include\n' +
        'ignore\n' +
        'sub/included\n'
      ),
      include: File(''),
      ignore: File(''),
      sub: Dir({
        include: File('')
      })
    })
  )
  withFixture(t, fixture, function (done) {
    t.notOk(fileExists('ignore'), 'toplevel file excluded')
    t.ok(fileExists('include'), 'unignored file included')
    t.ok(fileExists('sub/include'), 'nested file included')
    done()
  })
})
```
And, also, there is a typo in the test case :shrug: . You created a `sub.include` file, but the file specified in `.npmignore` is `sub.included`