### PR TITLE
this file needs to run on old nodes

### DIFF
--- a/lib/utils/unsupported.js
+++ b/lib/utils/unsupported.js
@@ -24,7 +24,7 @@ exports.checkForBrokenNode = function () {
     supportedNode.forEach(function (rel) {
       if (semver.satisfies(nodejs.version, rel.ver)) {
         console.error('Node.js ' + rel.ver + " is supported but the specific version you're running has")
-        console.error(`a bug known to break npm. Please update to at least ${rel.min} to use this`)
+        console.error('a bug known to break npm. Please update to at least' + rel.min + 'to use this')
         console.error('version of npm. You can find the latest release of Node.js at https://nodejs.org/')
         process.exit(1)
       }


### PR DESCRIPTION
I know that v0.10 etc are no longer supported, but this file
(unsupported) needs to run on unsupported version.

Also, this PR keeps the style internally consistent to the file

before:

```
/Users/tingle/.nvm/v0.10.47/lib/node_modules/npm/lib/utils/unsupported.js:27
        console.error(`a bug known to break npm. Please update to at least ${r
                      ^
SyntaxError: Unexpected token ILLEGAL
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/tingle/.nvm/v0.10.47/lib/node_modules/npm/bin/npm-cli.js:19:21
    at Object.<anonymous> (/Users/tingle/.nvm/v0.10.47/lib/node_modules/npm/bin/npm-cli.js:92:3)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
```

after:

```
ERROR: npm is known not to run on Node.js v0.10.47
You'll need to upgrade to a newer version in order to use this
version of npm. Supported versions are 4, 6, 7, 8. You can find the
latest version at https://nodejs.org/
```

related:

  https://github.com/npm/npm/issues/18963

I only got into this error b/c I followed (bugus) directions here:

  https://github.com/npm/docs/pull/900