### PR TITLE
inflate-shrinkwrap: Support replacing resolved with file: urls

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -14,6 +14,7 @@ const realizeShrinkwrapSpecifier = require('./realize-shrinkwrap-specifier.js')
 const validate = require('aproba')
 const path = require('path')
 const isRegistry = require('../utils/is-registry.js')
+const url = require('url')
 
 module.exports = function (tree, sw, opts, finishInflating) {
   if (!fetchPackageMetadata) {
@@ -144,11 +145,19 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
   return child
 }
 
+function isFile (href) {
+  try {
+    return url.parse(href).protocol === 'file:'
+  } catch (_) {
+    return false
+  }
+}
+
 function adaptResolved (requested, resolved) {
   const registry = requested.scope
   ? npm.config.get(`${requested.scope}:registry`) || npm.config.get('registry')
   : npm.config.get('registry')
-  if (!isRegistry(requested) || (resolved && resolved.indexOf(registry) === 0)) {
+  if (!isRegistry(requested) || (resolved && resolved.indexOf(registry) === 0) || isFile(resolved)) {
     // Nothing to worry about here. Pass it through.
     return resolved
   } else {


### PR DESCRIPTION
This will, finally, let shrinkpack work with npm@5