### PR TITLE
npm: Capture logging from log events on the process global

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -24,6 +24,16 @@
   var npm = module.exports = new EventEmitter()
   var npmconf = require('./config/core.js')
   var log = require('npmlog')
+  var inspect = require('util').inspect
+
+  // capture global logging
+  process.on('log', function (level) {
+    try {
+      return log[level].apply(log, [].slice.call(arguments, 1))
+    } catch (ex) {
+      log.verbose('attempt to log ' + inspect(arguments) + ' crashed: ' + ex.message)
+    }
+  })
 
   var path = require('path')
   var abbrev = require('abbrev')

--- a/test/tap/process-logger.js
+++ b/test/tap/process-logger.js
@@ -1,0 +1,12 @@
+'use strict'
+const test = require('tap').test
+require('../../lib/npm.js')
+
+test('process logging', (t) => {
+  t.ok(process.listenerCount('log') >= 1, `log listener attached ${process.listenerCount('log')} >= 1`)
+  t.doesNotThrow(() => process.emit('log', 'error', 'test', 'this'), 'logging does not throw')
+  t.doesNotThrow(() => process.emit('log', 2348), 'invalid args do not throw')
+  t.doesNotThrow(() => process.emit('log', null), 'null does not throw')
+  t.doesNotThrow(() => process.emit('log', {}), 'obj does not throw')
+  t.done()
+})


### PR DESCRIPTION
This allows npm to use npmlog to report logging from libraries like npm-profile.