### PR TITLE
install: skip deprecated versions when possible

### DIFF
--- a/lib/config/pacote.js
+++ b/lib/config/pacote.js
@@ -26,6 +26,7 @@ function pacoteOpts (moreOpts) {
     defaultTag: npm.config.get('tag'),
     dirPacker: pack.packGitDep,
     hashAlgorithm: 'sha1',
+    includeDeprecated: false,
     key: npm.config.get('key'),
     localAddress: npm.config.get('local-address'),
     log: log,


### PR DESCRIPTION
`npm-pick-manifest@2.1.0` included a change that makes it skip deprecated
versions when possible even if they would otherwise be the best semver range
match.

https://github.com/npm/npm/commit/3aaa6ef427b7a34ebc49cd656e188b5befc22bae
already uses `npm-pick-manifest` in such a way, and this patch guarantees that `pacote` itself
picks up this behavior as well (for `install`), since it defaults to including deprecated versions if
this option isn't passed through.

The patch for pacote to change this behavior can come later.