### PR TITLE
docs(version): fix git add in version script

### DIFF
--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -68,7 +68,7 @@ Take the following example:
 
     "scripts": {
       "preversion": "npm test",
-      "version": "npm run build && git add -A dist",
+      "version": "npm run build && git add -A",
       "postversion": "git push && git push --tags && rm -rf build/temp"
     }
 


### PR DESCRIPTION
`git add -A dist` is equivalent to `git add -A` or `git add dist` so we should choose one of them. i suggest to change it to `git add -A` supposing that every temporary files is alredy ignored via `.gitignore`