### PR TITLE
Load dependencies into ideal tree if installing with arguments

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -456,23 +456,23 @@ Installer.prototype.loadAllDepsIntoIdealTree = function (cb) {
   if (installNewModules) {
     steps.push([validateArgs, this.idealTree, this.args])
     steps.push([loadRequestedDeps, this.args, this.idealTree, saveDeps, cg.newGroup('loadRequestedDeps')])
-  } else {
-    const depsToPreload = Object.assign({},
-      this.dev ? this.idealTree.package.devDependencies : {},
-      this.prod ? this.idealTree.package.dependencies : {}
-    )
-    if (this.prod || this.dev) {
-      steps.push(
-        [prefetchDeps, this.idealTree, depsToPreload, cg.newGroup('prefetchDeps')])
-    }
-    if (this.prod) {
-      steps.push(
-        [loadDeps, this.idealTree, cg.newGroup('loadDeps')])
-    }
-    if (this.dev) {
-      steps.push(
-        [loadDevDeps, this.idealTree, cg.newGroup('loadDevDeps')])
-    }
+  }
+
+  const depsToPreload = Object.assign({},
+    this.dev ? this.idealTree.package.devDependencies : {},
+    this.prod ? this.idealTree.package.dependencies : {}
+  )
+  if (this.prod || this.dev) {
+    steps.push(
+      [prefetchDeps, this.idealTree, depsToPreload, cg.newGroup('prefetchDeps')])
+  }
+  if (this.prod) {
+    steps.push(
+      [loadDeps, this.idealTree, cg.newGroup('loadDeps')])
+  }
+  if (this.dev) {
+    steps.push(
+      [loadDevDeps, this.idealTree, cg.newGroup('loadDevDeps')])
   }
   steps.push(
     [loadExtraneous.andResolveDeps, this.idealTree, cg.newGroup('loadExtraneous')])


### PR DESCRIPTION
Previously, dependencies were only loaded into the tree during install if no
arguments were passed. That caused git dependencies to be deleted from the
`package-lock.json`.

Fixes #16839 (again)