### PR TITLE
Remove back-ticks not being parsed as markdown

### DIFF
--- a/doc/misc/npm-disputes.md
+++ b/doc/misc/npm-disputes.md
@@ -39,7 +39,7 @@ some other user wants to use that name. Here are some common ways that happens
    really has to be updated. Alice works for Foo Inc, the makers of the
    critically acclaimed and widely-marketed `foo` JavaScript toolkit framework.
    They publish it to npm as `foojs`, but people are routinely confused when
-   `npm install `foo`` is some different thing.
+   `npm install foo` is some different thing.
 4. Yusuf writes a parser for the widely-known `foo` file format, because he
    needs it for work. Then, he gets a new job, and never updates the prototype.
    Later on, Alice writes a much more complete `foo` parser, but can't publish,


### PR DESCRIPTION
I believe it should be:
`npm install foo`
instead of:
`npm install `foo``