### PR TITLE
Gracefully log ENOENT errors instead of failing hard

### DIFF
--- a/lib/install/action/finalize.js
+++ b/lib/install/action/finalize.js
@@ -62,17 +62,37 @@ module.exports = function (staging, pkg, log) {
   }
 
   function actuallyMoveStaging () {
-    return move(extractedTo, pkg.realpath, moveOpts)
+    return move(extractedTo, pkg.realpath, moveOpts).catch((e) => {
+      if (e.code === 'ENOENT') {
+        log.verbose('finalize', 'STAGING WAS NOT FOUND', e.toString())
+      } else {
+        throw e
+      }
+    })
   }
 
   function moveOldDestinationAway () {
     return rimraf(delpath).then(() => {
-      return move(pkg.realpath, delpath, moveOpts)
+      return move(pkg.realpath, delpath, moveOpts).catch((e) => {
+        if (e.code === 'ENOENT') {
+          log.verbose('finalize', 'OLD DESTINATION NOT FOUND', e.toString())
+        } else {
+          throw e
+        }
+      })
     }).then(() => { movedDestAway = true })
   }
 
   function moveOldDestinationBack () {
-    return move(delpath, pkg.realpath, moveOpts).then(() => { movedDestAway = false })
+    return move(delpath, pkg.realpath, moveOpts)
+      .then(() => { movedDestAway = false })
+      .catch((e) => {
+        if (e.code === 'ENOENT') {
+          log.verbose('finalize', 'COULD NOT MOVE BACK OLD DESTINATION', e.toString())
+        } else {
+          throw e
+        }
+      })
   }
 
   function restoreOldNodeModules () {

--- a/lib/install/action/refresh-package-json.js
+++ b/lib/install/action/refresh-package-json.js
@@ -33,6 +33,13 @@ module.exports = function (staging, pkg, log) {
     const requested = pkg.package._requested || getRequested(pkg)
     if (requested.type !== 'directory') {
       return updatePackageJson(pkg, pkg.path)
+        .catch((e) => {
+          if (e.code === 'ENOENT') {
+            log.verbose('refresh-package-json', 'package.json not found for for pkg:', pkg.path)
+          } else {
+            throw e
+          }
+        })
     }
   })
 }


### PR DESCRIPTION
It seems that npm@5 is not handling linked packages properly.

As a workaround, this PR add verbose logging for when these errors happen. Since they seem to be fully recoverable they shouldn't go unhandled (which is considered fatal).

This makes sure npm still works while making it easier to debug the issue. I've added some logging examples with npm running with the `-ddd` flag below.

ENOENT errors in in finalize action:

```
npm sill finalize <linked_package>\node_modules\jest-util
npm verb finalize STAGING WAS NOT FOUND Error: ENOENT: no such file or directory, rename '<parent_package>\node_modules\.staging\jest-util-05aa86e0' -> '<linked_package>\node_modules\jest-util'
npm sill finalize <linked_package>\node_modules\content-type
npm verb finalize STAGING WAS NOT FOUND Error: ENOENT: no such file or directory, rename '<parent_packlage>\node_modules\.staging\content-type-d38e00ba' -> '<linked_package>\node_modules\content-type'
```

ENOENT errors in refresh-package-json action:

```
npm verb refresh-package-json package.json not found for for pkg: <parent_package>\node_modules\<linked_package>\node_modules\typescript
npm verb refresh-package-json package.json not found for for pkg: <parent_package>\node_modules\<linked_package>\node_modules\typescript
npm verb refresh-package-json package.json not found for for pkg: <parent_package>\node_modules\<linked_package>\node_modules\http-errors
npm verb refresh-package-json package.json not found for for pkg:<parent_package>\node_modules\<linked_package>\node_modules\statuses
```
