### PR TITLE
Make outdated handle https URLs

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -331,6 +331,10 @@ function shouldUpdate (args, tree, dep, has, req, depth, pkgpath, cb, type) {
   if (parsed.type === 'git' || parsed.type === 'hosted') {
     return doIt('git', 'git')
   }
+  // If this is a http or https URL, don't consider it outdated.
+  if (parsed.type === 'remote') {
+    return doIt('remote', 'remote')
+  }
 
   // search for the latest package
   mapToRegistry(dep, npm.config, function (er, uri, auth) {


### PR DESCRIPTION
Fixes #17835

A dependency of type remote, i.e. a http or https URL, should not be considered outdated. This change will return `remote` for both _wanted_ and _latest_, similar to how git urls are handled, which will fix both `npm outdated` and `npm update`