### PR TITLE
Fix `npm version` command when `package-lock.json` is gitignored

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -313,9 +313,9 @@ function _commit (version, localData, cb) {
 function stagePackageFiles (localData, options) {
   return addLocalFile('package.json', options, false).then(() => {
     if (localData.hasShrinkwrap) {
-      return addLocalFile('npm-shrinkwrap.json', options, false)
+      return addLocalFile('npm-shrinkwrap.json', options, true)
     } else if (localData.hasPackageLock) {
-      return addLocalFile('package-lock.json', options, false)
+      return addLocalFile('package-lock.json', options, true)
     }
   })
 }


### PR DESCRIPTION
Fixes #17168

Fixes this error:

```
> npm version minor -m "v%s"
v0.1.0
npm ERR! code 1
npm ERR! Command failed: git -c core.longpaths=true add C:\GitHub\compile-mime-match\package-lock.json
npm ERR! The following paths are ignored by one of your .gitignore files:
npm ERR! package-lock.json
npm ERR! Use -f if you really want to add them.
npm ERR!
```

This was originally fixed by #17505 but the fix was accidentally undone in #17742.