### PR TITLE
install: fix: can’t execute .hooks scripts

### DIFF
--- a/node_modules/npm-lifecycle/index.js
+++ b/node_modules/npm-lifecycle/index.js
@@ -42,8 +42,6 @@ function lifecycle (pkg, stage, wd, opts) {
       delete pkg.scripts.prepublish
     }
 
-    if (!pkg.scripts[stage]) return resolve()
-
     validWd(wd || path.resolve(opts.dir, pkg.name), function (er, wd) {
       if (er) return reject(er)
 


### PR DESCRIPTION
Hook scripts can run normally in the earlier version **5.0.4**, but `npm i` can’t execute hook scripts from version **5.1.0**. 
The major cause is that, if currently running is `node_modules/.hooks/preinstall` and the `preinstall` scripts are not configured in `package.json`, the judgment logic result is `pkg.scripts` don’t run `preinstall` and return to `resolve`(or `cb`).