### PR TITLE
docs: add from field back into git dependencies

### DIFF
--- a/doc/spec/package-lock.md
+++ b/doc/spec/package-lock.md
@@ -107,10 +107,10 @@ transitive dependency of a non-optional dependency of the top level.
 All optional dependencies should be included even if they're uninstallable
 on the current platform.
 
-#### from *(deprecated)*
+#### from
 
 This is a record of what specifier was used to originally install this
-package.  This should not be included in new `package-lock.json` files.
+package.  This should be used only for git dependencies.
 
 #### requires
 


### PR DESCRIPTION
An update of the spec doc follows a change that the "from" field was returned.

Refs: https://github.com/npm/npm/pull/20384