### PR TITLE
Check validity of version before making fake pkg

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -13,6 +13,7 @@ const npm = require('../npm.js')
 const realizeShrinkwrapSpecifier = require('./realize-shrinkwrap-specifier.js')
 const validate = require('aproba')
 const path = require('path')
+const semver = require('semver')
 
 module.exports = function (tree, sw, opts, finishInflating) {
   if (!fetchPackageMetadata) {
@@ -87,9 +88,11 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     onDiskChild.swRequires = sw.requires
     tree.children.push(onDiskChild)
     return BB.resolve(onDiskChild)
-  } else if ((sw.version && sw.integrity) || sw.bundled) {
+  } else if ((sw.version && sw.integrity && semver.valid(sw.version)) || sw.bundled) {
     // The shrinkwrap entry has an integrity field. We can fake a pkg to get
     // the installer to do a content-address fetch from the cache, if possible.
+    // If the version isn't semver valid, then it is could be a git source,
+    // tarball or local link and the fake pkg is insufficient. 
     return BB.resolve(makeFakeChild(name, topPath, tree, sw, requested))
   } else {
     // It's not on disk, and we can't just look it up by address -- do a full

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -92,7 +92,7 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     // The shrinkwrap entry has an integrity field. We can fake a pkg to get
     // the installer to do a content-address fetch from the cache, if possible.
     // If the version isn't semver valid, then it is could be a git source,
-    // tarball or local link and the fake pkg is insufficient. 
+    // tarball or local link and the fake pkg is insufficient.
     return BB.resolve(makeFakeChild(name, topPath, tree, sw, requested))
   } else {
     // It's not on disk, and we can't just look it up by address -- do a full


### PR DESCRIPTION
Cheking the version against semver here ensures that a fake pkg with URL/path data in its version field doesn’t get created (if that happens, then that will propagate down into the version field of any refreshed package.json, overwriting whatever version should actually be there)

This resolves #17858 without violating the spec for package-lock.json (mea culpa!)