### PR TITLE
config: expose "node-options" passthrough for lifecycle scripts

### DIFF
--- a/lib/config/lifecycle.js
+++ b/lib/config/lifecycle.js
@@ -18,6 +18,7 @@ function lifecycleOpts (moreOpts) {
       ignorePrepublish: npm.config.get('ignore-prepublish'),
       ignoreScripts: npm.config.get('ignore-scripts'),
       log: log,
+      nodeOptions: npm.config.get('node-options'),
       production: npm.config.get('production'),
       scriptShell: npm.config.get('script-shell'),
       scriptsPrependNodePath: npm.config.get('scripts-prepend-node-path'),


### PR DESCRIPTION
intent here is to open a path to use `--inspect` with `npm run`

requires https://github.com/npm/lifecycle/pull/7