### PR TITLE
A trio of fixes to optional dependency handling

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -260,6 +260,7 @@ exports.loadRequestedDeps = function (args, tree, saveToDependencies, log, next)
             delete tree.package[saveType][childName]
           }
         }
+        if (child.save === 'optionalDependencies') tree.package.dependencies[childName] = child.saveSpec
       }
 
       // For things the user asked to install, that aren't a dependency (or

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -489,12 +489,6 @@ function loadDeps (tree, log, next) {
   if (!tree.package.dependencies) tree.package.dependencies = {}
   asyncMap(Object.keys(tree.package.dependencies), function (dep, done) {
     var version = tree.package.dependencies[dep]
-    if (tree.package.optionalDependencies &&
-        tree.package.optionalDependencies[dep] &&
-        !npm.config.get('optional')) {
-      return done()
-    }
-
     addDependency(dep, version, tree, log.newGroup('loadDep:' + dep), andHandleOptionalErrors(log, tree, dep, done))
   }, andForEachChild(loadDeps, andFinishTracker(log, next)))
 }

--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -8,6 +8,7 @@ var log = require('npmlog')
 var path = require('path')
 var ssri = require('ssri')
 var moduleName = require('../utils/module-name.js')
+var isOnlyOptional = require('./is-only-optional.js')
 
 // we don't use get-requested because we're operating on files on disk, and
 // we don't want to extropolate from what _should_ be there.
@@ -234,18 +235,26 @@ var diffTrees = module.exports._diffTrees = function (oldTree, newTree) {
     .map((flatname) => toRemove[flatname])
     .forEach((pkg) => setAction(differences, 'remove', pkg))
 
+  return filterActions(differences)
+}
+
+function filterActions (differences) {
+  const includeOpt = npm.config.get('optional')
   const includeDev = npm.config.get('dev') ||
     (!/^prod(uction)?$/.test(npm.config.get('only')) && !npm.config.get('production')) ||
     /^dev(elopment)?$/.test(npm.config.get('only')) ||
     /^dev(elopment)?$/.test(npm.config.get('also'))
   const includeProd = !/^dev(elopment)?$/.test(npm.config.get('only'))
-  if (!includeProd || !includeDev) {
-    log.silly('diff-trees', 'filtering actions:', 'includeDev', includeDev, 'includeProd', includeProd)
-    differences = differences.filter((diff) => {
-      const pkg = diff[1]
-      const pkgIsOnlyDev = isOnlyDev(pkg)
-      return (!includeProd && pkgIsOnlyDev) || (includeDev && pkgIsOnlyDev) || (includeProd && !pkgIsOnlyDev)
-    })
-  }
-  return differences
+  if (includeProd && includeDev && includeOpt) return differences
+
+  log.silly('diff-trees', 'filtering actions:', 'includeDev', includeDev, 'includeProd', includeProd, 'includeOpt', includeOpt)
+  return differences.filter((diff) => {
+    const pkg = diff[1]
+    const pkgIsOnlyDev = isOnlyDev(pkg)
+    const pkgIsOnlyOpt = isOnlyOptional(pkg)
+    if (!includeProd && pkgIsOnlyDev) return true
+    if (includeDev && pkgIsOnlyDev) return true
+    if (includeProd && !pkgIsOnlyDev && (includeOpt || !pkgIsOnlyOpt)) return true
+    return false
+  })
 }

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -142,7 +142,7 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
     fakeChild: sw,
     fromBundle: sw.bundled ? tree.fromBundle || tree : null,
     path: childPath(tree.path, pkg),
-    realpath: childPath(tree.realpath, pkg),
+    realpath: requested.type === 'directory' ? requested.fetchSpec : childPath(tree.realpath, pkg),
     location: (tree.location === '/' ? '' : tree.location + '/') + pkg.name,
     isLink: requested.type === 'directory',
     isInLink: tree.isLink,

--- a/lib/install/is-only-optional.js
+++ b/lib/install/is-only-optional.js
@@ -11,8 +11,9 @@ function isOptional (node, seen) {
     return false
   }
   seen.add(node)
