### PR TITLE
feat: handle missing open bin

### DIFF
--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -6,11 +6,7 @@ const npm = require('../npm.js')
 const output = require('../utils/output.js')
 const pacoteOpts = require('../config/pacote')
 const fetchOpts = require('../config/fetch-opts')
-const opener = require('opener')
-
-const openerPromise = (url) => new Promise((resolve, reject) => {
-  opener(url, { command: npm.config.get('browser') }, (er) => er ? reject(er) : resolve())
-})
+const openUrl = require('../utils/open-url')
 
 const loginPrompter = (creds) => {
   const opts = { log: log }
@@ -41,7 +37,7 @@ module.exports.login = (creds, registry, scope, cb) => {
 }
 
 function login (conf) {
-  return profile.login(openerPromise, loginPrompter, conf)
+  return profile.login((url) => openUrl(url, 'to complete your login please visit'), loginPrompter, conf)
     .catch((err) => {
       if (err.code === 'EOTP') throw err
       const u = conf.creds.username

--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -8,6 +8,10 @@ const pacoteOpts = require('../config/pacote')
 const fetchOpts = require('../config/fetch-opts')
 const openUrl = require('../utils/open-url')
 
+const openerPromise = (url) => new Promise((resolve, reject) => {
+  openUrl(url, 'to complete your login please visit', (er) => er ? reject(er) : resolve())
+})
+
 const loginPrompter = (creds) => {
   const opts = { log: log }
   return read.username('Username:', creds.username, opts).then((u) => {
@@ -37,7 +41,7 @@ module.exports.login = (creds, registry, scope, cb) => {
 }
 
 function login (conf) {
-  return profile.login((url) => openUrl(url, 'to complete your login please visit'), loginPrompter, conf)
+  return profile.login(openerPromise, loginPrompter, conf)
     .catch((err) => {
       if (err.code === 'EOTP') throw err
       const u = conf.creds.username

--- a/lib/auth/sso.js
+++ b/lib/auth/sso.js
@@ -1,7 +1,7 @@
 var log = require('npmlog')
 var npm = require('../npm.js')
 var output = require('../utils/output')
-var opener = require('opener')
+var openUrl = require('../utils/open-url')
 
 module.exports.login = function login (creds, registry, scope, cb) {
   var ssoType = npm.config.get('sso-type')
@@ -22,10 +22,7 @@ module.exports.login = function login (creds, registry, scope, cb) {
     if (!doc || !doc.token) return cb(new Error('no SSO token returned'))
     if (!doc.sso) return cb(new Error('no SSO URL returned by services'))
 
-    output('If your browser doesn\'t open, visit ' +
-           doc.sso +
-           ' to complete authentication')
-    opener(doc.sso, { command: npm.config.get('browser') }, function () {
+    openUrl(doc.sso, 'to complete your login please visit', function () {
       pollForSession(registry, doc.token, function (err, username) {
         if (err) return cb(err)
 

--- a/lib/bugs.js
+++ b/lib/bugs.js
@@ -2,7 +2,7 @@ module.exports = bugs
 
 var npm = require('./npm.js')
 var log = require('npmlog')
-var opener = require('opener')
+var openUrl = require('./utils/open-url')
 var fetchPackageMetadata = require('./fetch-package-metadata.js')
 var usage = require('./utils/usage')
 
@@ -27,6 +27,6 @@ function bugs (args, cb) {
       url = 'https://www.npmjs.org/package/' + d.name
     }
     log.silly('bugs', 'url', url)
-    opener(url, { command: npm.config.get('browser') }, cb)
+    openUrl(url, 'bug list available at the following URL', cb)
   })
 }

--- a/lib/bugs.js
+++ b/lib/bugs.js
@@ -1,6 +1,5 @@
 module.exports = bugs
 
-var npm = require('./npm.js')
 var log = require('npmlog')
 var openUrl = require('./utils/open-url')
 var fetchPackageMetadata = require('./fetch-package-metadata.js')

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,7 +1,7 @@
 module.exports = docs
 
 var npm = require('./npm.js')
-var opener = require('opener')
+var openUrl = require('./utils/open-url')
 var log = require('npmlog')
 var fetchPackageMetadata = require('./fetch-package-metadata.js')
 var usage = require('./utils/usage')
@@ -37,6 +37,6 @@ function getDoc (project, cb) {
     if (er) return cb(er)
     var url = d.homepage
     if (!url) url = 'https://www.npmjs.org/package/' + d.name
-    return opener(url, {command: npm.config.get('browser')}, cb)
+    return openUrl(url, 'docs available at the following URL', cb)
   })
 }

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,6 +1,5 @@
 module.exports = docs
 
-var npm = require('./npm.js')
 var openUrl = require('./utils/open-url')
 var log = require('npmlog')
 var fetchPackageMetadata = require('./fetch-package-metadata.js')

--- a/lib/help.js
+++ b/lib/help.js
@@ -10,7 +10,7 @@ var path = require('path')
 var spawn = require('./utils/spawn')
 var npm = require('./npm.js')
 var log = require('npmlog')
-var opener = require('opener')
+var openUrl = require('./utils/open-url')
 var glob = require('glob')
 var didYouMean = require('./utils/did-you-mean')
 var cmdList = require('./config/cmd-list').cmdList
@@ -127,7 +127,7 @@ function viewMan (man, cb) {
       break
 
     case 'browser':
-      opener(htmlMan(man), { command: npm.config.get('browser') }, cb)
+      openUrl(htmlMan(man), 'help available at the following URL', cb)
       break
 
     default:

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -3,7 +3,7 @@ module.exports = repo
 repo.usage = 'npm repo [<pkg>]'
 
 var npm = require('./npm.js')
-var opener = require('opener')
+var openUrl = require('./utils/open-url')
 var hostedGitInfo = require('hosted-git-info')
 var url_ = require('url')
 var fetchPackageMetadata = require('./fetch-package-metadata.js')
@@ -32,7 +32,7 @@ function getUrlAndOpen (d, cb) {
 
   if (!url) return cb(new Error('no repository: could not get url'))
 
-  opener(url, { command: npm.config.get('browser') }, cb)
+  openUrl(url, 'repository available at the following URL', cb)
 }
 
 function unknownHostedUrl (url) {

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -2,7 +2,6 @@ module.exports = repo
 
 repo.usage = 'npm repo [<pkg>]'
 
-var npm = require('./npm.js')
 var openUrl = require('./utils/open-url')
 var hostedGitInfo = require('hosted-git-info')
 var url_ = require('url')

--- a/lib/utils/open-url.js
+++ b/lib/utils/open-url.js
@@ -4,15 +4,13 @@ const output = require('./output.js')
 const opener = require('opener')
 
 // attempt to open URL in web-browser, print address otherwise:
-module.exports = function open (url, errMsg, cb = () => {}, browser = npm.config.get('browser')) {
-  return new Promise((resolve, reject) => {
-    opener(url, { command: npm.config.get('browser') }, (er) => {
-      if (er && er.code === 'ENOENT') {
-        output(`${errMsg}:\n\n${url}`)
-        return (cb(), resolve())
-      } else {
-        return (cb(er), er ? reject(er) : resolve())
-      }
-    })
+module.exports = function open (url, errMsg, cb, browser = npm.config.get('browser')) {
+  opener(url, { command: npm.config.get('browser') }, (er) => {
+    if (er && er.code === 'ENOENT') {
+      output(`${errMsg}:\n\n${url}`)
+      return cb()
+    } else {
+      return cb(er)
+    }
   })
 }

--- a/lib/utils/open-url.js
+++ b/lib/utils/open-url.js
@@ -1,0 +1,18 @@
+'use strict'
+const npm = require('../npm.js')
+const output = require('./output.js')
+const opener = require('opener')
+
+// attempt to open URL in web-browser, print address otherwise:
+module.exports = function open (url, errMsg, cb = () => {}, browser = npm.config.get('browser')) {
+  return new Promise((resolve, reject) => {
+    opener(url, { command: npm.config.get('browser') }, (er) => {
+      if (er && er.code === 'ENOENT') {
+        output(`${errMsg}:\n\n${url}`)
+        return (cb(), resolve())
+      } else {
+        return (cb(er), er ? reject(er) : resolve())
+      }
+    })
+  })
+}

--- a/test/tap/adduser-oauth.js
+++ b/test/tap/adduser-oauth.js
@@ -69,15 +69,9 @@ test('npm login', function (t) {
       }
     )
 
-    var buf = ''
-    runner.stdout.on('data', function (chunk) {
-      buf += chunk.toString('utf8')
-      if (buf.match(/complete authentication/)) {
-        s.get(
-          '/-/whoami', { authorization: 'Bearer foo' }
-        ).reply(200, { username: 'igotauthed' })
-      }
-    })
+    s.get(
+      '/-/whoami', { authorization: 'Bearer foo' }
+    ).reply(200, { username: 'igotauthed' })
   })
 })
 

--- a/test/tap/adduser-oauth.js
+++ b/test/tap/adduser-oauth.js
@@ -45,7 +45,7 @@ test('npm login', function (t) {
     s.get(
       '/-/whoami', { authorization: 'Bearer foo' }
     ).max(1).reply(401, {})
-    var runner = common.npm(
+    common.npm(
       [
         'login',
         '--registry', common.registry,

--- a/test/tap/adduser-saml.js
+++ b/test/tap/adduser-saml.js
@@ -69,15 +69,9 @@ test('npm login', function (t) {
       }
     )
 
-    var buf = ''
-    runner.stdout.on('data', function (chunk) {
-      buf += chunk.toString('utf8')
-      if (buf.match(/complete authentication/)) {
-        s.get(
-          '/-/whoami', { authorization: 'Bearer foo' }
-        ).reply(200, { username: 'igotauthed' })
-      }
-    })
+    s.get(
+      '/-/whoami', { authorization: 'Bearer foo' }
+    ).reply(200, { username: 'igotauthed' })
   })
 })
 

--- a/test/tap/adduser-saml.js
+++ b/test/tap/adduser-saml.js
@@ -45,7 +45,7 @@ test('npm login', function (t) {
     s.get(
       '/-/whoami', { authorization: 'Bearer foo' }
     ).max(1).reply(401, {})
-    var runner = common.npm(
+    common.npm(
       [
         'login',
         '--registry', common.registry,


### PR DESCRIPTION
## Problem

in some environments, e.g., docker, the bin necessary to open a URL in the browser is not present:

```bash
npm ERR! path xdg-open
npm ERR! code ENOENT
npm ERR! errno ENOENT
npm ERR! syscall spawn xdg-open
npm ERR! enoent spawn xdg-open ENOENT
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2018-05-10T22_34_37_812Z-debug.log
```

## Solution

catch the error and output the URL that should be opened to the terminal:

```bash
to complete your login please visit:

https://www.blerg.blerg.io
```