### PR TITLE
Paraquire - paranoidal require

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -16,6 +16,8 @@
   var unsupported = require('../lib/utils/unsupported.js')
   unsupported.checkForBrokenNode()
 
+  var paraquire = require('paraquire')(module)
+
   var gfs = require('graceful-fs')
   // Patch the global fs module here at the app level
   var fs = gfs.gracefulify(require('fs'))
@@ -30,7 +32,7 @@
   var which = require('which')
   var glob = require('glob')
   var rimraf = require('rimraf')
-  var lazyProperty = require('lazy-property')
+  var lazyProperty = paraquire('lazy-property')
   var parseJSON = require('./utils/parse-json.js')
   var clientConfig = require('./config/reg-client.js')
   var aliases = require('./config/cmd-list').aliases

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -18,7 +18,7 @@
 
   var paraquire = require('paraquire')(module)
 
-  var gfs = require('graceful-fs')
+  var gfs = paraquire('graceful-fs', {builtin: ['constants', 'fs'], process: ['cwd', 'version'], 'process.env': ['GRACEFUL_FS_PLATFORM']})
   // Patch the global fs module here at the app level
   var fs = gfs.gracefulify(require('fs'))
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "opener": "~1.4.3",
     "osenv": "~0.1.4",
     "pacote": "~6.0.1",
+    "paraquire": "0.0.23",
     "path-is-inside": "~1.0.2",
     "promise-inflight": "~1.0.1",
     "read": "~1.0.7",


### PR DESCRIPTION
NPM ecosystem is [quite unresistant](https://github.com/ChALkeR/notes/blob/master/Gathering-weak-npm-credentials.md) against dependency attacks. It means that if a hacker gets control over one small abandoned package, the hacker gets control over all it's dependents, dependents of dependents, etc.
So, hijacking only one of small `npm`'s dependencies will be very crucial for whole NPM ecosystem. This PR improves `npm`'s security by jailing most dependencies into `paraquire` - secure [alternative](https://github.com/nickkolok/paraquire) for standard `require`. I jailed only two libraries just to demonstrate the mechanism.
I realise that this PR probably will not be merged, but I hope for having a productive discussion. I could not open an issue first, because only PR can show my suggestion clearly enough.
