### PR TITLE
Support for noProxy configuration

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -663,6 +663,13 @@ The registry you want to send cli metrics to if `send-metrics` is true.
 
 The node version to use when checking a package's `engines` map.
 
+### no-proxy
+
+* Default: null
+* Type: String or Array
+
+A comma-separated string or an array of domain extensions that a proxy should not be used for.
+
 ### offline
 
 * Default: false

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -310,7 +310,7 @@ exports.types = {
   message: String,
   'metrics-registry': [null, String],
   'node-version': [null, semver],
-  'no-proxy': [null, String, Array],  
+  'no-proxy': [null, String, Array],
   offline: Boolean,
   'onload-script': [null, String],
   only: [null, 'dev', 'development', 'prod', 'production'],

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -310,6 +310,7 @@ exports.types = {
   message: String,
   'metrics-registry': [null, String],
   'node-version': [null, semver],
+  'no-proxy': [null, String, Array],  
   offline: Boolean,
   'onload-script': [null, String],
   only: [null, 'dev', 'development', 'prod', 'production'],

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -191,6 +191,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'progress': !process.env.TRAVIS && !process.env.CI,
     proxy: null,
     'https-proxy': null,
+    'no-proxy': null,
     'user-agent': 'npm/{npm-version} ' +
                     'node/{node-version} ' +
                     '{platform} ' +

--- a/lib/config/pacote.js
+++ b/lib/config/pacote.js
@@ -37,6 +37,7 @@ function pacoteOpts (moreOpts) {
     preferOnline: npm.config.get('prefer-online') || npm.config.get('cache-max') <= 0,
     projectScope: npm.projectScope,
     proxy: npm.config.get('https-proxy') || npm.config.get('proxy'),
+    noProxy: npm.config.get('no-proxy'),
     refer: npm.registry.refer,
     registry: npm.config.get('registry'),
     retry: {


### PR DESCRIPTION
This minor commit adds support for the noProxy configuration.

All whats really needed is passing the option to the `pacote` package,
this will pass it to `make-fetch-happen`.

pacote: https://github.com/zkat/pacote/blob/latest/lib/util/opt-check.js#L26
make-fetch-happen: https://github.com/zkat/make-fetch-happen#opts-no-proxy

Fixes #18350, #7168