### PR TITLE
get correct resolved/version for remote packages

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -113,7 +113,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     if (child.fromBundle || child.isInLink) {
       pkginfo.bundled = true
     } else {
-      if (requested.registry) {
+      if (requested.registry || requested.type === 'remote') {
         pkginfo.resolved = child.package._resolved
       }
       // no integrity for git deps as integirty hashes are based on the
@@ -153,7 +153,7 @@ function sortModules (modules) {
 function childVersion (top, child, req) {
   if (req.type === 'directory' || req.type === 'file') {
     return 'file:' + unixFormatPath(path.relative(top.path, child.package._resolved || req.fetchSpec))
-  } else if (!req.registry && !child.fromBundle) {
+  } else if (req.type !== 'remote' && !req.registry && !child.fromBundle) {
     return child.package._resolved || req.saveSpec || req.rawSpec
   } else {
     return child.package.version


### PR DESCRIPTION
When shrinkwrapping a remote dependency, use the package's `version` instead of `resolved` in `getChildVersion` (because `resolved` will be the URL to the package which semver will be very unhappy about later)
Additionally, grab the resolved value from a remote dependency as would be done for a registry dependency.

Resolves #17858