### PR TITLE
Profile UX improvements

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -189,8 +189,10 @@ function set (args) {
           output(JSON.stringify({[prop]: result[prop]}, null, 2))
         } else if (conf.parseable) {
           output(prop + '\t' + result[prop])
-        } else {
+        } else if (result[prop] != null) {
           output('Set', prop, 'to', result[prop])
+        } else {
+          output('Set', prop)
         }
       })
     }))

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -12,6 +12,7 @@ const qrcodeTerminal = require('qrcode-terminal')
 const url = require('url')
 const queryString = require('query-string')
 const pulseTillDone = require('./utils/pulse-till-done.js')
+const inspect = require('util').inspect
 
 module.exports = profileCmd
 
@@ -243,7 +244,7 @@ function enable2fa (args) {
       return
     }
     if (typeof challenge.tfa !== 'string' || !/^otpauth:[/][/]/.test(challenge.tfa)) {
-      throw new Error('Unknown error enabling two-factor authentication. Expected otpauth URL, got: ' + challenge.tfa)
+      throw new Error('Unknown error enabling two-factor authentication. Expected otpauth URL, got: ' + inspect(challenge.tfa))
     }
     const otpauth = url.parse(challenge.tfa)
     const opts = queryString.parse(otpauth.query)


### PR DESCRIPTION
Two small things:

1. Stop saying "password set to undefined" when setting your password.
2. If the 2fa endpoint doesn't respond with an otpauth URL, inspect the result instead of printing it, as it may be an object. (This should never happen during normal function of the registry.)