### PR TITLE
config: only create config dir before write

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,6 +9,8 @@ var types = npmconf.defs.types
 var ini = require('ini')
 var editor = require('editor')
 var os = require('os')
+var path = require('path')
+var mkdirp = require('mkdirp')
 var umask = require('./utils/umask')
 var usage = require('./utils/usage')
 var output = require('./utils/output')
@@ -113,14 +115,18 @@ function edit (cb) {
       }, []))
       .concat([''])
       .join(os.EOL)
-      writeFileAtomic(
-        f,
-        data,
-        function (er) {
-          if (er) return cb(er)
-          editor(f, { editor: e }, noProgressTillDone(cb))
-        }
-      )
+      var fdir = path.dirname(f)
+      mkdirp(fdir, function (er) {
+        if (er) return cb(er)
+        writeFileAtomic(
+          f,
+          data,
+          function (er) {
+            if (er) return cb(er)
+            editor(f, { editor: e }, noProgressTillDone(cb))
+          }
+        )
+      })
     })
   })
 }

--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -153,17 +153,10 @@ function load_ (builtin, rc, cli, cb) {
     // annoying humans and their expectations!
     if (conf.get('prefix')) {
       var etc = path.resolve(conf.get('prefix'), 'etc')
-      mkdirp(etc, function () {
-        defaults.globalconfig = path.resolve(etc, 'npmrc')
-        defaults.globalignorefile = path.resolve(etc, 'npmignore')
-        afterUserContinuation()
-      })
-    } else {
-      afterUserContinuation()
+      defaults.globalconfig = path.resolve(etc, 'npmrc')
+      defaults.globalignorefile = path.resolve(etc, 'npmignore')
     }
-  }
 
-  function afterUserContinuation () {
     conf.addFile(conf.get('globalconfig'), 'global')
 
     // move the builtin into the conf stack now.


### PR DESCRIPTION
This change fixes the bug that creates unnecessary `./etc` folder when calling `npm` with the `--prefix` flag.

See: https://github.com/npm/npm/pull/7249#issuecomment-96854630