### PR TITLE
Don't trim versions output

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -264,7 +264,7 @@ function printData (data, name, cb) {
         if (npm.config.get('json')) {
           msgJson[msgJson.length - 1][f] = d
         } else {
-          d = util.inspect(d, false, 5, npm.color)
+          d = util.inspect(d, { showHidden: false, depth: 5, colors: npm.color, maxArrayLength: null })
         }
       } else if (typeof d === 'string' && npm.config.get('json')) {
         d = JSON.stringify(d)


### PR DESCRIPTION
In node@6 array elements are trimmed at 100 when passed through `util.inspect`

https://nodejs.org/dist/latest-v4.x/docs/api/util.html#util_util_inspect_object_options
https://nodejs.org/dist/latest-v6.x/docs/api/util.html#util_util_inspect_object_options

Current:
```sh-session
$ npm show node-gyp versions
[ '0.0.1',
  '0.0.2',
  '0.0.3',
  '0.0.4',
  '0.0.5',
  '0.0.6',
  '0.1.0',
  '0.1.1',
  '0.1.2',
  '0.1.3',
  '0.1.4',
  '0.2.0',
  '0.2.1',
  '0.2.2',
  '0.3.0',
  '0.3.1',
  '0.3.2',
  '0.3.4',
  '0.3.5',
  '0.3.6',
  '0.3.7',
  '0.3.8',
  '0.3.9',
  '0.3.10',
  '0.3.11',
  '0.4.0',
  '0.4.1',
  '0.4.2',
  '0.4.3',
  '0.4.4',
  '0.4.5',
  '0.5.0',
  '0.5.1',
  '0.5.2',
  '0.5.3',
  '0.5.4',
  '0.5.5',
  '0.5.6',
  '0.5.7',
  '0.5.8',
  '0.6.0',
  '0.6.1',
  '0.6.2',
  '0.6.3',
  '0.6.4',
  '0.6.5',
  '0.6.6',
  '0.6.7',
  '0.6.8',
  '0.6.9',
  '0.6.10',
  '0.6.11',
  '0.7.0',
  '0.7.1',
  '0.7.2',
  '0.7.3',
  '0.8.0',
  '0.8.1',
  '0.8.2',
  '0.8.3',
  '0.8.4',
  '0.8.5',
  '0.9.0',
  '0.9.1',
  '0.9.2',
  '0.9.3',
  '0.9.4',
  '0.9.5',
  '0.9.6',
  '0.10.0',
  '0.10.1',
  '0.10.2',
  '0.10.3',
  '0.10.4',
  '0.10.5',
  '0.10.6',
  '0.10.7',
  '0.10.8',
  '0.10.9',
  '0.10.10',
  '0.11.0',
  '0.12.0',
  '0.12.1',
  '0.12.2',
  '0.13.0',
  '0.13.1',
  '1.0.0',
  '1.0.1',
  '1.0.2',
  '1.0.3',
  '2.0.0',
  '2.0.1',
  '2.0.2',
  '3.0.0',
  '3.0.1',
  '3.0.2',
  '3.0.3',
  '3.1.0',
  '3.2.0',
  '3.2.1',
  ... 7 more items ]
```

With this patch
```sh-session
$ npm show node-gyp versions
[ '0.0.1',
  '0.0.2',
  '0.0.3',
  '0.0.4',
  '0.0.5',
  '0.0.6',
  '0.1.0',
  '0.1.1',
  '0.1.2',
  '0.1.3',
  '0.1.4',
  '0.2.0',
  '0.2.1',
  '0.2.2',
  '0.3.0',
  '0.3.1',
  '0.3.2',
  '0.3.4',
  '0.3.5',
  '0.3.6',
  '0.3.7',
  '0.3.8',
  '0.3.9',
  '0.3.10',
  '0.3.11',
  '0.4.0',
  '0.4.1',
  '0.4.2',
  '0.4.3',
  '0.4.4',
  '0.4.5',
  '0.5.0',
  '0.5.1',
  '0.5.2',
  '0.5.3',
  '0.5.4',
  '0.5.5',
  '0.5.6',
  '0.5.7',
  '0.5.8',
  '0.6.0',
  '0.6.1',
  '0.6.2',
  '0.6.3',
  '0.6.4',
  '0.6.5',
  '0.6.6',
  '0.6.7',
  '0.6.8',
  '0.6.9',
  '0.6.10',
  '0.6.11',
  '0.7.0',
  '0.7.1',
  '0.7.2',
  '0.7.3',
  '0.8.0',
  '0.8.1',
  '0.8.2',
  '0.8.3',
  '0.8.4',
  '0.8.5',
  '0.9.0',
  '0.9.1',
  '0.9.2',
  '0.9.3',
  '0.9.4',
  '0.9.5',
  '0.9.6',
  '0.10.0',
  '0.10.1',
  '0.10.2',
  '0.10.3',
  '0.10.4',
  '0.10.5',
  '0.10.6',
  '0.10.7',
  '0.10.8',
  '0.10.9',
  '0.10.10',
  '0.11.0',
  '0.12.0',
  '0.12.1',
  '0.12.2',
  '0.13.0',
  '0.13.1',
  '1.0.0',
  '1.0.1',
  '1.0.2',
  '1.0.3',
  '2.0.0',
  '2.0.1',
  '2.0.2',
  '3.0.0',
  '3.0.1',
  '3.0.2',
  '3.0.3',
  '3.1.0',
  '3.2.0',
  '3.2.1',
  '3.3.0',
  '3.3.1',
  '3.4.0',
  '3.5.0',
  '3.6.0',
  '3.6.1',
  '3.6.2' ]
```