### PR TITLE
added possibility to provide json output for audit report

### DIFF
--- a/lib/install/audit.js
+++ b/lib/install/audit.js
@@ -105,7 +105,7 @@ function printInstallReport (auditResult) {
 function printFullReport (auditResult) {
   return auditReport(auditResult, {
     log: output,
-    reporter: 'detail',
+    reporter: npm.config.get('json') ? 'json' : 'detail',
     withColor: npm.color,
     withUnicode: npm.config.get('unicode')
   }).then((result) => output(result.report))


### PR DESCRIPTION
works with: 

- npm audit --json=true

- npmrc json setting

This provides the possibility to get parseable json output by the npm audit instead of the pretty printed human readable output
