### PR TITLE
feat: show suggestions for run-script

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -184,7 +184,7 @@ function npmUsage (valid, cb) {
   ].join('\n'))
 
   if (npm.argv.length > 1) {
-    didYouMean(npm.argv[1], commands)
+    output(didYouMean(npm.argv[1], commands))
   }
 
   cb(valid)

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -8,6 +8,7 @@ var log = require('npmlog')
 var chain = require('slide').chain
 var usage = require('./utils/usage')
 var output = require('./utils/output.js')
+var didYouMean = require('./utils/did-you-mean')
 
 runScript.usage = usage(
   'run-script',
@@ -148,7 +149,9 @@ function run (pkg, wd, cmd, args, cb) {
       } else if (npm.config.get('if-present')) {
         return cb(null)
       } else {
-        return cb(new Error('missing script: ' + cmd))
+        let suggestions = didYouMean(cmd, Object.keys(pkg.scripts))
+        suggestions = suggestions ? '\n' + suggestions : ''
+        return cb(new Error('missing script: ' + cmd + suggestions))
       }
     }
     cmds = [cmd]

--- a/lib/utils/did-you-mean.js
+++ b/lib/utils/did-you-mean.js
@@ -1,19 +1,16 @@
 var meant = require('meant')
-var output = require('./output.js')
 
 function didYouMean (scmd, commands) {
   var bestSimilarity = meant(scmd, commands).map(function (str) {
     return '    ' + str
   })
 
-  if (bestSimilarity.length === 0) return
+  if (bestSimilarity.length === 0) return ''
   if (bestSimilarity.length === 1) {
-    output('\nDid you mean this?\n' + bestSimilarity[0])
+    return '\nDid you mean this?\n' + bestSimilarity[0]
   } else {
-    output(
-      ['\nDid you mean one of these?']
-        .concat(bestSimilarity.slice(0, 3)).join('\n')
-    )
+    return ['\nDid you mean one of these?']
+      .concat(bestSimilarity.slice(0, 3)).join('\n')
   }
 }
 

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -356,6 +356,17 @@ test('npm run-script keep non-zero exit code', function (t) {
   })
 })
 
+test('npm run-script nonexistent script and display suggestions', function (t) {
+  writeMetadata(directOnly)
+
+  common.npm(['run-script', 'whoop'], opts, function (err, code, stdout, stderr) {
+    t.ifError(err, 'ran run-script without crashing')
+    t.equal(code, 1, 'got expected exit code')
+    t.has(stderr, 'Did you mean this?')
+    t.end()
+  })
+})
+
 test('cleanup', function (t) {
   cleanup()
   t.end()


### PR DESCRIPTION
##### How this works
![screen shot 2018-06-03 at 12 21 47](https://user-images.githubusercontent.com/1716463/40882826-e2db8272-6728-11e8-95f0-cce3f8d75792.png)

##### Summary
Whenever npm run 'script' is unable to find 'script',
display a list with all possible available scripts.

Refs: https://github.com/npm/rfcs/pull/9
Fixes: https://github.com/npm/npm/issues/20858

##### ToDo
- [x] Write test