### PR TITLE
Fixes error code when no `test` has been defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ npm-debug.log
 /node_modules/standard/
 /node_modules/tap/
 /node_modules/tacks/
+/test/npm_cache

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -136,7 +136,7 @@ function run (pkg, wd, cmd, args, cb) {
   } else {
     if (!pkg.scripts[cmd]) {
       if (cmd === 'test') {
-        pkg.scripts.test = 'echo \'Error: no test specified\''
+        pkg.scripts.test = 'echo \'Error: no test specified\' && exit 1'
       } else if (cmd === 'env') {
         if (process.platform === 'win32') {
           log.verbose('run-script using default platform env: SET (Windows)')

--- a/test/tap/install-test-cli-without-package-lock.js
+++ b/test/tap/install-test-cli-without-package-lock.js
@@ -38,7 +38,8 @@ test('\'npm install-test\' should not generate package-lock.json.*', function (t
     if (err) throw err
     t.comment(stdout.trim())
     t.comment(stderr.trim())
-    t.is(code, 0, 'npm install did not raise error code')
+    t.match(stderr, /Error: no test specified/, "npm test schould fail")
+    t.is(code, 1, 'npm install did not raise error code and npm test did')
     var files = fs.readdirSync(pkg).filter(function (f) {
       return f.indexOf('package-lock.json.') === 0
     })

--- a/test/tap/legacy-test-package.js
+++ b/test/tap/legacy-test-package.js
@@ -42,7 +42,7 @@ test('test-package', function (t) {
 
   function testCheckAndRemove (err, code, stdout, stderr) {
     if (err) throw err
-    t.is(code, 0, 'npm test w/o test is ok')
+    t.is(code, 1, 'npm test w/o test should return error')
     common.npm(['rm', fixturepath], {cwd: basepath}, removeCheckAndDone)
   }
 

--- a/test/tap/run-script.js
+++ b/test/tap/run-script.js
@@ -166,8 +166,9 @@ test('npm run-script explicitly call pre script with arg', function (t) {
 
 test('npm run-script test', function (t) {
   common.npm(['run-script', 'test'], opts, function (er, code, stdout, stderr) {
+    t.match(stderr, /Error: no test specified/)
     t.ifError(er, 'npm run-script test ran without issue')
-    t.notOk(stderr, 'should not generate errors')
+    t.ok(stderr, 'should not generate errors')
     t.end()
   })
 })


### PR DESCRIPTION
When no `test` script has been defined `npm run test` returns an exit code of 0, which is confusing and makes working with other scripts prone to errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/npm/npm/21026)
<!-- Reviewable:end -->
