### PR TITLE
Profile: fix typo and concatenation in error handling

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -210,8 +210,8 @@ function enable2fa (args) {
   const conf = config()
   if (conf.json || conf.parseable) {
     return Promise.reject(new Error(
-      'Enabling two-factor authentication is an interactive opperation and ' +
-      (conf.json ? 'JSON' : 'parseable') + 'output mode is not available'))
+      'Enabling two-factor authentication is an interactive operation and ' +
+      (conf.json ? 'JSON' : 'parseable') + ' output mode is not available'))
   }
   log.notice('profile', 'Enabling two factor authentication for ' + mode)
   const info = {


### PR DESCRIPTION
This PR fixes a minor typo (`opperation` --> `operation`) and adds a missing space in the error handling for when someone attempts to add the `--json` or `--parseable` options when enabling 2FA via `npm profile enable-2fa`. Both of these fixes should make the error message easier to read.

For reference, here's what the error messages currently look like :

```sh
$ npm profile enable-2fa --json
npm ERR! Enabling two-factor authentication is an interactive opperation and JSONoutput mode is not available

$ npm profile enable-2fa --parseable
npm ERR! Enabling two-factor authentication is an interactive opperation and parseableoutput mode is not available
```

Thanks again for adding 2FA to npm accounts and working so hard on account security! 🎉 🔐 I really appreciate it. I found both of these issues while I was reading the source code for `lib/profile.js` for fun 😄 .