### PR TITLE
cli: shinier update-notifier

### DIFF
--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -25,12 +25,6 @@
 
   unsupported.checkForUnsupportedNode()
 
-  if (!unsupported.checkVersion(process.version).unsupported) {
-    var updater = require('update-notifier')
-    var pkg = require('../package.json')
-    updater({pkg: pkg}).notify({defer: true})
-  }
-
   var path = require('path')
   var npm = require('../lib/npm.js')
   var npmconf = require('../lib/config/core.js')
@@ -80,6 +74,9 @@
   conf._exit = true
   npm.load(conf, function (er) {
     if (er) return errorHandler(er)
+    if (!unsupported.checkVersion(process.version).unsupported) {
+      require('../lib/notifier.js')(npm)
+    }
     npm.commands[npm.command](npm.argv, function (err) {
       // https://genius.com/Lin-manuel-miranda-your-obedient-servant-lyrics
       if (

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const updateNotifier = require('update-notifier')
+const pkg = require('../package.json')
+
+module.exports = notify
+function notify (config) {
+  const notifier = updateNotifier({pkg})
+  if (
+    notifier.update &&
+    notifier.update.latest !== pkg.version &&
+    notifier.update.current === pkg.version
+  ) {
+    const useUnicode = config.get('unicode')
+    const useColor = config.get('color')
+    const color = useColor && require('ansicolors')
+    const old = notifier.update.current
+    const latest = notifier.update.latest
+    let type = notifier.update.type
+    if (useColor) {
+      switch (type) {
+        case 'major':
+          type = color.red(type)
+          break
+        case 'minor':
+          type = color.yellow(type)
+          break
+        case 'patch':
+          type = color.green(type)
+          break
+      }
+    }
+    const changelog = `https://github.com/npm/npm/releases/tag/v${latest}`
+    notifier.notify({
+      message: `New ${type} version of npm available! ${
+        useColor ? color.red(old) : old
+      } ${useUnicode ? '→' : '->'} ${
+        useColor ? color.green(latest) : latest
+      }\n` +
+      `${
+        useColor ? color.yellow('Changelog:') : 'Changelog:'
+      } ${
+        useColor ? color.cyan(changelog + ':') : changelog + ':'
+      }\n` +
+      `Run ${
+        useColor ? color.green('npm install -g npm') : 'npm i -g npm'
+      } to update!`
+    })
+  }
+}


### PR DESCRIPTION
This message is based on the one pnpm uses, which
I think takes care of all the false update messages and
missing -g that happens with the default notifier message.

Preview:
<img width="440" alt="screen shot 2018-03-21 at 12 21 46" src="https://user-images.githubusercontent.com/17535/37709552-73c6dd06-2d02-11e8-83d6-25a47d38f32e.png">

I did 4 things:
1. Moved the update check to post-`npm.load()` so we have access to config. I think this is fine -- if your npm isn't even loading, you can't even update, so.
2. Added a colorful message about what "level" the update is (major/minor/patch)
3. Added a link to the changelog right in the message
4. Forced a `-g` in the message because `update-notifier`'s detection of globals keeps messing up and if people have npm installed locally, they probably know well enough that they need to omit the -g -- vs folks getting confused because the `-g` is missing.

Cheers to @zkochan for the [corresponding version of this in `pnpm`](https://github.com/pnpm/pnpm/blob/master/src/checkForUpdates.ts), which I think is *way better* than the default, and I hope he's ok with us cribbing it like this. 💚 
