### PR TITLE
install: support legacy npa output for type checking

### DIFF
--- a/lib/install/action/extract.js
+++ b/lib/install/action/extract.js
@@ -16,6 +16,7 @@ let pacoteOpts
 const path = require('path')
 const localWorker = require('./extract-worker.js')
 const workerFarm = require('worker-farm')
+const isRegistry = require('../../utils/is-registry.js')
 
 const WORKER_PATH = require.resolve('./extract-worker.js')
 let workers
@@ -72,7 +73,7 @@ function extract (staging, pkg, log) {
     let msg = args
     const spec = typeof args[0] === 'string' ? npa(args[0]) : args[0]
     args[0] = spec.raw
-    if (ENABLE_WORKERS && (spec.registry || spec.type === 'remote')) {
+    if (ENABLE_WORKERS && (isRegistry(spec) || spec.type === 'remote')) {
       // We can't serialize these options
       opts.loglevel = opts.log.level
       opts.log = null

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -32,6 +32,7 @@ var reportOptionalFailure = require('./report-optional-failure.js')
 var getSaveType = require('./save.js').getSaveType
 var unixFormatPath = require('../utils/unix-format-path.js')
 var isExtraneous = require('./is-extraneous.js')
+var isRegistry = require('../utils/is-registry.js')
 
 // The export functions in this module mutate a dependency tree, adding
 // items to them.
@@ -288,7 +289,7 @@ function computeVersionSpec (tree, child) {
   } else {
     requested = npa.resolve(child.package.name, child.package.version)
   }
-  if (requested.registry) {
+  if (isRegistry(requested)) {
     var version = child.package.version
     var rangeDescriptor = ''
     if (semver.valid(version, true) &&
@@ -443,7 +444,7 @@ function prefetchDeps (tree, deps, log, next) {
       var allDependencies = Object.keys(deps).map((dep) => {
         return npa.resolve(dep, deps[dep])
       }).filter((dep) => {
-        return dep.registry &&
+        return isRegistry(dep) &&
                !seen.has(dep.toString()) &&
                !findRequirement(tree, dep.name, dep)
       })

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -13,6 +13,7 @@ const npm = require('../npm.js')
 const realizeShrinkwrapSpecifier = require('./realize-shrinkwrap-specifier.js')
 const validate = require('aproba')
 const path = require('path')
+const isRegistry = require('../utils/is-registry.js')
 
 module.exports = function (tree, sw, opts, finishInflating) {
   if (!fetchPackageMetadata) {
@@ -147,7 +148,7 @@ function adaptResolved (requested, resolved) {
   const registry = requested.scope
   ? npm.config.get(`${requested.scope}:registry`) || npm.config.get('registry')
   : npm.config.get('registry')
-  if (!requested.registry || (resolved && resolved.indexOf(registry) === 0)) {
+  if (!isRegistry(requested) || (resolved && resolved.indexOf(registry) === 0)) {
     // Nothing to worry about here. Pass it through.
     return resolved
   } else {
@@ -199,7 +200,7 @@ function childIsEquivalent (sw, requested, child) {
   if (child.isLink && requested.type === 'directory') return path.relative(child.realpath, requested.fetchSpec) === ''
 
   if (sw.resolved) return child.package._resolved === sw.resolved
-  if (!requested.registry && sw.from) return child.package._from === sw.from
-  if (!requested.registry && child.package._resolved) return sw.version === child.package._resolved
+  if (!isRegistry(requested) && sw.from) return child.package._from === sw.from
+  if (!isRegistry(requested) && child.package._resolved) return sw.version === child.package._resolved
   return child.package.version === sw.version
 }

--- a/lib/install/realize-shrinkwrap-specifier.js
+++ b/lib/install/realize-shrinkwrap-specifier.js
@@ -1,5 +1,6 @@
 'use strict'
 var npa = require('npm-package-arg')
+const isRegistry = require('../utils/is-registry.js')
 
 module.exports = function (name, sw, where) {
   try {
@@ -7,7 +8,7 @@ module.exports = function (name, sw, where) {
       return npa.resolve(name, sw.version, where)
     } else if (sw.from) {
       const spec = npa(sw.from, where)
-      if (spec.registry && sw.version) {
+      if (isRegistry(spec) && sw.version) {
         return npa.resolve(name, sw.version, where)
       } else if (!sw.resolved) {
         return spec

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -21,6 +21,7 @@ const ssri = require('ssri')
 const validate = require('aproba')
 const writeFileAtomic = require('write-file-atomic')
 const unixFormatPath = require('./utils/unix-format-path.js')
+const isRegistry = require('./utils/is-registry.js')
 
 const PKGLOCK = 'package-lock.json'
 const SHRINKWRAP = 'npm-shrinkwrap.json'
@@ -113,7 +114,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     if (child.fromBundle || child.isInLink) {
       pkginfo.bundled = true
     } else {
-      if (requested.registry) {
+      if (isRegistry(requested)) {
         pkginfo.resolved = child.package._resolved
       }
       // no integrity for git deps as integirty hashes are based on the
@@ -153,7 +154,7 @@ function sortModules (modules) {
 function childVersion (top, child, req) {
   if (req.type === 'directory' || req.type === 'file') {
     return 'file:' + unixFormatPath(path.relative(top.path, child.package._resolved || req.fetchSpec))
-  } else if (!req.registry && !child.fromBundle) {
+  } else if (!isRegistry(req) && !child.fromBundle) {
     return child.package._resolved || req.saveSpec || req.rawSpec
   } else {
     return child.package.version

--- a/lib/utils/is-registry.js
+++ b/lib/utils/is-registry.js
@@ -1,0 +1,12 @@
+'use strict'
+module.exports = isRegistry
+
+function isRegistry (req) {
+  if (req == null) return false
+  // modern metadata
+  if ('registry' in req) return req.registry
+  // legacy metadata
+  if (req.type === 'range' || req.type === 'version' || req.type === 'tag') return true
+  return false
+}
+

--- a/test/tap/is-registry.js
+++ b/test/tap/is-registry.js
@@ -1,0 +1,27 @@
+'use strict'
+const test = require('tap').test
+const npa = require('npm-package-arg')
+const isRegistry = require('../../lib/utils/is-registry.js')
+
+test('current npa', (t) => {
+  t.is(Boolean(isRegistry(npa('foo@1.0.0'))), true, 'version')
+  t.is(Boolean(isRegistry(npa('foo@^1.0.0'))), true, 'range')
+  t.is(Boolean(isRegistry(npa('foo@test'))), true, 'tag')
+  t.is(Boolean(isRegistry(npa('foo@git://foo.bar/test.git'))), false, 'git')
+  t.is(Boolean(isRegistry(npa('foo@foo/bar'))), false, 'github')
+  t.is(Boolean(isRegistry(npa('foo@http://example.com/example.tgz'))), false, 'remote')
+  t.is(Boolean(isRegistry(npa('foo@file:example.tgz'))), false, 'file')
+  t.is(Boolean(isRegistry(npa('foo@file:example/'))), false, 'dir')
+  t.done()
+})
+
+test('legacy spec data', (t) => {
+  t.is(Boolean(isRegistry({type: 'version'})), true, 'version')
+  t.is(Boolean(isRegistry({type: 'range'})), true, 'range')
+  t.is(Boolean(isRegistry({type: 'tag'})), true, 'tag')
+  t.is(Boolean(isRegistry({type: 'git'})), false, 'git')
+  t.is(Boolean(isRegistry({type: 'file'})), false, 'file')
+  t.is(Boolean(isRegistry({type: 'directory'})), false, 'directory')
+  t.is(Boolean(isRegistry({type: 'remote'})), false, 'remote')
+  t.done()
+})


### PR DESCRIPTION
Current npa will pass `registry: true` for specs that will ultimately be
fetched from a registry. Older npa didn't do this.

When dealing with a `node_modules` that was created with older versions of
npm (and thus older versions of npa) we need to gracefully handle these
older spec entries. Failing to do so results in us treating those packages
as if they were http remote deps, which results in invalid lock files.

This fixes the issue where an `npm i` or `npm shrinkwrap` on a directory with a `node_modules` created by `npm@3` or `npm@4` would result in a lockfile that had http URLs for all the modules, instead of versions.