### PR TITLE
install: fix bug with rollback of failed optional packages on Windows

### DIFF
--- a/lib/install/update-package-json.js
+++ b/lib/install/update-package-json.js
@@ -47,7 +47,9 @@ module.exports = function (mod, buildpath, next) {
   var data = JSON.stringify(sortedObject(pkg), null, 2) + '\n'
 
   writeFileAtomic(path.resolve(buildpath, 'package.json'), data, {
-    // We really don't need this guarantee, and fsyncing here is super slow.
-    fsync: false
+    // We really don't need this guarantee, and fsyncing here is super slow. Except on
+    // Windows where there isn't a big performance difference and it prevents errors when
+    // rolling back optional packages (#17671)
+    fsync: process.platform === 'win32'
   }, next)
 }


### PR DESCRIPTION
This change ensures an fsync after updating `package.json` on Windows,
which prevents an issue that intermittently occurs when rolling back a
package with many dependencies such as fsevents.

In testing it does not appear that fsync has as much of a performance
impact on Windows as it does on other platforms, so this should not affect
install times on Windows materially.

Fixes: #17671