### PR TITLE
Fix root user node-gyp permission issues

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -234,7 +234,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
                        process.getgid && process.setgid) ||
                      process.getuid() !== 0,
     usage: false,
-    user: process.platform === 'win32' ? 0 : 'nobody',
+    user: process.platform === 'win32' ? 0 : (process.env.SUDO_UID || (process.getuid) ? process.getuid() : 'nobody'),
     userconfig: path.resolve(home, '.npmrc'),
     umask: process.umask ? process.umask() : umask.fromString('022'),
     version: false,


### PR DESCRIPTION
Per issue #17346, when running npm in docker builds some packages are failing to run installation scripts when installing globally due to the global node_modules directory being owned by `root` but npm is running the scripts as `nobody`. This commit attempts to massage the default user configuration to allow executing as root.

Please discuss whether I have approached this issue correctly, or if more thought needs to be applied....