### PR TITLE
fix: login w/ certificate info

### DIFF
--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -4,6 +4,8 @@ const profile = require('npm-profile')
 const log = require('npmlog')
 const npm = require('../npm.js')
 const output = require('../utils/output.js')
+const pacoteOpts = require('../config/pacote')
+const fetchOpts = require('../config/fetch-opts')
 
 module.exports.login = function login (creds, registry, scope, cb) {
   let username = creds.username || ''
@@ -22,7 +24,10 @@ module.exports.login = function login (creds, registry, scope, cb) {
     email = e
     return profile.login(username, password, {registry: registry, auth: auth}).catch((err) => {
       if (err.code === 'EOTP') throw err
-      return profile.adduser(username, email, password, {registry: registry})
+      return profile.adduser(username, email, password, {
+        registry: registry,
+        opts: fetchOpts.fromPacote(pacoteOpts())
+      })
     }).catch((err) => {
       if (err.code === 'EOTP' && !auth.otp) {
         return read.otp('Authenicator provided OTP:').then((otp) => {

--- a/lib/config/fetch-opts.js
+++ b/lib/config/fetch-opts.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const url = require('url')
+
+module.exports.fromPacote = fromPacote
+
+function fromPacote (opts) {
+  return {
+    cache: getCacheMode(opts),
+    cacheManager: opts.cache,
+    ca: opts.ca,
+    cert: opts.cert,
+    headers: getHeaders('', opts.registry, opts),
+    key: opts.key,
+    localAddress: opts.localAddress,
+    maxSockets: opts.maxSockets,
+    proxy: opts.proxy,
+    referer: opts.refer,
+    retry: opts.retry,
+    strictSSL: !!opts.strictSSL,
+    timeout: opts.timeout,
+    uid: opts.uid,
+    gid: opts.gid
+  }
+}
+
+function getCacheMode (opts) {
+  return opts.offline
+  ? 'only-if-cached'
+  : opts.preferOffline
+  ? 'force-cache'
+  : opts.preferOnline
+  ? 'no-cache'
+  : 'default'
+}
+
+function getHeaders (uri, registry, opts) {
+  const headers = Object.assign({
+    'npm-in-ci': opts.isFromCI,
+    'npm-scope': opts.projectScope,
+    'npm-session': opts.npmSession,
+    'user-agent': opts.userAgent,
+    'referer': opts.refer
+  }, opts.headers)
+  // check for auth settings specific to this registry
+  let auth = (
+    opts.auth &&
+    opts.auth[registryKey(registry)]
+  ) || opts.auth
+  // If a tarball is hosted on a different place than the manifest, only send
+  // credentials on `alwaysAuth`
+  const shouldAuth = auth && (
+    auth.alwaysAuth ||
+    url.parse(uri).host === url.parse(registry).host
+  )
+  if (shouldAuth && auth.token) {
+    headers.authorization = `Bearer ${auth.token}`
+  } else if (shouldAuth && auth.username && auth.password) {
+    const encoded = Buffer.from(
+      `${auth.username}:${auth.password}`, 'utf8'
+    ).toString('base64')
+    headers.authorization = `Basic ${encoded}`
+  } else if (shouldAuth && auth._auth) {
+    headers.authorization = `Basic ${auth._auth}`
+  }
+  return headers
+}
+
+function registryKey (registry) {
+  const parsed = url.parse(registry)
+  const formatted = url.format({
+    host: parsed.host,
+    pathname: parsed.pathname,
+    slashes: parsed.slashes
+  })
+  return url.resolve(formatted, '.')
+}

--- a/lib/config/fetch-opts.js
+++ b/lib/config/fetch-opts.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const url = require('url')
 


### PR DESCRIPTION
npm login should use the provided cert and key, avoiding `EPROTO` errors on custom registries with mutual TLS on the login endpoint.

Fixes #19041 