### PR TITLE
fix: spelling of the word authenticator

### DIFF
--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -25,7 +25,7 @@ module.exports.login = function login (creds, registry, scope, cb) {
       return profile.adduser(username, email, password, {registry: registry})
     }).catch((err) => {
       if (err.code === 'EOTP' && !auth.otp) {
-        return read.otp('Authenicator provided OTP:').then((otp) => {
+        return read.otp('Authenticator provided OTP:').then((otp) => {
           auth.otp = otp
           return profile.login(username, password, {registry: registry, auth: auth})
         })


### PR DESCRIPTION
Does what it says on the tin: the message that asks a user for an OTP has a typo, and this fixes that typo.