### PR TITLE
Added more detailed error message for inaccessible files.

### DIFF
--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -27,9 +27,12 @@ function errorMessage (er) {
         '',
         [
           '\nThe operation was rejected by your operating system.',
-          'It\'s possible that the file was already in use.',
-          'To resolve, try running this action again as root/Administrator',
-          'and make sure that that the file isn\'t being used by another program.'
+          (process.platform === 'win32'
+            ? 'It\'s possible that the file was already in use (by a text editor or antivirus),\nor that you lack permissions to access it.'
+            : 'It is likely you do not have the permissions to access this file as the current user'),
+          '\nIf you believe this might be a permissions issue, please double-check the',
+          'permissions of the file and its containing directories, or try running',
+          'the command again as root/Administrator (though this is not recommended).'
         ].join('\n')])
       break
 


### PR DESCRIPTION
This partially resolves issue #17321 by providing a more detailed error message for EPERM failures.
As per: https://github.com/npm/npm/issues/12059#issuecomment-309612391

**_Changes this error message:_**
Please try running this command again as root/Administrator.

_**To this one:**_
The operation was rejected by your operating system. It's possible that the file was already in use.  To resolve, try running this action again as root/Administrator, and make sure that that the file isn't being used by another program.

PS: This is my very first pull request, please excuse any lapse in formatting/documentation requirements.