### PR TITLE
fix: use detect-newline to detect newline instead of default \n

### DIFF
--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -124,7 +124,7 @@ function savePackageJson (tree, next) {
       tree.package.bundleDependencies = deepSortObject(bundle)
     }
 
-    var json = JSON.stringify(tree.package, null, indent) + newline
+    var json = JSON.stringify(tree.package, null, indent).replace(/\n/g, newline) + newline
     if (json === packagejson) {
       log.verbose('shrinkwrap', 'skipping write for package.json because there were no changes.')
       next()

--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -3,6 +3,7 @@
 const createShrinkwrap = require('../shrinkwrap.js').createShrinkwrap
 const deepSortObject = require('../utils/deep-sort-object.js')
 const detectIndent = require('detect-indent')
+const detectNewline = require('detect-newline')
 const fs = require('graceful-fs')
 const iferr = require('iferr')
 const log = require('npmlog')
@@ -61,6 +62,7 @@ function savePackageJson (tree, next) {
   // tricky npm-specific stuff that's in there.
   fs.readFile(saveTarget, 'utf8', iferr(next, function (packagejson) {
     const indent = detectIndent(packagejson).indent || '  '
+    const newline = detectNewline(packagejson) || '\n'
     try {
       tree.package = parseJSON(packagejson)
     } catch (ex) {
@@ -122,7 +124,7 @@ function savePackageJson (tree, next) {
       tree.package.bundleDependencies = deepSortObject(bundle)
     }
 
-    var json = JSON.stringify(tree.package, null, indent) + '\n'
+    var json = JSON.stringify(tree.package, null, indent) + newline
     if (json === packagejson) {
       log.verbose('shrinkwrap', 'skipping write for package.json because there were no changes.')
       next()

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -4,6 +4,7 @@ const BB = require('bluebird')
 
 const chain = require('slide').chain
 const detectIndent = require('detect-indent')
+const detectNewline = require('detect-newline')
 const readFile = BB.promisify(require('graceful-fs').readFile)
 const getRequested = require('./install/get-requested.js')
 const id = require('./install/deps.js')
@@ -179,11 +180,12 @@ function save (dir, pkginfo, opts, cb) {
         {
           path: path.resolve(dir, opts.defaultFile || PKGLOCK),
           data: '{}',
-          indent: (pkg && pkg.indent) || 2
+          indent: (pkg && pkg.indent) || 2,
+          newline: (pkg && pkg.newline) || '\n'
         }
       )
       const updated = updateLockfileMetadata(pkginfo, pkg && JSON.parse(pkg.raw))
-      const swdata = JSON.stringify(updated, null, info.indent) + '\n'
+      const swdata = JSON.stringify(updated, null, info.indent).replace(/\n/g, info.newline) + info.newline
       if (swdata === info.raw) {
         // skip writing if file is identical
         log.verbose('shrinkwrap', `skipping write for ${path.basename(info.path)} because there were no changes.`)
@@ -244,7 +246,8 @@ function checkPackageFile (dir, name) {
     return {
       path: file,
       raw: data,
-      indent: detectIndent(data).indent || 2
+      indent: detectIndent(data).indent || 2,
+      newline: detectNewline(data) || '\n'
     }
   }).catch({code: 'ENOENT'}, () => {})
 }

--- a/lib/version.js
+++ b/lib/version.js
@@ -4,6 +4,7 @@ const BB = require('bluebird')
 const assert = require('assert')
 const chain = require('slide').chain
 const detectIndent = require('detect-indent')
+const detectNewline = require('detect-newline')
 const fs = require('graceful-fs')
 const readFile = BB.promisify(require('graceful-fs').readFile)
 const git = require('./utils/git.js')
@@ -33,7 +34,7 @@ function version (args, silent, cb_) {
   }
   if (args.length > 1) return cb_(version.usage)
 
-  readPackage(function (er, data, indent) {
+  readPackage(function (er, data, indent, newline) {
     if (!args.length) return dump(data, cb_)
 
     if (er) {
@@ -115,14 +116,16 @@ function readPackage (cb) {
   fs.readFile(packagePath, 'utf8', function (er, data) {
     if (er) return cb(new Error(er))
     var indent
+    var newline
     try {
       indent = detectIndent(data).indent || '  '
+      newline = detectNewline(data) || '\n'
       data = JSON.parse(data)
     } catch (e) {
       er = e
       data = null
     }
-    cb(er, data, indent)
+    cb(er, data, indent, newline)
   })
 }
 
@@ -132,10 +135,10 @@ function updatePackage (newVersion, silent, cb_) {
     cb_(er)
   }
 
-  readPackage(function (er, data, indent) {
+  readPackage(function (er, data, indent, newline) {
     if (er) return cb(new Error(er))
     data.version = newVersion
-    write(data, 'package.json', indent, cb)
+    write(data, 'package.json', indent, newline, cb)
   })
 }
 
@@ -168,15 +171,17 @@ function updateShrinkwrap (newVersion, cb) {
       const file = shrinkwrap ? SHRINKWRAP : PKGLOCK
       let data
       let indent
+      let newline
       try {
         data = parseJSON(shrinkwrap || lockfile)
         indent = detectIndent(shrinkwrap || lockfile).indent || '  '
+        newline = detectNewline(shrinkwrap || lockfile) || '\n'
       } catch (err) {
         log.error('version', `Bad ${file} data.`)
         return cb(err)
       }
       data.version = newVersion
-      write(data, file, indent, (err) => {
+      write(data, file, indent, newline, (err) => {
         if (err) {
           log.error('version', `Failed to update version in ${file}`)
           return cb(err)
@@ -321,14 +326,14 @@ function addLocalFile (file, options, ignoreFailure) {
   : p
 }
 
-function write (data, file, indent, cb) {
+function write (data, file, indent, newline, cb) {
   assert(data && typeof data === 'object', 'must pass data to version write')
   assert(typeof file === 'string', 'must pass filename to write to version write')
 
   log.verbose('version.write', 'data', data, 'to', file)
   writeFileAtomic(
     path.join(npm.localPrefix, file),
-    new Buffer(JSON.stringify(data, null, indent || 2) + '\n'),
+    new Buffer(JSON.stringify(data, null, indent || 2).replace(/\n/g, newline) + newline),
     cb
   )
 }

--- a/node_modules/detect-newline/index.js
+++ b/node_modules/detect-newline/index.js
@@ -1,0 +1,24 @@
+'use strict';
+module.exports = function (str) {
+	if (typeof str !== 'string') {
+		throw new TypeError('Expected a string');
+	}
+
+	var newlines = (str.match(/(?:\r?\n)/g) || []);
+
+	if (newlines.length === 0) {
+		return null;
+	}
+
+	var crlf = newlines.filter(function (el) {
+		return el === '\r\n';
+	}).length;
+
+	var lf = newlines.length - crlf;
+
+	return crlf > lf ? '\r\n' : '\n';
+};
+
+module.exports.graceful = function (str) {
+	return module.exports(str) || '\n';
+};

--- a/node_modules/detect-newline/license
+++ b/node_modules/detect-newline/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/node_modules/detect-newline/package.json
+++ b/node_modules/detect-newline/package.json
@@ -1,0 +1,70 @@
+{
+  "_from": "detect-newline",
+  "_id": "detect-newline@2.1.0",
+  "_inBundle": false,
+  "_integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+  "_location": "/detect-newline",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "detect-newline",
+    "name": "detect-newline",
+    "escapedName": "detect-newline",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+  "_shasum": "f41f1c10be4b00e87b5f13da680759f2c5bfd3e2",
+  "_spec": "detect-newline",
+  "_where": "/Users/anh/code/npm",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/detect-newline/issues"
+  },
+  "bundleDependencies": false,
+  "deprecated": false,
+  "description": "Detect the dominant newline character of a string",
+  "devDependencies": {
+    "ava": "*",
+    "xo": "*"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "files": [
+    "index.js"
+  ],
+  "homepage": "https://github.com/sindresorhus/detect-newline#readme",
+  "keywords": [
+    "newline",
+    "linebreak",
+    "line-break",
+    "line",
+    "lf",
+    "crlf",
+    "eol",
+    "linefeed",
+    "character",
+    "char"
+  ],
+  "license": "MIT",
+  "name": "detect-newline",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/detect-newline.git"
+  },
+  "scripts": {
+    "test": "xo && ava"
+  },
+  "version": "2.1.0"
+}

--- a/node_modules/detect-newline/readme.md
+++ b/node_modules/detect-newline/readme.md
@@ -1,0 +1,42 @@
+# detect-newline [![Build Status](https://travis-ci.org/sindresorhus/detect-newline.svg?branch=master)](https://travis-ci.org/sindresorhus/detect-newline)
+
+> Detect the dominant newline character of a string
+
+
+## Install
+
+```
+$ npm install --save detect-newline
+```
+
+
+## Usage
+
+```js
+const detectNewline = require('detect-newline');
+
+detectNewline('foo\nbar\nbaz\r\n');
+//=> '\n'
+```
+
+
+## API
+
+### detectNewline(input)
+
+Returns detected newline or `null` when no newline character is found.
+
+### detectNewline.graceful(input)
+
+Returns detected newline or `\n` when no newline character is found.
+
+
+## Related
+
+- [detect-newline-cli](https://github.com/sindresorhus/detect-newline-cli) - CLI for this module
+- [detect-indent](https://github.com/sindresorhus/detect-indent) - Detect the indentation of code
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/package-lock.json
+++ b/package-lock.json
@@ -272,6 +272,11 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
       "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
     },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+    },
     "dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "columnify": "~1.5.4",
     "config-chain": "~1.1.11",
     "detect-indent": "~5.0.0",
+    "detect-newline": "^2.1.0",
     "dezalgo": "~1.0.3",
     "editor": "~1.0.0",
     "find-npm-prefix": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "config-chain",
     "debuglog",
     "detect-indent",
+    "detect-newline",
     "dezalgo",
     "editor",
     "find-npm-prefix",


### PR DESCRIPTION
use `detect-newline` to detect newline instead of using the default `\n` which may cause npm to find that `packagejson` string to be different even though there is no change. (causing by the `\n` newline)