### PR TITLE
feat: add npm cit command

### DIFF
--- a/doc/cli/npm-install-ci-test.md
+++ b/doc/cli/npm-install-ci-test.md
@@ -1,0 +1,16 @@
+# npm install-ci-test(1) -- Install a project with a clean slate and run tests
+
+## SYNOPSIS
+
+    npm install-ci-test
+
+    alias: npm cit
+
+## DESCRIPTION
+
+This command runs an `npm ci` followed immediately by an `npm test`.
+
+## SEE ALSO
+
+- npm-ci(1)
+- npm-test(1)

--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -6,6 +6,7 @@ var shorthands = {
   'ln': 'link',
   'i': 'install',
   'it': 'install-test',
+  'cit': 'install-ci-test',
   'up': 'update',
   'c': 'config',
   's': 'search',

--- a/lib/install-ci-test.js
+++ b/lib/install-ci-test.js
@@ -1,0 +1,26 @@
+'use strict'
+
+// npm install-ci-test
+// Runs `npm ci` and then runs `npm test`
+
+module.exports = installTest
+var ci = require('./ci.js')
+var test = require('./test.js')
+var usage = require('./utils/usage')
+
+installTest.usage = usage(
+  'install-ci-test',
+  '\nnpm install-ci-test [args]' +
+  '\nSame args as `npm ci`'
+)
+
+installTest.completion = ci.completion
+
+function installTest (args, cb) {
+  ci(args, function (er) {
+    if (er) {
+      return cb(er)
+    }
+    test([], cb)
+  })
+}


### PR DESCRIPTION
I think that, similar to `npm it` instead of `npm i && npm t`, an `npm cit` instead of `npm ci && npm t` would be nice to have. This was pretty quick to throw together, so no hard feelings if it's rejected