### PR TITLE
version doesn't commit when run in subdir

### DIFF
--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -20,7 +20,7 @@ valid second argument to [semver.inc](https://github.com/npm/node-semver#functio
 the existing version will be incremented by 1 in the specified field.
 `from-git` will try to read the latest git tag, and use that as the new npm version.
 
-If run in a git repo, it will also create a version commit and tag.
+If run in the root directory of a git working tree, it will also create a version commit and tag.
 This behavior is controlled by `git-tag-version` (see below), and can
 be disabled on the command line by running `npm --no-git-tag-version version`.
 It will fail if the working directory is not clean, unless the `-f` or


### PR DESCRIPTION
The version command doesn't currently detect that it should create a commit unless the current working directory is the root of a git working tree.  See #9099 and #9111.