### PR TITLE
Return non zero exit code when no tests defined.

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -136,7 +136,7 @@ function run (pkg, wd, cmd, args, cb) {
   } else {
     if (!pkg.scripts[cmd]) {
       if (cmd === 'test') {
-        pkg.scripts.test = 'echo \'Error: no test specified\''
+        pkg.scripts.test = 'echo \'Error: no test specified\' && exit 1'
       } else if (cmd === 'env') {
         if (process.platform === 'win32') {
           log.verbose('run-script using default platform env: SET (Windows)')


### PR DESCRIPTION
When running npm test, if it's not defined in package.json currently npm returns an exit code of 0, yet displays an error.

This PR changes that to return an exit code of 1 if it's not defined.