### PR TITLE
Stabilize optional shrinkwrapped dependencies.

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -81,6 +81,12 @@ function childDependencySpecifier (tree, name, spec) {
   return npa.resolve(name, spec, packageRelativePath(tree))
 }
 
+function shouldRetainChild (child) {
+  // Forgive shrinkwrapped dependencies for failing.  They should be retained
+  // for the sake of whatever environment they didn't fail in.
+  return !child.removed && (!child.failed || child.fromShrinkwrap)
+}
+
 exports.computeMetadata = computeMetadata
 function computeMetadata (tree, seen) {
   if (!seen) seen = new Set()
@@ -121,7 +127,7 @@ function computeMetadata (tree, seen) {
     }
   }
 
-  tree.children.filter((child) => !child.removed && !child.failed).forEach((child) => computeMetadata(child, seen))
+  tree.children.filter(shouldRetainChild).forEach((child) => computeMetadata(child, seen))
 
   return tree
 }
@@ -669,7 +675,7 @@ var findRequirement = exports.findRequirement = function (tree, name, requested,
   validate('OSO', [tree, name, requested])
   if (!requestor) requestor = tree
   var nameMatch = function (child) {
-    return moduleName(child) === name && child.parent && !child.removed && !child.failed
+    return moduleName(child) === name && child.parent && shouldRetainChild(child)
   }
   var versionMatch = function (child) {
     return doesChildVersionMatch(child, requested, requestor)

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -392,7 +392,10 @@ var failedDependency = exports.failedDependency = function (tree, name_pkg) {
     pkg = name_pkg
     name = moduleName(pkg)
   }
-  tree.children = tree.children.filter(noModuleNameMatches(name))
+  var notName = noModuleNameMatches(name)
+  // Preserve shrinkwrapped children for the sake of whatever environment they
+  // didn't fail in.
+  tree.children = tree.children.filter((c) => notName(c) || c.fromShrinkwrap)
 
   if (isDepOptional(tree, name, pkg)) {
     return false


### PR DESCRIPTION
Fixes https://github.com/npm/npm/issues/17722, ensuring that optional dependencies from a lockfile which fail to install are not removed from the lockfile.  Example: When `fsevents` is installed on macOS, but later fails to install on GNU/Linux, `fsevents` will not be removed from the lockfile.

Besides the unit test, I also confirmed that lockfiles remain unchanged on GNU/Linux by running `npm i` in this repo: https://github.com/jacksonrayhamilton/chokidar-test