### PR TITLE
doc: Fix default value for config save option

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -835,7 +835,7 @@ Remove failed installs.
 
 ### save
 
-* Default: false
+* Default: true
 * Type: Boolean
 
 Save installed packages to a package.json file as dependencies.


### PR DESCRIPTION
https://docs.npmjs.com/misc/config#save mentions that the default config value is `false`, however, in actuality, it is `true`, which can be verified from the code [here](https://github.com/npm/npm/blob/0cc9d89ed2d46745f91d746fda9d205fd39d3daa/lib/config/defaults.js#L204).

I haven't contributed to npm before, so let me know if there's something wrong with it. I was just very confused by this information in the docs, so made a PR!

EDIT: Seems Travis fails for unrelated reasons. Let me know if something is wrong with my change.