### PR TITLE
inflate-shrinkwrap: allow fakeChildren for non-integrity types

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -70,6 +70,11 @@ function normalizePackageDataNoErrors (pkg) {
 
 function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts) {
   validate('OSSOOOO|ZSSOOOO', arguments)
+  const usesIntegrity = (
+    requested.registry ||
+    requested.type === 'remote' ||
+    requested.type === 'file'
+  )
   if (hasModernMeta(onDiskChild) && childIsEquivalent(sw, requested, onDiskChild)) {
     // The version on disk matches the shrinkwrap entry.
     if (!onDiskChild.fromShrinkwrap) onDiskChild.fromShrinkwrap = true
@@ -90,7 +95,7 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     onDiskChild.swRequires = sw.requires
     tree.children.push(onDiskChild)
     return BB.resolve(onDiskChild)
-  } else if ((sw.version && sw.integrity) || sw.bundled) {
+  } else if ((sw.version && (sw.integrity || !usesIntegrity)) || sw.bundled) {
     // The shrinkwrap entry has an integrity field. We can fake a pkg to get
     // the installer to do a content-address fetch from the cache, if possible.
     return BB.resolve(makeFakeChild(name, topPath, tree, sw, requested))
@@ -127,18 +132,19 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
       pkg.bundleDependencies = bundleDependencies
     }
   }
+  const isLink = requested.type === 'directory'
   const child = createChild({
     package: pkg,
     loaded: true,
     parent: tree,
     children: [],
-    fromShrinkwrap: true,
+    fromShrinkwrap: requested,
     fakeChild: sw,
     fromBundle: sw.bundled ? tree.fromBundle || tree : null,
     path: childPath(tree.path, pkg),
-    realpath: childPath(tree.realpath, pkg),
+    realpath: isLink ? requested.fetchSpec : childPath(tree.realpath, pkg),
     location: tree.location + '/' + pkg.name,
-    isLink: requested.type === 'directory',
+    isLink,
     isInLink: tree.isLink,
     swRequires: sw.requires
   })

--- a/test/tap/install-cli-only-shrinkwrap.js
+++ b/test/tap/install-cli-only-shrinkwrap.js
@@ -18,10 +18,10 @@ var json = {
   description: 'fixture',
   version: '0.0.0',
   dependencies: {
-    dependency: 'file:./dependency'
+    dependency: 'file:dependency'
   },
   devDependencies: {
-    'dev-dependency': 'file:./dev-dependency'
+    'dev-dependency': 'file:dev-dependency'
   }
 }
 
@@ -31,12 +31,10 @@ var shrinkwrap = {
   version: '0.0.0',
   dependencies: {
     dependency: {
-      version: '0.0.0',
-      from: 'file:./dependency'
+      version: 'file:dependency'
     },
     'dev-dependency': {
-      version: '0.0.0',
-      from: 'file:./dev-dependency',
+      version: 'file:dev-dependency',
       dev: true
     }
   }


### PR DESCRIPTION
Fixes the case helpfully described in https://gist.github.com/jmorrell/057caf31563a95c7c9c880867afcfea3

/cc @jmorrell