### PR TITLE
Fix npm command typo

### DIFF
--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -22,7 +22,7 @@ var affordances = {
   'la': 'ls',
   'll': 'ls',
   'verison': 'version',
-  'isntall': 'install',
+  'install': 'install',
   'dist-tags': 'dist-tag',
   'apihelp': 'help',
   'find-dupes': 'dedupe',


### PR DESCRIPTION
There's a typo in the command list file `lib/config/cmd-list.js`.
For now, I've just found that it will be used in the help message.
I don't know whether it will be used in another place or not.
Thus, I revise it in case that `cmd-list.js` is required in another place and get unexpected behavior.