### PR TITLE
gyp: fix regex to match multi-digit versions

### DIFF
--- a/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
+++ b/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
@@ -1262,7 +1262,7 @@ def XcodeVersion():
   except:
     version = CLTVersion()
     if version:
-      version = re.match(r'(\d\.\d\.?\d*)', version).groups()[0]
+      version = re.match(r'(\d+\.\d+\.?\d*)', version).groups()[0]
     else:
       raise GypError("No Xcode or CLT version detected!")
     # The CLT has no build information, so we return an empty string.


### PR DESCRIPTION
Update to node-gyp@3.6.3 to accommodate LLVM 10.0.0. Earlier versions of
node-gyp had a regular expression that did not match the version string
'10.0.0'. node-gyp@3.6.3 fixes this bug.

Refs: https://github.com/nodejs/node/pull/21239
Refs: https://github.com/nodejs/node-gyp/issues/1454
Refs: https://github.com/nodejs/node-gyp/pull/1455
Refs: https://github.com/nodejs/node-gyp/commit/293092c362febffe19f72712467565045e08e8f1

Commit message from original patch:

    gyp: fix regex to match multi-digit versions
    
    This fixes the regular expression matching in `xcode_emulation`
    to also handle version numbers with multiple-digit major versions
    which would otherwise break under use of XCode 10
    
    Fixes: https://github.com/nodejs/node-gyp/issues/1454