### PR TITLE
audit: support for --json output

### DIFF
--- a/lib/install/audit.js
+++ b/lib/install/audit.js
@@ -105,7 +105,7 @@ function printInstallReport (auditResult) {
 function printFullReport (auditResult) {
   return auditReport(auditResult, {
     log: output,
-    reporter: 'detail',
+    reporter: npm.config.get('json') ? 'json' : 'detail',
     withColor: npm.color,
     withUnicode: npm.config.get('unicode')
   }).then(result => output(result.report))


### PR DESCRIPTION
Makes use of the `json` formatter of `npm-audit-report` when using the `--json` option.

resolves #20587