### PR TITLE
fix: inflate-shrinkwrap.js breaks when there is no sw.version

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -96,7 +96,7 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     requested.type === 'remote' ||
     requested.type === 'file'
   )
-  const regTarball = tarballToVersion(name, sw.version)
+  const regTarball = sw.version && tarballToVersion(name, sw.version)
   if (regTarball) {
     sw.resolved = sw.version
     sw.version = regTarball


### PR DESCRIPTION
When executing a command such as `npm prune`, if there is no version field for a dependency in the `package-lock.json` the command fails. Here is an example output of a failure:

```
0 info it worked if it ends with ok
1 verbose cli [ 'C:\\Program Files\\nodejs\\node.exe',
1 verbose cli   'C:\\Users\\stevhob\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js',
1 verbose cli   'prune',
1 verbose cli   '--dry-run' ]
2 info using npm@6.0.1
3 info using node@v8.7.0
4 verbose npm-session ce9b7bfbc8a7660c
5 silly install loadCurrentTree
6 silly install readLocalPackageData
7 timing stage:loadCurrentTree Completed in 2841ms
8 silly install loadIdealTree
9 silly install cloneCurrentTreeToIdealTree
10 timing stage:loadIdealTree:cloneCurrentTree Completed in 19ms
11 silly install loadShrinkwrap
12 verbose stack TypeError: Cannot read property 'match' of undefined
12 verbose stack     at tarballToVersion (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\lib\install\inflate-shrinkwrap.js:87:20)
12 verbose stack     at inflatableChild (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\lib\install\inflate-shrinkwrap.js:99:22)
12 verbose stack     at BB.each (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\lib\install\inflate-shrinkwrap.js:55:12)
12 verbose stack     at tryCatcher (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\util.js:16:23)
12 verbose stack     at Object.gotValue (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\reduce.js:155:18)
12 verbose stack     at Object.gotAccum (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\reduce.js:144:25)
12 verbose stack     at Object.tryCatcher (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\util.js:16:23)
12 verbose stack     at Promise._settlePromiseFromHandler (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\promise.js:512:31)
12 verbose stack     at Promise._settlePromise (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\promise.js:569:18)
12 verbose stack     at Promise._settlePromise0 (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\promise.js:614:10)
12 verbose stack     at Promise._settlePromises (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\promise.js:693:18)
12 verbose stack     at Async._drainQueue (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\async.js:133:16)
12 verbose stack     at Async._drainQueues (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\async.js:143:10)
12 verbose stack     at Immediate.Async.drainQueues (C:\Users\stevhob\AppData\Roaming\npm\node_modules\npm\node_modules\bluebird\js\release\async.js:17:14)
12 verbose stack     at runCallback (timers.js:785:20)
12 verbose stack     at tryOnImmediate (timers.js:747:5)
13 verbose cwd ###OBFUSCATED FOR PR###
14 verbose Windows_NT 10.0.16299
15 verbose argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\stevhob\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js" "prune" "--dry-run"
16 verbose node v8.7.0
17 verbose npm  v6.0.1
18 error Cannot read property 'match' of undefined
19 verbose exit [ 1, true ]
```

Note, I am not sure why the `package-lock.json` doesn't have the `version` property for this particular package.