### PR TITLE
Upgrade to bearer with otp

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -213,13 +213,28 @@ function enable2fa (args) {
       'Enabling two-factor authentication is an interactive opperation and ' +
       (conf.json ? 'JSON' : 'parseable') + 'output mode is not available'))
   }
-  log.notice('profile', 'Enabling two factor authentication for ' + mode)
+
   const info = {
     tfa: {
       mode: mode
     }
   }
-  return readUserInfo.password().then((password) => {
+
+  return Bluebird.try(() => {
+    // if they're using legacy auth currently then we have to update them to a
+    // bearer token before continuing.
+    if (conf.auth.basic) {
+      log.info('profile', 'Updating authentication to bearer token')
+      return profile.login(conf.auth.basic.username, conf.auth.basic.password, conf).then((result) => {
+        if (!result.token) throw new Error('Your registry ' + conf.registry + 'does not seem to support bearer tokens. Bearer tokens are required for two-factor authentication')
+        npm.config.setCredentialsByURI(conf.registry, {token: result.token})
+        return Bluebird.fromNode((cb) => npm.config.save('user', cb))
+      })
+    }
+  }).then(() => {
+    log.notice('profile', 'Enabling two factor authentication for ' + mode)
+    return readUserInfo.password()
+  }).then((password) => {
     info.tfa.password = password
     log.info('profile', 'Determine if tfa is pending')
     return pulseTillDone.withPromise(profile.get(conf)).then((info) => {


### PR DESCRIPTION
This adds legacy auth support to the new commands. (They thought they had it previously but weren't passing it along correctly.)

This also makes it so that enabling two-factor authentication upgrades your auth method to a bearer token. 2fa does not support basic authentication. If your registry does not support bearer authentication then we will now refuse to enable two-factor authentication.