### PR TITLE
install: fix the .hooks script does not running.

### DIFF
--- a/node_modules/npm-lifecycle/index.js
+++ b/node_modules/npm-lifecycle/index.js
@@ -42,8 +42,6 @@ function lifecycle (pkg, stage, wd, opts) {
       delete pkg.scripts.prepublish
     }
 
-    if (!pkg.scripts[stage]) return resolve()
-
     validWd(wd || path.resolve(opts.dir, pkg.name), function (er, wd) {
       if (er) return reject(er)
 


### PR DESCRIPTION
in npm@5.0.3 , `node_modules/.hook/preinstall` It works, but in npm@5.5.1 `node_modules/.hook/preinstall` It doesn't work.