### PR TITLE
Fix optional dependencies with npm outdated

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -247,10 +247,10 @@ function outdated_ (args, path, tree, parentHas, depth, cb) {
     deps.forEach(function (dep) {
       types[moduleName(dep)] = 'devDependencies'
     })
-  } else if (npm.config.get('save')) {
+  } else if (npm.config.get('save') && !npm.config.get('save-optional')) {
     // remove optional dependencies from dependencies during --save.
     deps = deps.filter(function (dep) { return !pkg.optionalDependencies[moduleName(dep)] })
-  } else if (npm.config.get('save-optional')) {
+  } else if (!npm.config.get('save') && npm.config.get('save-optional')) {
     deps = deps.filter(function (dep) { return pkg.optionalDependencies[moduleName(dep)] })
     deps.forEach(function (dep) {
       types[moduleName(dep)] = 'optionalDependencies'

--- a/test/tap/outdated-only-optional-dependencies.js
+++ b/test/tap/outdated-only-optional-dependencies.js
@@ -1,0 +1,85 @@
+var fs = require('graceful-fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var npm = require('../../')
+var common = require('../common-tap')
+
+var pkg = path.resolve(__dirname, 'outdated-only-optional-dependencies')
+
+var json = {
+  name: 'outdated-only-optional-dependencies',
+  version: '1.2.3',
+  dependencies: {
+    async: '0.2.9',
+    'npm-test-peer-deps': '0.0.0'
+  },
+  optionalDependencies: {
+    underscore: '1.3.1'
+  }
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
+
+  t.end()
+})
+
+test('with --save-optional', function (t) {
+  var expected = [
+    [
+      pkg,
+      'underscore',
+      '1.3.1',
+      '1.3.1',
+      '1.5.1',
+      '1.3.1',
+      null
+    ]
+  ]
+
+  mr({ port: common.port }, function (er, s) {
+    npm.load(
+      {
+        loglevel: 'silent',
+        registry: common.registry,
+        'save-optional': true,
+        'save': false
+      },
+      function () {
+        npm.install('.', function (er) {
+          if (er) throw new Error(er)
+          npm.outdated(function (err, d) {
+            t.ifError(err, 'npm outdated ran without error')
+            t.is(process.exitCode, 1, 'exit code set to 1')
+            process.exitCode = 0
+            t.deepEqual(d, expected)
+            s.close()
+            t.end()
+          })
+        })
+      }
+    )
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}

--- a/test/tap/outdated-optional-dependencies.js
+++ b/test/tap/outdated-optional-dependencies.js
@@ -1,0 +1,93 @@
+var fs = require('graceful-fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var mr = require('npm-registry-mock')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var npm = require('../../')
+var common = require('../common-tap')
+
+var pkg = path.resolve(__dirname, 'outdated-optional-dependencies')
+
+var json = {
+  name: 'outdated-optional-dependencies',
+  version: '1.2.3',
+  dependencies: {
+    async: '0.2.9',
+    'npm-test-peer-deps': '0.0.0'
+  },
+  optionalDependencies: {
+    underscore: '1.3.1'
+  }
+}
+
+test('setup', function (t) {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
+
+  t.end()
+})
+
+test('with --save-optional', function (t) {
+  var expected = [
+    [
+      pkg,
+      'async',
+      '0.2.9',
+      '0.2.9',
+      '0.2.10',
+      '0.2.9',
+      null
+    ],
+    [
+      pkg,
+      'underscore',
+      '1.3.1',
+      '1.3.1',
+      '1.5.1',
+      '1.3.1',
+      null
+    ]
+  ]
+
+  mr({ port: common.port }, function (er, s) {
+    npm.load(
+      {
+        loglevel: 'silent',
+        registry: common.registry,
+        'save-optional': true
+      },
+      function () {
+        npm.install('.', function (er) {
+          if (er) throw new Error(er)
+          npm.outdated(function (err, d) {
+            t.ifError(err, 'npm outdated ran without error')
+            t.is(process.exitCode, 1, 'exit code set to 1')
+            process.exitCode = 0
+            t.deepEqual(d, expected)
+            s.close()
+            t.end()
+          })
+        })
+      }
+    )
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}

--- a/test/tap/outdated.js
+++ b/test/tap/outdated.js
@@ -22,6 +22,9 @@ var json = {
     underscore: '1.3.1',
     async: '0.2.9',
     checker: '0.5.1'
+  },
+  optionalDependencies: {
+    request: '~0.9.0'
   }
 }
 


### PR DESCRIPTION
Previously the only way to check for updates on optional packages was by running:

`npm outdated --save false --save-optional`

This is cumbersome, but also means you have to do two specific operations to update your normal  and optional dependencies. (e.g. One operation to check `dependencies` and one to check `optionalDependencies`)

This allows some cross over between the commands so you can update everything in one shot.

`npm outdated --save-optional` will now list all packages from both `dependencies` and `optionalDependencies`

The original behaviour is still in place when you run the `npm outdated --save false --save-optional` command.