### PR TITLE
Document: Non-rooted package.json are not packed

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -213,6 +213,7 @@ Conversely, some files are always ignored:
 * `node_modules`
 * `config.gypi`
 * `*.orig`
+* Non-root `package.json`
 * `package-lock.json` (use shrinkwrap instead)
 
 ## main


### PR DESCRIPTION
There was a recent breaking change to NPM 5.4 that stopped publishing/packing `package.json` files that exist below the root.