### PR TITLE
Better message when an "OTP" error occurs

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -180,7 +180,7 @@ function set (args) {
       newUser[prop] = value
       return profile.set(newUser, conf).catch((err) => {
         if (err.code !== 'EOTP') throw err
-        return readUserInfo.otp('Enter OTP:  ').then((otp) => {
+        return readUserInfo.otp().then((otp) => {
           conf.auth.otp = otp
           return profile.set(newUser, conf)
         })
@@ -247,7 +247,7 @@ function enable2fa (args) {
         return pulseTillDone.withPromise(profile.set({tfa: {password, mode: 'disable'}}, conf))
       } else {
         if (conf.auth.otp) return
-        return readUserInfo.otp('Enter OTP:  ').then((otp) => {
+        return readUserInfo.otp().then((otp) => {
           conf.auth.otp = otp
         })
       }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -192,7 +192,7 @@ function upload (arg, pkg, isRetry, cached) {
     if (err.code !== 'EOTP' && !(err.code === 'E401' && /one-time pass/.test(err.message))) throw err
     // we prompt on stdout and read answers from stdin, so they need to be ttys.
     if (!process.stdin.isTTY || !process.stdout.isTTY) throw err
-    return readUserInfo.otp('Enter OTP:  ').then((otp) => {
+    return readUserInfo.otp().then((otp) => {
       npm.config.set('otp', otp)
       return upload(arg, pkg, isRetry, cached)
     })

--- a/lib/utils/read-user-info.js
+++ b/lib/utils/read-user-info.js
@@ -19,7 +19,7 @@ function read (opts) {
 }
 
 function readOTP (msg, otp, isRetry) {
-  if (!msg) msg = 'Enter OTP: '
+  if (!msg) msg = 'There was an error while trying authentication due to OTP (One-Time-Password).\nThe One-Time-Password is generated via applications like Authy or Google Authenticator, see https://docs.npmjs.com/getting-started/using-two-factor-authentication for more informations\nEnter OTP:  '
   if (isRetry && otp && /^[\d ]+$|^[A-Fa-f0-9]{64,64}$/.test(otp)) return otp.replace(/\s+/g, '')
 
   return read({prompt: msg, default: otp || ''})


### PR DESCRIPTION
When using 2FA, there is a weird `Enter OTP: ` without further explaination.

This PR adds more logging and a small explaination on OTP