### PR TITLE
Add emacs and vim backup files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+\#*\#
+*~
 *.swp
 npm-debug.log
 .nyc_output/


### PR DESCRIPTION
Vim and Emacs leave backup files in the file directory which we don't want commited