### PR TITLE
error-message: Fix messaging for 401 errors that lack a reason

### DIFF
--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -98,7 +98,7 @@ function errorMessage (er) {
     case 'E401':
       // the E401 message checking is a hack till we replace npm-registry-client with something
       // OTP aware.
-      if (er.code === 'EOTP' || (er.code === 'E401' && /one-time pass/.test(er.message))) {
+      if (er.code === 'EOTP' || /one-time pass/.test(er.message)) {
         short.push(['', 'This operation requires a one-time password from your authenticator.'])
         detail.push([
           '',
@@ -108,42 +108,40 @@ function errorMessage (er) {
             'it, or it timed out. Please try again.'
           ].join('\n')
         ])
-        break
       } else {
         // npm ERR! code E401
         // npm ERR! Unable to authenticate, need: Basic
-        if (er.headers && er.headers['www-authenticate']) {
-          const auth = er.headers['www-authenticate'].map((au) => au.split(/,\s*/))[0] || []
-          if (auth.indexOf('Bearer') !== -1) {
-            short.push(['', 'Unable to authenticate, your authentication token seems to be invalid.'])
-            detail.push([
+        const auth = er.headers && er.headers['www-authenticate'] && er.headers['www-authenticate'].map((au) => au.split(/,\s*/))[0] || []
+        if (auth.indexOf('Bearer') !== -1) {
+          short.push(['', 'Unable to authenticate, your authentication token seems to be invalid.'])
+          detail.push([
+            '',
+            [
+              'To correct this please trying logging in again with:',
+              '    npm login'
+            ].join('\n')
+          ])
+        } else if (auth.indexOf('Basic') !== -1) {
+          short.push(['', 'Incorrect or missing password.'])
+          detail.push([
+            '',
+            [
+              'If you were trying to login, change your password, create an',
+              'authentication token or enable two-factor authentication then',
+              'that means you likely typed your password in incorrectly.',
+              'Please try again, or recover your password at:',
+              '    https://www.npmjs.com/forgot',
               '',
-              [
-                'To correct this please trying logging in again with:',
-                '    npm login'
-              ].join('\n')
-            ])
-            break
-          } else if (auth.indexOf('Basic') !== -1) {
-            short.push(['', 'Incorrect or missing password.'])
-            detail.push([
-              '',
-              [
-                'If you were trying to login, change your password, create an',
-                'authentication token or enable two-factor authentication then',
-                'that means you likely typed your password in incorrectly.',
-                'Please try again, or recover your password at:',
-                '    https://www.npmjs.com/forgot',
-                '',
-                'If you were doing some other operation then your saved credentials are',
-                'probably out of date. To correct this please try logging in again with:',
-                '    npm login'
-              ].join('\n')
-            ])
-            break
-          }
+              'If you were doing some other operation then your saved credentials are',
+              'probably out of date. To correct this please try logging in again with:',
+              '    npm login'
+            ].join('\n')
+          ])
+        } else {
+          short.push(['', er.message || er])
         }
       }
+      break
 
     case 'E404':
       // There's no need to have 404 in the message as well.


### PR DESCRIPTION
Prevously they were falling through to 404 handling and being printed as:

npm ERR! 404 Registry returned 401 for DELETE on …