### PR TITLE
deactivate progress bar when loglevel is set to silent

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -315,7 +315,7 @@
           log.disableUnicode()
         }
 
-        if (config.get('progress') && process.stderr.isTTY && process.env['TERM'] !== 'dumb') {
+        if (config.get('progress') && log.level !== 'silent' && process.stderr.isTTY && process.env['TERM'] !== 'dumb') {
           log.enableProgress()
         } else {
           log.disableProgress()


### PR DESCRIPTION
deactivate progress bar when loglevel is set to silent, due to this bug: https://github.com/npm/npm/issues/7990