### PR TITLE
feat: allow optional @ prefix on scope

### DIFF
--- a/lib/team.js
+++ b/lib/team.js
@@ -41,7 +41,7 @@ function team (args, cb) {
     try {
       return npm.registry.team(cmd, uri, {
         auth: auth,
-        scope: entity[0],
+        scope: entity[0].replace(/^@/, ''), // '@' prefix on scope is optional.
         team: entity[1],
         user: args.shift()
       }, function (err, data) {

--- a/test/tap/team.js
+++ b/test/tap/team.js
@@ -37,6 +37,30 @@ test('team create basic', function (t) {
   })
 })
 
+test('team create (allow optional @ prefix on scope)', function (t) {
+  var teamData = {
+    name: 'test',
+    scope_id: 1234,
+    created: '2015-07-23T18:07:49.959Z',
+    updated: '2015-07-23T18:07:49.959Z',
+    deleted: null
+  }
+  server.put('/-/org/myorg/team', JSON.stringify({
+    name: teamData.name
+  })).reply(200, teamData)
+  common.npm([
+    'team', 'create', '@myorg:' + teamData.name,
+    '--registry', common.registry,
+    '--loglevel', 'silent'
+  ], {}, function (err, code, stdout, stderr) {
+    t.ifError(err, 'npm team')
+    t.equal(code, 0, 'exited OK')
+    t.equal(stderr, '', 'no error output')
+    t.same(JSON.parse(stdout), teamData)
+    t.end()
+  })
+})
+
 test('team destroy', function (t) {
   var teamData = {
     name: 'myteam',


### PR DESCRIPTION
when providing a scope, e.g., during login, we encourage our users in docs to provide an `@` prefix on scope:

`npm login --scope=@foo`

we don't currently allow a `@` prefix for `team` commands, this is a slightly confusing disconnect that I felt was worth fixing.