### PR TITLE
Match node's resolution when validating peer dependencies

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -683,8 +683,10 @@ var validatePeerDeps = exports.validatePeerDeps = function (tree, onInvalid) {
     try {
       var spec = npa.resolve(pkgname, version)
     } catch (e) {}
-    var match = spec && findRequirement(tree.parent || tree, pkgname, spec)
-    if (!match) onInvalid(tree, pkgname, version)
+    tree.requiredBy.forEach(function (requiredBy) {
+      var match = spec && findRequirement(requiredBy, pkgname, spec)
+      if (!match) onInvalid(tree, pkgname, version)
+    })
   })
 }
 


### PR DESCRIPTION
Fixes #15708

I've created an organization to reproduce the problem: `peer-deps-repro`

To reproduce:
``` bash
git clone git@github.com:peer-deps-repro/main.git
git checkout v1.2.0
npm install
```

There should be no warnings when you install.

The problem is that the validator was not using the same module resolution strategy as node and matching the wrong version. We need to go up the tree and use the nearest peer dependency.

