### PR TITLE
version: allow prerelease identifier

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -579,3 +579,4 @@ Thomas Reggi <socialtr@gmail.com>
 David Gilbertson <gilbertson.david@gmail.com>
 Rob Lourens <roblourens@gmail.com>
 Karan Thakkar <karanjthakkar@gmail.com>
+Daniel Wilches <dwilches@gmail.com>

--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -3,7 +3,7 @@ npm-version(1) -- Bump a package version
 
 ## SYNOPSIS
 
-    npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
+    npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]
 
     'npm [-v | --version]' to print npm version
     'npm view <pkg> version' to view a package's published version

--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -798,6 +798,14 @@ for updates immediately even for fresh package data.
 The location to install global items.  If set on the command line, then
 it forces non-global commands to run in the specified folder.
 
+### preid
+
+* Default: ""
+* Type: String
+
+The "prerelease identifier" to use as a prefix for the "prerelease" part of a
+semver. Like the `rc` in `1.2.0-rc.8`.
+
 ### production
 
 * Default: false

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -190,6 +190,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'prefer-offline': false,
     'prefer-online': false,
     prefix: globalPrefix,
+    preid: '',
     production: process.env.NODE_ENV === 'production',
     'progress': !process.env.TRAVIS && !process.env.CI,
     proxy: null,
@@ -328,6 +329,7 @@ exports.types = {
   'prefer-offline': Boolean,
   'prefer-online': Boolean,
   prefix: path,
+  preid: String,
   production: Boolean,
   progress: Boolean,
   proxy: [null, false, url], // allow proxy to be disabled explicitly

--- a/lib/version.js
+++ b/lib/version.js
@@ -18,7 +18,7 @@ const semver = require('semver')
 const stringifyPackage = require('./utils/stringify-package')
 const writeFileAtomic = require('write-file-atomic')
 
-version.usage = 'npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]' +
+version.usage = 'npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]' +
                 '\n(run in package dir)\n' +
                 "'npm -v' or 'npm --version' to print npm version " +
                 '(' + npm.version + ')\n' +
@@ -47,7 +47,7 @@ function version (args, silent, cb_) {
       retrieveTagVersion(silent, data, cb_)
     } else {
       var newVersion = semver.valid(args[0])
-      if (!newVersion) newVersion = semver.inc(data.version, args[0])
+      if (!newVersion) newVersion = semver.inc(data.version, args[0], npm.config.get('preid'))
       if (!newVersion) return cb_(version.usage)
       persistVersion(newVersion, silent, data, cb_)
     }

--- a/test/tap/version-prerelease-id.js
+++ b/test/tap/version-prerelease-id.js
@@ -1,0 +1,61 @@
+var fs = require('fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var npm = require('../../')
+var common = require('../common-tap.js')
+
+var pkg = path.resolve(__dirname, 'version-shrinkwrap')
+var cache = path.resolve(pkg, 'cache')
+
+var EXEC_OPTS = { cwd: pkg }
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+test('npm version --preid=rc uses prerelease id', function (t) {
+  setup()
+
+  npm.load({ cache: pkg + '/cache', registry: common.registry }, function () {
+    common.npm(['version', 'prerelease', '--preid=rc'], EXEC_OPTS, function (err) {
+      if (err) return t.fail('Error perform version prerelease')
+      var newVersion = require(path.resolve(pkg, 'package.json')).version
+      t.equal(newVersion, '0.0.1-rc.0', 'got expected version')
+      t.end()
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function setup () {
+  cleanup()
+  mkdirp.sync(pkg)
+  mkdirp.sync(cache)
+  var contents = {
+    author: 'Daniel Wilches',
+    name: 'version-prerelease-id',
+    version: '0.0.0',
+    description: 'Test for version of prereleases with preids'
+  }
+
+  fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify(contents), 'utf8')
+  fs.writeFileSync(path.resolve(pkg, 'npm-shrinkwrap.json'), JSON.stringify(contents), 'utf8')
+  process.chdir(pkg)
+}
+
+function cleanup () {
+  // windows fix for locked files
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(cache)
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
This modification was prompted by this SO question:
https://stackoverflow.com/questions/51050008/npm-version-add-r-c-to-current-version-and-use-prerelease/51050516

Where I didn't find an alternative for adding prerelease identifiers through `node version`.