### PR TITLE
install/deps: Let git deps w/ lock only match package.json

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -51,6 +51,16 @@ function doesChildVersionMatch (child, requested, requestor) {
     return path.relative(child.realpath, requested.fetchSpec) === ''
   }
 
+  if (requested.type === 'git' && child.fromShrinkwrap) {
+    const fromSw = child.fromShrinkwrap
+
+    if (fromSw.rawSpec === requested.rawSpec) return true
+
+    if (!fromSw.hosted || !requested.hosted) return false
+
+    return fromSw.hosted.toString() === requested.hosted.toString()
+  }
+
   if (!registryTypes[requested.type]) {
     var childReq = child.package._requested
     if (childReq) {

--- a/lib/install/has-modern-meta.js
+++ b/lib/install/has-modern-meta.js
@@ -11,7 +11,10 @@ function isLink (child) {
 function hasModernMeta (child) {
   if (!child) return false
   const resolved = child.package._resolved && npa.resolve(moduleName(child), child.package._resolved)
-  return child.isTop || isLink(child) || child.fromBundle ||
-    child.package._inBundle || child.package._integrity ||
-    child.package._shasum || (resolved && resolved.type === 'git')
+  const version = npa.resolve(moduleName(child), child.package.version)
+  return child.isTop ||
+    isLink(child) ||
+    child.fromBundle || child.package._inBundle ||
+    child.package._integrity || child.package._shasum ||
+    (resolved && resolved.type === 'git') || (version && version.type === 'git')
 }

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -78,7 +78,7 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
   const modernLink = requested.type === 'directory' && !sw.from
   if (hasModernMeta(onDiskChild) && childIsEquivalent(sw, requested, onDiskChild)) {
     // The version on disk matches the shrinkwrap entry.
-    if (!onDiskChild.fromShrinkwrap) onDiskChild.fromShrinkwrap = true
+    if (!onDiskChild.fromShrinkwrap) onDiskChild.fromShrinkwrap = requested
     onDiskChild.package._requested = requested
     onDiskChild.package._spec = requested.rawSpec
     onDiskChild.package._where = topPath

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -16,6 +16,7 @@ const path = require('path')
 const isRegistry = require('../utils/is-registry.js')
 const hasModernMeta = require('./has-modern-meta.js')
 const ssri = require('ssri')
+const npa = require('npm-package-arg')
 
 module.exports = function (tree, sw, opts, finishInflating) {
   if (!fetchPackageMetadata) {
@@ -108,13 +109,18 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
   }
 }
 
+function isGit (sw) {
+  const version = npa.resolve(sw.name, sw.version)
+  return (version && version.type === 'git')
+}
+
 function makeFakeChild (name, topPath, tree, sw, requested) {
   const from = sw.from || requested.raw
   const pkg = {
     name: name,
     version: sw.version,
     _id: name + '@' + sw.version,
-    _resolved: sw.resolved,
+    _resolved: sw.resolved || (isGit(sw) && sw.version),
     _requested: requested,
     _optional: sw.optional,
     _development: sw.dev,


### PR DESCRIPTION
Previously they would only match if the complete commitid was used.  This allows partial matching when no on-disk component is available.

This will need a minor patch to coordinate with https://github.com/npm/npm/pull/20384