### PR TITLE
Check for package name before removing.

### DIFF
--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -58,7 +58,9 @@ function rmStuff (pkg, folder, cb) {
   // if it's global, and folder is in {prefix}/node_modules,
   // then bins are in {prefix}/bin
   // otherwise, then bins are in folder/../.bin
-  var parent = pkg.name[0] === '@' ? path.dirname(path.dirname(folder)) : path.dirname(folder)
+  var parent = pkg.name && pkg.name[0] === '@'
+    ? path.dirname(path.dirname(folder))
+    : path.dirname(folder)
   var gnm = npm.dir
   // gnm might be an absolute path, parent might be relative
   // this checks they're the same directory regardless


### PR DESCRIPTION
Hello friends, not trying to waste anyone's time here but I haven't actually read the "contributing" docs. 

I keep running into an error:
```
cannot read '0' of undefined
```

I've run into on npm 5.4.0 as well as 5.6.0.

This PR fixes the problem. Although... if you log out all the `pkg` contents, I'm not getting any package objects with `name`.


I'm sure there's an issue in here that's already open, if someone can just point me there for the discussion that would be much appreciated.