### PR TITLE
Correctly save transitive dependencies

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -132,6 +132,7 @@ var decomposeActions = require('./install/decompose-actions.js')
 var validateTree = require('./install/validate-tree.js')
 var validateArgs = require('./install/validate-args.js')
 var saveRequested = require('./install/save.js').saveRequested
+var saveShrinkwrap = require('./install/save.js').saveShrinkwrap
 var getSaveType = require('./install/save.js').getSaveType
 var doSerialActions = require('./install/actions.js').doSerial
 var doReverseSerialActions = require('./install/actions.js').doReverseSerial
@@ -199,8 +200,9 @@ function install (where, args, cb) {
   new Installer(where, dryrun, args).run(cb)
 }
 
-function Installer (where, dryrun, args) {
-  validate('SBA', arguments)
+function Installer (where, dryrun, args, opts) {
+  validate('SBA|SBAO', arguments)
+  if (!opts) opts = {}
   this.where = where
   this.dryrun = dryrun
   this.args = args
@@ -215,23 +217,38 @@ function Installer (where, dryrun, args) {
   this.progress = {}
   this.noPackageJsonOk = !!args.length
   this.topLevelLifecycles = !args.length
-  this.dev = npm.config.get('dev') || (!/^prod(uction)?$/.test(npm.config.get('only')) && !npm.config.get('production')) || /^dev(elopment)?$/.test(npm.config.get('only'))
-  this.prod = !/^dev(elopment)?$/.test(npm.config.get('only'))
-  this.rollback = npm.config.get('rollback')
-  this.link = npm.config.get('link')
-  this.global = this.where === path.resolve(npm.globalDir, '..')
+
+  const dev = npm.config.get('dev')
+  const only = npm.config.get('only')
+  const onlyProd = /^prod(uction)?$/.test(only)
+  const onlyDev = /^dev(elopment)?$/.test(only)
+  const prod = npm.config.get('production')
+  this.dev = opts.dev != null ? opts.dev : dev || (!onlyProd && !prod) || onlyDev
+  this.prod = opts.prod != null ? opts.prod : !onlyDev
+
+  this.rollback = opts.rollback != null ? opts.rollback : npm.config.get('rollback')
+  this.link = opts.link != null ? opts.link : npm.config.get('link')
+  this.saveOnlyLock = opts.saveOnlyLock
+  this.global = opts.global != null ? opts.global : this.where === path.resolve(npm.globalDir, '..')
   this.started = Date.now()
 }
 Installer.prototype = {}
 
 Installer.prototype.run = function (_cb) {
-  validate('F', arguments)
+  validate('F|', arguments)
 
-  var cb = function (err) {
-    saveMetrics(!err)
-    return _cb.apply(this, arguments)
+  var result
+  var cb
+  if (_cb) {
+    cb = function (err) {
+      saveMetrics(!err)
+      return _cb.apply(this, arguments)
+    }
+  } else {
+    result = new Promise((resolve, reject) => {
+      cb = (err, value) => err ? reject(err) : resolve(value)
+    })
   }
-
   // FIXME: This is bad and I should feel bad.
   // lib/install needs to have some way of sharing _limited_
   // state with the things it calls. Passing the object is too
@@ -319,6 +336,7 @@ Installer.prototype.run = function (_cb) {
       cb(installEr || postInstallEr, self.getInstalledModules(), self.idealTree)
     })
   })
+  return result
 }
 
 Installer.prototype.loadArgMetadata = function (next) {
@@ -609,7 +627,11 @@ Installer.prototype.saveToDependencies = function (cb) {
   validate('F', arguments)
   if (this.failing) return cb()
   log.silly('install', 'saveToDependencies')
-  saveRequested(this.idealTree, cb)
+  if (this.saveOnlyLock) {
+    saveShrinkwrap(this.idealTree, cb)
+  } else {
+    saveRequested(this.idealTree, cb)
+  }
 }
 
 Installer.prototype.readGlobalPackageData = function (cb) {

--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -39,6 +39,8 @@ function andWarnErrors (cb) {
   }
 }
 
+exports.saveShrinkwrap = saveShrinkwrap
+
 function saveShrinkwrap (tree, next) {
   validate('OF', arguments)
   if (!npm.config.get('shrinkwrap') || !npm.config.get('package-lock')) {

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,11 +1,13 @@
+'use strict'
 module.exports = update
 
-var url = require('url')
-var log = require('npmlog')
-var chain = require('slide').chain
-var npm = require('./npm.js')
-var Installer = require('./install.js').Installer
-var usage = require('./utils/usage')
+const url = require('url')
+const log = require('npmlog')
+const Bluebird = require('bluebird')
+const npm = require('./npm.js')
+const Installer = require('./install.js').Installer
+const usage = require('./utils/usage')
+const outdated = Bluebird.promisify(npm.commands.outdated)
 
 update.usage = usage(
   'update',
@@ -15,12 +17,16 @@ update.usage = usage(
 update.completion = npm.commands.outdated.completion
 
 function update (args, cb) {
-  var dryrun = false
+  return update_(args).asCallback(cb)
+}
+
+function update_ (args) {
+  let dryrun = false
   if (npm.config.get('dry-run')) dryrun = true
 
-  npm.commands.outdated(args, true, function (er, rawOutdated) {
-    if (er) return cb(er)
-    var outdated = rawOutdated.map(function (ww) {
+  log.verbose('update', 'computing outdated modules to update')
+  return outdated(args, true).then((rawOutdated) => {
+    const outdated = rawOutdated.map(function (ww) {
       return {
         dep: ww[0],
         depname: ww[1],
@@ -32,7 +38,7 @@ function update (args, cb) {
       }
     })
 
-    var wanted = outdated.filter(function (ww) {
+    const wanted = outdated.filter(function (ww) {
       if (ww.current === ww.wanted && ww.wanted !== ww.latest) {
         log.verbose(
           'outdated',
@@ -42,23 +48,25 @@ function update (args, cb) {
       }
       return ww.current !== ww.wanted && ww.latest !== 'linked'
     })
-    if (wanted.length === 0) return cb()
+    if (wanted.length === 0) return
 
     log.info('outdated', 'updating', wanted)
-    var toInstall = {}
+    const toInstall = {}
+
     wanted.forEach(function (ww) {
       // use the initial installation method (repo, tar, git) for updating
       if (url.parse(ww.req).protocol) ww.what = ww.req
 
-      var where = ww.dep.parent && ww.dep.parent.path || ww.dep.path
-      if (toInstall[where]) {
-        toInstall[where].push(ww.what)
-      } else {
-        toInstall[where] = [ww.what]
-      }
+      const where = ww.dep.parent && ww.dep.parent.path || ww.dep.path
+      const isTransitive = !(ww.dep.requiredBy || []).some((p) => p.isTop)
+      const key = where + ':' + String(isTransitive)
+      if (!toInstall[key]) toInstall[key] = {where: where, opts: {saveOnlyLock: isTransitive}, what: []}
+      if (toInstall[key].what.indexOf(ww.what) === -1) toInstall[key].what.push(ww.what)
     })
-    chain(Object.keys(toInstall).map(function (where) {
-      return [new Installer(where, dryrun, toInstall[where]), 'run']
-    }), cb)
+    return Bluebird.each(Object.keys(toInstall), (key) => {
+      const deps = toInstall[key]
+      const inst = new Installer(deps.where, dryrun, deps.what, deps.opts)
+      return inst.run()
+    })
   })
 }

--- a/test/tap/update-examples.js
+++ b/test/tap/update-examples.js
@@ -125,7 +125,7 @@ function mockInstaller (where, dryrun, what) {
 }
 mockInstaller.prototype = {}
 mockInstaller.prototype.run = function (cb) {
-  cb()
+  return cb ? cb() : Promise.resolve()
 }
 
 var npm = requireInject.installGlobally('../../lib/npm.js', {


### PR DESCRIPTION
Direct deps get `package.json` and `package-lock.json`.  Transitive deps get `package-lock.json`.

This is a first step to ditching the depth=0 on `npm update`.  The other thing we need to do before we do that is fix a bug where asking to update a named transitive dependency can cause an infinite loop in `outdated`.