### PR TITLE
Consolidate code for stringifying package data and add tests

### DIFF
--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -11,6 +11,7 @@ const moduleName = require('../utils/module-name.js')
 const npm = require('../npm.js')
 const parseJSON = require('../utils/parse-json.js')
 const path = require('path')
+const stringifyPackage = require('../utils/stringify-package')
 const validate = require('aproba')
 const without = require('lodash.without')
 const writeFileAtomic = require('write-file-atomic')
@@ -61,8 +62,8 @@ function savePackageJson (tree, next) {
   // don't use readJson, because we don't want to do all the other
   // tricky npm-specific stuff that's in there.
   fs.readFile(saveTarget, 'utf8', iferr(next, function (packagejson) {
-    const indent = detectIndent(packagejson).indent || '  '
-    const newline = detectNewline(packagejson) || '\n'
+    const indent = detectIndent(packagejson).indent
+    const newline = detectNewline(packagejson)
     try {
       tree.package = parseJSON(packagejson)
     } catch (ex) {
@@ -124,7 +125,7 @@ function savePackageJson (tree, next) {
       tree.package.bundleDependencies = deepSortObject(bundle)
     }
 
-    var json = JSON.stringify(tree.package, null, indent).replace(/\n/g, newline) + newline
+    var json = stringifyPackage(tree.package, indent, newline)
     if (json === packagejson) {
       log.verbose('shrinkwrap', 'skipping write for package.json because there were no changes.')
       next()

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -19,6 +19,7 @@ const npm = require('./npm.js')
 const path = require('path')
 const readPackageTree = BB.promisify(require('read-package-tree'))
 const ssri = require('ssri')
+const stringifyPackage = require('./utils/stringify-package')
 const validate = require('aproba')
 const writeFileAtomic = require('write-file-atomic')
 const unixFormatPath = require('./utils/unix-format-path.js')
@@ -180,12 +181,12 @@ function save (dir, pkginfo, opts, cb) {
         {
           path: path.resolve(dir, opts.defaultFile || PKGLOCK),
           data: '{}',
-          indent: (pkg && pkg.indent) || 2,
-          newline: (pkg && pkg.newline) || '\n'
+          indent: pkg && pkg.indent,
+          newline: pkg && pkg.newline
         }
       )
       const updated = updateLockfileMetadata(pkginfo, pkg && JSON.parse(pkg.raw))
-      const swdata = JSON.stringify(updated, null, info.indent).replace(/\n/g, info.newline) + info.newline
+      const swdata = stringifyPackage(updated, info.indent, info.newline)
       if (swdata === info.raw) {
         // skip writing if file is identical
         log.verbose('shrinkwrap', `skipping write for ${path.basename(info.path)} because there were no changes.`)
@@ -246,8 +247,8 @@ function checkPackageFile (dir, name) {
     return {
       path: file,
       raw: data,
-      indent: detectIndent(data).indent || 2,
-      newline: detectNewline(data) || '\n'
+      indent: detectIndent(data).indent,
+      newline: detectNewline(data)
     }
   }).catch({code: 'ENOENT'}, () => {})
 }

--- a/lib/utils/stringify-package.js
+++ b/lib/utils/stringify-package.js
@@ -1,0 +1,17 @@
+'use strict'
+
+module.exports = stringifyPackage
+
+const DEFAULT_INDENT = 2
+const CRLF = '\r\n'
+const LF = '\n'
+
+function stringifyPackage (data, indent, newline) {
+  const json = JSON.stringify(data, null, indent || DEFAULT_INDENT)
+
+  if (newline === CRLF) {
+    return json.replace(/\n/g, CRLF) + CRLF
+  }
+
+  return json + LF
+}

--- a/lib/version.js
+++ b/lib/version.js
@@ -15,6 +15,7 @@ const output = require('./utils/output.js')
 const parseJSON = require('./utils/parse-json.js')
 const path = require('path')
 const semver = require('semver')
+const stringifyPackage = require('./utils/stringify-package')
 const writeFileAtomic = require('write-file-atomic')
 
 version.usage = 'npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]' +
@@ -118,8 +119,8 @@ function readPackage (cb) {
     var indent
     var newline
     try {
-      indent = detectIndent(data).indent || '  '
-      newline = detectNewline(data) || '\n'
+      indent = detectIndent(data).indent
+      newline = detectNewline(data)
       data = JSON.parse(data)
     } catch (e) {
       er = e
@@ -174,8 +175,8 @@ function updateShrinkwrap (newVersion, cb) {
       let newline
       try {
         data = parseJSON(shrinkwrap || lockfile)
-        indent = detectIndent(shrinkwrap || lockfile).indent || '  '
-        newline = detectNewline(shrinkwrap || lockfile) || '\n'
+        indent = detectIndent(shrinkwrap || lockfile).indent
+        newline = detectNewline(shrinkwrap || lockfile)
       } catch (err) {
         log.error('version', `Bad ${file} data.`)
         return cb(err)
@@ -333,7 +334,7 @@ function write (data, file, indent, newline, cb) {
   log.verbose('version.write', 'data', data, 'to', file)
   writeFileAtomic(
     path.join(npm.localPrefix, file),
-    new Buffer(JSON.stringify(data, null, indent || 2).replace(/\n/g, newline) + newline),
+    new Buffer(stringifyPackage(data, indent, newline)),
     cb
   )
 }

--- a/test/tap/install-save-consistent-newlines.js
+++ b/test/tap/install-save-consistent-newlines.js
@@ -1,0 +1,122 @@
+'use strict'
+
+const fs = require('graceful-fs')
+const path = require('path')
+
+const mkdirp = require('mkdirp')
+const mr = require('npm-registry-mock')
+const osenv = require('osenv')
+const rimraf = require('rimraf')
+const test = require('tap').test
+
+const common = require('../common-tap.js')
+
+const pkg = path.join(__dirname, 'install-save-consistent-newlines')
+
+const EXEC_OPTS = { cwd: pkg }
+
+const json = {
+  name: 'install-save-consistent-newlines',
+  version: '0.0.1',
+  description: 'fixture'
+}
+
+var server
+
+test('setup', function (t) {
+  setup('\n')
+  mr({ port: common.port }, function (er, s) {
+    server = s
+    t.end()
+  })
+})
+
+test('\'npm install --save\' should keep the original package.json line endings (LF)', function (t) {
+  common.npm(
+    [
+      '--loglevel', 'silent',
+      '--registry', common.registry,
+      '--save',
+      'install', 'underscore@1.3.1'
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'npm ran without issue')
+      t.notOk(code, 'npm install exited without raising an error code')
+
+      const pkgPath = path.resolve(pkg, 'package.json')
+      const pkgStr = fs.readFileSync(pkgPath, 'utf8')
+
+      t.match(pkgStr, '\n')
+      t.notMatch(pkgStr, '\r')
+
+      const pkgLockPath = path.resolve(pkg, 'package-lock.json')
+      const pkgLockStr = fs.readFileSync(pkgLockPath, 'utf8')
+
+      t.match(pkgLockStr, '\n')
+      t.notMatch(pkgLockStr, '\r')
+
+      t.end()
+    }
+  )
+})
+
+test('\'npm install --save\' should keep the original package.json line endings (CRLF)', function (t) {
+  setup('\r\n')
+
+  common.npm(
+    [
+      '--loglevel', 'silent',
+      '--registry', common.registry,
+      '--save',
+      'install', 'underscore@1.3.1'
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'npm ran without issue')
+      t.notOk(code, 'npm install exited without raising an error code')
+
+      const pkgPath = path.resolve(pkg, 'package.json')
+      const pkgStr = fs.readFileSync(pkgPath, 'utf8')
+
+      t.match(pkgStr, '\r\n')
+      t.notMatch(pkgStr, /[^\r]\n/)
+
+      const pkgLockPath = path.resolve(pkg, 'package-lock.json')
+      const pkgLockStr = fs.readFileSync(pkgLockPath, 'utf8')
+
+      t.match(pkgLockStr, '\r\n')
+      t.notMatch(pkgLockStr, /[^\r]\n/)
+
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  server.close()
+  cleanup()
+  t.end()
+})
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}
+
+function setup (lineEnding) {
+  cleanup()
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+
+  var jsonStr = JSON.stringify(json, null, 2)
+
+  if (lineEnding === '\r\n') {
+    jsonStr = jsonStr.replace(/\n/g, '\r\n')
+  }
+
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    jsonStr
+  )
+  process.chdir(pkg)
+}

--- a/test/tap/version-consistent-newlines.js
+++ b/test/tap/version-consistent-newlines.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const common = require('../common-tap.js')
+const test = require('tap').test
+const npm = require('../../')
+const osenv = require('osenv')
+const path = require('path')
+const fs = require('fs')
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+const requireInject = require('require-inject')
+
+const pkg = path.resolve(__dirname, 'version-no-git')
+const cache = path.resolve(pkg, 'cache')
+const gitDir = path.resolve(pkg, '.git')
+
+test('npm version does not alter the line endings in package.json (LF)', function (t) {
+  setup('\n')
+
+  npm.load({cache: cache, registry: common.registry}, function () {
+    const version = requireInject('../../lib/version', {
+      which: function (cmd, cb) {
+        process.nextTick(function () {
+          cb(new Error('ENOGIT!'))
+        })
+      }
+    })
+
+    version(['patch'], function (err) {
+      if (!t.error(err)) return t.end()
+
+      const pkgPath = path.resolve(pkg, 'package.json')
+      const pkgStr = fs.readFileSync(pkgPath, 'utf8')
+
+      t.match(pkgStr, '\n')
+      t.notMatch(pkgStr, '\r')
+
+      t.end()
+    })
+  })
+})
+
+test('npm version does not alter the line endings in package.json (CRLF)', function (t) {
+  setup('\r\n')
+
+  npm.load({cache: cache, registry: common.registry}, function () {
+    const version = requireInject('../../lib/version', {
+      which: function (cmd, cb) {
+        process.nextTick(function () {
+          cb(new Error('ENOGIT!'))
+        })
+      }
+    })
+
+    version(['patch'], function (err) {
+      if (!t.error(err)) return t.end()
+
+      const pkgPath = path.resolve(pkg, 'package.json')
+      const pkgStr = fs.readFileSync(pkgPath, 'utf8')
+
+      t.match(pkgStr, '\r\n')
+      t.notMatch(pkgStr, /[^\r]\n/)
+
+      t.end()
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  process.chdir(osenv.tmpdir())
+
+  rimraf.sync(pkg)
+  t.end()
+})
+
+function setup (lineEnding) {
+  mkdirp.sync(pkg)
+  mkdirp.sync(cache)
+  mkdirp.sync(gitDir)
+  fs.writeFileSync(
+    path.resolve(pkg, 'package.json'),
+    JSON.stringify({
+      author: 'Terin Stock',
+      name: 'version-no-git-test',
+      version: '0.0.0',
+      description: "Test for npm version if git binary doesn't exist"
+    }, null, 2).replace(/\n/g, lineEnding),
+    'utf8'
+  )
+  process.chdir(pkg)
+}


### PR DESCRIPTION
This reduces code duplication for detecting indentation and new lines in `package[-lock].json` and stringifying the data. This also improves performance on Unix systems since it avoids replacing newlines when it's not necessary.

Tests have been added to test that `package[-lock].json` files are written to disk with their original line endings.

Mostly based on #18943 rebased after #19904.