### PR TITLE
fix: add --scope to npm init usage

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -13,7 +13,7 @@ var usage = require('./utils/usage')
 
 init.usage = usage(
   'init',
-  '\nnpm init [--force|-f|--yes|-y]' +
+  '\nnpm init [--force|-f|--yes|-y|--scope]' +
   '\nnpm init <@scope> (same as `npx <@scope>/create`)' +
   '\nnpm init [<@scope>/]<pkg> (same as `npx [<@scope>/]create-<pkg>`)'
 )


### PR DESCRIPTION
Adds `--scope` mentioned https://github.com/npm/npm/commit/385fdd44c1013f737d526d22d7b89014b723d586 to the `npm init --help` usage example.