### PR TITLE
audit: add subcommand to automatically fix vulns

### DIFF
--- a/doc/cli/npm-audit.md
+++ b/doc/cli/npm-audit.md
@@ -4,13 +4,63 @@ npm-audit(1) -- Run a security audit
 ## SYNOPSIS
 
     npm audit [--json]
+    npm audit fix [--force|--package-lock-only|--dry-run|--production|--only=dev]
 
-## DESCRIPTION 
+## EXAMPLES
+
+Scan your project for vulnerabilities and automatically install any compatible
+updates to vulnerable dependencies:
+```
+$ npm audit fix
+```
+
+Run `audit fix` without modifying `node_modules`, but still updating the
+pkglock:
+```
+$ npm audit fix --package-lock-only
+```
+
+Skip updating `devDependencies`:
+```
+$ npm audit fix --only=prod
+```
+
+Have `audit fix` install semver-major updates to toplevel dependencies, not just
+semver-compatible ones:
+```
+$ npm audit fix --force
+```
+
+Do a dry run to get an idea of what `audit fix` will do, and _also_ output
+install information in JSON format:
+```
+$ npm audit fix --dry-run --json
+```
+
+Scan your project for vulnerabilities and just show the details, without fixing
+anything:
+```
+$ npm audit
+```
+
+Get the detailed audit report in JSON format:
+```
+$ npm audit --json
+```
+
+## DESCRIPTION
 
 The audit command submits a description of the dependencies configured in
 your project to your default registry and asks for a report of known
-vulnerabilities.  The report returned includes instructions on how to act on
+vulnerabilities. The report returned includes instructions on how to act on
 this information.
+
+You can also have npm automatically fix the vulnerabilities by running `npm
+audit fix`. Note that some vulnerabilities cannot be fixed automatically and
+will require manual intervention or review. Also note that since `npm audit fix`
+runs a full-fledged `npm install` under the hood, all configs that apply to the
+installer will also apply to `npm install` -- so things like `npm audit fix
+--package-lock-only` will work as expected.
 
 ## CONTENT SUBMITTED
 
@@ -29,7 +79,7 @@ the following dependency types:
 
 * Any module referencing a scope that is configured for a non-default
   registry has its name scrubbed.  (That is, a scope you did a `npm login --scope=@ourscope` for.)
-* All git dependencies have their names and specifiers scrubbed. 
+* All git dependencies have their names and specifiers scrubbed.
 * All remote tarball dependencies have their names and specifiers scrubbed.
 * All local directory and tarball dependencies have their names and specifiers scrubbed.
 
@@ -40,4 +90,5 @@ different between runs.
 ## SEE ALSO
 
 * npm-install(1)
+* package-locks(5)
 * config(7)

--- a/lib/audit.js
+++ b/lib/audit.js
@@ -1,18 +1,24 @@
 'use strict'
-const fs = require('graceful-fs')
+
 const Bluebird = require('bluebird')
+
 const audit = require('./install/audit.js')
-const npm = require('./npm.js')
-const log = require('npmlog')
-const parseJson = require('json-parse-better-errors')
+const fs = require('graceful-fs')
+const Installer = require('./install.js').Installer
 const lockVerify = require('lock-verify')
+const log = require('npmlog')
+const npa = require('npm-package-arg')
+const npm = require('./npm.js')
+const output = require('./utils/output.js')
+const parseJson = require('json-parse-better-errors')
 
 const readFile = Bluebird.promisify(fs.readFile)
 
 module.exports = auditCmd
 
 auditCmd.usage =
