### PR TITLE
errors: direct people to npm.community instead of github

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -57,7 +57,7 @@ process.on('exit', function (code) {
       log.error('', 'cb() never called!')
       console.error('')
       log.error('', 'This is an error with npm itself. Please report this error at:')
-      log.error('', '    <https://github.com/npm/npm/issues>')
+      log.error('', '    <https://npm.community>')
       writeLogFile()
     }
 

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -348,7 +348,7 @@ function errorMessage (er) {
         'typeerror',
         [
           'This is an error with npm itself. Please report this error at:',
-          '    <https://github.com/npm/npm/issues>'
+          '    <https://npm.community>'
         ].join('\n')
       ])
       break


### PR DESCRIPTION
This is part of our move to https://npm.community for issues.