### PR TITLE
fix(prune): do not remove .bin folder

### DIFF
--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -79,12 +79,7 @@ function rmBins (pkg, folder, parent, top, cb) {
     } else {
       gentlyRm(path.resolve(binRoot, b), true, folder, cb)
     }
-  }, gentlyRmBinRoot)
-
-  function gentlyRmBinRoot (err) {
-    if (err || top) return cb(err)
-    return gentlyRm(binRoot, true, parent, cb)
-  }
+  }, cb)
 }
 
 function rmMans (pkg, folder, parent, top, cb) {


### PR DESCRIPTION
See #17781 

On prune --production npm tries to remove the .bin folder, which
has been denied in https://github.com/npm/npm/blob/39495d07b9a66c88621e8a2ad07739ee98b70a56/lib/utils/gently-rm.js#L37-L50

This fix removes the routine that tries to remove this folder.