-  'npm audit\n'
+  'npm audit\n' +
+  'npm audit fix\n'
 
 auditCmd.completion = function (opts, cb) {
   const argv = opts.conf.argv.remain
@@ -23,6 +29,63 @@ auditCmd.completion = function (opts, cb) {
     default:
       return cb(new Error(argv[2] + ' not recognized'))
   }
+}
+
+class Auditor extends Installer {
+  constructor (where, dryrun, args, opts) {
+    super(where, dryrun, args, opts)
+    this.deepArgs = (opts && opts.deepArgs) || []
+    this.runId = opts.runId || ''
+    this.audit = false
+  }
+
+  loadAllDepsIntoIdealTree (cb) {
+    Bluebird.fromNode(cb => super.loadAllDepsIntoIdealTree(cb)).then(() => {
+      if (this.deepArgs && this.deepArgs.length) {
+        this.deepArgs.forEach(arg => {
+          arg.reduce((acc, child, ii) => {
+            if (!acc) {
+              // We might not always be able to find `target` through the given
+              // path. If we can't we'll just ignore it.
+              return
+            }
+            const spec = npa(child)
+            const target = (
+              acc.requires.find(n => n.package.name === spec.name) ||
+              acc.requires.find(
+                n => audit.scrub(n.package.name, this.runId) === spec.name
+              )
+            )
+            if (target && ii === arg.length - 1) {
+              target.loaded = false
+              // This kills `hasModernMeta()` and forces a re-fetch
+              target.package = {
+                name: spec.name,
+                version: spec.fetchSpec,
+                _requested: target.package._requested
+              }
+              delete target.fakeChild
+              let parent = target.parent
+              while (parent) {
+                parent.loaded = false
+                parent = parent.parent
+              }
+              target.requiredBy.forEach(par => {
+                par.loaded = false
+                delete par.fakeChild
+              })
+            }
+            return target
+          }, this.idealTree)
+        })
+        return Bluebird.fromNode(cb => super.loadAllDepsIntoIdealTree(cb))
+      }
+    }).nodeify(cb)
+  }
+
+  // no top level lifecycles on audit
+  runPreinstallTopLevelLifecycles (cb) { cb() }
+  runPostinstallTopLevelLifecycles (cb) { cb() }
 }
 
 function maybeReadFile (name) {
@@ -43,11 +106,28 @@ function maybeReadFile (name) {
     })
 }
 
+function filterEnv (action) {
+  const includeDev = npm.config.get('dev') ||
+    (!/^prod(uction)?$/.test(npm.config.get('only')) && !npm.config.get('production')) ||
+    /^dev(elopment)?$/.test(npm.config.get('only')) ||
+    /^dev(elopment)?$/.test(npm.config.get('also'))
+  const includeProd = !/^dev(elopment)?$/.test(npm.config.get('only'))
+  const resolves = action.resolves.filter(({dev}) => {
+    return (dev && includeDev) || (!dev && includeProd)
+  })
+  if (resolves.length) {
+    return Object.assign({}, action, {resolves})
+  }
+}
+
 function auditCmd (args, cb) {
   if (npm.config.get('global')) {
     const err = new Error('`npm audit` does not support testing globals')
     err.code = 'EAUDITGLOBAL'
     throw err
+  }
+  if (args.length && args[0] !== 'fix') {
+    return cb(new Error('Invalid audit subcommand: `' + args[0] + '`\n\nUsage:\n' + auditCmd.usage))
   }
   return Bluebird.all([
     maybeReadFile('npm-shrinkwrap.json'),
@@ -92,12 +172,93 @@ function auditCmd (args, cb) {
     }
     throw err
   }).then((auditResult) => {
-    const vulns =
-      auditResult.metadata.vulnerabilities.low +
-      auditResult.metadata.vulnerabilities.moderate +
-      auditResult.metadata.vulnerabilities.high +
-      auditResult.metadata.vulnerabilities.critical
-    if (vulns > 0) process.exitCode = 1
-    return audit.printFullReport(auditResult)
+    if (args[0] === 'fix') {
+      const actions = (auditResult.actions || []).reduce((acc, action) => {
+        action = filterEnv(action)
+        if (!action) { return acc }
+        if (action.isMajor) {
+          acc.major.add(`${action.module}@${action.target}`)
+          action.resolves.forEach(({id, path}) => acc.majorFixes.add(`${id}::${path}`))
+        } else if (action.action === 'install') {
+          acc.install.add(`${action.module}@${action.target}`)
+          action.resolves.forEach(({id, path}) => acc.installFixes.add(`${id}::${path}`))
+        } else if (action.action === 'update') {
+          const name = action.module
+          const version = action.target
+          action.resolves.forEach(vuln => {
+            acc.updateFixes.add(`${vuln.id}::${vuln.path}`)
+            const modPath = vuln.path.split('>')
+            const newPath = modPath.slice(
+              0, modPath.indexOf(name)
+            ).concat(`${name}@${version}`)
+            if (newPath.length === 1) {
+              acc.install.add(newPath[0])
+            } else {
+              acc.update.add(newPath.join('>'))
+            }
+          })
+        } else if (action.action === 'review') {
+          action.resolves.forEach(({id, path}) => acc.review.add(`${id}::${path}`))
+        }
+        return acc
+      }, {
+        install: new Set(),
+        installFixes: new Set(),
+        update: new Set(),
+        updateFixes: new Set(),
+        major: new Set(),
+        majorFixes: new Set(),
+        review: new Set()
+      })
+      return Bluebird.try(() => {
+        const installMajor = npm.config.get('force')
+        const installCount = actions.install.size + (installMajor ? actions.major.size : 0) + actions.update.size
+        const vulnFixCount = new Set([...actions.installFixes, ...actions.updateFixes, ...(installMajor ? actions.majorFixes : [])]).size
+        const metavuln = auditResult.metadata.vulnerabilities
+        const total = Object.keys(metavuln).reduce((acc, key) => acc + metavuln[key], 0)
+        if (installCount) {
+          log.verbose(
+            'audit',
+            'installing',
+            [...actions.install, ...(installMajor ? actions.major : []), ...actions.update]
+          )
+        }
+        return Bluebird.fromNode(cb => {
+          new Auditor(
+            npm.prefix,
+            !!npm.config.get('dry-run'),
+            [...actions.install, ...(installMajor ? actions.major : [])],
+            {
+              runId: auditResult.runId,
+              deepArgs: [...actions.update].map(u => u.split('>'))
+            }
+          ).run(cb)
+        }).then(() => {
+          const numScanned = auditResult.metadata.totalDependencies
+          if (!npm.config.get('json') && !npm.config.get('parseable')) {
+            output(`fixed ${vulnFixCount} of ${total} vulnerabilit${total === 1 ? 'y' : 'ies'} in ${numScanned} scanned package${numScanned === 1 ? '' : 's'}`)
+            if (actions.review.size) {
+              output(`  ${actions.review.size} vulnerabilit${actions.review.size === 1 ? 'y' : 'ies'} required manual review and could not be updated`)
+            }
+            if (actions.major.size) {
+              output(`  ${actions.major.size} package update${actions.major.size === 1 ? '' : 's'} for ${actions.majorFixes.size} vuln${actions.majorFixes.size === 1 ? '' : 's'} involved breaking changes`)
+              if (installMajor) {
+                output('  (installed due to `--force` option)')
+              } else {
+                output('  (use `npm audit fix --force` to install breaking changes; or do it by hand)')
+              }
+            }
+          }
+        })
+      })
+    } else {
+      const vulns =
+        auditResult.metadata.vulnerabilities.low +
+        auditResult.metadata.vulnerabilities.moderate +
+        auditResult.metadata.vulnerabilities.high +
+        auditResult.metadata.vulnerabilities.critical
+      if (vulns > 0) process.exitCode = 1
+      return audit.printFullReport(auditResult)
+    }
   }).asCallback(cb)
 }

