### PR TITLE
fix npx prefix issue

### DIFF
--- a/bin/npx
+++ b/bin/npx
@@ -12,18 +12,19 @@ if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE=node
 fi
 
+NPM_CLI_JS="$basedir/node_modules/npm/bin/npm-cli.js"
 NPX_CLI_JS="$basedir/node_modules/npm/bin/npx-cli.js"
 
 case `uname` in
   *MINGW*)
-    NPM_PREFIX=`"$NODE_EXE" "$NPX_CLI_JS" prefix -g`
+    NPM_PREFIX=`"$NODE_EXE" "$NPM_CLI_JS" prefix -g`
     NPM_PREFIX_NPX_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npx-cli.js"
     if [ -f "$NPM_PREFIX_NPX_CLI_JS" ]; then
       NPX_CLI_JS="$NPM_PREFIX_NPX_CLI_JS"
     fi
     ;;
   *CYGWIN*)
-    NPM_PREFIX=`"$NODE_EXE" "$NPX_CLI_JS" prefix -g`
+    NPM_PREFIX=`"$NODE_EXE" "$NPM_CLI_JS" prefix -g`
     NPM_PREFIX_NPX_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npx-cli.js"
     if [ -f "$NPM_PREFIX_NPX_CLI_JS" ]; then
       NPX_CLI_JS="$NPM_PREFIX_NPX_CLI_JS"

--- a/bin/npx.cmd
+++ b/bin/npx.cmd
@@ -8,8 +8,9 @@ IF NOT EXIST "%NODE_EXE%" (
   SET "NODE_EXE=node"
 )
 
+SET "NPM_CLI_JS=%~dp0\node_modules\npm\bin\npm-cli.js"
 SET "NPX_CLI_JS=%~dp0\node_modules\npm\bin\npx-cli.js"
-FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPX_CLI_JS%" prefix -g') DO (
+FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPM_CLI_JS%" prefix -g') DO (
   SET "NPM_PREFIX_NPX_CLI_JS=%%F\node_modules\npm\bin\npx-cli.js"
 )
 IF EXIST "%NPM_PREFIX_NPX_CLI_JS%" (


### PR DESCRIPTION
It was incorrectly calling `node npx-cli prefix` which led to downloading "prefix" package.

Instead it should be calling `node npm-cli prefix`

Fixes https://github.com/zkat/npx/issues/148 https://github.com/zkat/npx/issues/144