### PR TITLE
install: include number of audited packages in output

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -834,6 +834,9 @@ Installer.prototype.printInstalledForHuman = function (diffs, auditResult) {
   if (removed) actions.push('removed ' + packages(removed))
   if (updated) actions.push('updated ' + packages(updated))
   if (moved) actions.push('moved ' + packages(moved))
+  if (auditResult && auditResult.metadata.totalDependencies) {
+    actions.push('audited ' + packages(auditResult.metadata.totalDependencies))
+  }
   if (actions.length === 0) {
     report += 'up to date'
   } else if (actions.length === 1) {


### PR DESCRIPTION
Expects https://github.com/npm/npm-audit-report/pull/12 for the full effect but can land without it. This bit only makes the installer print out the number of audited packages.

<img width="619" alt="screen shot 2018-05-09 at 15 23 19" src="https://user-images.githubusercontent.com/17535/39846736-38e61c0c-53b2-11e8-8ec9-10907af8a173.png">
