### PR TITLE
fix(install): Find required package even if it's a local dependency

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -689,7 +689,6 @@ var findRequirement = exports.findRequirement = function (tree, name, requested,
     return null
   }
   if (tree.isTop) return null
-  if (!preserveSymlinks() && /^[.][.][\\/]/.test(path.relative(tree.parent.realpath, tree.realpath))) return null
   return findRequirement(tree.parent, name, requested, requestor)
 }
 


### PR DESCRIPTION
Filtering out local dependencies from the `findRequirement` function leads
to infinite loops if two local packages depended on each other.

closes: #18638