### PR TITLE
config: Only translate environment variables up to the first colon

### DIFF
--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -346,11 +346,13 @@ Conf.prototype.addEnv = function (env) {
     .forEach(function (k) {
       if (!env[k]) return
 
-      // leave first char untouched, even if
-      // it is a '_' - convert all other to '-'
-      var p = k.toLowerCase()
+      // leave first char untouched, even if it is a '_'
+      // convert all other to '-', up to the first ':'
+      var ps = k.split(':')
+      ps[0] = ps[0].toLowerCase()
         .replace(/^npm_config_/, '')
         .replace(/(?!^)_/g, '-')
+      var p = ps.join(':')
       conf[p] = env[k]
     })
   return CC.prototype.addEnv.call(this, '', conf, 'env')


### PR DESCRIPTION
As discussed on [npm.community][1], the fact that
npm registry authentication tokens
cannot be defined using environment variables
does not seem justified anymore.

The restriction is caused by the config loader translating

* all `_` to `-`
* the whole variable name to lowercase

while the credential checker expects a key ending in `:_authToken`.

As suggested, this change fixes the problem
by limiting the translation by the config loader
to the part *before* the first colon.

Closes #15565

[1]: https://npm.community/t/cannot-set-npm-config-keys-containing-underscores-registry-auth-tokens-for-example-via-npm-config-environment-variables/233