### PR TITLE
pack/publish/install shasum fix

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -4,6 +4,7 @@ const BB = require('bluebird')
 
 const assert = require('assert')
 const cacache = require('cacache')
+const finished = BB.promisify(require('mississippi').finished)
 const log = require('npmlog')
 const npa = require('npm-package-arg')
 const npm = require('./npm.js')
@@ -105,7 +106,7 @@ function add (args, where) {
   log.verbose('cache add', 'spec', spec)
   if (!spec) return BB.reject(new Error(usage))
   log.silly('cache add', 'parsed spec', spec)
-  return pacote.prefetch(spec, pacoteOpts({where}))
+  return finished(pacote.tarball.stream(spec, pacoteOpts({where})).resume())
 }
 
 cache.verify = verify

--- a/lib/install/action/fetch.js
+++ b/lib/install/action/fetch.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const BB = require('bluebird')
+
+const finished = BB.promisify(require('mississippi').finished)
 const packageId = require('../../utils/package-id.js')
 const pacote = require('pacote')
 const pacoteOpts = require('../../config/pacote')
@@ -8,5 +11,6 @@ module.exports = fetch
 function fetch (staging, pkg, log, next) {
   log.silly('fetch', packageId(pkg))
   const opts = pacoteOpts({integrity: pkg.package._integrity})
-  pacote.prefetch(pkg.package._requested, opts).then(() => next(), next)
+  return finished(pacote.tarball.stream(pkg.package._requested, opts))
+  .then(() => next(), next)
 }

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -6,7 +6,6 @@
 
 const BB = require('bluebird')
 
-const cache = require('./cache')
 const cacache = require('cacache')
 const cp = require('child_process')
 const deprCheck = require('./utils/depr-check')
@@ -18,6 +17,7 @@ const log = require('npmlog')
 const move = require('move-concurrently')
 const npm = require('./npm')
 const output = require('./utils/output')
+const pacote = require('pacote')
 const pacoteOpts = require('./config/pacote')
 const path = require('path')
 const PassThrough = require('stream').PassThrough
@@ -26,7 +26,6 @@ const pipe = BB.promisify(require('mississippi').pipe)
 const prepublishWarning = require('./utils/warn-deprecated')('prepublish-on-install')
 const pinflight = require('promise-inflight')
 const readJson = BB.promisify(require('read-package-json'))
-const writeStreamAtomic = require('fs-write-stream-atomic')
 const tar = require('tar')
 const packlist = require('npm-packlist')
 
@@ -69,12 +68,8 @@ function pack_ (pkg, dir) {
           return packDirectory(mani, mani._resolved, target)
         })
       } else {
-        return cache.add(pkg).then((info) => {
-          return pipe(
-            cacache.get.stream.byDigest(pacoteOpts().cache, info.integrity || mani._integrity),
-            writeStreamAtomic(target)
-          )
-        }).then(() => target)
+        return pacote.tarball.toFile(pkg, target, pacoteOpts())
+        .then(() => target)
       }
     })
   })

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -3,7 +3,6 @@
 const BB = require('bluebird')
 
 const cacache = require('cacache')
-const cache = require('./cache')
 const createReadStream = require('graceful-fs').createReadStream
 const getPublishConfig = require('./utils/get-publish-config.js')
 const lifecycle = BB.promisify(require('./utils/lifecycle.js'))
@@ -16,11 +15,9 @@ const pack = require('./pack')
 const pacote = require('pacote')
 const pacoteOpts = require('./config/pacote')
 const path = require('path')
-const pipe = BB.promisify(require('mississippi').pipe)
 const readJson = BB.promisify(require('read-package-json'))
 const semver = require('semver')
 const statAsync = BB.promisify(require('graceful-fs').stat)
-const writeStreamAtomic = require('fs-write-stream-atomic')
 const readUserInfo = require('./utils/read-user-info.js')
 
 publish.usage = 'npm publish [<tarball>|<folder>] [--tag <tag>] [--access <public|restricted>]' +
@@ -105,20 +102,11 @@ function publishFromPackage (arg) {
   return cacache.tmp.withTmp(npm.tmp, {tmpPrefix: 'fromPackage'}, (tmp) => {
     const extracted = path.join(tmp, 'package')
     const target = path.join(tmp, 'package.json')
-    return cache.add(arg).then((info) => {
-      const opts = pacoteOpts({integrity: info.integrity})
-      return BB.all([
-        pipe(
-          cacache.get.stream.byDigest(opts.cache, info.integrity),
-          writeStreamAtomic(target)
-        ).then(() => target),
-        pacote.extract(arg, extracted, opts).then(() => {
-          return readJson(path.join(extracted, 'package.json'))
-        })
-      ]).spread((target, pkg) => {
-        return upload(arg, pkg, false, target)
-      })
-    })
+    const opts = pacoteOpts()
+    return pacote.tarball.toFile(arg, target, opts)
+    .then(() => pacote.extract(arg, extracted, opts))
+    .then(() => readJson(path.join(extracted, 'package.json')))
+    .tap((pkg) => upload(arg, pkg, false, target))
   })
 }
 

--- a/test/tap/shrinkwrap-_auth.js
+++ b/test/tap/shrinkwrap-_auth.js
@@ -1,3 +1,6 @@
+'use strict'
+
+var fs = require('fs')
 var path = require('path')
 var writeFileSync = require('graceful-fs').writeFileSync
 
