### PR TITLE
Add synopsis to audit brief help and suppress trailing newline

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -16,9 +16,13 @@ const readFile = Bluebird.promisify(fs.readFile)
 
 module.exports = auditCmd
 
-auditCmd.usage =
-  'npm audit\n' +
-  'npm audit fix\n'
+const usage = require('./utils/usage')
+auditCmd.usage = usage(
+  'audit',
+  '\nnpm audit [--json]' +
+  '\nnpm audit fix ' +
+  '[--force|--package-lock-only|--dry-run|--production|--only=(dev|prod)]'
+)
 
 auditCmd.completion = function (opts, cb) {
   const argv = opts.conf.argv.remain


### PR DESCRIPTION
I realize these are documented in `npm help audit`, but this brings `npm audit --help` a bit more in line with say, `npm install`, and makes it clear that there are other arguments.