### PR TITLE
update to latest version of pacote (Security Bug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "once": "~1.4.0",
     "opener": "~1.4.3",
     "osenv": "~0.1.4",
-    "pacote": "^7.0.2",
+    "pacote": "^7.4.0",
     "path-is-inside": "~1.0.2",
     "promise-inflight": "~1.0.1",
     "qrcode-terminal": "~0.11.0",


### PR DESCRIPTION
✗ Medium severity vulnerability found on ssri@5.0.0
- desc: Regular Expression Denial of Service (ReDoS)
- info: https://snyk.io/vuln/npm:ssri:20180214
- from: node_services@1.0.0 > npm@5.6.0 > pacote@7.0.2 > ssri@5.0.0
Your dependencies are out of date, otherwise you would be using a newer ssri than ssri@5.0.0.
Try deleting node_modules, reinstalling and running `snyk test` again.
If the problem persists, one of your dependencies may be bundling outdated modules.