### PR TITLE
update-notifier: remove colon + support canary

### DIFF
--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -102,7 +102,7 @@
         }
         const changelog = `https://github.com/npm/npm/releases/tag/v${latest}`
         notifier.notify({
-          message: `New ${type} version of npm available! ${
+          message: `New ${type} version of ${pkg.name} available! ${
             useColor ? color.red(old) : old
           } ${useUnicode ? '→' : '->'} ${
             useColor ? color.green(latest) : latest
@@ -110,10 +110,12 @@
           `${
             useColor ? color.yellow('Changelog:') : 'Changelog:'
           } ${
-            useColor ? color.cyan(changelog + ':') : changelog + ':'
+            useColor ? color.cyan(changelog) : changelog
           }\n` +
           `Run ${
-            useColor ? color.green('npm install -g npm') : 'npm i -g npm'
+            useColor
+              ? color.green(`npm install -g ${pkg.name}`)
+              : `npm i -g ${pkg.name}`
           } to update!`
         })
       }


### PR DESCRIPTION
Noticed a couple of things after getting an update notification for `canary` that looked like this:

<img width="610" alt="screen shot 2018-05-07 at 12 04 54" src="https://user-images.githubusercontent.com/17535/39719710-e1137f0c-51ee-11e8-936d-ec338a1844a7.png">

Things should look better now.