### PR TITLE
update graceful-fs dependency from 4.1.9 to 4.1.11

### DIFF
--- a/node_modules/graceful-fs/package.json
+++ b/node_modules/graceful-fs/package.json
@@ -2,39 +2,39 @@
   "_args": [
     [
       {
-        "raw": "graceful-fs@4.1.9",
+        "raw": "graceful-fs@4.1.11",
         "scope": null,
         "escapedName": "graceful-fs",
         "name": "graceful-fs",
-        "rawSpec": "4.1.9",
-        "spec": "4.1.9",
+        "rawSpec": "4.1.11",
+        "spec": "4.1.11",
         "type": "version"
       },
-      "/Users/rebecca/code/npm"
+      "C:\\Users\\Dave\\git\\npm-new"
     ]
   ],
-  "_from": "graceful-fs@4.1.9",
-  "_id": "graceful-fs@4.1.9",
+  "_from": "graceful-fs@4.1.11",
+  "_id": "graceful-fs@4.1.11",
   "_inCache": true,
   "_location": "/graceful-fs",
   "_nodeVersion": "6.5.0",
   "_npmOperationalInternal": {
-    "host": "packages-12-west.internal.npmjs.com",
-    "tmp": "tmp/graceful-fs-4.1.9.tgz_1475103672016_0.7011275647673756"
+    "host": "packages-18-east.internal.npmjs.com",
+    "tmp": "tmp/graceful-fs-4.1.11.tgz_1479843029430_0.2122855328489095"
   },
   "_npmUser": {
     "name": "isaacs",
     "email": "i@izs.me"
   },
-  "_npmVersion": "3.10.7",
+  "_npmVersion": "3.10.9",
   "_phantomChildren": {},
   "_requested": {
-    "raw": "graceful-fs@4.1.9",
+    "raw": "graceful-fs@4.1.11",
     "scope": null,
     "escapedName": "graceful-fs",
     "name": "graceful-fs",
-    "rawSpec": "4.1.9",
-    "spec": "4.1.9",
+    "rawSpec": "4.1.11",
+    "spec": "4.1.11",
     "type": "version"
   },
   "_requiredBy": [
@@ -51,15 +51,13 @@
     "/read-package-json",
     "/readdir-scoped-modules",
     "/sha",
-    "/standard/eslint/file-entry-cache/flat-cache",
-    "/tacks",
     "/write-file-atomic"
   ],
-  "_resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-  "_shasum": "baacba37d19d11f9d146d3578bc99958c3787e29",
+  "_resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+  "_shasum": "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658",
   "_shrinkwrap": null,
-  "_spec": "graceful-fs@4.1.9",
-  "_where": "/Users/rebecca/code/npm",
+  "_spec": "graceful-fs@4.1.11",
+  "_where": "C:\\Users\\Dave\\git\\npm-new",
   "bugs": {
     "url": "https://github.com/isaacs/node-graceful-fs/issues"
   },
@@ -74,8 +72,8 @@
     "test": "test"
   },
   "dist": {
-    "shasum": "baacba37d19d11f9d146d3578bc99958c3787e29",
-    "tarball": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+    "shasum": "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658",
+    "tarball": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
   },
   "engines": {
     "node": ">=0.4.0"
@@ -86,7 +84,7 @@
     "legacy-streams.js",
     "polyfills.js"
   ],
-  "gitHead": "0798db3711e33de92de5a93979278bb89d629143",
+  "gitHead": "65cf80d1fd3413b823c16c626c1e7c326452bee5",
   "homepage": "https://github.com/isaacs/node-graceful-fs#readme",
   "keywords": [
     "fs",
@@ -122,5 +120,5 @@
   "scripts": {
     "test": "node test.js | tap -"
   },
-  "version": "4.1.9"
+  "version": "4.1.11"
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fstream": "~1.0.10",
     "fstream-npm": "~1.2.0",
     "glob": "~7.1.0",
-    "graceful-fs": "~4.1.9",
+    "graceful-fs": "~4.1.11",
     "has-unicode": "~2.0.1",
     "hosted-git-info": "~2.1.5",
     "iferr": "~0.1.5",


### PR DESCRIPTION
npm 3.x does not work reliably on Windows systems with AntiVirus when installing modules because it copies module files to a temporary location before completing installation and AntiVirus software can lock these files causing npm to fail when trying to move the module files to their permanent location. graceful-fs 4.1.11 has a fix for this.