### PR TITLE
Do not redirect the `env` command to `set`, for windows bash shell

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -8,6 +8,7 @@ var log = require('npmlog')
 var chain = require('slide').chain
 var usage = require('./utils/usage')
 var output = require('./utils/output.js')
+var isWindowsShell = require('./utils/is-windows-shell.js')
 
 runScript.usage = usage(
   'run-script',
@@ -138,7 +139,7 @@ function run (pkg, wd, cmd, args, cb) {
       if (cmd === 'test') {
         pkg.scripts.test = 'echo \'Error: no test specified\''
       } else if (cmd === 'env') {
-        if (process.platform === 'win32') {
+        if (isWindowsShell) {
           log.verbose('run-script using default platform env: SET (Windows)')
           pkg.scripts[cmd] = 'SET'
         } else {

--- a/lib/utils/is-windows-bash.js
+++ b/lib/utils/is-windows-bash.js
@@ -1,3 +1,4 @@
 'use strict'
 var isWindows = require('./is-windows.js')
-module.exports = isWindows && /^MINGW(32|64)$/.test(process.env.MSYSTEM)
+var env = process.env
+module.exports = isWindows && (env.MSYSTEM ? /^MINGW(32|64)$/.test(env.MSYSTEM) : env.TERM === "cygwin")


### PR DESCRIPTION
- Redirect the `env` only for window cmd shell
- Add support `%ProgramFiles%\Git\usr\bin\bash.exe`  for `lib/utils/is-windows-bash.js`

https://github.com/npm/npm/issues/19419