@@ -5,6 +8,7 @@ var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
 var osenv = require('osenv')
 var rimraf = require('rimraf')
+var ssri = require('ssri')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -16,6 +20,7 @@ var modules = path.resolve(pkg, 'node_modules')
 var tarballPath = '/scoped-underscore/-/scoped-underscore-1.3.1.tgz'
 var tarballURL = common.registry + tarballPath
 var tarball = path.resolve(__dirname, '../fixtures/scoped-underscore-1.3.1.tgz')
+var tarballIntegrity = ssri.fromData(fs.readFileSync(tarball)).toString()
 
 var _auth = '0xabad1dea'
 
@@ -43,9 +48,10 @@ test('authed npm install with shrinkwrapped global package using _auth', functio
   common.npm(
     [
       'install',
-      '--loglevel', 'warn',
+      '--loglevel', 'error',
       '--json',
       '--fetch-retries', 0,
+      '--registry', common.registry,
       '--userconfig', outfile
     ],
     {cwd: pkg, stdio: [0, 'pipe', 2]},
@@ -86,9 +92,11 @@ var json = {
 var shrinkwrap = {
   name: 'test-package-install',
   version: '1.0.0',
+  lockfileVersion: 1,
   dependencies: {
     '@scoped/underscore': {
       resolved: tarballURL,
+      integrity: tarballIntegrity,
       version: '1.3.1'
     }
   }

--- a/test/tap/shrinkwrap-global-auth.js
+++ b/test/tap/shrinkwrap-global-auth.js
@@ -1,3 +1,6 @@
+'use strict'
+
+var fs = require('fs')
 var path = require('path')
 var writeFileSync = require('graceful-fs').writeFileSync
 
@@ -5,6 +8,7 @@ var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
 var osenv = require('osenv')
 var rimraf = require('rimraf')
+var ssri = require('ssri')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -16,6 +20,7 @@ var modules = path.resolve(pkg, 'node_modules')
 var tarballPath = '/scoped-underscore/-/scoped-underscore-1.3.1.tgz'
 var tarballURL = common.registry + tarballPath
 var tarball = path.resolve(__dirname, '../fixtures/scoped-underscore-1.3.1.tgz')
+var tarballIntegrity = ssri.fromData(fs.readFileSync(tarball)).toString()
 
 var server
 
@@ -41,10 +46,11 @@ test('authed npm install with shrinkwrapped global package', function (t) {
   common.npm(
     [
       'install',
-      '--loglevel', 'warn',
+      '--loglevel', 'error',
       '--json',
       '--fetch-retries', 0,
-      '--userconfig', outfile
+      '--userconfig', outfile,
+      '--registry', common.registry
     ],
     {cwd: pkg, stdio: [0, 'pipe', 2]},
     function (err, code, stdout) {
@@ -84,9 +90,11 @@ var json = {
 var shrinkwrap = {
   name: 'test-package-install',
   version: '1.0.0',
+  lockfileVersion: 1,
   dependencies: {
     '@scoped/underscore': {
       resolved: tarballURL,
+      integrity: tarballIntegrity,
       version: '1.3.1'
     }
   }

--- a/test/tap/shrinkwrap-scoped-auth.js
+++ b/test/tap/shrinkwrap-scoped-auth.js
@@ -1,3 +1,6 @@
+'use strict'
+
+var fs = require('fs')
 var path = require('path')
 var writeFileSync = require('graceful-fs').writeFileSync
 
@@ -5,6 +8,7 @@ var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
 var osenv = require('osenv')
 var rimraf = require('rimraf')
+var ssri = require('ssri')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -16,6 +20,7 @@ var modules = path.resolve(pkg, 'node_modules')
 var tarballPath = '/scoped-underscore/-/scoped-underscore-1.3.1.tgz'
 var tarballURL = common.registry + tarballPath
 var tarball = path.resolve(__dirname, '../fixtures/scoped-underscore-1.3.1.tgz')
+var tarballIntegrity = ssri.fromData(fs.readFileSync(tarball)).toString()
 
 var server
 
@@ -41,10 +46,11 @@ test('authed npm install with shrinkwrapped scoped package', function (t) {
   common.npm(
     [
       'install',
-      '--loglevel', 'warn',
+      '--loglevel', 'error',
       '--json',
       '--fetch-retries', 0,
-      '--userconfig', outfile
+      '--userconfig', outfile,
+      '--registry', common.registry
     ],
     {cwd: pkg, stdio: [0, 'pipe', 2]},
     function (err, code, stdout) {
@@ -83,9 +89,11 @@ var json = {
 var shrinkwrap = {
   name: 'test-package-install',
   version: '1.0.0',
+  lockfileVersion: 1,
   dependencies: {
     '@scoped/underscore': {
       resolved: tarballURL,
+      integrity: tarballIntegrity,
       version: '1.3.1'
     }
   }


### PR DESCRIPTION
This PR should fix *a number* of issues surrounding git and tarball deps. Packing and publishing both git repos and tarball deps should work better now, and this applies to installing directly from these sources, whereas before, they'd cause shasum errors.

This pacote bump also includes a patch that returns the default shasum to sha512, which should at least ease some ongoing issues we've had with checksum errors. It also stops trying to verify shasums for git repos, which is another common source of these problems. Because it's hard to pin down what exactly was causing that stuff, I'm not sure if it'll actually solve everything for people.

#### NOTE
This still needs tests for the bits that _are_ predictable, so holding off on merging this until I've written those.