### PR TITLE
config: disable color by default when $NO_COLOR is set

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -284,6 +284,9 @@ This is a list of CIDR address to be used when configuring limited access tokens
 If false, never shows colors.  If `"always"` then always shows colors.
 If true, then only prints color codes for tty file descriptors.
 
+This option can also be changed using the environment: colors are
+disabled when the environment variable `NO_COLOR` is set to any value.
+
 ### depth
 
 * Default: Infinity

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -130,7 +130,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
 
     cidr: null,
 
-    color: true,
+    color: process.env.NO_COLOR == null,
     depth: Infinity,
     description: true,
     dev: false,


### PR DESCRIPTION
This makes npm follow the NO_COLOR standard, as explained in
http://no-color.org/

> All command-line software which outputs text with ANSI color added
> should check for the presence of a NO_COLOR environment variable that,
> when present (regardless of its value), prevents the addition of ANSI
> color.

npm already provides environment variables (npm_config_color=false) and
options (--no-color) to disable coloring by default, but NO_COLOR is an
comprehensive approach to disable colors for all tools.