### PR TITLE
Stop dropping failed optional deps

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -106,6 +106,7 @@ var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var iferr = require('iferr')
 var validate = require('aproba')
+var uniq = require('lodash.uniq')
 
 // npm internal utils
 var npm = require('./npm.js')
@@ -544,11 +545,11 @@ Installer.prototype.executeActions = function (cb) {
 
 Installer.prototype.rollbackFailedOptional = function (staging, actionsToRun, cb) {
   if (!this.rollback) return cb()
-  var failed = actionsToRun.map(function (action) {
+  var failed = uniq(actionsToRun.map(function (action) {
     return action[1]
   }).filter(function (pkg) {
     return pkg.failed && pkg.rollback
-  })
+  }))
   var top = this.currentTree && this.currentTree.path
   asyncMap(failed, function (pkg, next) {
     asyncMap(pkg.rollback, function (rollback, done) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -749,6 +749,8 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
   var moved = 0
   diffs.forEach(function (action) {
     var mutation = action[0]
+    var pkg = action[1]
+    if (pkg.failed) return
     if (mutation === 'remove') {
       ++removed
     } else if (mutation === 'move') {

--- a/lib/install.js
+++ b/lib/install.js
@@ -107,6 +107,7 @@ var rimraf = require('rimraf')
 var iferr = require('iferr')
 var validate = require('aproba')
 var uniq = require('lodash.uniq')
+var Bluebird = require('bluebird')
 
 // npm internal utils
 var npm = require('./npm.js')
@@ -552,11 +553,9 @@ Installer.prototype.rollbackFailedOptional = function (staging, actionsToRun, cb
     return pkg.failed && pkg.rollback
   }))
   var top = this.currentTree && this.currentTree.path
-  asyncMap(failed, function (pkg, next) {
-    asyncMap(pkg.rollback, function (rollback, done) {
-      rollback(top, staging, pkg, done)
-    }, next)
-  }, cb)
+  Bluebird.map(failed, (pkg) => {
+    return Bluebird.map(pkg.rollback, (rollback) => rollback(top, staging, pkg))
+  }).asCallback(cb)
 }
 
 Installer.prototype.commit = function (staging, actionsToRun, cb) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -297,6 +297,7 @@ Installer.prototype.run = function (_cb) {
         // until after we extract them
         [this, (next) => { computeMetadata(this.idealTree); next() }],
         [this, this.pruneIdealTree],
+        [this, this.debugLogicalTree, 'saveTree', 'idealTree'],
         [this, this.saveToDependencies])
     }
   }
@@ -886,11 +887,11 @@ Installer.prototype.debugActions = function (name, actionListName, cb) {
 // to define the arguments for use by chain before the property exists yet.
 Installer.prototype.debugTree = function (name, treeName, cb) {
   validate('SSF', arguments)
-  log.silly(name, this.prettify(this[treeName]).trim())
+  log.silly(name, this.archyDebugTree(this[treeName]).trim())
   cb()
 }
 
-Installer.prototype.prettify = function (tree) {
+Installer.prototype.archyDebugTree = function (tree) {
   validate('O', arguments)
   var seen = new Set()
   function byName (aa, bb) {
@@ -900,7 +901,29 @@ Installer.prototype.prettify = function (tree) {
     seen.add(tree)
     return {
       label: packageId(tree),
-      nodes: tree.children.filter((tree) => { return !seen.has(tree) && !tree.removed && !tree.failed }).sort(byName).map(expandTree)
+      nodes: tree.children.filter((tree) => { return !seen.has(tree) && !tree.removed }).sort(byName).map(expandTree)
+    }
+  }
+  return archy(expandTree(tree), '', { unicode: npm.config.get('unicode') })
+}
+
+Installer.prototype.debugLogicalTree = function (name, treeName, cb) {
+  validate('SSF', arguments)
+  this[treeName] && log.silly(name, this.archyDebugLogicalTree(this[treeName]).trim())
+  cb()
+}
+
+Installer.prototype.archyDebugLogicalTree = function (tree) {
+  validate('O', arguments)
+  var seen = new Set()
+  function byName (aa, bb) {
+    return packageId(aa).localeCompare(packageId(bb))
+  }
+  function expandTree (tree) {
+    seen.add(tree)
+    return {
+      label: packageId(tree),
+      nodes: tree.requires.filter((tree) => { return !seen.has(tree) && !tree.removed }).sort(byName).map(expandTree)
     }
   }
   return archy(expandTree(tree), '', { unicode: npm.config.get('unicode') })

--- a/lib/install/action/finalize.js
+++ b/lib/install/action/finalize.js
@@ -7,7 +7,7 @@ const mkdirp = Bluebird.promisify(require('mkdirp'))
 const lstat = Bluebird.promisify(fs.lstat)
 const readdir = Bluebird.promisify(fs.readdir)
 const symlink = Bluebird.promisify(fs.symlink)
-const gentlyRm = require('../../utils/gently-rm')
+const gentlyRm = Bluebird.promisify(require('../../utils/gently-rm'))
 const moduleStagingPath = require('../module-staging-path.js')
 const move = require('move-concurrently')
 const moveOpts = {fs: fs, Promise: Bluebird, maxConcurrency: 4}
@@ -88,8 +88,11 @@ module.exports = function (staging, pkg, log) {
   }
 }
 
-module.exports.rollback = function (top, staging, pkg, next) {
-  const requested = pkg.package._requested || getRequested(pkg)
-  if (requested && requested.type === 'directory') return next()
-  gentlyRm(pkg.path, false, top, next)
+module.exports.rollback = function (top, staging, pkg) {
+  // strictly speaking rolling back a finalize should ONLY remove module that
+  // was being finalized, not any of the things under it. But currently
+  // those modules are guaranteed to be useless so we may as well remove them too.
+  // When/if we separate `commit` step and can rollback to previous versions
+  // of upgraded modules then we'll need to revisit this…
+  return gentlyRm(pkg.path, false, top).catch(() => {})
 }

--- a/lib/install/actions.js
+++ b/lib/install/actions.js
@@ -83,10 +83,8 @@ function markAsFailed (pkg) {
   if (pkg.failed) return
   pkg.failed = true
   pkg.requires.forEach((req) => {
-    req.requiredBy = req.requiredBy.filter((reqReqBy) => {
-      return reqReqBy !== pkg
-    })
-    if (req.requiredBy.length === 0 && !req.userRequired) {
+    var requiredBy = req.requiredBy.filter((reqReqBy) => !reqReqBy.failed)
+    if (requiredBy.length === 0 && !req.userRequired) {
       markAsFailed(req)
     }
   })
@@ -94,12 +92,7 @@ function markAsFailed (pkg) {
 
 function handleOptionalDepErrors (pkg, err) {
   markAsFailed(pkg)
-  var anyFatal = pkg.userRequired || pkg.isTop
-  for (var ii = 0; ii < pkg.requiredBy.length; ++ii) {
-    var parent = pkg.requiredBy[ii]
-    var isFatal = failedDependency(parent, pkg)
-    if (isFatal) anyFatal = true
-  }
+  var anyFatal = failedDependency(pkg)
   if (anyFatal) {
     throw err
   } else {

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -121,7 +121,7 @@ function computeMetadata (tree, seen) {
     }
   }
 
-  tree.children.filter((child) => !child.removed && !child.failed).forEach((child) => computeMetadata(child, seen))
+  tree.children.filter((child) => !child.removed).forEach((child) => computeMetadata(child, seen))
 
   return tree
 }
@@ -276,7 +276,7 @@ function isNotEmpty (value) {
   return value != null && value !== ''
 }
 
-module.exports.computeVersionSpec = computeVersionSpec
+exports.computeVersionSpec = computeVersionSpec
 function computeVersionSpec (tree, child) {
   validate('OO', arguments)
   var requested
@@ -306,10 +306,6 @@ function computeVersionSpec (tree, child) {
 
 function moduleNameMatches (name) {
   return function (child) { return moduleName(child) === name }
-}
-
-function noModuleNameMatches (name) {
-  return function (child) { return moduleName(child) !== name }
 }
 
 // while this implementation does not require async calling, doing so
@@ -377,19 +373,12 @@ function isDepOptional (tree, name, pkg) {
   return false
 }
 
-var failedDependency = exports.failedDependency = function (tree, name_pkg) {
-  var name
-  var pkg = {}
-  if (typeof name_pkg === 'string') {
-    name = name_pkg
-  } else {
-    pkg = name_pkg
-    name = moduleName(pkg)
-  }
-  tree.children = tree.children.filter(noModuleNameMatches(name))
-
-  if (isDepOptional(tree, name, pkg)) {
-    return false
+exports.failedDependency = failedDependency
+function failedDependency (tree, name, pkg) {
+  if (name) {
+    if (isDepOptional(tree, name, pkg || {})) {
+      return false
+    }
   }
 
   tree.failed = true
@@ -398,17 +387,16 @@ var failedDependency = exports.failedDependency = function (tree, name_pkg) {
 
   if (tree.userRequired) return true
 
-  removeObsoleteDep(tree)
-
   if (!tree.requiredBy) return false
 
+  let anyFailed = false
   for (var ii = 0; ii < tree.requiredBy.length; ++ii) {
     var requireParent = tree.requiredBy[ii]
-    if (failedDependency(requireParent, tree.package)) {
-      return true
+    if (failedDependency(requireParent, moduleName(tree), tree)) {
+      anyFailed = true
     }
   }
-  return false
+  return anyFailed
 }
 
 function andHandleOptionalErrors (log, tree, name, done) {
@@ -418,7 +406,6 @@ function andHandleOptionalErrors (log, tree, name, done) {
     if (!er) return done(er, child, childLog)
     var isFatal = failedDependency(tree, name)
     if (er && !isFatal) {
-      tree.children = tree.children.filter(noModuleNameMatches(name))
       reportOptionalFailure(tree, name, er)
       return done()
     } else {
@@ -601,8 +588,9 @@ function resolveWithNewModule (pkg, tree, log, next) {
   validate('OOOF', arguments)
 
   log.silly('resolveWithNewModule', packageId(pkg), 'checking installable status')
-  return isInstallable(pkg, iferr(next, function () {
-    addBundled(pkg, iferr(next, function () {
+  return isInstallable(pkg, (err) => {
+    let installable = !err
+    addBundled(pkg, (bundleErr) => {
       var parent = earliestInstallable(tree, tree, pkg) || tree
       var isLink = pkg._requested.type === 'directory'
       var child = createChild({
@@ -613,8 +601,9 @@ function resolveWithNewModule (pkg, tree, log, next) {
         children: pkg._bundled || [],
         isLink: isLink,
         isInLink: parent.isLink,
-        knownInstallable: true
+        knownInstallable: installable
       })
+      if (!installable || bundleErr) child.failed = true
       delete pkg._bundled
       var hasBundled = child.children.length
 
@@ -630,13 +619,14 @@ function resolveWithNewModule (pkg, tree, log, next) {
       }
 
       if (pkg._shrinkwrap && pkg._shrinkwrap.dependencies) {
-        return inflateShrinkwrap(child, pkg._shrinkwrap, function (er) {
-          next(er, child, log)
+        return inflateShrinkwrap(child, pkg._shrinkwrap, (swErr) => {
+          if (swErr) child.failed = true
+          next(err || bundleErr || swErr, child, log)
         })
       }
-      next(null, child, log)
-    }))
-  }))
+      next(err || bundleErr, child, log)
+    })
+  })
 }
 
 var validatePeerDeps = exports.validatePeerDeps = function (tree, onInvalid) {
@@ -669,7 +659,7 @@ var findRequirement = exports.findRequirement = function (tree, name, requested,
   validate('OSO', [tree, name, requested])
   if (!requestor) requestor = tree
   var nameMatch = function (child) {
-    return moduleName(child) === name && child.parent && !child.removed && !child.failed
+    return moduleName(child) === name && child.parent && !child.removed
   }
   var versionMatch = function (child) {
     return doesChildVersionMatch(child, requested, requestor)

--- a/test/tap/optional-metadep-rollback-collision.js
+++ b/test/tap/optional-metadep-rollback-collision.js
@@ -158,7 +158,7 @@ test('setup', function (t) {
   })
 })
 test('go go test racer', function (t) {
-  common.npm(
+  return common.npm(
     [
       '--prefix', pkg,
       '--fetch-retries', '0',
@@ -175,19 +175,13 @@ test('go go test racer', function (t) {
         PATH: process.env.PATH,
         Path: process.env.Path
       },
-      stdio: [ 0, 'pipe', 2 ]
-    },
-    function (er, code, stdout, stderr) {
-      t.ifError(er, 'install ran to completion without error')
-      t.is(code, 0, 'npm install exited with code 0')
+      stdio: 'pipe'
+    }).spread((code, stdout, stderr) => {
+      t.comment(stdout.trim())
       t.comment(stderr.trim())
-      // stdout should be empty, because we only have one, optional, dep and
-      // if it fails we shouldn't try installing anything
-      t.equal(stdout, '')
+      t.is(code, 0, 'npm install exited with code 0')
       t.notOk(/not ok/.test(stdout), 'should not contain the string \'not ok\'')
-      t.end()
-    }
-  )
+    })
 })
 
 test('verify results', function (t) {


### PR DESCRIPTION
Makes full package-locks even the package.json has optional deps that are currently uninstallable. Also stops deleting optionals from package-locks when we can't install them.