### PR TITLE
Fix cache location on Windows

### DIFF
--- a/doc/files/npm-folders.md
+++ b/doc/files/npm-folders.md
@@ -69,7 +69,7 @@ Man pages are not installed on Windows systems.
 ### Cache
 
 See `npm-cache(1)`.  Cache files are stored in `~/.npm` on Posix, or
-`~/npm-cache` on Windows.
+`%AppData%/npm-cache` on Windows.
 
 This is controlled by the `cache` configuration param.
 


### PR DESCRIPTION
Make consistent with `cache` cli command documentation