### PR TITLE
install: count contributors and mention npx thanks

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -774,6 +774,9 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
   var added = 0
   var updated = 0
   var moved = 0
+  // Count the number of contributors to packages added, tracking
+  // contributors we've seen, so we can produce a running unique count.
+  var contributorsSet = []
   diffs.forEach(function (action) {
     var mutation = action[0]
     var pkg = action[1]
@@ -784,6 +787,28 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
       ++moved
     } else if (mutation === 'add') {
       ++added
+      // Count contributors to added packages. Start by combining `author`
+      // and `contributors` data into a single array of contributor-people
+      // for this package.
+      var people = []
+      var meta = pkg.package
+      if (meta.author) people.push(meta.author)
+      if (meta.contributors && Array.isArray(meta.contributors)) {
+        people = people.concat(meta.contributors)
+      }
+      // Make sure a normalized string for every person behind this
+      // package is in `contributorsSet`.
+      people.forEach(function (person) {
+        // Ignore errors from malformed `author` and `contributors`.
+        try {
+          var normalized = normalizePerson(person)
+        } catch (error) {
+          return
+        }
+        if (contributorsSet.indexOf(normalized) === -1) {
+          contributorsSet.push(normalized)
+        }
+      })
     } else if (mutation === 'update' || mutation === 'update-linked') {
       ++updated
     }
@@ -795,7 +820,11 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
     }).join('\n') + '\n'
   }
   var actions = []
-  if (added) actions.push('added ' + packages(added))
+  if (added) {
+    var action = 'added ' + packages(added)
+    if (contributorsSet.length) action += from(contributorsSet.length)
+    actions.push(action)
+  }
   if (removed) actions.push('removed ' + packages(removed))
   if (updated) actions.push('updated ' + packages(updated))
   if (moved) actions.push('moved ' + packages(moved))
@@ -808,12 +837,34 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
     report += actions.join(', ') + ' and ' + lastAction
   }
   report += ' in ' + ((Date.now() - this.started) / 1000) + 's'
+  // If we're listing an added-packages-contributors count,
+  // add a note about `npx thanks`.
+  if (contributorsSet.length) {
+    report += '\nRun `npx thanks` for info on how to support contributors.'
+  }
 
   output(report)
   return cb()
 
   function packages (num) {
     return num + ' package' + (num > 1 ? 's' : '')
+  }
+
+  function from (num) {
+    return ' from ' + num + ' contributor' + (num > 1 ? 's' : '')
+  }
+
+  // Values of `author` and elements of `contributors` in `package.json`
+  // files can be e-mail style strings or Objects with `name`, `email,
+  // and `url` String properties.  Convert Objects to Strings so that
+  // we can efficiently keep a set of contributors we have already seen.
+  function normalizePerson (argument) {
+    if (typeof argument === 'string') return argument
+    var returned = ''
+    if (argument.name) returned += argument.name
+    if (argument.email) returned += ' <' + argument.email + '>'
+    if (argument.url) returned += ' (' + argument.email + ')'
+    return returned
   }
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -776,7 +776,7 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
   var moved = 0
   // Count the number of contributors to packages added, tracking
   // contributors we've seen, so we can produce a running unique count.
-  var contributorsSet = []
+  var contributors = new Set()
   diffs.forEach(function (action) {
     var mutation = action[0]
     var pkg = action[1]
@@ -797,7 +797,7 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
         people = people.concat(meta.contributors)
       }
       // Make sure a normalized string for every person behind this
-      // package is in `contributorsSet`.
+      // package is in `contributors`.
       people.forEach(function (person) {
         // Ignore errors from malformed `author` and `contributors`.
         try {
@@ -805,9 +805,7 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
         } catch (error) {
           return
         }
-        if (contributorsSet.indexOf(normalized) === -1) {
-          contributorsSet.push(normalized)
-        }
+        if (!contributors.has(normalized)) contributors.add(normalized)
       })
     } else if (mutation === 'update' || mutation === 'update-linked') {
       ++updated
@@ -822,7 +820,7 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
   var actions = []
   if (added) {
     var action = 'added ' + packages(added)
-    if (contributorsSet.length) action += from(contributorsSet.length)
+    if (contributors.size) action += from(contributors.size)
     actions.push(action)
   }
   if (removed) actions.push('removed ' + packages(removed))
@@ -839,7 +837,7 @@ Installer.prototype.printInstalledForHuman = function (diffs, cb) {
   report += ' in ' + ((Date.now() - this.started) / 1000) + 's'
   // If we're listing an added-packages-contributors count,
   // add a note about `npx thanks`.
-  if (contributorsSet.length) {
+  if (contributors.size) {
     report += '\nRun `npx thanks` for info on how to support contributors.'
   }
 

--- a/test/tap/install-contributors-count.js
+++ b/test/tap/install-contributors-count.js
@@ -1,0 +1,71 @@
+'use strict'
+var path = require('path')
+var test = require('tap').test
+var Tacks = require('tacks')
+var Dir = Tacks.Dir
+var File = Tacks.File
+var common = require('../common-tap.js')
+
+var testdir = path.resolve(__dirname, path.basename(__filename, '.js'))
+var fixture = new Tacks(Dir({
+  node_modules: Dir({
+    a: Dir({
+      'package.json': File({
+        name: 'a',
+        version: '1.0.0',
+        dependencies: {
+          b: '1.0.0'
+        }
+      }),
+      node_modules: Dir({
+        b: Dir({
+          'package.json': File({
+            name: 'b',
+            version: '1.0.0'
+          })
+        })
+      })
+    })
+  }),
+  'b-src': Dir({
+    'package.json': File({
+      name: 'b',
+      author: 'Author Contributor',
+      contributors: [
+        {name: 'Author Contributor'},
+        'Another Contributor'
+      ],
+      version: '1.0.0'
+    })
+  })
+}))
+
+function setup () {
+  cleanup()
+  fixture.create(testdir)
+}
+
+function cleanup () {
+  fixture.remove(testdir)
+}
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+test('install', function (t) {
+  common.npm(['install', '--no-save', './b-src'], {cwd: testdir}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'installed successfully')
+    t.is(stderr, '', 'no warnings')
+    t.includes(stdout, 'added 1 package from 2 contributors', 'lists number of unique contributors')
+    t.includes(stdout, '`npx thanks`', 'mentions npx thanks')
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})


### PR DESCRIPTION
This small pull request affects console reporting on `npm install` and friends.

In addition to reporting the number of packages added, the script now also reports the number of unique contributors to those added packages, based on `author` and `contributors` data. When the script reports a contributors count, it also prints a message encouraging users to run @feross' `npx thanks` for more information on how to support contributors to the code they use.

I've also added a TAP test, based on the test for `npm install --report`.