### PR TITLE
Add a note to install --production.

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -54,6 +54,9 @@ after packing it up into a tarball (b).
     With the `--production` flag (or when the `NODE_ENV` environment variable
     is set to `production`), npm will not install modules listed in
     `devDependencies`.
+    
+    > NOTE: The `--production` flag has no particular meaning when adding a
+    dependency to a project.
 
 * `npm install <folder>`:
 


### PR DESCRIPTION
The `npm install --production` CLI command was quite confusing when it comes to the difference between installing the dependencies for a project and for adding a dependency to a project. This PR adds a note about it specifying the flag is only meaningful in the former case.