### PR TITLE
Fix a typo in the documentation for the "engine" section of package.json files

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -678,7 +678,7 @@ are capable of properly installing your program.  For example:
     { "engines" : { "npm" : "~1.0.20" } }
 
 Unless the user has set the `engine-strict` config flag, this
-field is advisory only will produce warnings when your package is installed as a dependency.
+field is advisory only and will only produce warnings when your package is installed as a dependency.
 
 ## engineStrict
 


### PR DESCRIPTION
I was checking the documentation about the "engine" section of package.json files and found a grammar problem in this sentence. I think this is what it means to say, but I don't know enough about NPM to know for sure that this is an accurate statement.