### PR TITLE
Do replace environment in config files (like .npmrc) even for keys

### DIFF
--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -332,7 +332,10 @@ Conf.prototype.parse = function (content, file) {
 Conf.prototype.add = function (data, marker) {
   try {
     Object.keys(data).forEach(function (k) {
-      data[k] = parseField(data[k], k)
+      const newKey = envReplace(k)
+      const newField = parseField(data[k], newKey)
+      delete data[k]
+      data[newKey] = newField
     })
   } catch (e) {
     this.emit('error', e)

--- a/test/tap/config-envReplace.js
+++ b/test/tap/config-envReplace.js
@@ -1,0 +1,55 @@
+const fs = require('fs')
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+const path = require('path')
+const ini = require('ini')
+const test = require('tap').test
+const npmconf = require('../../lib/config/core.js')
+
+const packagePath = path.resolve(__dirname, 'config-envReplace')
+
+const packageJsonFile = JSON.stringify({
+  name: 'config-envReplace'
+})
+
+const inputConfigFile = [
+  'registry=${NPM_REGISTRY_URL}',
+  '//${NPM_REGISTRY_HOST}/:_authToken=${NPM_AUTH_TOKEN}',
+  'always-auth=true',
+  ''
+].join('\n')
+
+const expectConfigFile = [
+  'registry=http://my.registry.com/',
+  '//my.registry.com/:_authToken=xxxxxxxxxxxxxxx',
+  'always-auth=true',
+  ''
+].join('\n')
+
+test('environment variables replacing in configs', function (t) {
+  process.env = Object.assign(process.env, {
+    NPM_REGISTRY_URL: 'http://my.registry.com/',
+    NPM_REGISTRY_HOST: 'my.registry.com',
+    NPM_AUTH_TOKEN: 'xxxxxxxxxxxxxxx'
+  })
+  mkdirp.sync(packagePath)
+  const packageJsonPath = path.resolve(packagePath, 'package.json')
+  const configPath = path.resolve(packagePath, '.npmrc')
+  fs.writeFileSync(packageJsonPath, packageJsonFile)
+  fs.writeFileSync(configPath, inputConfigFile)
+
+  const originalCwdPath = process.cwd()
+  process.chdir(packagePath)
+  npmconf.load(function (error, conf) {
+    if (error) throw error
+
+    const foundConfigFile = ini.stringify(conf.sources.project.data)
+    t.same(ini.parse(foundConfigFile), ini.parse(expectConfigFile))
+
+    fs.unlinkSync(packageJsonPath)
+    fs.unlinkSync(configPath)
+    rimraf.sync(packagePath)
+    process.chdir(originalCwdPath)
+    t.end()
+  })
+})


### PR DESCRIPTION
Current .npmrc will keep keys with not replaced Environment variables. However values are replaced. So it may confuse somebody & has no option to solve this  problem

`.npmrc example`
```ini
registry=${NPM_REGISTRY_URL}
//${NPM_REGISTRY_HOST}/:_authToken=${NPM_AUTH_TOKEN}
always-auth=true
```
With env.vars:
```sh
export NPM_REGISTRY_URL=http://my.registry.com/
export NPM_REGISTRY_HOST=my.registry.com
export NPM_AUTH_TOKEN=xxxxxxxxxxxxxxx
```
NOW it will produce bellow options:
```ini
registry=http://my.registry.com/
//${NPM_REGISTRY_HOST}/:_authToken=xxxxxxxxxxxxxxx
always-auth=true
```

But expected options are:
```ini
registry=http://my.registry.com/
//my.registry.com/:_authToken=xxxxxxxxxxxxxxx
always-auth=true
```

Probably it is expected state & it would be very helpful when it will be merged for private registries which are using CI for publishing npm packages. For example: Then no more "`npm login | answer_input $AUTH_TOKEN ... # etc. constructions`" are necessary.
