### PR TITLE
docs:sync package-lock spec and help page

### DIFF
--- a/doc/files/package-lock.json.md
+++ b/doc/files/package-lock.json.md
@@ -120,6 +120,15 @@ transitive dependency of a non-optional dependency of the top level.
 All optional dependencies should be included even if they're uninstallable
 on the current platform.
 
+
+#### requires
+
+This is a mapping of module name to version.  This is a list of everything
+this module requires, regardless of where it will be installed.  The version
+should match via normal matching rules a dependency either in our
+`dependencies` or in a level higher than us.
+
+
 #### dependencies
 
 The dependencies of this dependency, exactly as at the top level.


### PR DESCRIPTION
Per https://twitter.com/ReBeccaOrg/status/935307487707774976 at least this field `requires` didn't make it over into the main help file.

I didn't change the others as I'm not sure whether they are intended for the main helpfile - for example, `from *(deprecated)*` in spec, `packageIntegrity` in helpfile and not spec, and `link` (to be implemented post npm@5).

Note: folks at https://stackoverflow.com/questions/45117589/what-does-requires-true-do-in-package-lock-json noticed that there was no docs on this - I will update that when this is merged.