### PR TITLE
Fix #18781 - name and version optional

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -11,11 +11,11 @@ settings described in `npm-config(7)`.
 
 ## name
 
-The *most* important things in your package.json are the name and version fields.
-Those are actually required, and your package won't install without
-them.  The name and version together form an identifier that is assumed
-to be completely unique.  Changes to the package should come along with
-changes to the version.
+If you plan to publish your package, the *most* important things in your 
+package.json are the name and version fields as they will be required. The name 
+and version together form an identifier that is assumed to be completely unique. 
+Changes to the package should come along with changes to the version. If you don't 
+plan to publish your package, the name and version fields are optional.
 
 The name is what your thing is called.
 
@@ -44,11 +44,11 @@ A name can be optionally prefixed by a scope, e.g. `@myorg/mypackage`. See
 
 ## version
 
-The *most* important things in your package.json are the name and version fields.
-Those are actually required, and your package won't install without
-them.  The name and version together form an identifier that is assumed
-to be completely unique.  Changes to the package should come along with
-changes to the version.
+If you plan to publish your package, the *most* important things in your 
+package.json are the name and version fields as they will be required. The name 
+and version together form an identifier that is assumed to be completely unique. 
+Changes to the package should come along with changes to the version. If you don't 
+plan to publish your package, the name and version fields are optional.
 
 Version must be parseable by
 [node-semver](https://github.com/isaacs/node-semver), which is bundled


### PR DESCRIPTION
This PR fixes #18781 by explaining that `name` and `version` are required only to publish your package.