-
+  const swOptional = node.fromShrinkwrap && node.package._optional
   return node.requiredBy.every(function (req) {
+    if (req.fakeChild && swOptional) return true
     return isOptDep(req, node.package.name) || isOptional(req, seen)
   })
 }

--- a/test/tap/save-optional.js
+++ b/test/tap/save-optional.js
@@ -1,0 +1,82 @@
+'use strict'
+const path = require('path')
+const test = require('tap').test
+const mr = require('npm-registry-mock')
+const Tacks = require('tacks')
+const fs = require('fs')
+const File = Tacks.File
+const Dir = Tacks.Dir
+const common = require('../common-tap.js')
+
+const basedir = path.join(__dirname, path.basename(__filename, '.js'))
+const testdir = path.join(basedir, 'testdir')
+const cachedir = path.join(basedir, 'cache')
+const globaldir = path.join(basedir, 'global')
+const tmpdir = path.join(basedir, 'tmp')
+
+const conf = {
+  cwd: testdir,
+  stdio: [0,1,2],
+  env: Object.assign({}, process.env, {
+    npm_config_cache: cachedir,
+    npm_config_tmp: tmpdir,
+    npm_config_prefix: globaldir,
+    npm_config_registry: common.registry,
+    npm_config_loglevel: 'silly'
+  })
+}
+
+let server
+const fixture = new Tacks(Dir({
+  cache: Dir(),
+  global: Dir(),
+  tmp: Dir(),
+  testdir: Dir({
+    example: Dir({
+      'package.json': File({
+        name: 'example',
+        version: '1.0.0'
+      })
+    }),
+    'package.json': File({
+      name: 'save-optional',
+      version: '1.0.0'
+    })
+  })
+}))
+
+function setup () {
+  cleanup()
+  fixture.create(basedir)
+}
+
+function cleanup () {
+  fixture.remove(basedir)
+}
+
+test('setup', function (t) {
+  setup()
+  mr({port: common.port, throwOnUnmatched: true}, function (err, s) {
+    if (err) throw err
+    server = s
+    t.done()
+  })
+})
+
+test('example', function (t) {
+  common.npm(['install', '-O', '--package-lock-only', 'file:example'], conf, function (err, code) {
+    if (err) throw err
+    t.is(code, 0, 'command ran ok')
+    const plock = JSON.parse(fs.readFileSync(`${testdir}/package-lock.json`))
+    t.like(plock, {dependencies: { example: { optional: true } } }, 'optional status saved')
+    // your assertions here
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  server.close()
+  cleanup()
+  t.done()
+})
+


### PR DESCRIPTION
1. When running `npm i -O module` we weren't saving `module`'s optional status to the `package-lock.json`. This was due to our adding the module to the in memory `optionalDependencies` but not also adding it to `dependencies`, which resulted in it not having any `requiredBy`, which in turn meant that the optional check on the module object run when saving the package-lock failed, resulting it being saved as an ordinary dependency.
2. We were filtering optionals during `loadDeps`. This moves the filtering to `diff-trees`, in the same place we filter dev and production dependencies. The `loadDeps` filter had two problems:
    1. First, if you didn't have a package-lock, but did have an optional dependency, but couldn't install it on your current platform then it wouldn't be saved to the new package-lock (as it would never be added to the tree.
    2. Second, if you HAD a package-lock that already had an optional dependency then `loadDeps` wouldn't have anything to do and so it's skipping optional dependencies wouldn't matter. This meant that `--no-optional` with a package-lock had no effect.
3. Previously our ability to detect optionals was predicated on having an `optionalDependencies` field in the package manifest. Ordinarily this is fine, as indeed, that's where it's stored. But when installing from a lock file we now generate synthetic manifests (_fake children_ in the jargon of cli internals) and our lock file doesn't track which _requirements_ are optional so we can't regenerate this. The fix to this was to look for the lock-file's optional annotation on the module itself when any of the things that require it  are synthetic (and thus can't express this themselves).

* [x] A brief regression test, demonstrating proper package-lock updating with `npm i -O` and that it obeys `--no-optional` with an extant package-lock.
* [x] Check if `devDependencies` suffer from the same problem as #3 (which would call for the same solution). (edit: it does not)
* [x] Ensure that _replacing_ the optional dependency when it's `requiredBy` are synthetic still marks the dependency as optional