### PR TITLE
Fixes #19505 Use a safer method of escaping characters in run-script to allow $

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -175,7 +175,7 @@ function run (pkg, wd, cmd, args, cb) {
 function joinArgs (args) {
   var joinedArgs = ''
   args.forEach(function (arg) {
-    joinedArgs += ' "' + arg.replace(/"/g, '\\"') + '"'
+    joinedArgs += ' \'' + arg.replace(/'/g, '\'\\\'\'') + '\''
   })
   return joinedArgs
 }

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -144,6 +144,10 @@ test('npm run-script with args that contain ticks', function (t) {
   common.npm(['run-script', 'start', '--', 'what\'s \'up\'?'], opts, testOutput.bind(null, t, 'what\'s \'up\'?'))
 })
 
+test('npm run-script with args that contain dollar signs', function (t) {
+  common.npm(['run-script', 'start', '--', 'what$ up$?'], opts, testOutput.bind(null, t, 'what$ up$?'))
+})
+
 test('npm run-script with pre script', function (t) {
   common.npm(['run-script', 'with-post'], opts, testOutput.bind(null, t, 'main;post'))
 })


### PR DESCRIPTION
as well as all existing chars. 