### PR TITLE
fix "npm --depth 2 update"

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -193,6 +193,8 @@ function makeJSON (list) {
 }
 
 function outdated_ (args, path, tree, parentHas, depth, cb) {
+  if (!tree.children) tree.children = []
+  if (!tree.missingDeps) tree.missingDeps = {}
   if (!tree.package) tree.package = {}
   if (path && tree.package.name) path += ' > ' + tree.package.name
   if (!path && tree.package.name) path = tree.package.name


### PR DESCRIPTION
fixes #19107 

Still needs a test but I can prove it's working using: https://github.com/aheckmann/npm-update-test

Steps to see this working:

1. git clone https://github.com/aheckmann/npm-update-test
1. npm --registry=https://registry.npmjs.org/ install
1. npm --depth 2 --registry=https://registry.npmjs.org/ update