### PR TITLE
Add a common open reason to the issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -3,6 +3,7 @@
   - [ ] npm is crashing.
   - [ ] npm is producing an incorrect install.
   - [ ] npm is doing something I don't understand.
+  - [ ] npm is producing incorrect or undesirable behavior.
   - [ ] Other (_see below for feature requests_):
 
 #### What's going wrong?


### PR DESCRIPTION
`npm is doing something I don't understand.` is often inappropriately used when the author means `npm is producing incorrect or undesirable behavior.`. I only had to look thru the first page of open issues to find 5 examples of this.