### PR TITLE
19151: Log the fact line endings are being changed upon install.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -526,3 +526,4 @@ Carsten Brandt <mail@cebe.cc>
 Marcin Szczepanski <marcin@imagichine.com.au>
 Josh Clow <josh@textio.com>
 Jakub Holy <jakubholy@jakubholy.net>
+Marcos Scriven <marcos@scriven.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -526,4 +526,3 @@ Carsten Brandt <mail@cebe.cc>
 Marcin Szczepanski <marcin@imagichine.com.au>
 Josh Clow <josh@textio.com>
 Jakub Holy <jakubholy@jakubholy.net>
-Marcos Scriven <marcos@scriven.org>

--- a/lib/build.js
+++ b/lib/build.js
@@ -191,7 +191,10 @@ function linkBins (pkg, folder, parent, gtop, cb) {
           }
           if (er) return cb(er)
           isHashbangFile(src).then((isHashbang) => {
-            if (isHashbang) return dos2Unix(src)
+            if (isHashbang) {
+              log.silly('linkBins', 'Converting line endings of file:', src)              
+              return dos2Unix(src)
+            }
           }).then(() => {
             if (!gtop) return cb()
             var dest = path.resolve(binRoot, b)

--- a/lib/build.js
+++ b/lib/build.js
@@ -192,7 +192,7 @@ function linkBins (pkg, folder, parent, gtop, cb) {
           if (er) return cb(er)
           isHashbangFile(src).then((isHashbang) => {
             if (isHashbang) {
-              log.silly('linkBins', 'Converting line endings of hashbang file:', src)              
+              log.silly('linkBins', 'Converting line endings of hashbang file:', src)
               return dos2Unix(src)
             }
           }).then(() => {

--- a/lib/build.js
+++ b/lib/build.js
@@ -192,7 +192,7 @@ function linkBins (pkg, folder, parent, gtop, cb) {
           if (er) return cb(er)
           isHashbangFile(src).then((isHashbang) => {
             if (isHashbang) {
-              log.silly('linkBins', 'Converting line endings of file:', src)              
+              log.silly('linkBins', 'Converting line endings of hashbang file:', src)              
               return dos2Unix(src)
             }
           }).then(() => {


### PR DESCRIPTION
Per https://github.com/npm/npm/issues/19151, as an interim measure I'm just adding a log line on the `silly` level to make it clearer some files are having their line endings changed.

This is to save other developers time if they hit the same issue of having their binary hashbang files corrupted during install.