### PR TITLE
Rollback failed optional installs only once

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -549,6 +549,8 @@ Installer.prototype.rollbackFailedOptional = function (staging, actionsToRun, cb
   }).filter(function (pkg) {
     return pkg.failed && pkg.rollback
   })
+  failed = failed.filter(function (pkg, i) {
+    return failed.indexOf(pkg) === i })
   var top = this.currentTree && this.currentTree.path
   asyncMap(failed, function (pkg, next) {
     asyncMap(pkg.rollback, function (rollback, done) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -555,7 +555,7 @@ Installer.prototype.rollbackFailedOptional = function (staging, actionsToRun, cb
     return failed.indexOf(pkg) === i
   })
   // also remove child packages since they are rolled back by their parents
-  failed = failed.filter(function(pkg) {
+  failed = failed.filter(function (pkg) {
     return failed.indexOf(pkg.parent) === -1
   })
   var top = this.currentTree && this.currentTree.path

--- a/lib/install.js
+++ b/lib/install.js
@@ -554,6 +554,10 @@ Installer.prototype.rollbackFailedOptional = function (staging, actionsToRun, cb
   failed = failed.filter(function (pkg, i) {
     return failed.indexOf(pkg) === i
   })
+  // also remove child packages since they are rolled back by their parents
+  failed = failed.filter(function(pkg) {
+    return failed.indexOf(pkg.parent) === -1
+  })
   var top = this.currentTree && this.currentTree.path
   asyncMap(failed, function (pkg, next) {
     asyncMap(pkg.rollback, function (rollback, done) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -544,11 +544,13 @@ Installer.prototype.executeActions = function (cb) {
 
 Installer.prototype.rollbackFailedOptional = function (staging, actionsToRun, cb) {
   if (!this.rollback) return cb()
+  // get list of all failed optional installs, potentially with duplicates
   var failed = actionsToRun.map(function (action) {
     return action[1]
   }).filter(function (pkg) {
     return pkg.failed && pkg.rollback
   })
+  // remove duplicates to avoid concurrent rollbacks of the same package
   failed = failed.filter(function (pkg, i) {
     return failed.indexOf(pkg) === i
   })

--- a/lib/install.js
+++ b/lib/install.js
@@ -550,7 +550,8 @@ Installer.prototype.rollbackFailedOptional = function (staging, actionsToRun, cb
     return pkg.failed && pkg.rollback
   })
   failed = failed.filter(function (pkg, i) {
-    return failed.indexOf(pkg) === i })
+    return failed.indexOf(pkg) === i
+  })
   var top = this.currentTree && this.currentTree.path
   asyncMap(failed, function (pkg, next) {
     asyncMap(pkg.rollback, function (rollback, done) {


### PR DESCRIPTION
This patch removes all duplicates from the list of failed
installs before the packages in the list are rolled back.
This should speed up the rollback process and also prevent
errors when the asynchronous rollback operations
try to e.g. delete a file that has already been deleted,
yielding errors under Windows.

This should solve issue #17671 and maybe similar ones
like #17747 and #18380.