### PR TITLE
Right single quotation mark broke function checkForBrokenNode on file unsupported.js

### DIFF
--- a/lib/utils/unsupported.js
+++ b/lib/utils/unsupported.js
@@ -25,7 +25,7 @@ exports.checkForBrokenNode = function () {
     supportedNode.forEach(function (rel) {
       if (semver.satisfies(nodejs.version, rel.ver)) {
         console.error('Node.js ' + rel.ver + " is supported but the specific version you're running has")
-        console.error(`a bug known to break npm. Please update to at least ${rel.min} to use this`)
+        console.error('a bug known to break npm. Please update to at least ${rel.min} to use this')
         console.error('version of npm. You can find the latest release of Node.js at https://nodejs.org/')
         process.exit(1)
       }


### PR DESCRIPTION
In my environment I get this error trying to install npm with this tutorial: https://docs.npmjs.com/troubleshooting/if-your-npm-is-broken
https://ibb.co/gNkJ6w
The code has a right single quotation mark on line 28 that causes the error.