### PR TITLE
Fix nested aliases, restore alias 'sit': 'cit'

### DIFF
--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -46,7 +46,7 @@ var affordances = {
   'rm': 'uninstall',
   'r': 'uninstall',
   'rum': 'run-script',
-  'sit': 'install-ci-test',
+  'sit': 'cit',
   'urn': 'run-script'
 }
 

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -191,7 +191,9 @@
     }
     if (plumbing.indexOf(c) !== -1) return c
     var a = abbrevs[c]
-    if (aliases[a]) a = aliases[a]
+    while (aliases[a]) {
+      a = aliases[a]
+    }
     return a
   }
 


### PR DESCRIPTION
I investigated why `npm sit` was failing and fixed nested aliases not being dereferenced.

I see that the issue was already fixed in https://github.com/npm/npm/commit/6644cdb1fef9941b05f1415ae7fe86429fecefa8 but I'm opening this PR to prevent similar issues in the future, and to restore the better looking `'sit': 'cit'` :)