### PR TITLE
docs: Fix default value for save

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -730,7 +730,7 @@ Remove failed installs.
 
 ### save
 
-* Default: false
+* Default: true
 * Type: Boolean
 
 Save installed packages to a package.json file as dependencies.


### PR DESCRIPTION
https://docs.npmjs.com/misc/config#save mentions that the default config value is `false`, however, in actuality, it is `true`, which can be verified from the code [here](https://github.com/npm/npm/blob/0cc9d89ed2d46745f91d746fda9d205fd39d3daa/lib/config/defaults.js#L204).

I haven't read/contributed to npm before, so let me know if there's something wrong with it. I was just very confused by this information in the docs, so made a PR!