### PR TITLE
docs: write about script-shell config

### DIFF
--- a/doc/cli/npm-run-script.md
+++ b/doc/cli/npm-run-script.md
@@ -44,6 +44,12 @@ instead of
 
 to run your tests.
 
+The actual shell your script is run within is platform dependent. By default,
+on Unix-like systems it is the `/bin/sh` command, on Windows it is the `cmd.exe`.
+The actual shell referred to by `/bin/sh` also depends on the system.
+As of [`npm@5.1.0`](https://github.com/npm/npm/releases/tag/v5.1.0) you can
+customize the shell with the `script-shell` configuration.
+
 Scripts are run from the root of the module, regardless of what your current
 working directory is when you call `npm run`. If you want your script to
 use different behavior based on what subdirectory you're in, you can use the
@@ -69,3 +75,4 @@ You can use the `--silent` flag to prevent showing `npm ERR!` output on error.
 * npm-start(1)
 * npm-restart(1)
 * npm-stop(1)
+* npm-config(7)


### PR DESCRIPTION
Hi folks!

I believe the mechanism how npm runs custom scripts (`sh -c '...'`) is not very well known and documented. I had issues in the past that the script command worked in my `zsh` shell, but not when npm ran it, so I had a vague idea that the scripts are write into my `package.json` should follow `bash` syntax. 

When I was preparing for a university lecture, I wanted to know for sure that it is `bash` indeed. I didn't find any helpful clue in the documentation, Google didn't help, so I had to find it in the source code. Then I found the `script-shell` configuration in the code, and even googling that only had meaningful results on the 4th page. 

So I suggest this behaviour and configuration feature deserves more publicity and documentation. I wasn't able to find the npm blog post about 5.1.0 changes, so I linked the github releases page. I checked to contributing guide, but if anything needs to be changed or added to this PR, please let me know, and I'd be happy to adjust.

Cheers,
Gabor