--- a/lib/install/audit.js
+++ b/lib/install/audit.js
@@ -76,6 +76,7 @@ function submitForFullReport (auditData) {
       return response.json()
     }).then(result => {
       perf.emit('timeEnd', 'audit body')
+      result.runId = runId
       return result
     })
   })
@@ -207,8 +208,9 @@ function scrubSpec (name, spec) {
   }
 }
 
-function scrub (value) {
-  return ssri.fromData(runId + ' ' + value, {algorithms: ['sha256']}).hexDigest()
+module.exports.scrub = scrub
+function scrub (value, rid) {
+  return ssri.fromData((rid || runId) + ' ' + value, {algorithms: ['sha256']}).hexDigest()
 }
 
 function generateMetadata () {

--- a/lib/install/save.js
+++ b/lib/install/save.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const createShrinkwrap = require('../shrinkwrap.js').createShrinkwrap
 const deepSortObject = require('../utils/deep-sort-object.js')
 const detectIndent = require('detect-indent')
 const detectNewline = require('detect-newline')
@@ -48,7 +47,7 @@ function saveShrinkwrap (tree, next) {
   if (!npm.config.get('shrinkwrap') || !npm.config.get('package-lock')) {
     return next()
   }
-  createShrinkwrap(tree, {silent: false}, next)
+  require('../shrinkwrap.js').createShrinkwrap(tree, {silent: false}, next)
 }
 
 function savePackageJson (tree, next) {

--- a/test/tap/audit-fix.js
+++ b/test/tap/audit-fix.js
@@ -1,0 +1,669 @@
+'use strict'
+
+const BB = require('bluebird')
+
+const common = BB.promisifyAll(require('../common-tap.js'))
+const fs = require('fs')
+const mr = BB.promisify(require('npm-registry-mock'))
+const path = require('path')
+const rimraf = BB.promisify(require('rimraf'))
+const Tacks = require('tacks')
+const tap = require('tap')
+const test = tap.test
+
+const Dir = Tacks.Dir
+const File = Tacks.File
+const testDir = path.join(__dirname, path.basename(__filename, '.js'))
+
+const EXEC_OPTS = { cwd: testDir }
+
+tap.tearDown(function () {
+  process.chdir(__dirname)
+  try {
+    rimraf.sync(testDir)
+  } catch (e) {
+    if (process.platform !== 'win32') {
+      throw e
+    }
+  }
+})
+
+function tmock (t) {
+  return mr({port: common.port}).then(s => {
+    t.tearDown(function () {
+      s.done()
+      s.close()
+      rimraf.sync(testDir)
+    })
+    return s
+  })
+}
+
+test('fixes shallow vulnerabilities', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      t.equal(code, 0, 'exited OK')
+      t.comment(stderr)
+      t.similar(JSON.parse(stdout), {
+        added: [{
+          action: 'add',
+          name: 'baddep',
+          version: '1.0.0'
+        }]
+      }, 'installed bad version')
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'update',
+          module: 'baddep',
+          target: '1.2.3',
+          resolves: [{path: 'baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            critical: 1
+          }
+        }
+      })
+      return common.npm([
+        'audit', 'fix',
+        '--package-lock-only',
+        '--json',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 0, 'exited OK')
+        t.comment(stderr)
+        t.similar(JSON.parse(stdout), {
+          added: [{
+            action: 'add',
+            name: 'baddep',
+            version: '1.2.3'
+          }]
+        }, 'reported dependency update')
+        t.similar(JSON.parse(fs.readFileSync(path.join(testDir, 'package-lock.json'), 'utf8')), {
+          dependencies: {
+            baddep: {
+              version: '1.2.3',
+              resolved: common.registry + '/idk/-/idk-1.2.3.tgz',
+              integrity: 'sha1-3q2+7w=='
+            }
+          }
+        }, 'pkglock updated correctly')
+      })
+    })
+  })
+})
+
+test('fixes nested dep vulnerabilities', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        gooddep: '^1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/baddep').reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.0.0'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'c0ffee',
+            integrity: 'sha1-c0ffee',
+            tarball: common.registry + '/baddep/-/baddep-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'bada55',
+            integrity: 'sha1-bada55',
+            tarball: common.registry + '/baddep/-/baddep-1.2.3.tgz'
+          }
+        }
+      }
+    })
+
+    srv.get('/gooddep').reply(200, {
+      name: 'gooddep',
+      'dist-tags': {
+        'latest': '1.0.0'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'gooddep',
+          version: '1.0.0',
+          dependencies: {
+            baddep: '^1.0.0'
+          },
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: '1234',
+            tarball: common.registry + '/gooddep/-/gooddep-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'gooddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dependencies: {
+            baddep: '^1.0.0'
+          },
+          dist: {
+            shasum: '123456',
+            tarball: common.registry + '/gooddep/-/gooddep-1.2.3.tgz'
+          }
+        }
+      }
+    })
+
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--global-style',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      t.equal(code, 0, 'exited OK')
+      t.comment(stderr)
+      t.similar(JSON.parse(stdout), {
+        added: [{
+          action: 'add',
+          name: 'baddep',
+          version: '1.0.0'
+        }, {
+          action: 'add',
+          name: 'gooddep',
+          version: '1.0.0'
+        }]
+      }, 'installed bad version')
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'update',
+          module: 'baddep',
+          target: '1.2.3',
+          resolves: [{path: 'gooddep>baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            critical: 1
+          }
+        }
+      })
+      return common.npm([
+        'audit', 'fix',
+        '--package-lock-only',
+        '--offline',
+        '--json',
+        '--global-style',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 0, 'exited OK')
+        t.comment(stderr)
+        t.similar(JSON.parse(stdout), {
+          added: [{
+            action: 'add',
+            name: 'baddep',
+            version: '1.2.3'
+          }, {
+            action: 'add',
+            name: 'gooddep',
+            version: '1.0.0'
+          }]
+        }, 'reported dependency update')
+        t.similar(JSON.parse(fs.readFileSync(path.join(testDir, 'package-lock.json'), 'utf8')), {
+          dependencies: {
+            gooddep: {
+              version: '1.0.0',
+              resolved: common.registry + '/gooddep/-/gooddep-1.0.0.tgz',
+              integrity: 'sha1-EjQ=',
+              requires: {
+                baddep: '^1.0.0'
+              },
+              dependencies: {
+                baddep: {
+                  version: '1.2.3',
+                  resolved: common.registry + '/baddep/-/baddep-1.2.3.tgz',
+                  integrity: 'sha1-bada55'
+                }
+              }
+            }
+          }
+        }, 'pkglock updated correctly')
+      })
+    })
+  })
+})
+
+test('no semver-major without --force', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '2.0.0'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '2.0.0': {
+          name: 'baddep',
+          version: '2.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-2.0.0.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      t.equal(code, 0, 'exited OK')
+      t.comment(stderr)
+      t.similar(JSON.parse(stdout), {
+        added: [{
+          action: 'add',
+          name: 'baddep',
+          version: '1.0.0'
+        }]
+      }, 'installed bad version')
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'install',
+          module: 'baddep',
+          target: '2.0.0',
+          isMajor: true,
+          resolves: [{path: 'baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            critical: 1
+          }
+        }
+      })
+      return common.npm([
+        'audit', 'fix',
+        '--package-lock-only',
+        '--registry', common.registry,
+        '--loglevel=warn',
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 0, 'exited OK')
+        t.comment(stderr)
+        t.match(stdout, /breaking changes/, 'informs about semver-major')
+        t.match(stdout, /npm audit fix --force/, 'recommends --force')
+        t.similar(JSON.parse(fs.readFileSync(path.join(testDir, 'package-lock.json'), 'utf8')), {
+          dependencies: {
+            baddep: {
+              version: '1.0.0'
+            }
+          }
+        }, 'pkglock not updated')
+      })
+    })
+  })
+})
+
+test('semver-major when --force', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '2.0.0'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '2.0.0': {
+          name: 'baddep',
+          version: '2.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-2.0.0.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      t.equal(code, 0, 'exited OK')
+      t.comment(stderr)
+      t.similar(JSON.parse(stdout), {
+        added: [{
+          action: 'add',
+          name: 'baddep',
+          version: '1.0.0'
+        }]
+      }, 'installed bad version')
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'install',
+          module: 'baddep',
+          target: '2.0.0',
+          isMajor: true,
+          resolves: [{path: 'baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            critical: 1
+          }
+        }
+      })
+      return common.npm([
+        'audit', 'fix',
+        '--package-lock-only',
+        '--registry', common.registry,
+        '--force',
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 0, 'exited OK')
+        t.comment(stderr)
+        t.match(stdout, /breaking changes/, 'informs about semver-major')
+        t.similar(JSON.parse(fs.readFileSync(path.join(testDir, 'package-lock.json'), 'utf8')), {
+          dependencies: {
+            baddep: {
+              version: '2.0.0'
+            }
+          }
+        }, 'pkglock not updated')
+      })
+    })
+  })
+})
+
+test('no installs for review-requires', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'k')
+    srv.post('/-/npm/v1/security/audits/quick', 'k').reply(200, 'yeah')
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      t.equal(code, 0, 'exited OK')
+      t.comment(stderr)
+      t.similar(JSON.parse(stdout), {
+        added: [{
+          action: 'add',
+          name: 'baddep',
+          version: '1.0.0'
+        }]
+      }, 'installed bad version')
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'review',
+          module: 'baddep',
+          target: '1.2.3',
+          resolves: [{path: 'baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            critical: 1
+          }
+        }
+      })
+      return common.npm([
+        'audit', 'fix',
+        '--package-lock-only',
+        '--json',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 0, 'exited OK')
+        t.comment(stderr)
+        t.similar(JSON.parse(stdout), {
+          added: [{
+            action: 'add',
+            name: 'baddep',
+            version: '1.0.0'
+          }]
+        }, 'no update for dependency')
+      })
+    })
+  })
+})
+
+test('nothing to fix', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        gooddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/gooddep').twice().reply(200, {
+      name: 'gooddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'gooddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'gooddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      t.equal(code, 0, 'exited OK')
+      t.comment(stderr)
+      t.similar(JSON.parse(stdout), {
+        added: [{
+          action: 'add',
+          name: 'gooddep',
+          version: '1.0.0'
+        }]
+      }, 'installed good version')
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [],
+        metadata: {
+          vulnerabilities: { }
+        }
+      })
+      return common.npm([
+        'audit', 'fix',
+        '--package-lock-only',
+        '--json',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 0, 'exited OK')
+        t.comment(stderr)
+        t.similar(JSON.parse(stdout), {
+          added: [{
+            action: 'add',
+            name: 'gooddep',
+            version: '1.0.0'
+          }]
+        }, 'nothing to update')
+      })
+    })
+  })
+})
+
+test('cleanup', t => {
+  return rimraf(testDir)
+})


### PR DESCRIPTION
Example, combined with https://github.com/npm/npm-audit-report/pull/12 to give a better idea of what it'll look like with both changes (that PR is aesthetic).

<img width="639" alt="screen shot 2018-05-09 at 17 30 41" src="https://user-images.githubusercontent.com/17535/39846710-01ed57f6-53b2-11e8-9dae-edf08224441a.png">
