### PR TITLE
ci: pause log before logging summary

### DIFF
--- a/lib/ci.js
+++ b/lib/ci.js
@@ -29,9 +29,12 @@ function ci (args, cb) {
   })
     .run()
     .then(
-      (details) => console.error(`added ${details.pkgCount} packages in ${
-        details.runTime / 1000
-      }s`)
+      (details) => {
+        npmlog.pause()
+        console.error(`added ${details.pkgCount} packages in ${
+          details.runTime / 1000
+        }s`)
+      }
     )
     .then(() => cb(), cb)
 }

--- a/lib/ci.js
+++ b/lib/ci.js
@@ -30,7 +30,7 @@ function ci (args, cb) {
     .run()
     .then(
       (details) => {
-        npmlog.pause()
+        npmlog.disableProgress()
         console.error(`added ${details.pkgCount} packages in ${
           details.runTime / 1000
         }s`)


### PR DESCRIPTION
From [here](https://npm.trydiscourse.com/t/npm-ci-progress-bar-not-properly-removed/61/2), this will remove the progress bar before logging the summary, so that it doesn't log the summary over the progress bar and print something like `added 2 pacakges in 0.966sractTree: extractTree`.