### PR TITLE
Remove *.swp files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.swp
 npm-debug.log
 .nyc_output/
 /test/bin


### PR DESCRIPTION
Remove *.swp files from .gitignore because `.git/info/exclude` should be used for editor-specific files instead