### PR TITLE
Fixed npm CLI version call format.

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -205,7 +205,7 @@ function dump (data, cb) {
 
   if (npm.config.get('json')) v = JSON.stringify(v, null, 2)
 
-  output(v)
+  output('v' + v)
   cb()
 }
 


### PR DESCRIPTION
npm did not show the 'v' in front of the version (as shown below); this change adds the 'v' in front of the returned value.

![versioncall](https://user-images.githubusercontent.com/18338408/41953912-956947e8-7995-11e8-8fa1-c7716c2f6009.png)