### PR TITLE
Don't attempt to mkdir() a path that just failed

### DIFF
--- a/node_modules/mkdirp/index.js
+++ b/node_modules/mkdirp/index.js
@@ -31,11 +31,15 @@ function mkdirP (p, opts, f, made) {
         }
         switch (er.code) {
             case 'ENOENT':
-                mkdirP(path.dirname(p), opts, function (er, made) {
-                    if (er) cb(er, made);
-                    else mkdirP(p, opts, cb, made);
-                });
-                break;
+                const parentdir = path.dirname(p);
+                if (parentdir != p) {
+                    mkdirP(path.dirname(p), opts, function (er, made) {
+                        if (er) cb(er, made);
+                        else mkdirP(p, opts, cb, made);
+                    });
+                    break;
+                }
+            // Fall through
 
             // In the case of any other error, just see if there's a dir
             // there already.  If so, then hooray!  If not, then something


### PR DESCRIPTION
This fixes an infinite recursion on Windows when a drive that doesn't exist is
not specified. Eg. `mkdir D:\` would get ENOENT, find the "parent" which is
also D:\, and repeat infinitely.

See also #20069