### PR TITLE
doc: Update npm-version.md

### DIFF
--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -12,7 +12,7 @@ npm-version(1) -- Bump a package version
 ## DESCRIPTION
 
 Run this in a package directory to bump the version and write the new
-data back to `package.json` and, if present, `npm-shrinkwrap.json`.
+data back to `package.json`, `package-lock.json`, and, if present, `npm-shrinkwrap.json`.
 
 The `newversion` argument should be a valid semver string, a
 valid second argument to [semver.inc](https://github.com/npm/node-semver#functions) (one of `patch`, `minor`, `major`,


### PR DESCRIPTION
Docs for `npm version` did not specify that `package-lock.json` also gets updated.