### PR TITLE
fix: Output package.json with original line endings

### DIFF
--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -3,6 +3,7 @@
 const createShrinkwrap = require('../shrinkwrap.js').createShrinkwrap
 const deepSortObject = require('../utils/deep-sort-object.js')
 const detectIndent = require('detect-indent')
+const detectLineEnding = require('../utils/detect-line-ending')
 const fs = require('graceful-fs')
 const iferr = require('iferr')
 const log = require('npmlog')
@@ -10,6 +11,7 @@ const moduleName = require('../utils/module-name.js')
 const npm = require('../npm.js')
 const parseJSON = require('../utils/parse-json.js')
 const path = require('path')
+const stringifyPackage = require('../utils/stringify-package')
 const validate = require('aproba')
 const without = require('lodash.without')
 const writeFileAtomic = require('write-file-atomic')
@@ -61,6 +63,7 @@ function savePackageJson (tree, next) {
   // tricky npm-specific stuff that's in there.
   fs.readFile(saveTarget, 'utf8', iferr(next, function (packagejson) {
     const indent = detectIndent(packagejson).indent || '  '
+    const lineEnding = detectLineEnding(packagejson)
     try {
       tree.package = parseJSON(packagejson)
     } catch (ex) {
@@ -122,7 +125,7 @@ function savePackageJson (tree, next) {
       tree.package.bundleDependencies = deepSortObject(bundle)
     }
 
-    var json = JSON.stringify(tree.package, null, indent) + '\n'
+    var json = stringifyPackage(tree.package, indent, lineEnding)
     if (json === packagejson) {
       log.verbose('shrinkwrap', 'skipping write for package.json because there were no changes.')
       next()

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -4,6 +4,7 @@ const BB = require('bluebird')
 
 const chain = require('slide').chain
 const detectIndent = require('detect-indent')
+const detectLineEnding = require('./utils/detect-line-ending')
 const readFile = BB.promisify(require('graceful-fs').readFile)
 const getRequested = require('./install/get-requested.js')
 const id = require('./install/deps.js')
@@ -18,6 +19,7 @@ const npm = require('./npm.js')
 const path = require('path')
 const readPackageTree = BB.promisify(require('read-package-tree'))
 const ssri = require('ssri')
+const stringifyPackage = require('./utils/stringify-package')
 const validate = require('aproba')
 const writeFileAtomic = require('write-file-atomic')
 const unixFormatPath = require('./utils/unix-format-path.js')
@@ -179,11 +181,12 @@ function save (dir, pkginfo, opts, cb) {
         {
           path: path.resolve(dir, opts.defaultFile || PKGLOCK),
           data: '{}',
-          indent: (pkg && pkg.indent) || 2
+          indent: (pkg && pkg.indent) || 2,
+          lineEnding: pkg && pkg.lineEnding
         }
       )
       const updated = updateLockfileMetadata(pkginfo, pkg && pkg.data)
-      const swdata = JSON.stringify(updated, null, info.indent) + '\n'
+      const swdata = stringifyPackage(updated, info.indent, info.lineEnding)
       if (swdata === info.raw) {
         // skip writing if file is identical
         log.verbose('shrinkwrap', `skipping write for ${path.basename(info.path)} because there were no changes.`)
@@ -245,7 +248,8 @@ function checkPackageFile (dir, name) {
       path: file,
       raw: data,
       data: JSON.parse(data),
-      indent: detectIndent(data).indent || 2
+      indent: detectIndent(data).indent || 2,
+      lineEnding: detectLineEnding(data)
     }
   }).catch({code: 'ENOENT'}, () => {})
 }

--- a/lib/utils/detect-line-ending.js
+++ b/lib/utils/detect-line-ending.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = detectLineEnding
+
+function detectLineEnding (str) {
+  const lfIndex = str.indexOf('\n')
+  return lfIndex > 0 && str[lfIndex - 1] === '\r'
+    ? '\r\n'
+    : '\n'
+}

--- a/lib/utils/stringify-package.js
+++ b/lib/utils/stringify-package.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = stringifyPackage
+
+function stringifyPackage (data, indent, lineEnding) {
+  lineEnding = lineEnding || '\n'
+  var json = JSON.stringify(data, null, indent || 2)
+
+  if (lineEnding === '\r\n') {
+    json = json.replace(/\n/g, '\r\n')
+  }
+
+  return json + lineEnding
+}

--- a/lib/version.js
+++ b/lib/version.js
@@ -4,6 +4,7 @@ const BB = require('bluebird')
 const assert = require('assert')
 const chain = require('slide').chain
 const detectIndent = require('detect-indent')
+const detectLineEnding = require('./utils/detect-line-ending')
 const fs = require('graceful-fs')
 const readFile = BB.promisify(require('graceful-fs').readFile)
 const git = require('./utils/git.js')
@@ -14,6 +15,7 @@ const output = require('./utils/output.js')
 const parseJSON = require('./utils/parse-json.js')
 const path = require('path')
 const semver = require('semver')
+const stringifyPackage = require('./utils/stringify-package')
 const writeFileAtomic = require('write-file-atomic')
 
 version.usage = 'npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]' +
@@ -115,14 +117,16 @@ function readPackage (cb) {
   fs.readFile(packagePath, 'utf8', function (er, data) {
     if (er) return cb(new Error(er))
     var indent
+    var lineEnding
     try {
       indent = detectIndent(data).indent || '  '
+      lineEnding = detectLineEnding(data)
       data = JSON.parse(data)
     } catch (e) {
       er = e
       data = null
     }
-    cb(er, data, indent)
+    cb(er, data, indent, lineEnding)
   })
 }
 
@@ -132,10 +136,10 @@ function updatePackage (newVersion, silent, cb_) {
     cb_(er)
   }
 
-  readPackage(function (er, data, indent) {
+  readPackage(function (er, data, indent, lineEnding) {
     if (er) return cb(new Error(er))
     data.version = newVersion
-    write(data, 'package.json', indent, cb)
+    write(data, 'package.json', indent, lineEnding, cb)
   })
 }
 
@@ -168,15 +172,17 @@ function updateShrinkwrap (newVersion, cb) {
       const file = shrinkwrap ? SHRINKWRAP : PKGLOCK
       let data
       let indent
+      let lineEnding
       try {
         data = parseJSON(shrinkwrap || lockfile)
         indent = detectIndent(shrinkwrap || lockfile).indent || '  '
+        lineEnding = detectLineEnding(shrinkwrap || lockfile)
       } catch (err) {
         log.error('version', `Bad ${file} data.`)
         return cb(err)
       }
       data.version = newVersion
-      write(data, file, indent, (err) => {
+      write(data, file, indent, lineEnding, (err) => {
         if (err) {
           log.error('version', `Failed to update version in ${file}`)
           return cb(err)
@@ -321,14 +327,14 @@ function addLocalFile (file, options, ignoreFailure) {
   : p
 }
 
-function write (data, file, indent, cb) {
+function write (data, file, indent, lineEnding, cb) {
   assert(data && typeof data === 'object', 'must pass data to version write')
   assert(typeof file === 'string', 'must pass filename to write to version write')
 
   log.verbose('version.write', 'data', data, 'to', file)
   writeFileAtomic(
     path.join(npm.localPrefix, file),
-    new Buffer(JSON.stringify(data, null, indent || 2) + '\n'),
+    new Buffer(stringifyPackage(data, indent, lineEnding)),
     cb
   )
 }

--- a/test/tap/install-save-consistent-newlines.js
+++ b/test/tap/install-save-consistent-newlines.js
@@ -1,0 +1,122 @@
+'use strict'
+
+const fs = require('graceful-fs')
+const path = require('path')
+
+const mkdirp = require('mkdirp')
+const mr = require('npm-registry-mock')
+const osenv = require('osenv')
+const rimraf = require('rimraf')
+const test = require('tap').test
+
+const common = require('../common-tap.js')
+
+const pkg = path.join(__dirname, 'install-save-consistent-newlines')
+
+const EXEC_OPTS = { cwd: pkg }
+
+const json = {
+  name: 'install-save-consistent-newlines',
+  version: '0.0.1',
+  description: 'fixture'
+}
+
+var server
+
+test('setup', function (t) {
+  setup('\n')
+  mr({ port: common.port }, function (er, s) {
+    server = s
+    t.end()
+  })
+})
+
+test('\'npm install --save\' should keep the original package.json line endings (\\n)', function (t) {
+  common.npm(
+    [
+      '--loglevel', 'silent',
+      '--registry', common.registry,
+      '--save',
+      'install', 'underscore@1.3.1'
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'npm ran without issue')
+      t.notOk(code, 'npm install exited without raising an error code')
+
+      const pkgPath = path.resolve(pkg, 'package.json')
+      const pkgStr = fs.readFileSync(pkgPath, 'utf8')
+
+      t.match(pkgStr, '\n')
+      t.notMatch(pkgStr, '\r')
+
+      const pkgLockPath = path.resolve(pkg, 'package-lock.json')
+      const pkgLockStr = fs.readFileSync(pkgLockPath, 'utf8')
+
+      t.match(pkgLockStr, '\n')
+      t.notMatch(pkgLockStr, '\r')
+
+      t.end()
+    }
+  )
+})
+
+test('\'npm install --save\' should keep the original package.json line endings (\\r\\n)', function (t) {
+  setup('\r\n')
+
+  common.npm(
+    [
+      '--loglevel', 'silent',
+      '--registry', common.registry,
+      '--save',
+      'install', 'underscore@1.3.1'
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'npm ran without issue')
+      t.notOk(code, 'npm install exited without raising an error code')
+
+      const pkgPath = path.resolve(pkg, 'package.json')
+      const pkgStr = fs.readFileSync(pkgPath, 'utf8')
+
+      t.match(pkgStr, '\r\n')
+      t.notMatch(pkgStr, /[^\r]\n/)
+
+      const pkgLockPath = path.resolve(pkg, 'package-lock.json')
+      const pkgLockStr = fs.readFileSync(pkgLockPath, 'utf8')
+
+      t.match(pkgLockStr, '\r\n')
+      t.notMatch(pkgLockStr, /[^\r]\n/)
+
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  server.close()
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}
+
+function setup (lineEnding) {
+  cleanup()
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+
+  var jsonStr = JSON.stringify(json, null, 2)
+
+  if (lineEnding === '\r\n') {
+    jsonStr = jsonStr.replace(/\n/g, '\r\n')
+  }
+
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    jsonStr
+  )
+  process.chdir(pkg)
+}

--- a/test/tap/version-consistent-newlines.js
+++ b/test/tap/version-consistent-newlines.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const common = require('../common-tap.js')
+const test = require('tap').test
+const npm = require('../../')
+const osenv = require('osenv')
+const path = require('path')
+const fs = require('fs')
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+const requireInject = require('require-inject')
+
+const pkg = path.resolve(__dirname, 'version-no-git')
+const cache = path.resolve(pkg, 'cache')
+const gitDir = path.resolve(pkg, '.git')
+
+test('npm version does not alter the line endings in package.json (\\n)', function (t) {
+  setup('\n')
+
+  npm.load({cache: cache, registry: common.registry}, function () {
+    const version = requireInject('../../lib/version', {
+      which: function (cmd, cb) {
+        process.nextTick(function () {
+          cb(new Error('ENOGIT!'))
+        })
+      }
+    })
+
+    version(['patch'], function (err) {
+      if (!t.error(err)) return t.end()
+
+      const pkgPath = path.resolve(pkg, 'package.json')
+      const pkgStr = fs.readFileSync(pkgPath, 'utf8')
+
+      t.match(pkgStr, '\n')
+      t.notMatch(pkgStr, '\r')
+
+      t.end()
+    })
+  })
+})
+
+test('npm version does not alter the line endings in package.json (\\r\\n)', function (t) {
+  setup('\r\n')
+
+  npm.load({cache: cache, registry: common.registry}, function () {
+    const version = requireInject('../../lib/version', {
+      which: function (cmd, cb) {
+        process.nextTick(function () {
+          cb(new Error('ENOGIT!'))
+        })
+      }
+    })
+
+    version(['patch'], function (err) {
+      if (!t.error(err)) return t.end()
+
+      const pkgPath = path.resolve(pkg, 'package.json')
+      const pkgStr = fs.readFileSync(pkgPath, 'utf8')
+
+      t.match(pkgStr, '\r\n')
+      t.notMatch(pkgStr, /[^\r]\n/)
+
+      t.end()
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  process.chdir(osenv.tmpdir())
+
+  rimraf.sync(pkg)
+  t.end()
+})
+
+function setup (lineEnding) {
+  mkdirp.sync(pkg)
+  mkdirp.sync(cache)
+  mkdirp.sync(gitDir)
+  fs.writeFileSync(
+    path.resolve(pkg, 'package.json'),
+    JSON.stringify({
+      author: 'Terin Stock',
+      name: 'version-no-git-test',
+      version: '0.0.0',
+      description: "Test for npm version if git binary doesn't exist"
+    }, null, 2).replace(/\n/g, lineEnding),
+    'utf8'
+  )
+  process.chdir(pkg)
+}


### PR DESCRIPTION
Same for `package-lock.json` and `npm-shrinkwrap.json`.

Detect the line endings used in the original file and use the same line endings when updating the file.

Fixes #17161