### PR TITLE
Fix package-json typo in npm-config.md

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -742,7 +742,7 @@ This option is an alias for `--shrinkwrap`.
 * Default: false
 * Type: Boolean
 
-If set to true, it will update only the `package-json`,
+If set to true, it will update only the `package-lock.json`,
 instead of checking `node_modules` and downloading dependencies.
 
 ### parseable


### PR DESCRIPTION
Fix `package-json` typo in `package-lock-only` doc