### PR TITLE
Exclude /.github directory from npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 *.swp
 .*.swp
 npm-debug.log
+/.github
 /test
 node_modules/marked
 node_modules/ronn


### PR DESCRIPTION
The `/.github` directory is only used by GitHub issues so it doesn't need to be published to npm.