### PR TITLE
pkglock: automatically resolve conflicts

### DIFF
--- a/doc/files/npm-package-locks.md
+++ b/doc/files/npm-package-locks.md
@@ -136,6 +136,25 @@ on. Additionally, the diffs from these changes are human-readable and will
 inform you of any changes npm has made to your `node_modules`, so you can notice
 if any transitive dependencies were updated, hoisted, etc.
 
+### Resolving lockfile conflicts
+
+Occasionally, two separate npm install will create package locks that cause
+merge conflicts in source control systems. As of `npm@5.7.0`, these conflicts
+can be resolved by manually fixing any `package.json` conflicts, and then
+running `npm install [--package-lock-only]` again. npm will automatically
+resolve any conflicts for you and write a merged package lock that includes all
+the dependencies from both branches in a reasonable tree. If
+`--package-lock-only` is provided, it will do this without also modifying your
+local `node_modules/`.
+
+To make this process seamless on git, consider installing
+[`npm-merge-driver`](https://npm.im/npm-merge-driver), which will teach git how
+to do this itself without any user interaction. In short: `$ npx
+npm-merge-driver install -g` will let you do this, and even works with
+pre-`npm@5.7.0` versions of npm 5, albeit a bit more noisily. Note that if
+`package.json` itself conflicts, you will have to resolve that by hand and run
+`npm install` manually, even with the merge driver.
+
 ## SEE ALSO
 
 * https://medium.com/@sdboyer/so-you-want-to-write-a-package-manager-4ae9c17d9527

--- a/doc/files/package-lock.json.md
+++ b/doc/files/package-lock.json.md
@@ -128,5 +128,6 @@ The dependencies of this dependency, exactly as at the top level.
 
 * npm-shrinkwrap(1)
 * npm-shrinkwrap.json(5)
+* npm-package-locks(5)
 * package.json(5)
 * npm-install(1)

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -182,7 +182,7 @@ function save (dir, pkginfo, opts, cb) {
           indent: (pkg && pkg.indent) || 2
         }
       )
-      const updated = updateLockfileMetadata(pkginfo, pkg && pkg.data)
+      const updated = updateLockfileMetadata(pkginfo, pkg && JSON.parse(pkg.raw))
       const swdata = JSON.stringify(updated, null, info.indent) + '\n'
       if (swdata === info.raw) {
         // skip writing if file is identical
@@ -244,9 +244,7 @@ function checkPackageFile (dir, name) {
     return {
       path: file,
       raw: data,
-      data: JSON.parse(data),
       indent: detectIndent(data).indent || 2
     }
   }).catch({code: 'ENOENT'}, () => {})
 }
-

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -52,6 +52,25 @@ function errorMessage (er) {
       break
 
     case 'EJSONPARSE':
+      const path = require('path')
+      // Check whether we ran into a conflict in our own package.json
+      if (er.file === path.join(npm.prefix, 'package.json')) {
+        const isDiff = require('../install/read-shrinkwrap.js')._isDiff
+        const txt = require('fs').readFileSync(er.file, 'utf8')
+        if (isDiff(txt)) {
+          detail.push([
+            '',
+            [
+              'Merge conflict detected in your package.json.',
+              '',
+              'Please resolve the package.json conflict and retry the command:',
+              '',
+              `$ ${process.argv.join(' ')}`
+            ].join('\n')
+          ])
+          break
+        }
+      }
       short.push(['', er.message])
       short.push(['', 'File: ' + er.file])
       detail.push([

--- a/test/tap/shrinkwrap-resolve-conflict.js
+++ b/test/tap/shrinkwrap-resolve-conflict.js
@@ -1,0 +1,117 @@
+'use strict'
+
+const BB = require('bluebird')
+
+const common = require('../common-tap.js')
+const fs = BB.promisifyAll(require('fs'))
+const path = require('path')
+const rimraf = BB.promisify(require('rimraf'))
+const test = require('tap').test
+const Tacks = require('tacks')
+
+const File = Tacks.File
+const Dir = Tacks.Dir
+
+const testDir = path.resolve(__dirname, path.basename(__filename, '.js'))
+const modAdir = path.resolve(testDir, 'modA')
+const modBdir = path.resolve(testDir, 'modB')
+const modCdir = path.resolve(testDir, 'modC')
+
+test('conflicts in shrinkwrap are auto-resolved on install', (t) => {
+  const fixture = new Tacks(Dir({
+    'package.json': File({
+      name: 'foo',
+      dependencies: {
+        modA: 'file://' + modAdir,
+        modB: 'file://' + modBdir
+      },
+      devDependencies: {
+        modC: 'file://' + modCdir
+      }
+    }),
+    'npm-shrinkwrap.json': File(
+`
+{
+  "name": "foo",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+<<<<<<< HEAD
+    "modA": {
+      "version": "file:modA"
+||||||| merged common ancestors
+    "modB": {
+      "version": "file:modB"
+=======
+    "modC": {
+      "version": "file:modC",
+      "dev": true
+>>>>>>> branch
+    }
+  }
+}
+`),
+    'modA': Dir({
+      'package.json': File({
+        name: 'modA',
+        version: '1.0.0'
+      })
+    }),
+    'modB': Dir({
+      'package.json': File({
+        name: 'modB',
+        version: '1.0.0'
+      })
+    }),
+    'modC': Dir({
+      'package.json': File({
+        name: 'modC',
+        version: '1.0.0'
+      })
+    })
+  }))
+  fixture.create(testDir)
+  function readJson (file) {
+    return fs.readFileAsync(path.join(testDir, file)).then(JSON.parse)
+  }
+  return BB.fromNode((cb) => {
+    common.npm([
+      'install',
+      '--loglevel', 'warn'
+    ], {cwd: testDir}, (err, code, out, stderr) => {
+      t.comment(stderr)
+      t.match(stderr, /warn.*conflict/gi, 'warns about a conflict')
+      cb(err || (code && new Error('non-zero exit code')) || null, out)
+    })
+  })
+  .then(() => BB.join(
+    readJson('npm-shrinkwrap.json'),
+    readJson('node_modules/modA/package.json'),
+    readJson('node_modules/modB/package.json'),
+    readJson('node_modules/modC/package.json'),
+    (lockfile, A, B, C) => {
+      t.deepEqual(lockfile, {
+        name: 'foo',
+        requires: true,
+        lockfileVersion: 1,
+        dependencies: {
+          modA: {
+            version: 'file:modA'
+          },
+          modB: {
+            version: 'file:modB'
+          },
+          modC: {
+            version: 'file:modC',
+            dev: true
+          }
+        }
+      }, 'resolved lockfile matches expectations')
+      t.equal(A.name, 'modA', 'installed modA')
+      t.equal(B.name, 'modB', 'installed modB')
+      t.equal(C.name, 'modC', 'installed modC')
+    }
+  ))
+})
+
+test('cleanup', () => rimraf(testDir))


### PR DESCRIPTION
This adds a shiny new feature to npm: If you run `npm install` when you get a merge conflict in `package-lock.json` or `npm-shrinkwrap.json`, npm will auto-detect the conflict and resolve it automatically. You can then add the lockfile and commit it, without any further attention!